### PR TITLE
Fix refunded value calculation in order view

### DIFF
--- a/src/orders/components/OrderPayment/OrderPayment.tsx
+++ b/src/orders/components/OrderPayment/OrderPayment.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, CardActions, CardContent } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import { Hr } from "@saleor/components/Hr";
-import Money, { subtractMoney } from "@saleor/components/Money";
+import Money from "@saleor/components/Money";
 import Skeleton from "@saleor/components/Skeleton";
 import StatusLabel from "@saleor/components/StatusLabel";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -15,6 +15,7 @@ import {
   OrderStatus
 } from "../../../types/globalTypes";
 import { OrderDetails_order } from "../../types/OrderDetails";
+import { extractOutstandingBalance, extractRefundedAmount } from "./utils";
 
 const useStyles = makeStyles(
   theme => ({
@@ -59,10 +60,9 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
     maybe(() => order.paymentStatus),
     intl
   );
-  const refundedAmount =
-    order?.totalCaptured &&
-    order?.total?.gross &&
-    subtractMoney(order.totalCaptured, order.total.gross);
+  const refundedAmount = extractRefundedAmount(order);
+  const outstandingBalance = extractOutstandingBalance(order);
+
   return (
     <Card>
       <CardTitle
@@ -266,17 +266,10 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
                 />
               </td>
               <td className={classes.textRight}>
-                {maybe(
-                  () => order.total.gross.amount && order.totalCaptured.amount
-                ) === undefined ? (
+                {outstandingBalance?.amount === undefined ? (
                   <Skeleton />
                 ) : (
-                  <Money
-                    money={subtractMoney(
-                      order.totalCaptured,
-                      order.total.gross
-                    )}
-                  />
+                  <Money money={outstandingBalance} />
                 )}
               </td>
             </tr>

--- a/src/orders/components/OrderPayment/utils.ts
+++ b/src/orders/components/OrderPayment/utils.ts
@@ -1,0 +1,23 @@
+import { IMoney, subtractMoney } from "@saleor/components/Money";
+import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import { PaymentChargeStatusEnum } from "@saleor/types/globalTypes";
+
+export const extractOutstandingBalance = (order: OrderDetails_order): IMoney =>
+  order?.totalCaptured &&
+  order?.total?.gross &&
+  subtractMoney(order.total.gross, order.totalCaptured);
+
+export const extractRefundedAmount = (order: OrderDetails_order): IMoney => {
+  if (order?.paymentStatus === PaymentChargeStatusEnum.FULLY_REFUNDED) {
+    return order?.total?.gross;
+  }
+  if (order?.paymentStatus === PaymentChargeStatusEnum.PARTIALLY_REFUNDED) {
+    return extractOutstandingBalance(order);
+  }
+  return (
+    order?.total?.gross && {
+      amount: 0,
+      currency: order.total.gross.currency
+    }
+  );
+};


### PR DESCRIPTION
I want to merge this change because... it fixes refunded value calculation in order view.

⚠️ Reviewed in main PR: https://github.com/saleor/saleor-dashboard/pull/1601

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="788" alt="Zrzut ekranu 2021-11-18 o 13 12 01" src="https://user-images.githubusercontent.com/9825562/142413229-9a3c15c2-fde0-4ee7-a16d-5ebb0726eb3e.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
