### PR TITLE
Add current usage on vouchers (#1519)

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3123,6 +3123,10 @@
     "context": "voucher usage limit, header",
     "string": "Usage Limit"
   },
+  "src_dot_discounts_dot_components_dot_VoucherLimits_dot_usesLeftCaption": {
+    "context": "usage limit uses left caption",
+    "string": "Uses left"
+  },
   "src_dot_discounts_dot_components_dot_VoucherListPage_dot_1112241061": {
     "context": "tab name",
     "string": "All Vouchers"

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -45,7 +45,8 @@ export interface FormData extends MetadataFormData {
   startDate: string;
   startTime: string;
   type: VoucherTypeEnum;
-  usageLimit: string;
+  usageLimit: number;
+  used: number;
   value: number;
 }
 
@@ -95,7 +96,8 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     startDate: "",
     startTime: "",
     type: VoucherTypeEnum.ENTIRE_ORDER,
-    usageLimit: "0",
+    usageLimit: 1,
+    used: 0,
     value: 0,
     metadata: [],
     privateMetadata: []
@@ -103,7 +105,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit, triggerChange }) => {
+      {({ change, data, hasChanged, submit, triggerChange, set }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(
           change
         );
@@ -173,9 +175,12 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
                 <CardSpacer />
                 <VoucherLimits
                   data={data}
+                  initialUsageLimit={initialForm.usageLimit}
                   disabled={disabled}
                   errors={errors}
                   onChange={change}
+                  setData={set}
+                  isNewVoucher
                 />
                 <CardSpacer />
                 <VoucherDates

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -1,6 +1,7 @@
-import { Card, CardContent, TextField } from "@material-ui/core";
+import { Card, CardContent, TextField, Typography } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import { ControlledCheckbox } from "@saleor/components/ControlledCheckbox";
+import { Grid } from "@saleor/components/Grid";
 import { DiscountErrorFragment } from "@saleor/fragments/types/DiscountErrorFragment";
 import { getFormErrors } from "@saleor/utils/errors";
 import getDiscountErrorMessage from "@saleor/utils/errors/discounts";
@@ -9,50 +10,89 @@ import { useIntl } from "react-intl";
 
 import { VoucherDetailsPageFormData } from "../VoucherDetailsPage";
 import messages from "./messages";
+import { useStyles } from "./styles";
 
 interface VoucherLimitsProps {
   data: VoucherDetailsPageFormData;
   disabled: boolean;
   errors: DiscountErrorFragment[];
+  initialUsageLimit: number;
   onChange: (event: React.ChangeEvent<any>) => void;
+  setData: (data: Partial<VoucherDetailsPageFormData>) => void;
+  isNewVoucher: boolean;
 }
 
 const VoucherLimits = ({
   data,
   disabled,
   errors,
-  onChange
+  initialUsageLimit,
+  onChange,
+  setData,
+  isNewVoucher
 }: VoucherLimitsProps) => {
   const intl = useIntl();
+  const classes = useStyles();
 
   const formErrors = getFormErrors(["usageLimit"], errors);
+
+  const usesLeft = data.usageLimit - data.used;
 
   return (
     <Card>
       <CardTitle title={intl.formatMessage(messages.usageLimitsTitle)} />
-      <CardContent>
+      <CardContent className={classes.cardContent}>
         <ControlledCheckbox
           checked={data.hasUsageLimit}
           label={intl.formatMessage(messages.hasUsageLimit)}
           name={"hasUsageLimit" as keyof VoucherDetailsPageFormData}
-          onChange={onChange}
+          onChange={evt => {
+            onChange(evt);
+            setData({ usageLimit: initialUsageLimit });
+          }}
         />
-        {data.hasUsageLimit && (
-          <TextField
-            disabled={disabled}
-            error={!!formErrors.usageLimit}
-            helperText={getDiscountErrorMessage(formErrors.usageLimit, intl)}
-            label={intl.formatMessage(messages.usageLimit)}
-            name={"usageLimit" as keyof VoucherDetailsPageFormData}
-            value={data.usageLimit}
-            onChange={onChange}
-            type="number"
-            inputProps={{
-              min: 0
-            }}
-            fullWidth
-          />
-        )}
+        {data.hasUsageLimit &&
+          (isNewVoucher ? (
+            <TextField
+              disabled={disabled}
+              error={!!formErrors.usageLimit || data.usageLimit <= 0}
+              helperText={getDiscountErrorMessage(formErrors.usageLimit, intl)}
+              label={intl.formatMessage(messages.usageLimit)}
+              name={"usageLimit" as keyof VoucherDetailsPageFormData}
+              value={data.usageLimit}
+              onChange={onChange}
+              type="number"
+              fullWidth
+              inputProps={{
+                min: 1
+              }}
+            />
+          ) : (
+            <Grid variant="uniform">
+              <TextField
+                disabled={disabled}
+                error={!!formErrors.usageLimit || data.usageLimit <= 0}
+                helperText={getDiscountErrorMessage(
+                  formErrors.usageLimit,
+                  intl
+                )}
+                label={intl.formatMessage(messages.usageLimit)}
+                name={"usageLimit" as keyof VoucherDetailsPageFormData}
+                value={data.usageLimit}
+                onChange={onChange}
+                type="number"
+                inputProps={{
+                  min: 1
+                }}
+              />
+              <div className={classes.usesLeftLabelWrapper}>
+                <Typography variant="caption">
+                  {intl.formatMessage(messages.usesLeftCaption)}
+                </Typography>
+                <Typography>{usesLeft >= 0 ? usesLeft : 0}</Typography>
+              </div>
+            </Grid>
+          ))}
         <ControlledCheckbox
           checked={data.applyOncePerCustomer}
           label={intl.formatMessage(messages.applyOncePerCustomer)}

--- a/src/discounts/components/VoucherLimits/messages.ts
+++ b/src/discounts/components/VoucherLimits/messages.ts
@@ -13,6 +13,10 @@ export default defineMessages({
     defaultMessage: "Limit of Uses",
     description: "limit voucher"
   },
+  usesLeftCaption: {
+    defaultMessage: "Uses left",
+    description: "usage limit uses left caption"
+  },
   applyOncePerCustomer: {
     defaultMessage: "Limit to one use per customer",
     description: "limit voucher"

--- a/src/discounts/components/VoucherLimits/styles.ts
+++ b/src/discounts/components/VoucherLimits/styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    cardContent: {
+      display: "flex",
+      flexDirection: "column"
+    },
+    usesLeftLabelWrapper: {
+      display: "flex",
+      flexDirection: "column",
+      flex: 1
+    }
+  }),
+  { name: "VoucherLimits" }
+);

--- a/src/discounts/views/VoucherCreate/handlers.ts
+++ b/src/discounts/views/VoucherCreate/handlers.ts
@@ -49,9 +49,7 @@ export function createHandler(
           formData.discountType === DiscountTypeEnum.SHIPPING
             ? VoucherTypeEnum.SHIPPING
             : formData.type,
-        usageLimit: formData.hasUsageLimit
-          ? parseInt(formData.usageLimit, 10)
-          : null
+        usageLimit: formData.hasUsageLimit ? formData.usageLimit : null
       }
     });
 

--- a/src/discounts/views/VoucherDetails/handlers.ts
+++ b/src/discounts/views/VoucherDetails/handlers.ts
@@ -56,9 +56,7 @@ export function createUpdateHandler(
             formData.discountType === DiscountTypeEnum.SHIPPING
               ? VoucherTypeEnum.SHIPPING
               : formData.type,
-          usageLimit: formData.hasUsageLimit
-            ? parseInt(formData.usageLimit, 10)
-            : null
+          usageLimit: formData.hasUsageLimit ? formData.usageLimit : null
         }
       }).then(({ data }) => data?.voucherUpdate.errors ?? []),
 


### PR DESCRIPTION
Cherry pick of #1519 

* wip design label

* add usesLeft calculation

* snapshots & messages

* fix type errors

* add error on input and disable save button when value is invalid

* resetting input value to initial after checkbox state change

* remove uses left on new vouchers & set initial value to 1

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
