### PR TITLE
Adjust changed permission requirements

### DIFF
--- a/src/hooks/makeTopLevelSearch/makeTopLevelSearch.ts
+++ b/src/hooks/makeTopLevelSearch/makeTopLevelSearch.ts
@@ -21,7 +21,7 @@ function makeTopLevelSearch<
   TVariables extends SearchVariables
 >(query: DocumentNode): UseSearchHook<TData, TVariables> {
   return makeSearch<TData, TVariables>(query, result => {
-    if (result.data.search.pageInfo.hasNextPage) {
+    if (result?.data?.search?.pageInfo?.hasNextPage) {
       result.loadMore(
         (prev, next) => {
           if (

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -110,7 +110,7 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
           !!canEditCustomer && (
             <RequirePermissions
               userPermissions={userPermissions}
-              requiredPermissions={[PermissionEnum.MANAGE_USERS]}
+              requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
             >
               <Button
                 data-test-id="edit-customer"


### PR DESCRIPTION
I want to merge this change because I added the dropdown for non-admin users with the MANAGE_ORDERS permission.
Note that this also requires a change in permission requirements in the backend.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-3154-permissions-orders-customer-list-is-unavailable.api.saleor.rocks/graphql/
