### PR TITLE
Fix partially cut checkboxes in channel dialogs

### DIFF
--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -6,8 +6,6 @@ import {
   Typography
 } from "@material-ui/core";
 import { ChannelData } from "@saleor/channels/utils";
-import IconCheckboxChecked from "@saleor/icons/CheckboxChecked";
-import IconCheckboxSemiChecked from "@saleor/icons/CheckboxSemiChecked";
 import IconChevronDown from "@saleor/icons/ChevronDown";
 import { makeStyles } from "@saleor/macaw-ui";
 import Label from "@saleor/orders/components/OrderHistory/Label";

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -126,16 +126,6 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
       ? addVariantToChannel(channelId, variantId)
       : removeVariantFromChannel(channelId, variantId);
 
-  const selectChannelIcon = (channelId: string) =>
-    areAllChannelVariantsSelected(
-      allVariants?.map(variant => variant.id),
-      channelVariantListingDiffToDict(channelsWithVariants)[channelId]
-    ) ? (
-      <IconCheckboxChecked />
-    ) : (
-      <IconCheckboxSemiChecked />
-    );
-
   return (
     <>
       {map(channelsWithVariants, ({ selectedVariantsIds }, channelId) => {
@@ -172,7 +162,25 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                 <div className={classes.channelCheckboxContainer}>
                   <ControlledCheckbox
                     checked={isChannelSelected(channelId)}
-                    checkedIcon={selectChannelIcon(channelId)}
+                    indeterminate={(() => {
+                      const selectedChannels = channelVariantListingDiffToDict(
+                        channelsWithVariants
+                      )[channelId];
+                      if (selectedChannels.length === 0) {
+                        return false;
+                      }
+
+                      if (
+                        areAllChannelVariantsSelected(
+                          allVariants?.map(variant => variant.id),
+                          selectedChannels
+                        )
+                      ) {
+                        return false;
+                      } else {
+                        return true;
+                      }
+                    })()}
                     name={name}
                     label={
                       <div className={classes.channelTitleContainer}>

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -124,6 +124,20 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
       ? addVariantToChannel(channelId, variantId)
       : removeVariantFromChannel(channelId, variantId);
 
+  const isChannelPartiallySelected = (channelId: string) => {
+    const selectedVariants = channelVariantListingDiffToDict(
+      channelsWithVariants
+    )[channelId];
+
+    if (selectedVariants.length === 0) {
+      return false;
+    }
+    return !areAllChannelVariantsSelected(
+      allVariants?.map(variant => variant.id),
+      selectedVariants
+    );
+  };
+
   return (
     <>
       {map(channelsWithVariants, ({ selectedVariantsIds }, channelId) => {
@@ -160,25 +174,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                 <div className={classes.channelCheckboxContainer}>
                   <ControlledCheckbox
                     checked={isChannelSelected(channelId)}
-                    indeterminate={(() => {
-                      const selectedChannels = channelVariantListingDiffToDict(
-                        channelsWithVariants
-                      )[channelId];
-                      if (selectedChannels.length === 0) {
-                        return false;
-                      }
-
-                      if (
-                        areAllChannelVariantsSelected(
-                          allVariants?.map(variant => variant.id),
-                          selectedChannels
-                        )
-                      ) {
-                        return false;
-                      } else {
-                        return true;
-                      }
-                    })()}
+                    indeterminate={isChannelPartiallySelected(channelId)}
                     name={name}
                     label={
                       <div className={classes.channelTitleContainer}>

--- a/src/components/ChannelsAvailabilityDialogWrapper/ChannelsAvailabilityDialogWrapper.tsx
+++ b/src/components/ChannelsAvailabilityDialogWrapper/ChannelsAvailabilityDialogWrapper.tsx
@@ -35,6 +35,11 @@ export const useStyles = makeStyles(
       maxHeight: 400,
       overflowY: "scroll",
       overflowX: "hidden",
+      // overflowX can't be "visible" when overflowY is "scroll"
+      // workaround for visible button ripples:
+      marginLeft: -15,
+      paddingLeft: 15,
+
       marginBottom: theme.spacing(3)
     },
     text: {

--- a/src/components/ControlledCheckbox.tsx
+++ b/src/components/ControlledCheckbox.tsx
@@ -6,6 +6,7 @@ interface ControlledCheckboxProps {
   name: string;
   label?: React.ReactNode;
   checked: boolean;
+  indeterminate?: boolean;
   disabled?: boolean;
   checkedIcon?: React.ReactNode;
   onChange(event: any);
@@ -18,6 +19,7 @@ export const ControlledCheckbox: React.FC<ControlledCheckboxProps> = ({
   label,
   onChange,
   checkedIcon,
+  indeterminate,
   ...props
 }) => (
   <FormControlLabel
@@ -26,6 +28,7 @@ export const ControlledCheckbox: React.FC<ControlledCheckboxProps> = ({
       <Checkbox
         checkedIcon={checkedIcon}
         checked={!!checked}
+        indeterminate={indeterminate}
         disabled={disabled}
         name={name}
         onChange={() => onChange({ target: { name, value: !checked } })}


### PR DESCRIPTION
I want to merge this change because:
- it fixes a problem with checkbox hover & onClick ripples being cut off in channel dialogs
- it fixes a problem with some checkboxes having different images than others

Before reviewing, consider the following situation:
```
<div className={classes.wrapper}>
   <Checkbox className={classes.checkbox} />
   ...
   ...
   // (a lot of these checkboxes)
</div>
```
And styling:
```
wrapper: {
      height: 400,
      overflowY: "scroll",
      overflowX: "visible",
},
checkbox: {
    marginLeft: -15
}
```

In theory, wrapper's horizontal overflow is set to "visible", so it should correctly display overflowing checkboxes 15 pixels to the left. **However, this is just not the case.** Some combinations of overflow X&Y with "visible" are not possible, e.g. browsers do not allow using "visible" when overflow in the other direction is set either to "scroll" or "hidden" due to the W3C specs.

Fortunately checkboxes don't have dynamic size, so the current workaround for this case is to introduce negative margin and positive, mirrored padding with size of the overflowing content.


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

Hover circle is barely visible, I recommend zooming in to see it.

Before:
![image](https://user-images.githubusercontent.com/41952692/139829130-8262f6ad-5d08-45e9-8831-fa227298175f.png)

After:
![image](https://user-images.githubusercontent.com/41952692/139828914-0e5715e3-03a4-446a-8761-c5e4d3af2c8c.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
