### PR TITLE
Fix savebar hiding on short screens

### DIFF
--- a/src/components/ChannelsAvailabilityDialogWrapper/ChannelsAvailabilityDialogWrapper.tsx
+++ b/src/components/ChannelsAvailabilityDialogWrapper/ChannelsAvailabilityDialogWrapper.tsx
@@ -32,7 +32,10 @@ export const useStyles = makeStyles(
       paddingBottom: theme.spacing(2)
     },
     scrollArea: {
-      maxHeight: 400,
+      maxHeight: "calc(100vh - 400px)",
+      "@media (min-height: 800px)": {
+        maxHeight: 400
+      },
       overflowY: "scroll",
       overflowX: "hidden",
       marginBottom: theme.spacing(3)


### PR DESCRIPTION
I want to merge this change because I want to fix an issue that makes savebar hide if user's screen is short while maintaining original margins on tall screens.

3.1 PR: https://github.com/saleor/saleor-dashboard/pull/1608

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
