### PR TITLE
Add tests for swatch attributes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,3 +69,44 @@ jobs:
         with:
           name: cypress-videos
           path: cypress/videos
+
+  cypress-run-critical:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && ((github.event.label.name != 'run e2e') || !(contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for CYPRESS_API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: CYPRESS_API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+
+      - name: Cypress run critical
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:critical
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/cypress/elements/attribute/attributes_details.js
+++ b/cypress/elements/attribute/attributes_details.js
@@ -15,7 +15,8 @@ export const ATTRIBUTES_DETAILS = {
     REFERENCE: '[data-test-id="REFERENCE"]',
     RICH_TEXT: '[data-test-id="RICH_TEXT"]',
     NUMERIC: '[data-test-id="NUMERIC"]',
-    BOOLEAN: '[data-test-id="BOOLEAN"]'
+    BOOLEAN: '[data-test-id="BOOLEAN"]',
+    SWATCH: '[data-test-id="SWATCH"]'
   },
   entityTypeSelect: '[id="mui-component-select-entityType"]',
   entityTypeOptions: {
@@ -38,5 +39,8 @@ export const ATTRIBUTES_DETAILS = {
     CUBIC_CENTIMETER: '[data-test-id="CUBIC_CENTIMETER"]',
     FT: '[data-test-id="FT"]'
   },
-  pageTypeAttributeCheckbox: '[value="PAGE_TYPE"]'
+  imageCheckbox: '[value= "image"]',
+  uploadFileButton: '[data-test="button-upload-file"]',
+  pageTypeAttributeCheckbox: '[value="PAGE_TYPE"]',
+  swatchValueImage: '[data-test-id="swatch-image"]'
 };

--- a/cypress/integration/configuration/attributes/attributes.js
+++ b/cypress/integration/configuration/attributes/attributes.js
@@ -3,6 +3,7 @@
 
 import faker from "faker";
 
+import { ATTRIBUTES_DETAILS } from "../../../elements/attribute/attributes_details";
 import { ATTRIBUTES_LIST } from "../../../elements/attribute/attributes_list";
 import { urlList } from "../../../fixtures/urlList";
 import { getAttribute } from "../../../support/api/requests/Attribute";
@@ -118,6 +119,49 @@ filterTests({ definedTags: ["all"] }, () => {
             attributeType,
             valueRequired: false
           });
+        });
+    });
+
+    it("should create swatch attribute", () => {
+      const attributeType = "SWATCH";
+      const attributeName = `${startsWith}${faker.datatype.number()}`;
+      createAttributeWithInputType({
+        name: attributeName,
+        attributeType
+      })
+        .then(({ attribute }) => {
+          getAttribute(attribute.id);
+        })
+        .then(attribute => {
+          expectCorrectDataInAttribute(attribute, {
+            attributeName,
+            attributeType,
+            valueRequired: true
+          });
+        });
+    });
+
+    it("should create swatch attribute with image", () => {
+      const attributeType = "SWATCH";
+      const attributeName = `${startsWith}${faker.datatype.number()}`;
+      const swatchImage = "images/saleorDemoProductSneakers.png";
+      createAttributeWithInputType({
+        name: attributeName,
+        attributeType,
+        swatchImage
+      })
+        .then(({ attribute }) => {
+          getAttribute(attribute.id);
+        })
+        .then(attribute => {
+          expectCorrectDataInAttribute(attribute, {
+            attributeName,
+            attributeType,
+            valueRequired: true
+          });
+          cy.get(ATTRIBUTES_DETAILS.swatchValueImage)
+            .invoke("have.attr", "style")
+            .should("include", "saleorDemoProductSneakers");
         });
     });
   });

--- a/cypress/integration/configuration/attributes/attributes.js
+++ b/cypress/integration/configuration/attributes/attributes.js
@@ -160,7 +160,7 @@ filterTests({ definedTags: ["all"] }, () => {
             valueRequired: true
           });
           cy.get(ATTRIBUTES_DETAILS.swatchValueImage)
-            .invoke("have.attr", "style")
+            .invoke("attr", "style")
             .should("include", "saleorDemoProductSneakers");
         });
     });

--- a/cypress/support/api/requests/Attribute.js
+++ b/cypress/support/api/requests/Attribute.js
@@ -81,6 +81,15 @@ export function getAttribute(attributeId) {
       visibleInStorefront
       availableInGrid
       unit
+      choices{
+        edges{
+          node{
+            file{
+              contentType
+            }
+          }
+        }
+      }
     }
   }`;
   return cy.sendRequestWithQuery(query).its("body.data.attribute");

--- a/cypress/support/pages/attributesPage.js
+++ b/cypress/support/pages/attributesPage.js
@@ -1,5 +1,6 @@
 import { ATTRIBUTES_DETAILS } from "../../elements/attribute/attributes_details";
 import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
+import { SHARED_ELEMENTS } from "../../elements/shared/sharedElements";
 import { attributeDetailsUrl } from "../../fixtures/urlList";
 
 export function createAttributeWithInputType({
@@ -7,10 +8,15 @@ export function createAttributeWithInputType({
   attributeType,
   entityType,
   numericSystemType,
+  swatchImage,
   valueRequired = true
 }) {
   fillUpAttributeCreateFields({ name, attributeType, valueRequired });
-  if (attributeType === "DROPDOWN" || attributeType === "MULTISELECT") {
+  if (
+    attributeType === "DROPDOWN" ||
+    attributeType === "MULTISELECT" ||
+    (attributeType === "SWATCH" && !swatchImage)
+  ) {
     addSingleValue(name);
   }
   if (attributeType === "REFERENCE") {
@@ -18,6 +24,9 @@ export function createAttributeWithInputType({
   }
   if (attributeType === "NUMERIC" && numericSystemType.unitsOf) {
     selectNumericSystem(numericSystemType);
+  }
+  if (attributeType === "SWATCH" && swatchImage) {
+    selectSwatchImage(name, swatchImage);
   }
   return saveAttribute();
 }
@@ -93,4 +102,21 @@ export function enterAttributeAndChanegeIsFilterableInDashbord(attributeId) {
     .get(ATTRIBUTES_DETAILS.dashboardProperties.useInFilteringCheckbox)
     .click();
   submitAttribute();
+}
+
+export function selectSwatchImage(valueName, image) {
+  cy.get(ATTRIBUTES_DETAILS.assignValuesButton)
+    .click()
+    .get(ATTRIBUTES_DETAILS.valueNameInput)
+    .type(valueName)
+    .get(ATTRIBUTES_DETAILS.imageCheckbox)
+    .click()
+    .get(ATTRIBUTES_DETAILS.uploadFileButton)
+    .click()
+    .get(SHARED_ELEMENTS.fileInput)
+    .attachFile(image)
+    .get(ATTRIBUTES_DETAILS.uploadFileButton)
+    .should("be.enabled")
+    .get(BUTTON_SELECTORS.submit)
+    .click();
 }

--- a/src/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/src/attributes/components/AttributeValues/AttributeValues.tsx
@@ -169,6 +169,7 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
                 {isSwatch && (
                   <TableCell className={classes.columnSwatch}>
                     <div
+                      data-test-id="swatch-image"
                       className={classes.swatch}
                       style={
                         value?.file


### PR DESCRIPTION
I want to merge this change because I added tests for swatch attributes

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
