### PR TITLE
Add permissions to Catalog menu item

### DIFF
--- a/src/components/AppLayout/menuStructure.ts
+++ b/src/components/AppLayout/menuStructure.ts
@@ -72,6 +72,10 @@ function createMenuStructure(intl: IntlShape, user: User): SidebarMenuItem[] {
       ],
       iconSrc: catalogIcon,
       label: intl.formatMessage(commonMessages.catalog),
+      permissions: [
+        PermissionEnum.MANAGE_GIFT_CARD,
+        PermissionEnum.MANAGE_PRODUCTS
+      ],
       id: "catalogue"
     },
     {


### PR DESCRIPTION
I want to merge this change because I want to fix a bug that makes user without permission show Catalog menu item.

Reviewed here: https://github.com/saleor/saleor-dashboard/pull/1554

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
