### PR TITLE
Fix navigation menu items reordering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix order links on home page - #1219 by @jwm0
 - Fix huge payload issue for plugins view - #1203 by @kamilpastuszka
 - Fix content type validation in create page view - #1205 by @orzechdev
+- Fixed navigation menu items reordering issue - #1239 by @kamilpastuszka
 
 # 2.11.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13497,9 +13497,9 @@
       "integrity": "sha512-6G3lzZXWjWfqTJDS9KhHFIislZMGdrzDqews3T14E/dsANVbs3YT4A3jSNDrbA/gbtmjLuKJx9DzcLucdXBqBw=="
     },
     "fast-array-diff": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-array-diff/-/fast-array-diff-0.2.0.tgz",
-      "integrity": "sha1-9T6JEQl0/+lgP2LnpePvcfCvU3k="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-array-diff/-/fast-array-diff-1.0.1.tgz",
+      "integrity": "sha512-pU83E/Y7+c/hRrDlmIiPYHy0Ugt+QypqzHKZI5qFOWMJAspWdmOyIeN/1FbdnGPlROp6FeGLLfhMO075DBqb4A=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "editorjs-inline-tool": "^0.4.0",
     "editorjs-undo": "^0.1.4",
     "faker": "^5.1.0",
-    "fast-array-diff": "^0.2.0",
+    "fast-array-diff": "^1.0.1",
     "fsevents": "^1.2.9",
     "fuzzaldrin": "^2.1.0",
     "graphql": "^14.4.2",

--- a/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
+++ b/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
@@ -69,7 +69,7 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
     });
 
     if (result) {
-      setTreeOperations([]);
+      setTreeOperations([...treeOperations]);
     }
 
     return result;


### PR DESCRIPTION
I want to merge this change so that navigation menu can keep its state after reordering.

 There was a need to upgrade fast-array-diff module to the latest version as one of the functions returned incorrect values.


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/