### PR TITLE
Use order token for metadata updates

### DIFF
--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -181,6 +181,7 @@ export const fragmentOrderDetails = gql`
   ${fragmentMoney}
   fragment OrderDetailsFragment on Order {
     id
+    token
     ...MetadataFragment
     billingAddress {
       ...AddressFragment

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -551,6 +551,7 @@ export interface OrderDetailsFragment_channel {
 export interface OrderDetailsFragment {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDetailsFragment_metadata | null)[];
   privateMetadata: (OrderDetailsFragment_privateMetadata | null)[];
   billingAddress: OrderDetailsFragment_billingAddress | null;

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1186,6 +1186,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
     }
   ],
   id: "T3JkZXI6OQ==",
+  token: "e5cfc543-6a62-472f-8b80-6a2311f9ff14",
   invoices: [
     {
       __typename: "Invoice",
@@ -1431,6 +1432,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
   events: [],
   fulfillments: [],
   id: "T3JkZXI6MjQ=",
+  token: "e5cfc543-6a62-472f-8b80-6a2311f9ff14",
   invoices: [
     {
       __typename: "Invoice",

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -560,6 +560,7 @@ export interface FulfillOrder_orderFulfill_order_channel {
 export interface FulfillOrder_orderFulfill_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (FulfillOrder_orderFulfill_order_metadata | null)[];
   privateMetadata: (FulfillOrder_orderFulfill_order_privateMetadata | null)[];
   billingAddress: FulfillOrder_orderFulfill_order_billingAddress | null;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -558,6 +558,7 @@ export interface OrderCancel_orderCancel_order_channel {
 export interface OrderCancel_orderCancel_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderCancel_orderCancel_order_metadata | null)[];
   privateMetadata: (OrderCancel_orderCancel_order_privateMetadata | null)[];
   billingAddress: OrderCancel_orderCancel_order_billingAddress | null;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -558,6 +558,7 @@ export interface OrderCapture_orderCapture_order_channel {
 export interface OrderCapture_orderCapture_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderCapture_orderCapture_order_metadata | null)[];
   privateMetadata: (OrderCapture_orderCapture_order_privateMetadata | null)[];
   billingAddress: OrderCapture_orderCapture_order_billingAddress | null;

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -558,6 +558,7 @@ export interface OrderConfirm_orderConfirm_order_channel {
 export interface OrderConfirm_orderConfirm_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderConfirm_orderConfirm_order_metadata | null)[];
   privateMetadata: (OrderConfirm_orderConfirm_order_privateMetadata | null)[];
   billingAddress: OrderConfirm_orderConfirm_order_billingAddress | null;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -551,6 +551,7 @@ export interface OrderDetails_order_channel {
 export interface OrderDetails_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDetails_order_metadata | null)[];
   privateMetadata: (OrderDetails_order_privateMetadata | null)[];
   billingAddress: OrderDetails_order_billingAddress | null;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -558,6 +558,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_channel {
 export interface OrderDiscountAdd_orderDiscountAdd_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDiscountAdd_orderDiscountAdd_order_metadata | null)[];
   privateMetadata: (OrderDiscountAdd_orderDiscountAdd_order_privateMetadata | null)[];
   billingAddress: OrderDiscountAdd_orderDiscountAdd_order_billingAddress | null;

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -558,6 +558,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_channel {
 export interface OrderDiscountDelete_orderDiscountDelete_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDiscountDelete_orderDiscountDelete_order_metadata | null)[];
   privateMetadata: (OrderDiscountDelete_orderDiscountDelete_order_privateMetadata | null)[];
   billingAddress: OrderDiscountDelete_orderDiscountDelete_order_billingAddress | null;

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -558,6 +558,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_channel {
 export interface OrderDiscountUpdate_orderDiscountUpdate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDiscountUpdate_orderDiscountUpdate_order_metadata | null)[];
   privateMetadata: (OrderDiscountUpdate_orderDiscountUpdate_order_privateMetadata | null)[];
   billingAddress: OrderDiscountUpdate_orderDiscountUpdate_order_billingAddress | null;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -558,6 +558,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_channel {
 export interface OrderDraftCancel_draftOrderDelete_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDraftCancel_draftOrderDelete_order_metadata | null)[];
   privateMetadata: (OrderDraftCancel_draftOrderDelete_order_privateMetadata | null)[];
   billingAddress: OrderDraftCancel_draftOrderDelete_order_billingAddress | null;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -558,6 +558,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_channel {
 export interface OrderDraftFinalize_draftOrderComplete_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDraftFinalize_draftOrderComplete_order_metadata | null)[];
   privateMetadata: (OrderDraftFinalize_draftOrderComplete_order_privateMetadata | null)[];
   billingAddress: OrderDraftFinalize_draftOrderComplete_order_billingAddress | null;

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -558,6 +558,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_channel {
 export interface OrderDraftUpdate_draftOrderUpdate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderDraftUpdate_draftOrderUpdate_order_metadata | null)[];
   privateMetadata: (OrderDraftUpdate_draftOrderUpdate_order_privateMetadata | null)[];
   billingAddress: OrderDraftUpdate_draftOrderUpdate_order_billingAddress | null;

--- a/src/orders/types/OrderFulfillmentApprove.ts
+++ b/src/orders/types/OrderFulfillmentApprove.ts
@@ -558,6 +558,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_channel {
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderFulfillmentApprove_orderFulfillmentApprove_order_metadata | null)[];
   privateMetadata: (OrderFulfillmentApprove_orderFulfillmentApprove_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentApprove_orderFulfillmentApprove_order_billingAddress | null;

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -558,6 +558,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_channel {
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderFulfillmentCancel_orderFulfillmentCancel_order_metadata | null)[];
   privateMetadata: (OrderFulfillmentCancel_orderFulfillmentCancel_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentCancel_orderFulfillmentCancel_order_billingAddress | null;

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -660,6 +660,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_metadata | null)[];
   privateMetadata: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_billingAddress | null;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -558,6 +558,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_metadata | null)[];
   privateMetadata: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_billingAddress | null;

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -558,6 +558,7 @@ export interface OrderLineDelete_orderLineDelete_order_channel {
 export interface OrderLineDelete_orderLineDelete_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderLineDelete_orderLineDelete_order_metadata | null)[];
   privateMetadata: (OrderLineDelete_orderLineDelete_order_privateMetadata | null)[];
   billingAddress: OrderLineDelete_orderLineDelete_order_billingAddress | null;

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -558,6 +558,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_channel {
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderLineDiscountRemove_orderLineDiscountRemove_order_metadata | null)[];
   privateMetadata: (OrderLineDiscountRemove_orderLineDiscountRemove_order_privateMetadata | null)[];
   billingAddress: OrderLineDiscountRemove_orderLineDiscountRemove_order_billingAddress | null;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -558,6 +558,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel {
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_metadata | null)[];
   privateMetadata: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_privateMetadata | null)[];
   billingAddress: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_billingAddress | null;

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -558,6 +558,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_channel {
 export interface OrderLineUpdate_orderLineUpdate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderLineUpdate_orderLineUpdate_order_metadata | null)[];
   privateMetadata: (OrderLineUpdate_orderLineUpdate_order_privateMetadata | null)[];
   billingAddress: OrderLineUpdate_orderLineUpdate_order_billingAddress | null;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -558,6 +558,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_channel {
 export interface OrderLinesAdd_orderLinesCreate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderLinesAdd_orderLinesCreate_order_metadata | null)[];
   privateMetadata: (OrderLinesAdd_orderLinesCreate_order_privateMetadata | null)[];
   billingAddress: OrderLinesAdd_orderLinesCreate_order_billingAddress | null;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -558,6 +558,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_channel {
 export interface OrderMarkAsPaid_orderMarkAsPaid_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderMarkAsPaid_orderMarkAsPaid_order_metadata | null)[];
   privateMetadata: (OrderMarkAsPaid_orderMarkAsPaid_order_privateMetadata | null)[];
   billingAddress: OrderMarkAsPaid_orderMarkAsPaid_order_billingAddress | null;

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -558,6 +558,7 @@ export interface OrderRefund_orderRefund_order_channel {
 export interface OrderRefund_orderRefund_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderRefund_orderRefund_order_metadata | null)[];
   privateMetadata: (OrderRefund_orderRefund_order_privateMetadata | null)[];
   billingAddress: OrderRefund_orderRefund_order_billingAddress | null;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -571,6 +571,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order {
   shippingMethod: OrderShippingMethodUpdate_orderUpdateShipping_order_shippingMethod | null;
   shippingMethodName: string | null;
   shippingPrice: OrderShippingMethodUpdate_orderUpdateShipping_order_shippingPrice;
+  token: string;
   metadata: (OrderShippingMethodUpdate_orderUpdateShipping_order_metadata | null)[];
   privateMetadata: (OrderShippingMethodUpdate_orderUpdateShipping_order_privateMetadata | null)[];
   billingAddress: OrderShippingMethodUpdate_orderUpdateShipping_order_billingAddress | null;

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -558,6 +558,7 @@ export interface OrderUpdate_orderUpdate_order_channel {
 export interface OrderUpdate_orderUpdate_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderUpdate_orderUpdate_order_metadata | null)[];
   privateMetadata: (OrderUpdate_orderUpdate_order_privateMetadata | null)[];
   billingAddress: OrderUpdate_orderUpdate_order_billingAddress | null;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -558,6 +558,7 @@ export interface OrderVoid_orderVoid_order_channel {
 export interface OrderVoid_orderVoid_order {
   __typename: "Order";
   id: string;
+  token: string;
   metadata: (OrderVoid_orderVoid_order_metadata | null)[];
   privateMetadata: (OrderVoid_orderVoid_order_privateMetadata | null)[];
   billingAddress: OrderVoid_orderVoid_order_billingAddress | null;

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -86,7 +86,11 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
           }
 
           const update = createMetadataUpdateHandler(
-            order,
+            {
+              id: order.token,
+              metadata: order.metadata,
+              privateMetadata: order.privateMetadata
+            },
             () => Promise.resolve([]),
             variables => updateMetadata({ variables }),
             variables => updatePrivateMetadata({ variables })

--- a/src/productTypes/types/ProductAttributeAssignmentUpdate.ts
+++ b/src/productTypes/types/ProductAttributeAssignmentUpdate.ts
@@ -13,6 +13,7 @@ export interface ProductAttributeAssignmentUpdate_productAttributeAssignmentUpda
   __typename: "ProductError";
   field: string | null;
   message: string | null;
+  attributes: string[] | null;
 }
 
 export interface ProductAttributeAssignmentUpdate_productAttributeAssignmentUpdate_productType_taxType {


### PR DESCRIPTION
I want to merge this change because... it uses order token instead of id for metadata updates.

3.0 PR: https://github.com/saleor/saleor-dashboard/pull/1605

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
