### PR TITLE
Add contentType prop to file attribute mutation

### DIFF
--- a/src/attributes/types/AttributeOfUploadedFile.ts
+++ b/src/attributes/types/AttributeOfUploadedFile.ts
@@ -1,0 +1,3 @@
+import { AttributeValueInput } from "@saleor/types/globalTypes";
+
+export type AtributesOfFiles = Pick<AttributeValueInput, "file" | "id" | "values" | "contentType">

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -25,6 +25,7 @@ import { MutationFetchResult } from "react-apollo";
 
 import { AttributePageFormData } from "../components/AttributePage";
 import { AttributeValueEditDialogFormData } from "../components/AttributeValueEditDialog";
+import { AtributesOfFiles } from "../types/AttributeOfUploadedFile";
 import { AttributeValueDelete } from "../types/AttributeValueDelete";
 
 export const ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES = [
@@ -193,17 +194,18 @@ export const getFileValuesRemovedFromAttributes = (
 
 export const getAttributesOfRemovedFiles = (
   fileAttributesRemoved: FormsetData<null, File>
-) =>
+): AtributesOfFiles[] =>
   fileAttributesRemoved.map(attribute => ({
     file: undefined,
     id: attribute.id,
+    contentType: attribute.value?.type,
     values: []
   }));
 
 export const getAttributesOfUploadedFiles = (
   fileValuesToUpload: FormsetData<null, File>,
   uploadFilesResult: Array<MutationFetchResult<FileUpload>>
-) =>
+): AtributesOfFiles[] =>
   uploadFilesResult.map((uploadFileResult, index) => {
     const attribute = fileValuesToUpload[index];
 

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -209,6 +209,7 @@ export const getAttributesOfUploadedFiles = (
 
     return {
       file: uploadFileResult.data.fileUpload.uploadedFile.url,
+      contentType: uploadFileResult.data.fileUpload.uploadedFile.contentType,
       id: attribute.id,
       values: []
     };

--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -188,11 +188,13 @@ function getFileInput(
   if (updatedFileAttribute) {
     return {
       file: updatedFileAttribute.file,
-      id: updatedFileAttribute.id
+      id: updatedFileAttribute.id,
+      contentType: updatedFileAttribute.contentType
     };
   }
   return {
     file: attribute.data.selectedValues?.[0]?.file?.url,
+    contentType: attribute.data.selectedValues?.[0]?.file.contentType,
     id: attribute.id
   };
 }


### PR DESCRIPTION
I want to merge this change because I want to fix an issue that makes uploaded files not have contentType prop

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
