### PR TITLE
Limit number of channel list items

### DIFF
--- a/src/components/SingleSelectField/SingleSelectField.tsx
+++ b/src/components/SingleSelectField/SingleSelectField.tsx
@@ -13,6 +13,8 @@ import classNames from "classnames";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { singleSelectFieldItemHeight } from "./consts";
+
 const useStyles = makeStyles(
   theme => ({
     formControl: {
@@ -26,6 +28,9 @@ const useStyles = makeStyles(
     },
     noLabel: {
       padding: theme.spacing(2, 1.5)
+    },
+    paper: {
+      maxHeight: `calc(${singleSelectFieldItemHeight}px * 10 + ${singleSelectFieldItemHeight}px * 0.5)`
     }
   }),
   { name: "SingleSelectField" }
@@ -110,6 +115,11 @@ export const SingleSelectField: React.FC<SingleSelectFieldProps> = props => {
           />
         }
         {...selectProps}
+        MenuProps={{
+          classes: {
+            paper: classes.paper
+          }
+        }}
       >
         {choices.length > 0 ? (
           choices.map(choice => (

--- a/src/components/SingleSelectField/consts.ts
+++ b/src/components/SingleSelectField/consts.ts
@@ -1,0 +1,1 @@
+export const singleSelectFieldItemHeight = "36";

--- a/src/storybook/stories/components/SingleSelectField.tsx
+++ b/src/storybook/stories/components/SingleSelectField.tsx
@@ -12,6 +12,25 @@ const choices = [
   { label: "Accessories", value: "4" }
 ];
 
+const manyChoices = [
+  { label: "Apparel", value: "1" },
+  { label: "Groceries", value: "2" },
+  { label: "Books", value: "3" },
+  { label: "Accessories", value: "4" },
+  { label: "Audiobooks", value: "5" },
+  { label: "Bananas", value: "6" },
+  { label: "Apples", value: "7" },
+  { label: "Fridge", value: "8" },
+  { label: "PCs", value: "9" },
+  { label: "Music", value: "10" },
+  { label: "Clothes", value: "11" },
+  { label: "Smartphones", value: "12" },
+  { label: "Keyboards", value: "13" },
+  { label: "LEDs", value: "14" },
+  { label: "Cars", value: "15" },
+  { label: "Petrol", value: "16" }
+];
+
 storiesOf("Generics / SingleSelectField", module)
   .addDecorator(CardDecorator)
   .addDecorator(Decorator)
@@ -23,6 +42,13 @@ storiesOf("Generics / SingleSelectField", module)
       choices={choices}
       onChange={undefined}
       value={choices[0].value}
+    />
+  ))
+  .add("with many values", () => (
+    <SingleSelectField
+      choices={manyChoices}
+      onChange={undefined}
+      value={manyChoices[0].value}
     />
   ))
   .add("with label", () => (


### PR DESCRIPTION
I want to merge this change because I want to limit the number of viewable menu items to 10. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
