### PR TITLE
Fix fulfillment of lines with not enough stock and no image

### DIFF
--- a/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
+++ b/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
@@ -44,7 +44,7 @@ const OrderFulfillStockExceededDialogLines: React.FC<OrderFulfillStockExceededDi
     <TableRow key={line?.id + stock?.id}>
       <TableCellAvatar
         className={classes.colName}
-        thumbnail={line?.thumbnail.url}
+        thumbnail={line?.thumbnail?.url}
       >
         {line?.productName}
         <Typography color="textSecondary" variant="caption">


### PR DESCRIPTION
I want to merge this change because it fixes a problem with fulfillment stock exceeded dialog, when exceeded lines have no image.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
