### PR TITLE
Adds vercel.json with URL rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+    "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+  }
+  


### PR DESCRIPTION
Adds a `vercel.json` file so the built dashboard will always serve the index file on vercel.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**To simplify hosting the dashboard SPA on Vercel**

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
