### PR TITLE
Disable save in product create & edit when product name is empty

### DIFF
--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -305,15 +305,24 @@ function useProductCreateForm(
   const data = getData();
   const submit = () => onSubmit(data);
 
-  const disabled =
-    (!opts.selectedProductType?.hasVariants &&
-      (!data.sku ||
-        data.channelListings.some(
-          channel =>
-            validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-        ) ||
-        !data.category)) ||
-    !data.name;
+  const shouldEnableSave = () => {
+    if (!data.name) {
+      return false;
+    }
+
+    if (!!opts.selectedProductType?.hasVariants) {
+      return true;
+    }
+
+    const hasInvalidChannelListingPrices = data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    );
+
+    return !data.sku || !data.category || hasInvalidChannelListingPrices;
+  };
+
+  const disabled = shouldEnableSave();
 
   return {
     change: handleChange,

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -306,11 +306,11 @@ function useProductCreateForm(
   const submit = () => onSubmit(data);
 
   const shouldEnableSave = () => {
-    if (!data.name) {
+    if (!data.name || !data.productType) {
       return false;
     }
 
-    if (!opts.selectedProductType?.hasVariants) {
+    if (opts.selectedProductType?.hasVariants) {
       return true;
     }
 
@@ -319,7 +319,10 @@ function useProductCreateForm(
         validatePrice(channel.price) || validateCostPrice(channel.costPrice)
     );
 
-    return !data.sku || !data.category || hasInvalidChannelListingPrices;
+    if (!data.sku || hasInvalidChannelListingPrices) {
+      return false;
+    }
+    return true;
   };
 
   const disabled = !shouldEnableSave();

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -306,13 +306,14 @@ function useProductCreateForm(
   const submit = () => onSubmit(data);
 
   const disabled =
-    !opts.selectedProductType?.hasVariants &&
-    (!data.sku ||
-      data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      ) ||
-      !data.category);
+    (!opts.selectedProductType?.hasVariants &&
+      (!data.sku ||
+        data.channelListings.some(
+          channel =>
+            validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+        ) ||
+        !data.category)) ||
+    !data.name;
 
   return {
     change: handleChange,

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -310,7 +310,7 @@ function useProductCreateForm(
       return false;
     }
 
-    if (!!opts.selectedProductType?.hasVariants) {
+    if (!opts.selectedProductType?.hasVariants) {
       return true;
     }
 

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -322,7 +322,7 @@ function useProductCreateForm(
     return !data.sku || !data.category || hasInvalidChannelListingPrices;
   };
 
-  const disabled = shouldEnableSave();
+  const disabled = !shouldEnableSave();
 
   return {
     change: handleChange,

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -352,12 +352,13 @@ function useProductUpdateForm(
     handleFormSubmit(getSubmitData(), handleSubmit, setChanged);
 
   const disabled =
-    !opts.hasVariants &&
-    (!data.sku ||
-      data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      ));
+    (!opts.hasVariants &&
+      (!data.sku ||
+        data.channelListings.some(
+          channel =>
+            validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+        ))) ||
+    !data.name;
 
   return {
     change: handleChange,

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -351,14 +351,24 @@ function useProductUpdateForm(
   const submit = async () =>
     handleFormSubmit(getSubmitData(), handleSubmit, setChanged);
 
-  const disabled =
-    (!opts.hasVariants &&
-      (!data.sku ||
-        data.channelListings.some(
-          channel =>
-            validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-        ))) ||
-    !data.name;
+  const shouldEnableSave = () => {
+    if (!data.name) {
+      return false;
+    }
+
+    if (!!opts.hasVariants) {
+      return true;
+    }
+
+    const hasInvalidChannelListingPrices = data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    );
+
+    return !data.sku || hasInvalidChannelListingPrices;
+  };
+
+  const disabled = shouldEnableSave();
 
   return {
     change: handleChange,

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -356,7 +356,7 @@ function useProductUpdateForm(
       return false;
     }
 
-    if (!opts.hasVariants) {
+    if (opts.hasVariants) {
       return true;
     }
 
@@ -365,7 +365,10 @@ function useProductUpdateForm(
         validatePrice(channel.price) || validateCostPrice(channel.costPrice)
     );
 
-    return !data.sku || hasInvalidChannelListingPrices;
+    if (!data.sku || hasInvalidChannelListingPrices) {
+      return false;
+    }
+    return true;
   };
 
   const disabled = !shouldEnableSave();

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -356,7 +356,7 @@ function useProductUpdateForm(
       return false;
     }
 
-    if (!!opts.hasVariants) {
+    if (!opts.hasVariants) {
       return true;
     }
 

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -368,7 +368,7 @@ function useProductUpdateForm(
     return !data.sku || hasInvalidChannelListingPrices;
   };
 
-  const disabled = shouldEnableSave();
+  const disabled = !shouldEnableSave();
 
   return {
     change: handleChange,

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -215,11 +215,12 @@ function useProductVariantUpdateForm(
     stock => !stockDiff.added.some(addedStock => addedStock === stock.id)
   );
 
-  const disabled = channels?.data.some(
-    channelData =>
-      validatePrice(channelData.value.price) ||
-      validateCostPrice(channelData.value.costPrice)
-  );
+  const disabled =
+    channels?.data.some(
+      channelData =>
+        validatePrice(channelData.value.price) ||
+        validateCostPrice(channelData.value.costPrice)
+    ) || !form.data.sku;
   const data: ProductVariantUpdateData = {
     ...form.data,
     attributes: getAttributesDisplayData(


### PR DESCRIPTION
I want to merge this change because... it disables save button in product create & edit forms when product name is not provided.

Also disables form when SKU is empty in both product & variant edit pages.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
