### PR TITLE
Remove hover state from order lines

### DIFF
--- a/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
+++ b/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
@@ -17,9 +17,6 @@ import { orderProductsCardElementsMessages as messages } from "./messages";
 
 const useStyles = makeStyles(
   theme => ({
-    clickableRow: {
-      cursor: "pointer"
-    },
     colName: {
       width: "auto"
     },
@@ -99,7 +96,7 @@ const TableLine: React.FC<TableLineProps> = ({
   const isDeleted = !line.orderLine.variant;
 
   return (
-    <TableRow className={classes.clickableRow} hover>
+    <TableRow>
       <TableCellAvatar
         className={classes.colName}
         thumbnail={maybe(() => line.orderLine.thumbnail.url)}


### PR DESCRIPTION
I want to merge this change because it removes hover state from order lines in order details.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/41952692/139423596-88902f1a-4ec4-44c5-af64-e1e888ecf51b.png)

After:
![image](https://user-images.githubusercontent.com/41952692/139423499-12e01899-736e-40e4-a4ed-6fe9ed9e677e.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
