### PR TITLE
Add tests for preorders- threshold and stocks

### DIFF
--- a/cypress/elements/catalog/products/variants-selectors.js
+++ b/cypress/elements/catalog/products/variants-selectors.js
@@ -9,5 +9,7 @@ export const VARIANTS_SELECTORS = {
   addWarehouseButton: "button[class*='MuiIconButton-colorPrimary']",
   warehouseOption: "[role='menuitem']",
   saveButton: "[data-test='button-bar-confirm']",
-  skuInputInAddVariant: "[name='sku']"
+  skuInputInAddVariant: "[name='sku']",
+  preorderCheckbox: "[name='isPreorder']",
+  channelThresholdInput: "[name='channel-threshold']"
 };

--- a/cypress/fixtures/urlList.js
+++ b/cypress/fixtures/urlList.js
@@ -26,6 +26,7 @@ export const urlList = {
   staffMembers: "staff/",
   stripeApiPaymentMethods: "https://api.stripe.com/v1/payment_methods",
   translations: "translations/",
+  variant: "variant/",
   vouchers: "discounts/vouchers/",
   warehouses: "warehouses/",
   weightRete: "weight/"
@@ -73,6 +74,9 @@ export const giftCardDetailsUrl = giftCardId =>
   `${urlList.giftCards}${giftCardId}`;
 
 export const saleDetailsUrl = saleId => `${urlList.sales}${saleId}`;
+
+export const variantDetailsUrl = (productId, variantId) =>
+  `${urlList.products}${productId}/${urlList.variant}${variantId}`;
 
 export const voucherDetailsUrl = voucherId => `${urlList.vouchers}${voucherId}`;
 

--- a/cypress/integration/preorders/stocksAndThreshold.js
+++ b/cypress/integration/preorders/stocksAndThreshold.js
@@ -51,7 +51,7 @@ filterTests({ definedTags: ["all"], version: "3.1.0" }, () => {
       cy.clearSessionData().loginUserViaRequest();
     });
 
-    xit("should allocate variants bought in preorder to correct warehouses", () => {
+    it("should allocate variants bought in preorder to correct warehouses", () => {
       let order;
       createWaitingForCaptureOrder(checkoutData)
         .then(({ order: orderResp }) => {
@@ -93,8 +93,10 @@ filterTests({ definedTags: ["all"], version: "3.1.0" }, () => {
     it("should not be able to order more products then channel threshold", () => {
       cy.visit(variantDetailsUrl(product.id, variantsList[0].id))
         .get(VARIANTS_SELECTORS.channelThresholdInput)
-        .type(5);
+        .type(5)
+        .addAliasToGraphRequest("ProductVariantChannelListingUpdate");
       saveVariant("VariantUpdate");
+      cy.wait("@ProductVariantChannelListingUpdate");
       checkoutData.productQuantity = 7;
       createCheckout(checkoutData).then(({ errors }) => {
         expect(errors[0].field).to.eq("quantity");

--- a/cypress/integration/preorders/stocksAndThreshold.js
+++ b/cypress/integration/preorders/stocksAndThreshold.js
@@ -1,0 +1,115 @@
+/// <reference types="cypress"/>
+/// <reference types="../../support"/>
+
+import { VARIANTS_SELECTORS } from "../../elements/catalog/products/variants-selectors";
+import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
+import { variantDetailsUrl } from "../../fixtures/urlList";
+import { createCheckout } from "../../support/api/requests/Checkout";
+import { fulfillOrder } from "../../support/api/requests/Order";
+import { getVariant } from "../../support/api/requests/Product";
+import { createWaitingForCaptureOrder } from "../../support/api/utils/ordersUtils";
+import { createProductWithShipping } from "../../support/api/utils/products/productsUtils";
+import filterTests from "../../support/filterTests";
+import { saveVariant } from "../../support/pages/catalog/products/VariantsPage";
+
+filterTests({ definedTags: ["all"], version: "3.1.0" }, () => {
+  describe("Creating variants", () => {
+    const startsWith = "CreatePreOrder";
+    const attributeValues = ["value1", "value2"];
+    const preorder = {
+      globalThreshold: 15
+    };
+
+    let defaultChannel;
+    let product;
+    let variantsList;
+    let warehouse;
+    let checkoutData;
+
+    before(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      createProductWithShipping({
+        name: startsWith,
+        attributeValues,
+        preorder
+      }).then(resp => {
+        checkoutData = {
+          address: resp.address,
+          channelSlug: resp.defaultChannel.slug,
+          email: "example@example.com",
+          shippingMethodId: resp.shippingMethod.id,
+          variantsList: resp.variantsList
+        };
+        warehouse = resp.warehouse;
+        defaultChannel = resp.defaultChannel;
+        product = resp.product;
+        variantsList = resp.variantsList;
+      });
+    });
+
+    beforeEach(() => {
+      cy.clearSessionData().loginUserViaRequest();
+    });
+
+    xit("should allocate variants bought in preorder to correct warehouses", () => {
+      let order;
+      createWaitingForCaptureOrder(checkoutData)
+        .then(({ order: orderResp }) => {
+          order = orderResp;
+          cy.visit(variantDetailsUrl(product.id, variantsList[0].id))
+            .get(VARIANTS_SELECTORS.preorderCheckbox)
+            .click()
+            .addAliasToGraphRequest("ProductVariantPreorderDeactivate")
+            .get(BUTTON_SELECTORS.submit)
+            .click()
+            .waitForRequestAndCheckIfNoErrors(
+              "@ProductVariantPreorderDeactivate"
+            );
+          getVariant(variantsList[0].id, defaultChannel.slug);
+        })
+        .then(variantResp => {
+          expect(
+            variantResp.stocks[0].quantityAllocated,
+            "product is allocated with correct quantity"
+          ).to.eq(1);
+          expect(
+            variantResp.stocks[0].warehouse.id,
+            "product is allocated to correct warehouse"
+          ).to.eq(warehouse.id);
+        })
+        .then(() => {
+          fulfillOrder({
+            orderId: order.id,
+            warehouse: warehouse.id,
+            quantity: 1,
+            linesId: order.lines
+          });
+        })
+        .then(({ errors }) => {
+          expect(errors, "no errors when fulfilling order").to.be.empty;
+        });
+    });
+
+    it("should not be able to order more products then channel threshold", () => {
+      cy.visit(variantDetailsUrl(product.id, variantsList[0].id))
+        .get(VARIANTS_SELECTORS.channelThresholdInput)
+        .type(5);
+      saveVariant("VariantUpdate");
+      checkoutData.productQuantity = 7;
+      createCheckout(checkoutData).then(({ errors }) => {
+        expect(errors[0].field).to.eq("quantity");
+      });
+    });
+
+    it("should not be able to order more products then threshold even if channel is not exceeded", () => {
+      cy.visit(variantDetailsUrl(product.id, variantsList[0].id))
+        .get(VARIANTS_SELECTORS.channelThresholdInput)
+        .type(40);
+      saveVariant("VariantUpdate");
+      checkoutData.productQuantity = 20;
+      createCheckout(checkoutData).then(({ errors }) => {
+        expect(errors[0].field).to.eq("quantity");
+      });
+    });
+  });
+});

--- a/cypress/support/api/requests/Checkout.js
+++ b/cypress/support/api/requests/Checkout.js
@@ -141,6 +141,9 @@ export function completeCheckout(checkoutId, paymentData) {
     checkoutComplete(checkoutId:"${checkoutId}" ${paymentDataLine}){
       order{
         id
+        lines{
+          id
+        }
         paymentStatus
         total{
           gross{

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -153,8 +153,14 @@ export function createVariant({
   costPrice = 1,
   trackInventory = true,
   weight = 1,
-  attributeValues = ["value"]
+  attributeValues = ["value"],
+  preorder
 }) {
+  const preorderLines = getValueWithDefault(
+    preorder,
+    `preorder:${stringify(preorder)}`
+  );
+
   const channelListings = getValueWithDefault(
     channelId,
     `channelListings:{
@@ -174,6 +180,7 @@ export function createVariant({
 
   const mutation = `mutation{
     productVariantBulkCreate(product: "${productId}", variants: {
+      ${preorderLines}
       attributes: [{
         id:"${attributeId}"
         values: ${getValuesInArray(attributeValues)}
@@ -231,11 +238,17 @@ export function getVariants(variantsList) {
   return cy.sendRequestWithQuery(query).its("body.data.productVariants");
 }
 
-export function getVariant(id, channel, auth = "auth") {
+export function getVariant(id, channelSlug, auth = "auth") {
   const query = `query{
-    productVariant(id:"${id}" channel:"${channel}"){
+    productVariant(id:"${id}" channel:"${channelSlug}"){
       id
       name
+      stocks{
+        warehouse{
+          id
+        }
+        quantityAllocated
+      }
       pricing{
         onSale
         discount{

--- a/cypress/support/api/utils/products/productsUtils.js
+++ b/cypress/support/api/utils/products/productsUtils.js
@@ -12,7 +12,7 @@ import {
 import { deleteAttributesStartsWith } from "../attributes/attributeUtils";
 import { deleteCollectionsStartsWith } from "../catalog/collectionsUtils";
 import { getDefaultChannel } from "../channelsUtils";
-import { createShipping } from "../shippingUtils";
+import { createShipping, deleteShippingStartsWith } from "../shippingUtils";
 
 export function createProductInChannel({
   name,
@@ -29,7 +29,8 @@ export function createProductInChannel({
   collectionId = null,
   description = null,
   trackInventory = true,
-  weight = 1
+  weight = 1,
+  preorder
 }) {
   let product;
   let variantsList;
@@ -62,7 +63,8 @@ export function createProductInChannel({
         channelId,
         price,
         trackInventory,
-        weight
+        weight,
+        preorder
       });
     })
     .then(variantsResp => {
@@ -121,7 +123,8 @@ export function deleteProductsAndCreateNewOneWithNewDataAndDefaultChannel({
   name,
   description = name,
   warehouseId,
-  productPrice = 10
+  productPrice = 10,
+  preorder
 }) {
   let defaultChannel;
   let collection;
@@ -149,7 +152,8 @@ export function deleteProductsAndCreateNewOneWithNewDataAndDefaultChannel({
         collectionId: collection.id,
         description,
         warehouseId,
-        price: productPrice
+        price: productPrice,
+        preorder
       });
     })
     .then(({ product, variantsList }) => ({ product, variantsList }));
@@ -158,7 +162,8 @@ export function deleteProductsAndCreateNewOneWithNewDataAndDefaultChannel({
 export function createProductWithShipping({
   name,
   productPrice = 10,
-  shippingPrice = 10
+  shippingPrice = 10,
+  preorder
 }) {
   let address;
   let warehouse;
@@ -166,6 +171,7 @@ export function createProductWithShipping({
   let defaultChannel;
   let shippingZone;
 
+  deleteShippingStartsWith(name);
   return cy
     .fixture("addresses")
     .then(addresses => {
@@ -193,7 +199,8 @@ export function createProductWithShipping({
         deleteProductsAndCreateNewOneWithNewDataAndDefaultChannel({
           name,
           warehouseId: warehouse.id,
-          productPrice
+          productPrice,
+          preorder
         });
       }
     )

--- a/cypress/support/customCommands/basicOperations/index.js
+++ b/cypress/support/customCommands/basicOperations/index.js
@@ -12,7 +12,7 @@ Cypress.Commands.add("waitForRequestAndCheckIfNoErrors", alias => {
   cy.wait(alias).then(resp => {
     expect(
       resp.response.body.errors,
-      `There are errors in ${alias} operation in graphql response`
+      `No errors in ${alias} operation in graphql response`
     ).to.be.undefined;
     return resp;
   });

--- a/cypress/support/pages/catalog/products/VariantsPage.js
+++ b/cypress/support/pages/catalog/products/VariantsPage.js
@@ -84,3 +84,11 @@ export function createVariant({
     .get(AVAILABLE_CHANNELS_FORM.menageChannelsButton)
     .should("be.visible");
 }
+
+export function saveVariant(waitForAlias = "VariantCreate") {
+  return cy
+    .addAliasToGraphRequest(waitForAlias)
+    .get(BUTTON_SELECTORS.confirm)
+    .click()
+    .waitForRequestAndCheckIfNoErrors(`@${waitForAlias}`);
+}

--- a/src/products/components/ProductStocks/ProductStocks.tsx
+++ b/src/products/components/ProductStocks/ProductStocks.tsx
@@ -602,6 +602,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
                   </TableCell>
                   <TableCell className={classes.colQuantity}>
                     <TextField
+                      name="channel-threshold"
                       disabled={disabled}
                       fullWidth
                       inputProps={{


### PR DESCRIPTION
I want to merge this change because I added tests for preorders

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
