### PR TITLE
Add optional channel selection in price and weight rates view + voucher view

### DIFF
--- a/src/discounts/views/VoucherDetails/VoucherDetails.tsx
+++ b/src/discounts/views/VoucherDetails/VoucherDetails.tsx
@@ -201,7 +201,7 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
       currentChannels.map(choice => choice.id)
     );
 
-    return !(added.length === 0 && added.length === removed.length);
+    return added.length !== 0 || removed.length !== 0;
   };
 
   return (

--- a/src/discounts/views/VoucherDetails/VoucherDetails.tsx
+++ b/src/discounts/views/VoucherDetails/VoucherDetails.tsx
@@ -46,6 +46,7 @@ import { commonMessages, sectionNames } from "@saleor/intl";
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductSearch from "@saleor/searches/useProductSearch";
+import { arrayDiff } from "@saleor/utils/arrays";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
 import { mapEdgesToItems } from "@saleor/utils/maps";
@@ -53,7 +54,7 @@ import {
   useMetadataUpdate,
   usePrivateMetadataUpdate
 } from "@saleor/utils/metadata/updateMetadata";
-import React from "react";
+import React, { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { categoryUrl } from "../../../categories/urls";
@@ -132,9 +133,11 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
     data?.voucher,
     availableChannels
   );
-  const voucherChannelsChoices: ChannelVoucherData[] = createSortedChannelsDataFromVoucher(
-    data?.voucher
+  const voucherChannelsChoices: ChannelVoucherData[] = useMemo(
+    () => createSortedChannelsDataFromVoucher(data?.voucher),
+    [data?.voucher]
   );
+
   const {
     channelListElements,
     channelsToggle,
@@ -150,12 +153,6 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
     closeModal,
     openModal
   });
-
-  React.useEffect(() => {
-    if (!currentChannels.length && voucherChannelsChoices.length) {
-      setCurrentChannels(voucherChannelsChoices);
-    }
-  }, [voucherChannelsChoices]);
 
   const [updateChannels, updateChannelsOpts] = useVoucherChannelListingUpdate(
     {}
@@ -198,12 +195,21 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
 
   const canOpenBulkActionDialog = maybe(() => params.ids.length > 0);
 
+  const hasArrChanged = () => {
+    const { added, removed } = arrayDiff(
+      voucherChannelsChoices.map(choice => choice.id),
+      currentChannels.map(choice => choice.id)
+    );
+
+    return !(added.length === 0 && added.length === removed.length);
+  };
+
   return (
     <>
       {!!allChannels?.length && (
         <ChannelsAvailabilityDialog
           isSelected={isChannelSelected}
-          disabled={!channelListElements.length}
+          disabled={false}
           channels={allChannels}
           onChange={channelsToggle}
           onClose={handleChannelsModalClose}
@@ -295,10 +301,7 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
                             voucher={data?.voucher}
                             allChannelsCount={allChannels?.length}
                             channelListings={currentChannels}
-                            hasChannelChanged={
-                              voucherChannelsChoices?.length !==
-                              currentChannels?.length
-                            }
+                            hasChannelChanged={hasArrChanged()}
                             disabled={
                               loading ||
                               voucherCataloguesRemoveOpts.loading ||

--- a/src/hooks/useChannels.test.ts
+++ b/src/hooks/useChannels.test.ts
@@ -1,0 +1,89 @@
+import { ChannelData } from "@saleor/channels/utils";
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import useChannels from "./useChannels";
+
+const channels: ChannelData[] = [
+  {
+    id: "channel1",
+    name: "Channel 1",
+    variantsIds: ["variant1", "variant2"]
+  },
+  {
+    id: "channel2",
+    name: "Channel 2",
+    variantsIds: []
+  }
+];
+
+describe("useChannels", () => {
+  it("properly toggles channels", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useChannels(channels, "", {
+        closeModal: jest.fn,
+        openModal: jest.fn
+      })
+    );
+
+    // When
+    act(() => {
+      result.current.channelsToggle(channels[0]);
+    });
+
+    act(() => {
+      result.current.handleChannelsConfirm();
+    });
+
+    // Then
+    expect(result.current.currentChannels).toStrictEqual([channels[1]]);
+    expect(result.current.currentChannels[0].id).toBe(channels[1].id);
+  });
+  it("properly removes channels", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useChannels(channels, "", {
+        closeModal: jest.fn,
+        openModal: jest.fn
+      })
+    );
+
+    // When
+    act(() => {
+      result.current.channelsToggle(channels[0]);
+    });
+
+    act(() => {
+      result.current.channelsToggle(channels[1]);
+    });
+
+    act(() => {
+      result.current.handleChannelsConfirm();
+    });
+
+    // Then
+    expect(result.current.currentChannels).toStrictEqual([]);
+  });
+
+  it("doesn't not save changes if closed without confirm", () => {
+    // Given
+    const { result } = renderHook(() =>
+      useChannels(channels, "", {
+        closeModal: jest.fn,
+        openModal: jest.fn
+      })
+    );
+
+    // When
+    act(() => {
+      result.current.channelsToggle(channels[0]);
+    });
+
+    act(() => {
+      result.current.handleChannelsModalClose();
+    });
+
+    // Then
+    expect(result.current.currentChannels).toStrictEqual(channels);
+  });
+});

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -131,7 +131,6 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
       {!!allChannels?.length && (
         <ChannelsAvailabilityDialog
           isSelected={isChannelSelected}
-          disabled={!channelListElements.length}
           channels={allChannels}
           onChange={channelsToggle}
           onClose={handleChannelsModalClose}

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -304,7 +304,6 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
       {!!allChannels?.length && (
         <ChannelsAvailabilityDialog
           isSelected={isChannelSelected}
-          disabled={!channelListElements.length}
           channels={allChannels}
           onChange={channelsToggle}
           onClose={handleChannelsModalClose}

--- a/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
+++ b/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
@@ -137,7 +137,6 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
       {!!allChannels?.length && (
         <ChannelsAvailabilityDialog
           isSelected={isChannelSelected}
-          disabled={!channelListElements.length}
           channels={allChannels}
           onChange={channelsToggle}
           onClose={handleChannelsModalClose}

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -303,7 +303,6 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
       {!!allChannels?.length && (
         <ChannelsAvailabilityDialog
           isSelected={isChannelSelected}
-          disabled={!channelListElements.length}
           channels={allChannels}
           onChange={channelsToggle}
           onClose={handleChannelsModalClose}


### PR DESCRIPTION
I want to merge this change because I want to make channel selection in price and weight rates views and voucher view optional. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
