### PR TITLE
Add current usage on vouchers

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3051,6 +3051,10 @@
     "context": "voucher usage limit, header",
     "string": "Usage Limit"
   },
+  "src_dot_discounts_dot_components_dot_VoucherLimits_dot_usesLeftCaption": {
+    "context": "usage limit uses left caption",
+    "string": "Uses left"
+  },
   "src_dot_discounts_dot_components_dot_VoucherListPage_dot_1112241061": {
     "context": "tab name",
     "string": "All Vouchers"

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -45,7 +45,8 @@ export interface FormData extends MetadataFormData {
   startDate: string;
   startTime: string;
   type: VoucherTypeEnum;
-  usageLimit: string;
+  usageLimit: number;
+  used: number;
   value: number;
 }
 
@@ -95,7 +96,8 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     startDate: "",
     startTime: "",
     type: VoucherTypeEnum.ENTIRE_ORDER,
-    usageLimit: "0",
+    usageLimit: 0,
+    used: 0,
     value: 0,
     metadata: [],
     privateMetadata: []

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -105,7 +105,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit, triggerChange }) => {
+      {({ change, data, hasChanged, submit, triggerChange, set }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(
           change
         );
@@ -175,9 +175,11 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
                 <CardSpacer />
                 <VoucherLimits
                   data={data}
+                  initialUsageLimit={initialForm.usageLimit}
                   disabled={disabled}
                   errors={errors}
                   onChange={change}
+                  setData={set}
                 />
                 <CardSpacer />
                 <VoucherDates

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -96,7 +96,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     startDate: "",
     startTime: "",
     type: VoucherTypeEnum.ENTIRE_ORDER,
-    usageLimit: 0,
+    usageLimit: 1,
     used: 0,
     value: 0,
     metadata: [],
@@ -180,6 +180,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
                   errors={errors}
                   onChange={change}
                   setData={set}
+                  isNewVoucher
                 />
                 <CardSpacer />
                 <VoucherDates

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -74,7 +74,8 @@ export interface VoucherDetailsPageFormData extends MetadataFormData {
   startDate: string;
   startTime: string;
   type: VoucherTypeEnum;
-  usageLimit: string;
+  usageLimit: number;
+  used: number;
 }
 
 export interface VoucherDetailsPageProps
@@ -191,7 +192,8 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
     startDate: splitDateTime(voucher?.startDate ?? "").date,
     startTime: splitDateTime(voucher?.startDate ?? "").time,
     type: voucher?.type ?? VoucherTypeEnum.ENTIRE_ORDER,
-    usageLimit: voucher?.usageLimit?.toString() ?? "0",
+    usageLimit: voucher?.usageLimit ?? 0,
+    used: voucher?.used ?? 0,
     metadata: voucher?.metadata.map(mapMetadataItemToInput),
     privateMetadata: voucher?.privateMetadata.map(mapMetadataItemToInput)
   };

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -210,13 +210,14 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
           triggerChange
         );
         const formDisabled =
-          data.discountType.toString() !== "SHIPPING" &&
-          data.channelListings?.some(
-            channel =>
-              validatePrice(channel.discountValue) ||
-              (data.requirementsPicker === RequirementsPicker.ORDER &&
-                validatePrice(channel.minSpent))
-          );
+          (data.discountType.toString() !== "SHIPPING" &&
+            data.channelListings?.some(
+              channel =>
+                validatePrice(channel.discountValue) ||
+                (data.requirementsPicker === RequirementsPicker.ORDER &&
+                  validatePrice(channel.minSpent))
+            )) ||
+          data.usageLimit <= 0;
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -200,7 +200,7 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit, triggerChange }) => {
+      {({ change, data, hasChanged, submit, triggerChange, set }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(
           change
         );
@@ -401,9 +401,11 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
                 <CardSpacer />
                 <VoucherLimits
                   data={data}
+                  initialUsageLimit={initialForm.usageLimit}
                   disabled={disabled}
                   errors={errors}
                   onChange={change}
+                  setData={set}
                 />
                 <CardSpacer />
                 <DiscountDates

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -192,7 +192,7 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
     startDate: splitDateTime(voucher?.startDate ?? "").date,
     startTime: splitDateTime(voucher?.startDate ?? "").time,
     type: voucher?.type ?? VoucherTypeEnum.ENTIRE_ORDER,
-    usageLimit: voucher?.usageLimit ?? 0,
+    usageLimit: voucher?.usageLimit ?? 1,
     used: voucher?.used ?? 0,
     metadata: voucher?.metadata.map(mapMetadataItemToInput),
     privateMetadata: voucher?.privateMetadata.map(mapMetadataItemToInput)
@@ -406,6 +406,7 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
                   errors={errors}
                   onChange={change}
                   setData={set}
+                  isNewVoucher={false}
                 />
                 <CardSpacer />
                 <DiscountDates

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -30,6 +30,8 @@ const VoucherLimits = ({
 
   const formErrors = getFormErrors(["usageLimit"], errors);
 
+  const usesLeft = data.usageLimit - data.used;
+
   return (
     <Card>
       <CardTitle title={intl.formatMessage(messages.usageLimitsTitle)} />
@@ -59,7 +61,7 @@ const VoucherLimits = ({
               <Typography variant="caption">
                 {intl.formatMessage(messages.usesLeftCaption)}
               </Typography>
-              <Typography>1234567</Typography>
+              <Typography>{usesLeft}</Typography>
             </div>
           </Grid>
         )}

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -1,6 +1,7 @@
-import { Card, CardContent, TextField } from "@material-ui/core";
+import { Card, CardContent, TextField, Typography } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import { ControlledCheckbox } from "@saleor/components/ControlledCheckbox";
+import { Grid } from "@saleor/components/Grid";
 import { DiscountErrorFragment } from "@saleor/fragments/types/DiscountErrorFragment";
 import { getFormErrors } from "@saleor/utils/errors";
 import getDiscountErrorMessage from "@saleor/utils/errors/discounts";
@@ -9,6 +10,7 @@ import { useIntl } from "react-intl";
 
 import { VoucherDetailsPageFormData } from "../VoucherDetailsPage";
 import messages from "./messages";
+import { useStyles } from "./styles";
 
 interface VoucherLimitsProps {
   data: VoucherDetailsPageFormData;
@@ -24,13 +26,14 @@ const VoucherLimits = ({
   onChange
 }: VoucherLimitsProps) => {
   const intl = useIntl();
+  const classes = useStyles();
 
   const formErrors = getFormErrors(["usageLimit"], errors);
 
   return (
     <Card>
       <CardTitle title={intl.formatMessage(messages.usageLimitsTitle)} />
-      <CardContent>
+      <CardContent className={classes.cardContent}>
         <ControlledCheckbox
           checked={data.hasUsageLimit}
           label={intl.formatMessage(messages.hasUsageLimit)}
@@ -38,20 +41,27 @@ const VoucherLimits = ({
           onChange={onChange}
         />
         {data.hasUsageLimit && (
-          <TextField
-            disabled={disabled}
-            error={!!formErrors.usageLimit}
-            helperText={getDiscountErrorMessage(formErrors.usageLimit, intl)}
-            label={intl.formatMessage(messages.usageLimit)}
-            name={"usageLimit" as keyof VoucherDetailsPageFormData}
-            value={data.usageLimit}
-            onChange={onChange}
-            type="number"
-            inputProps={{
-              min: 0
-            }}
-            fullWidth
-          />
+          <Grid variant="uniform">
+            <TextField
+              disabled={disabled}
+              error={!!formErrors.usageLimit}
+              helperText={getDiscountErrorMessage(formErrors.usageLimit, intl)}
+              label={intl.formatMessage(messages.usageLimit)}
+              name={"usageLimit" as keyof VoucherDetailsPageFormData}
+              value={data.usageLimit}
+              onChange={onChange}
+              type="number"
+              inputProps={{
+                min: 0
+              }}
+            />
+            <div className={classes.usesLeftLabelWrapper}>
+              <Typography variant="caption">
+                {intl.formatMessage(messages.usesLeftCaption)}
+              </Typography>
+              <Typography>1234567</Typography>
+            </div>
+          </Grid>
         )}
         <ControlledCheckbox
           checked={data.applyOncePerCustomer}

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -19,6 +19,7 @@ interface VoucherLimitsProps {
   initialUsageLimit: number;
   onChange: (event: React.ChangeEvent<any>) => void;
   setData: (data: Partial<VoucherDetailsPageFormData>) => void;
+  isNewVoucher: boolean;
 }
 
 const VoucherLimits = ({
@@ -27,7 +28,8 @@ const VoucherLimits = ({
   errors,
   initialUsageLimit,
   onChange,
-  setData
+  setData,
+  isNewVoucher
 }: VoucherLimitsProps) => {
   const intl = useIntl();
   const classes = useStyles();
@@ -49,8 +51,8 @@ const VoucherLimits = ({
             setData({ usageLimit: initialUsageLimit });
           }}
         />
-        {data.hasUsageLimit && (
-          <Grid variant="uniform">
+        {data.hasUsageLimit &&
+          (isNewVoucher ? (
             <TextField
               disabled={disabled}
               error={!!formErrors.usageLimit || data.usageLimit <= 0}
@@ -60,18 +62,37 @@ const VoucherLimits = ({
               value={data.usageLimit}
               onChange={onChange}
               type="number"
+              fullWidth
               inputProps={{
                 min: 1
               }}
             />
-            <div className={classes.usesLeftLabelWrapper}>
-              <Typography variant="caption">
-                {intl.formatMessage(messages.usesLeftCaption)}
-              </Typography>
-              <Typography>{usesLeft >= 0 ? usesLeft : 0}</Typography>
-            </div>
-          </Grid>
-        )}
+          ) : (
+            <Grid variant="uniform">
+              <TextField
+                disabled={disabled}
+                error={!!formErrors.usageLimit || data.usageLimit <= 0}
+                helperText={getDiscountErrorMessage(
+                  formErrors.usageLimit,
+                  intl
+                )}
+                label={intl.formatMessage(messages.usageLimit)}
+                name={"usageLimit" as keyof VoucherDetailsPageFormData}
+                value={data.usageLimit}
+                onChange={onChange}
+                type="number"
+                inputProps={{
+                  min: 1
+                }}
+              />
+              <div className={classes.usesLeftLabelWrapper}>
+                <Typography variant="caption">
+                  {intl.formatMessage(messages.usesLeftCaption)}
+                </Typography>
+                <Typography>{usesLeft >= 0 ? usesLeft : 0}</Typography>
+              </div>
+            </Grid>
+          ))}
         <ControlledCheckbox
           checked={data.applyOncePerCustomer}
           label={intl.formatMessage(messages.applyOncePerCustomer)}

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -16,14 +16,18 @@ interface VoucherLimitsProps {
   data: VoucherDetailsPageFormData;
   disabled: boolean;
   errors: DiscountErrorFragment[];
+  initialUsageLimit: number;
   onChange: (event: React.ChangeEvent<any>) => void;
+  setData: (data: Partial<VoucherDetailsPageFormData>) => void;
 }
 
 const VoucherLimits = ({
   data,
   disabled,
   errors,
-  onChange
+  initialUsageLimit,
+  onChange,
+  setData
 }: VoucherLimitsProps) => {
   const intl = useIntl();
   const classes = useStyles();
@@ -40,7 +44,10 @@ const VoucherLimits = ({
           checked={data.hasUsageLimit}
           label={intl.formatMessage(messages.hasUsageLimit)}
           name={"hasUsageLimit" as keyof VoucherDetailsPageFormData}
-          onChange={onChange}
+          onChange={evt => {
+            onChange(evt);
+            setData({ usageLimit: initialUsageLimit });
+          }}
         />
         {data.hasUsageLimit && (
           <Grid variant="uniform">

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -46,7 +46,7 @@ const VoucherLimits = ({
           <Grid variant="uniform">
             <TextField
               disabled={disabled}
-              error={!!formErrors.usageLimit}
+              error={!!formErrors.usageLimit || data.usageLimit <= 0}
               helperText={getDiscountErrorMessage(formErrors.usageLimit, intl)}
               label={intl.formatMessage(messages.usageLimit)}
               name={"usageLimit" as keyof VoucherDetailsPageFormData}
@@ -54,14 +54,14 @@ const VoucherLimits = ({
               onChange={onChange}
               type="number"
               inputProps={{
-                min: 0
+                min: 1
               }}
             />
             <div className={classes.usesLeftLabelWrapper}>
               <Typography variant="caption">
                 {intl.formatMessage(messages.usesLeftCaption)}
               </Typography>
-              <Typography>{usesLeft}</Typography>
+              <Typography>{usesLeft >= 0 ? usesLeft : 0}</Typography>
             </div>
           </Grid>
         )}

--- a/src/discounts/components/VoucherLimits/messages.ts
+++ b/src/discounts/components/VoucherLimits/messages.ts
@@ -13,6 +13,10 @@ export default defineMessages({
     defaultMessage: "Limit of Uses",
     description: "limit voucher"
   },
+  usesLeftCaption: {
+    defaultMessage: "Uses left",
+    description: "usage limit uses left caption"
+  },
   applyOncePerCustomer: {
     defaultMessage: "Limit to one use per customer",
     description: "limit voucher"

--- a/src/discounts/components/VoucherLimits/styles.ts
+++ b/src/discounts/components/VoucherLimits/styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    cardContent: {
+      display: "flex",
+      flexDirection: "column"
+    },
+    usesLeftLabelWrapper: {
+      display: "flex",
+      flexDirection: "column",
+      flex: 1
+    }
+  }),
+  { name: "VoucherLimits" }
+);

--- a/src/discounts/components/VoucherLimits/styles.ts
+++ b/src/discounts/components/VoucherLimits/styles.ts
@@ -1,7 +1,7 @@
 import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
-  theme => ({
+  () => ({
     cardContent: {
       display: "flex",
       flexDirection: "column"

--- a/src/discounts/views/VoucherCreate/handlers.ts
+++ b/src/discounts/views/VoucherCreate/handlers.ts
@@ -49,9 +49,7 @@ export function createHandler(
           formData.discountType === DiscountTypeEnum.SHIPPING
             ? VoucherTypeEnum.SHIPPING
             : formData.type,
-        usageLimit: formData.hasUsageLimit
-          ? parseInt(formData.usageLimit, 10)
-          : null
+        usageLimit: formData.hasUsageLimit ? formData.usageLimit : null
       }
     });
 

--- a/src/discounts/views/VoucherDetails/handlers.ts
+++ b/src/discounts/views/VoucherDetails/handlers.ts
@@ -56,9 +56,7 @@ export function createUpdateHandler(
             formData.discountType === DiscountTypeEnum.SHIPPING
               ? VoucherTypeEnum.SHIPPING
               : formData.type,
-          usageLimit: formData.hasUsageLimit
-            ? parseInt(formData.usageLimit, 10)
-            : null
+          usageLimit: formData.hasUsageLimit ? formData.usageLimit : null
         }
       }).then(({ data }) => data?.voucherUpdate.errors ?? []),
 


### PR DESCRIPTION
I want to merge this change because it add current usage on vouchers with limited usage.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** 3.0
### Screenshots

Before:
![image](https://user-images.githubusercontent.com/41952692/137857233-0253f98d-4412-4f30-aa02-064b5bfa761a.png)

After:
![image](https://user-images.githubusercontent.com/41952692/137857101-17d9c570-4ca2-4513-b5e8-623f7542e369.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
