### PR TITLE
Return/Refund amount improvements

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4527,7 +4527,7 @@
   },
   "src_dot_orders_dot_components_dot_OrderRefundReturnAmount_dot_amountTooSmall": {
     "context": "Amount error message",
-    "string": "Amount can not be less than 0"
+    "string": "Amount cannot be less than 0"
   },
   "src_dot_orders_dot_components_dot_OrderRefundReturnAmount_dot_authorizedAmount": {
     "context": "order refund amount",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4527,7 +4527,7 @@
   },
   "src_dot_orders_dot_components_dot_OrderRefundReturnAmount_dot_amountTooSmall": {
     "context": "Amount error message",
-    "string": "Amount must be bigger than 0"
+    "string": "Amount can not be less than 0"
   },
   "src_dot_orders_dot_components_dot_OrderRefundReturnAmount_dot_authorizedAmount": {
     "context": "order refund amount",

--- a/src/orders/components/OrderRefundReturnAmount/OrderRefundReturnAmount.tsx
+++ b/src/orders/components/OrderRefundReturnAmount/OrderRefundReturnAmount.tsx
@@ -39,7 +39,7 @@ import {
   OrderRefundType
 } from "../OrderRefundPage/form";
 import { OrderReturnFormData } from "../OrderReturnPage/form";
-import { getById } from "../OrderReturnPage/utils";
+import { getCurrentPaymentValue } from "../OrderReturnPage/utils";
 import OrderRefundAmountValues, {
   OrderRefundAmountValuesProps
 } from "./OrderRefundReturnAmountValues";
@@ -201,23 +201,27 @@ const OrderRefundAmount: React.FC<OrderRefundAmountProps> = props => {
       ? refundTotalAmount?.amount
       : paymentsTotalAmount?.amount;
 
-  const isAnyPaymentAmountTooSmall =
-    order?.payments.filter(payment => {
-      const currentPayment = data.paymentsToRefund?.find(getById(payment.id));
-      return (
-        payment.availableRefundAmount?.amount > 0 &&
-        Number(currentPayment?.value) < 0
-      );
-    }).length > 0;
+  const isAnyPaymentAmountTooSmall = order?.payments.some(payment => {
+    const currentPaymentValue = getCurrentPaymentValue(
+      data.paymentsToRefund,
+      payment.id
+    );
+    return (
+      payment.availableRefundAmount?.amount > 0 &&
+      Number(currentPaymentValue) < 0
+    );
+  });
 
-  const isAnyPaymentAmountTooBig =
-    order?.payments.filter(payment => {
-      const currentPayment = data.paymentsToRefund?.find(getById(payment.id));
-      return (
-        payment.availableRefundAmount?.amount > 0 &&
-        Number(currentPayment?.value) > payment.availableRefundAmount?.amount
-      );
-    }).length > 0;
+  const isAnyPaymentAmountTooBig = order?.payments.some(payment => {
+    const currentPaymentValue = getCurrentPaymentValue(
+      data.paymentsToRefund,
+      payment.id
+    );
+    return (
+      payment.availableRefundAmount?.amount > 0 &&
+      Number(currentPaymentValue) > payment.availableRefundAmount?.amount
+    );
+  });
 
   const isAmountTooSmall =
     (!!selectedRefundAmount && selectedRefundAmount < 0) ||

--- a/src/orders/components/OrderRefundReturnAmount/OrderRefundReturnAmount.tsx
+++ b/src/orders/components/OrderRefundReturnAmount/OrderRefundReturnAmount.tsx
@@ -39,6 +39,7 @@ import {
   OrderRefundType
 } from "../OrderRefundPage/form";
 import { OrderReturnFormData } from "../OrderReturnPage/form";
+import { getById } from "../OrderReturnPage/utils";
 import OrderRefundAmountValues, {
   OrderRefundAmountValuesProps
 } from "./OrderRefundReturnAmountValues";
@@ -200,8 +201,29 @@ const OrderRefundAmount: React.FC<OrderRefundAmountProps> = props => {
       ? refundTotalAmount?.amount
       : paymentsTotalAmount?.amount;
 
-  const isAmountTooSmall = selectedRefundAmount && selectedRefundAmount <= 0;
-  const isAmountTooBig = selectedRefundAmount > maxRefund?.amount;
+  const isAnyPaymentAmountTooSmall =
+    order?.payments.filter(payment => {
+      const currentPayment = data.paymentsToRefund?.find(getById(payment.id));
+      return (
+        payment.availableRefundAmount?.amount > 0 &&
+        Number(currentPayment?.value) < 0
+      );
+    }).length > 0;
+
+  const isAnyPaymentAmountTooBig =
+    order?.payments.filter(payment => {
+      const currentPayment = data.paymentsToRefund?.find(getById(payment.id));
+      return (
+        payment.availableRefundAmount?.amount > 0 &&
+        Number(currentPayment?.value) > payment.availableRefundAmount?.amount
+      );
+    }).length > 0;
+
+  const isAmountTooSmall =
+    (!!selectedRefundAmount && selectedRefundAmount < 0) ||
+    isAnyPaymentAmountTooSmall;
+  const isAmountTooBig =
+    selectedRefundAmount > maxRefund?.amount || isAnyPaymentAmountTooBig;
   const disableRefundButton = isReturn
     ? disableSubmitButton ||
       isAmountTooSmall ||

--- a/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
+++ b/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
@@ -55,7 +55,7 @@ const messages = defineMessages({
     description: "Amount error message"
   },
   amountTooSmall: {
-    defaultMessage: "Amount must be bigger than 0",
+    defaultMessage: "Amount can not be less than 0",
     description: "Amount error message"
   },
   label: {
@@ -73,7 +73,7 @@ const RefundAmountInput: React.FC<RefundAmountInputProps> = props => {
   const amountTooBig =
     Number(currentPayment?.value) > payment.availableRefundAmount?.amount;
   const amountTooSmall =
-    currentPayment?.value && Number(currentPayment.value) <= 0;
+    currentPayment?.value && Number(currentPayment.value) < 0;
 
   const formErrors = getFormErrors(["paymentsToRefund"], errors);
   const isError =

--- a/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
+++ b/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
@@ -55,7 +55,7 @@ const messages = defineMessages({
     description: "Amount error message"
   },
   amountTooSmall: {
-    defaultMessage: "Amount can not be less than 0",
+    defaultMessage: "Amount cannot be less than 0",
     description: "Amount error message"
   },
   label: {

--- a/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
+++ b/src/orders/components/OrderRefundReturnAmount/RefundAmountInput.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 import { OrderRefundFormData } from "../OrderRefundPage/form";
-import { getById } from "../OrderReturnPage/utils";
+import { getCurrentPaymentValue } from "../OrderReturnPage/utils";
 
 const useStyles = makeStyles(
   theme => ({
@@ -69,11 +69,13 @@ const RefundAmountInput: React.FC<RefundAmountInputProps> = props => {
   const intl = useIntl();
   const classes = useStyles(props);
   const maxRefund = payment.availableRefundAmount;
-  const currentPayment = data.paymentsToRefund?.find(getById(payment.id));
+  const currentPaymentValue = getCurrentPaymentValue(
+    data.paymentsToRefund,
+    payment.id
+  );
   const amountTooBig =
-    Number(currentPayment?.value) > payment.availableRefundAmount?.amount;
-  const amountTooSmall =
-    currentPayment?.value && Number(currentPayment.value) < 0;
+    Number(currentPaymentValue) > payment.availableRefundAmount?.amount;
+  const amountTooSmall = Number(currentPaymentValue) < 0;
 
   const formErrors = getFormErrors(["paymentsToRefund"], errors);
   const isError =
@@ -100,7 +102,7 @@ const RefundAmountInput: React.FC<RefundAmountInputProps> = props => {
         "/ " + currencySymbol + " " + maxRefund?.amount.toFixed(2)
       }
       name={"amount" as keyof FormData}
-      value={currentPayment?.value}
+      value={currentPaymentValue}
       label={intl.formatMessage(messages.label)}
       className={classes.priceField}
       InputProps={{ inputProps: { max: maxRefund?.amount } }}

--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -1,4 +1,5 @@
 import { OrderDetailsFragment_fulfillments_lines } from "@saleor/fragments/types/OrderDetailsFragment";
+import { FormsetData } from "@saleor/hooks/useFormset";
 import {
   OrderDetails_order,
   OrderDetails_order_fulfillments
@@ -120,4 +121,12 @@ export function getByUnmatchingIds<T extends Node>(
   arrayToCompare: string[] | T[]
 ) {
   return (obj: Node) => !isIncludedInIds(arrayToCompare, obj);
+}
+
+export function getCurrentPaymentValue(
+  paymentsToRefund: FormsetData<null, string>,
+  paymentId: string
+): string {
+  const currentPayment = paymentsToRefund?.find(getById(paymentId));
+  return currentPayment?.value || "";
 }

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -215,10 +215,9 @@ export function mergeRepeatedOrderLines(
 export function getPaymentsTotalAmount(
   paymentsToRefund: FormsetData<LineItemData, string | number>
 ) {
-  return paymentsToRefund.reduce(
-    (sum, payment) => sum + Number(payment.value || 0),
-    0
-  );
+  return paymentsToRefund
+    .filter(payment => Number(payment.value || 0) > 0)
+    .reduce((sum, payment) => sum + Number(payment.value), 0);
 }
 
 export function getPaymentsToRefund(

--- a/src/orders/views/OrderRefund/OrderRefund.tsx
+++ b/src/orders/views/OrderRefund/OrderRefund.tsx
@@ -43,12 +43,10 @@ const getAutomaticallyCalculatedProductsRefundInput = (
 const getManuallySetProductsRefundInput = (
   formData: OrderRefundSubmitData
 ) => ({
-  paymentsToRefund: formData.paymentsToRefund
-    .filter(payment => Number(payment.value) > 0)
-    .map(payment => ({
-      paymentId: payment.id,
-      amount: payment.value
-    })),
+  paymentsToRefund: formData.paymentsToRefund.map(payment => ({
+    paymentId: payment.id,
+    amount: Number(payment.value) > 0 ? payment.value : 0
+  })),
   fulfillmentLines: formData.refundedFulfilledProductQuantities
     .filter(line => line.value !== "0")
     .map(line => ({

--- a/src/orders/views/OrderReturn/utils.tsx
+++ b/src/orders/views/OrderReturn/utils.tsx
@@ -41,12 +41,10 @@ class ReturnFormDataParser {
 
     const paymentsToRefundValues =
       amountCalculationMode === OrderRefundAmountCalculationMode.MANUAL
-        ? paymentsToRefund
-            .filter(payment => Number(payment.value) > 0)
-            .map(field => ({
-              paymentId: field.id,
-              amount: field.value
-            }))
+        ? paymentsToRefund.map(field => ({
+            paymentId: field.id,
+            amount: Number(field.value) > 0 ? field.value : 0
+          }))
         : paymentsToRefund.map(field => ({
             paymentId: field.id
           }));


### PR DESCRIPTION
I want to merge this change because it contains code improvements for order Return/Refund page (Manual refund type):
* Allow zero as payment refund amount
* Send zero if payment refund amount is empty
* Handle negative payment refund amount values

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

feature/partial-payments-3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
