### PR TITLE
Add sorting products by update at date

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5621,7 +5621,7 @@
   },
   "src_dot_products_dot_components_dot_ProductList_dot_updatedAt": {
     "context": "product updated at",
-    "string": "Updated At"
+    "string": "Last updated"
   },
   "src_dot_products_dot_components_dot_ProductList_dot_willBePublished": {
     "context": "product publication date",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5527,17 +5527,9 @@
     "context": "modal button",
     "string": "Upload URL"
   },
-  "src_dot_products_dot_components_dot_ProductListPage_dot_1134347598": {
-    "context": "product price",
-    "string": "Price"
-  },
   "src_dot_products_dot_components_dot_ProductListPage_dot_1542417144": {
     "context": "button",
     "string": "Create Product"
-  },
-  "src_dot_products_dot_components_dot_ProductListPage_dot_1952810469": {
-    "context": "product type",
-    "string": "Type"
   },
   "src_dot_products_dot_components_dot_ProductListPage_dot_2059406063": {
     "context": "export products to csv file, button",
@@ -5592,10 +5584,6 @@
     "context": "product is visible",
     "string": "Visible"
   },
-  "src_dot_products_dot_components_dot_ProductList_dot_1134347598": {
-    "context": "product price",
-    "string": "Price"
-  },
   "src_dot_products_dot_components_dot_ProductList_dot_150865454": {
     "context": "product type",
     "string": "Simple"
@@ -5603,29 +5591,37 @@
   "src_dot_products_dot_components_dot_ProductList_dot_1657559629": {
     "string": "No products found"
   },
-  "src_dot_products_dot_components_dot_ProductList_dot_1952810469": {
-    "context": "product type",
-    "string": "Type"
-  },
   "src_dot_products_dot_components_dot_ProductList_dot_2754779425": {
     "context": "product type",
     "string": "Configurable"
-  },
-  "src_dot_products_dot_components_dot_ProductList_dot_3326160357": {
-    "context": "product channels",
-    "string": "Availability"
   },
   "src_dot_products_dot_components_dot_ProductList_dot_636461959": {
     "context": "product",
     "string": "Name"
   },
+  "src_dot_products_dot_components_dot_ProductList_dot_availability": {
+    "context": "product channels",
+    "string": "Availability"
+  },
+  "src_dot_products_dot_components_dot_ProductList_dot_price": {
+    "context": "product price",
+    "string": "Price"
+  },
   "src_dot_products_dot_components_dot_ProductList_dot_published": {
     "context": "product publication date",
     "string": "Published on {date}"
   },
+  "src_dot_products_dot_components_dot_ProductList_dot_type": {
+    "context": "product type",
+    "string": "Type"
+  },
   "src_dot_products_dot_components_dot_ProductList_dot_unpublished": {
     "context": "product publication date",
     "string": "Unpublished"
+  },
+  "src_dot_products_dot_components_dot_ProductList_dot_updatedAt": {
+    "context": "product updated at",
+    "string": "Updated At"
   },
   "src_dot_products_dot_components_dot_ProductList_dot_willBePublished": {
     "context": "product publication date",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,11 @@ export const DEFAULT_INITIAL_PAGINATION_DATA: Pagination = {
 export const PAGINATE_BY = 20;
 export const VALUES_PAGINATE_BY = 10;
 
-export type ProductListColumns = "productType" | "availability" | "price";
+export type ProductListColumns =
+  | "productType"
+  | "availability"
+  | "price"
+  | "date";
 
 export interface AppListViewSettings {
   [ListViews.APPS_LIST]: ListSettings;

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,7 +81,7 @@ export const defaultListSettings: AppListViewSettings = {
     rowNumber: PAGINATE_BY
   },
   [ListViews.PRODUCT_LIST]: {
-    columns: ["availability", "price", "productType"],
+    columns: ["availability", "price", "productType", "date"],
     rowNumber: PAGINATE_BY
   },
   [ListViews.SALES_LIST]: {

--- a/src/products/components/ProductList/ProductList.tsx
+++ b/src/products/components/ProductList/ProductList.tsx
@@ -164,6 +164,9 @@ export const ProductList: React.FC<ProductListProps> = props => {
           {gridAttributesFromSettings.map(gridAttribute => (
             <col className={classes.colAttribute} key={gridAttribute} />
           ))}
+          <DisplayColumn column="date" displayColumns={settings.columns}>
+            <col className={classes.colDate} />
+          </DisplayColumn>
           <DisplayColumn column="price" displayColumns={settings.columns}>
             <col className={classes.colPrice} />
           </DisplayColumn>
@@ -259,6 +262,20 @@ export const ProductList: React.FC<ProductListProps> = props => {
               </TableCellHeader>
             );
           })}
+          <DisplayColumn column="date" displayColumns={settings.columns}>
+            <TableCellHeader
+              data-test-id="colDateHeader"
+              className={classes.colDate}
+              direction={
+                sort.sort === ProductListUrlSortField.date
+                  ? getArrowDirection(sort.asc)
+                  : undefined
+              }
+              onClick={() => onSort(ProductListUrlSortField.date)}
+            >
+              <FormattedMessage {...columnsMessages.updatedAt} />
+            </TableCellHeader>
+          </DisplayColumn>
           <DisplayColumn column="price" displayColumns={settings.columns}>
             <TableCellHeader
               data-test-id="colPriceHeader"
@@ -275,20 +292,6 @@ export const ProductList: React.FC<ProductListProps> = props => {
               }
             >
               <FormattedMessage {...columnsMessages.price} />
-            </TableCellHeader>
-          </DisplayColumn>
-          <DisplayColumn column="date" displayColumns={settings.columns}>
-            <TableCellHeader
-              data-test-id="colDateHeader"
-              className={classes.colDate}
-              direction={
-                sort.sort === ProductListUrlSortField.date
-                  ? getArrowDirection(sort.asc)
-                  : undefined
-              }
-              onClick={() => onSort(ProductListUrlSortField.date)}
-            >
-              <FormattedMessage {...columnsMessages.updatedAt} />
             </TableCellHeader>
           </DisplayColumn>
         </TableHead>
@@ -423,6 +426,18 @@ export const ProductList: React.FC<ProductListProps> = props => {
                     </TableCell>
                   ))}
                   <DisplayColumn
+                    column="date"
+                    displayColumns={settings.columns}
+                  >
+                    <TableCell className={classes.colDate} data-test="date">
+                      {product?.updatedAt ? (
+                        <Date date={product.updatedAt} />
+                      ) : (
+                        <Skeleton />
+                      )}
+                    </TableCell>
+                  </DisplayColumn>
+                  <DisplayColumn
                     column="price"
                     displayColumns={settings.columns}
                   >
@@ -432,18 +447,6 @@ export const ProductList: React.FC<ProductListProps> = props => {
                           from={channel?.pricing?.priceRange?.start?.net}
                           to={channel?.pricing?.priceRange?.stop?.net}
                         />
-                      ) : (
-                        <Skeleton />
-                      )}
-                    </TableCell>
-                  </DisplayColumn>
-                  <DisplayColumn
-                    column="date"
-                    displayColumns={settings.columns}
-                  >
-                    <TableCell className={classes.colDate} data-test="date">
-                      {product?.updatedAt ? (
-                        <Date date={product.updatedAt} />
                       ) : (
                         <Skeleton />
                       )}

--- a/src/products/components/ProductList/ProductList.tsx
+++ b/src/products/components/ProductList/ProductList.tsx
@@ -8,6 +8,7 @@ import {
 import AvailabilityStatusLabel from "@saleor/components/AvailabilityStatusLabel";
 import { ChannelsAvailabilityDropdown } from "@saleor/components/ChannelsAvailabilityDropdown";
 import Checkbox from "@saleor/components/Checkbox";
+import Date from "@saleor/components/Date";
 import MoneyRange from "@saleor/components/MoneyRange";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
@@ -36,7 +37,7 @@ import classNames from "classnames";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
-import { messages } from "./messages";
+import { columnsMessages, messages } from "./messages";
 
 const useStyles = makeStyles(
   theme => ({
@@ -51,6 +52,9 @@ const useStyles = makeStyles(
         width: 200
       },
       colType: {
+        width: 200
+      },
+      colDate: {
         width: 200
       }
     },
@@ -200,10 +204,7 @@ export const ProductList: React.FC<ProductListProps> = props => {
               }
               onClick={() => onSort(ProductListUrlSortField.productType)}
             >
-              <FormattedMessage
-                defaultMessage="Type"
-                description="product type"
-              />
+              <FormattedMessage {...columnsMessages.type} />
             </TableCellHeader>
           </DisplayColumn>
           <DisplayColumn
@@ -226,10 +227,7 @@ export const ProductList: React.FC<ProductListProps> = props => {
                 )
               }
             >
-              <FormattedMessage
-                defaultMessage="Availability"
-                description="product channels"
-              />
+              <FormattedMessage {...columnsMessages.availability} />
             </TableCellHeader>
           </DisplayColumn>
           {gridAttributesFromSettings.map(gridAttributeFromSettings => {
@@ -276,10 +274,21 @@ export const ProductList: React.FC<ProductListProps> = props => {
                 !canBeSorted(ProductListUrlSortField.price, !!selectedChannelId)
               }
             >
-              <FormattedMessage
-                defaultMessage="Price"
-                description="product price"
-              />
+              <FormattedMessage {...columnsMessages.price} />
+            </TableCellHeader>
+          </DisplayColumn>
+          <DisplayColumn column="date" displayColumns={settings.columns}>
+            <TableCellHeader
+              data-test-id="colDateHeader"
+              className={classes.colDate}
+              direction={
+                sort.sort === ProductListUrlSortField.date
+                  ? getArrowDirection(sort.asc)
+                  : undefined
+              }
+              onClick={() => onSort(ProductListUrlSortField.date)}
+            >
+              <FormattedMessage {...columnsMessages.updatedAt} />
             </TableCellHeader>
           </DisplayColumn>
         </TableHead>
@@ -423,6 +432,18 @@ export const ProductList: React.FC<ProductListProps> = props => {
                           from={channel?.pricing?.priceRange?.start?.net}
                           to={channel?.pricing?.priceRange?.stop?.net}
                         />
+                      ) : (
+                        <Skeleton />
+                      )}
+                    </TableCell>
+                  </DisplayColumn>
+                  <DisplayColumn
+                    column="date"
+                    displayColumns={settings.columns}
+                  >
+                    <TableCell className={classes.colDate} data-test="date">
+                      {product?.updatedAt ? (
+                        <Date date={product.updatedAt} />
                       ) : (
                         <Skeleton />
                       )}

--- a/src/products/components/ProductList/messages.ts
+++ b/src/products/components/ProductList/messages.ts
@@ -14,3 +14,22 @@ export const messages = defineMessages({
     description: "product publication date"
   }
 });
+
+export const columnsMessages = defineMessages({
+  availability: {
+    defaultMessage: "Availability",
+    description: "product channels"
+  },
+  price: {
+    defaultMessage: "Price",
+    description: "product price"
+  },
+  type: {
+    defaultMessage: "Type",
+    description: "product type"
+  },
+  updatedAt: {
+    defaultMessage: "Updated At",
+    description: "product updated at"
+  }
+});

--- a/src/products/components/ProductList/messages.ts
+++ b/src/products/components/ProductList/messages.ts
@@ -29,7 +29,7 @@ export const columnsMessages = defineMessages({
     description: "product type"
   },
   updatedAt: {
-    defaultMessage: "Updated At",
+    defaultMessage: "Last updated",
     description: "product updated at"
   }
 });

--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -29,6 +29,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { ProductListUrlSortField } from "../../urls";
 import ProductList from "../ProductList";
+import { columnsMessages } from "../ProductList/messages";
 import {
   createFilterStructure,
   ProductFilterKeys,
@@ -115,18 +116,16 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
 
   const columns: ColumnPickerChoice[] = [
     {
-      label: intl.formatMessage({
-        defaultMessage: "Price",
-        description: "product price"
-      }),
+      label: intl.formatMessage(columnsMessages.price),
       value: "price" as ProductListColumns
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "Type",
-        description: "product type"
-      }),
+      label: intl.formatMessage(columnsMessages.type),
       value: "productType" as ProductListColumns
+    },
+    {
+      label: intl.formatMessage(columnsMessages.updatedAt),
+      value: "date" as ProductListColumns
     },
     ...availableInGridAttributes.map(attribute => ({
       label: attribute.name,

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -714,6 +714,7 @@ export const products = (
 ): ProductList_products_edges_node[] => [
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [],
     channelListings: [
       {
@@ -804,6 +805,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [],
     channelListings: [
       {
@@ -894,6 +896,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [],
     channelListings: [
       {
@@ -984,6 +987,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1096,6 +1100,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1208,6 +1213,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1321,6 +1327,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1433,6 +1440,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1545,6 +1553,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1657,6 +1666,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1769,6 +1779,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1881,6 +1892,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -1993,6 +2005,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2105,6 +2118,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2217,6 +2231,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2329,6 +2344,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2441,6 +2457,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2553,6 +2570,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2665,6 +2683,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",
@@ -2777,6 +2796,7 @@ export const products = (
   },
   {
     __typename: "Product",
+    updatedAt: "2020-06-22T13:52:05.094636+00:00",
     attributes: [
       {
         __typename: "SelectedAttribute",

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -158,6 +158,7 @@ const productListQuery = gql`
       edges {
         node {
           ...ProductFragment
+          updatedAt
           attributes {
             attribute {
               id

--- a/src/products/types/ProductList.ts
+++ b/src/products/types/ProductList.ts
@@ -109,6 +109,7 @@ export interface ProductList_products_edges_node {
   thumbnail: ProductList_products_edges_node_thumbnail | null;
   productType: ProductList_products_edges_node_productType;
   channelListings: ProductList_products_edges_node_channelListings[] | null;
+  updatedAt: any | null;
   attributes: ProductList_products_edges_node_attributes[];
 }
 

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -50,7 +50,8 @@ export enum ProductListUrlSortField {
   productType = "productType",
   status = "status",
   price = "price",
-  rank = "rank"
+  rank = "rank",
+  date = "date"
 }
 export type ProductListUrlSort = Sort<ProductListUrlSortField>;
 export interface ProductListUrlQueryParams

--- a/src/products/views/ProductList/sort.ts
+++ b/src/products/views/ProductList/sort.ts
@@ -16,6 +16,7 @@ export function canBeSorted(
     case ProductListUrlSortField.productType:
     case ProductListUrlSortField.attribute:
     case ProductListUrlSortField.rank:
+    case ProductListUrlSortField.date:
       return true;
     case ProductListUrlSortField.price:
     case ProductListUrlSortField.status:
@@ -39,6 +40,8 @@ export function getSortQueryField(
       return ProductOrderField.PUBLISHED;
     case ProductListUrlSortField.rank:
       return ProductOrderField.RANK;
+    case ProductListUrlSortField.date:
+      return ProductOrderField.DATE;
     default:
       return undefined;
   }


### PR DESCRIPTION
I want to merge this change because... it adds option to sort products by update date.

Reviewed in https://github.com/saleor/saleor-dashboard/pull/1581

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="1244" alt="Zrzut ekranu 2021-11-15 o 10 56 03" src="https://user-images.githubusercontent.com/9825562/141763416-24c2f6a6-13d2-4011-bca6-9e84ca8ca44f.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
