### PR TITLE
Fix order fulfill warehouse filtering

### DIFF
--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -208,6 +208,12 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
     return isAtLeastOneFulfilled && areProperlyFulfilled;
   };
 
+  const filteredWarehouses = warehouses?.filter(warehouse =>
+    order?.lines.some(line =>
+      line.variant.stocks.some(stock => stock.warehouse.id === warehouse.id)
+    )
+  );
+
   return (
     <Container>
       <Backlink onClick={onBack}>
@@ -265,7 +271,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
                         description="quantity of fulfilled products"
                       />
                     </TableCell>
-                    {warehouses?.map(warehouse => (
+                    {filteredWarehouses?.map(warehouse => (
                       <TableCell
                         key={warehouse.id}
                         className={classNames(
@@ -295,7 +301,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
                               {" "}
                               <Skeleton />
                             </TableCell>
-                            {warehouses?.map(warehouse => (
+                            {filteredWarehouses?.map(warehouse => (
                               <TableCell
                                 className={classes.colQuantity}
                                 key={warehouse.id}
@@ -354,7 +360,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
                             </span>{" "}
                             / {remainingQuantity}
                           </TableCell>
-                          {warehouses?.map(warehouse => {
+                          {filteredWarehouses?.map(warehouse => {
                             const warehouseStock = line.variant.stocks.find(
                               stock => stock.warehouse.id === warehouse.id
                             );

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -210,7 +210,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
 
   const filteredWarehouses = warehouses?.filter(warehouse =>
     order?.lines.some(line =>
-      line.variant.stocks.some(stock => stock.warehouse.id === warehouse.id)
+      line.variant?.stocks.some(stock => stock.warehouse.id === warehouse.id)
     )
   );
 

--- a/src/orders/components/OrderFulfillStockExceededDialog/styles.ts
+++ b/src/orders/components/OrderFulfillStockExceededDialog/styles.ts
@@ -23,8 +23,8 @@ export const useStyles = makeStyles(
       margin: theme.spacing(2)
     },
     scrollable: {
-      height: 450,
-      overflow: "scroll"
+      maxHeight: 450,
+      overflowY: "scroll"
     }
   }),
   { name: "OrderFulfillStockExceededDialog" }

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -47,7 +47,9 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
     OrderFulfillStockInput[]
   >(
     data?.order?.lines
-      .filter(line => line.quantity - line.quantityFulfilled > 0)
+      .filter(
+        line => line.quantity - line.quantityFulfilled > 0 && !!line.variant
+      )
       .map(line => ({
         data: null,
         id: line.id,

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -31,7 +31,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
   const { data: warehouseData, loading: warehousesLoading } = useWarehouseList({
     displayLoader: true,
     variables: {
-      first: 20
+      first: 50
     }
   });
 


### PR DESCRIPTION
I want to merge this change because it fixes:

- displaying too many warehouses in order fulfill view when none of order lines have stock for given warehouse
- not displaying a warehouse when their number exceeds 20
- constant height and horizontal scroll for order fulfill stock exceeded dialog
- order line filtering on order fulfill page when some products are deleted but not all of them

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
