### PR TITLE
Add scrollable area for user addresses

### DIFF
--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -92,7 +92,7 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
         className={classes.optionLabel}
       />
       {addressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS && (
-        <>
+        <div className={classes.scrollabeWrapper}>
           {customerAddresses.map(customerAddress => (
             <React.Fragment key={customerAddress.id}>
               <CardSpacer />
@@ -104,7 +104,7 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
             </React.Fragment>
           ))}
           <FormSpacer />
-        </>
+        </div>
       )}
       <FormControlLabel
         value={AddressInputOptionEnum.NEW_ADDRESS}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -92,7 +92,7 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
         className={classes.optionLabel}
       />
       {addressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS && (
-        <div className={classes.scrollabeWrapper}>
+        <div className={classes.scrollableWrapper}>
           {customerAddresses.map(customerAddress => (
             <React.Fragment key={customerAddress.id}>
               <CardSpacer />

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -140,7 +140,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
             <DialogTitle>
               <FormattedMessage {...dialogMessages.title} />
             </DialogTitle>
-            <DialogContent className={classes.overflow}>
+            <DialogContent className={classes.scrollableContent}>
               <Typography>
                 {customerAddresses.length > 0 ? (
                   <FormattedMessage

--- a/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
@@ -2,6 +2,10 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
   {
+    scrollabeWrapper: {
+      height: 400,
+      overflow: "scroll"
+    },
     container: {
       display: "block"
     },

--- a/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
@@ -2,8 +2,12 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
   {
-    scrollabeWrapper: {
-      height: 400,
+    scrollableContent: {
+      maxHeight: `calc(100vh - 250px)`,
+      overflow: "scroll"
+    },
+    scrollableWrapper: {
+      maxHeight: 400,
       overflow: "scroll"
     },
     container: {


### PR DESCRIPTION
I want to merge this change because it fixes a problem with address cards in order's add customer address dialog.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

Before:
![image](https://user-images.githubusercontent.com/41952692/140046991-239f8008-04c0-4e89-8684-fc14e22e3b03.png)
After:
![image](https://user-images.githubusercontent.com/41952692/140047115-90801b72-0f45-4f25-8d13-5827a68f0e71.png)



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
