### PR TITLE
Fix auto scroll

### DIFF
--- a/src/categories/index.tsx
+++ b/src/categories/index.tsx
@@ -15,7 +15,7 @@ import {
   CategoryUrlQueryParams
 } from "./urls";
 import { CategoryCreateView } from "./views/CategoryCreate";
-import CategoryDetailsView, { getActiveTab } from "./views/CategoryDetails";
+import CategoryDetailsView from "./views/CategoryDetails";
 import CategoryListComponent from "./views/CategoryList";
 
 interface CategoryDetailsRouteParams {
@@ -25,10 +25,7 @@ const CategoryDetails: React.FC<RouteComponentProps<
   CategoryDetailsRouteParams
 >> = ({ location, match }) => {
   const qs = parseQs(location.search.substr(1));
-  const params: CategoryUrlQueryParams = {
-    ...qs,
-    activeTab: getActiveTab(qs.activeTab)
-  };
+  const params: CategoryUrlQueryParams = qs;
 
   return (
     <CategoryDetailsView

--- a/src/categories/urls.ts
+++ b/src/categories/urls.ts
@@ -10,7 +10,6 @@ import {
   Sort,
   TabActionDialog
 } from "../types";
-import { CategoryPageTab } from "./components/CategoryUpdatePage";
 
 const categorySectionUrl = "/categories/";
 
@@ -40,10 +39,7 @@ export type CategoryUrlDialog =
   | "delete"
   | "delete-categories"
   | "delete-products";
-export type CategoryUrlQueryParams = BulkAction &
-  Dialog<CategoryUrlDialog> &
-  Pagination &
-  ActiveTab<CategoryPageTab>;
+export type CategoryUrlQueryParams = BulkAction & Dialog<CategoryUrlDialog>;
 export const categoryUrl = (id: string, params?: CategoryUrlQueryParams) =>
   categoryPath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -4,11 +4,11 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
+import useLocalPaginator, {
+  useSectionLocalPaginationState
+} from "@saleor/hooks/useLocalPaginator";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, {
-  createPaginationState
-} from "@saleor/hooks/usePaginator";
 import { commonMessages, errorMessages } from "@saleor/intl";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
@@ -18,7 +18,7 @@ import {
   usePrivateMetadataUpdate
 } from "@saleor/utils/metadata/updateMetadata";
 import { getParsedDataForJsonStringField } from "@saleor/utils/richText/misc";
-import React from "react";
+import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { PAGINATE_BY } from "../../config";
@@ -65,7 +65,6 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
 }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
-  const paginate = usePaginator();
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(
     params.ids
   );
@@ -73,7 +72,19 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const [activeTab, setActiveTab] = useState<CategoryPageTab>(
+    CategoryPageTab.categories
+  );
+  const [paginationState, setPaginationState] = useSectionLocalPaginationState(
+    PAGINATE_BY,
+    activeTab
+  );
+  const paginate = useLocalPaginator(setPaginationState);
+  const changeTab = (tab: CategoryPageTab) => {
+    reset();
+    setActiveTab(tab);
+  };
+
   const { data, loading, refetch } = useCategoryDetailsQuery({
     displayLoader: true,
     variables: { ...paginationState, id }
@@ -155,26 +166,16 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
     }
   });
 
-  const changeTab = (tabName: CategoryPageTab) => {
-    reset();
-    navigate(
-      categoryUrl(id, {
-        activeTab: tabName
-      })
-    );
-  };
-
   const [openModal, closeModal] = createDialogActionHandlers<
     CategoryUrlDialog,
     CategoryUrlQueryParams
   >(navigate, params => categoryUrl(id, params), params);
 
   const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
-    params.activeTab === CategoryPageTab.categories
+    activeTab === CategoryPageTab.categories
       ? maybe(() => data.category.children.pageInfo)
       : maybe(() => data.category.products.pageInfo),
-    paginationState,
-    params
+    paginationState
   );
 
   const handleUpdate = async (formData: CategoryUpdateData) => {
@@ -208,7 +209,7 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
       <WindowTitle title={maybe(() => data.category.name)} />
       <CategoryUpdatePage
         changeTab={changeTab}
-        currentTab={params.activeTab}
+        currentTab={activeTab}
         category={maybe(() => data.category)}
         disabled={loading}
         errors={updateResult.data?.categoryUpdate.errors || []}

--- a/src/collections/urls.ts
+++ b/src/collections/urls.ts
@@ -44,9 +44,7 @@ export type CollectionUrlDialog =
   | "assign"
   | "unassign"
   | ChannelsAction;
-export type CollectionUrlQueryParams = BulkAction &
-  Pagination &
-  Dialog<CollectionUrlDialog>;
+export type CollectionUrlQueryParams = BulkAction & Dialog<CollectionUrlDialog>;
 export type CollectionCreateUrlQueryParams = Dialog<ChannelsAction>;
 export const collectionUrl = (id: string, params?: CollectionUrlQueryParams) =>
   collectionPath(encodeURIComponent(id)) + "?" + stringifyQs(params);

--- a/src/collections/views/CollectionDetails.tsx
+++ b/src/collections/views/CollectionDetails.tsx
@@ -12,12 +12,12 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA, PAGINATE_BY } from "@saleor/config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useChannels from "@saleor/hooks/useChannels";
+import useLocalPaginator, {
+  useLocalPaginationState
+} from "@saleor/hooks/useLocalPaginator";
 import useLocalStorage from "@saleor/hooks/useLocalStorage";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, {
-  createPaginationState
-} from "@saleor/hooks/usePaginator";
 import { commonMessages, errorMessages } from "@saleor/intl";
 import useProductSearch from "@saleor/searches/useProductSearch";
 import { arrayDiff } from "@saleor/utils/arrays";
@@ -67,7 +67,6 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(
     params.ids
   );
-  const paginate = usePaginator();
   const intl = useIntl();
   const { search, loadMore, result } = useProductSearch({
     variables: DEFAULT_INITIAL_SEARCH_DATA
@@ -158,7 +157,11 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
     }
   });
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const [paginationState, setPaginationState] = useLocalPaginationState(
+    PAGINATE_BY
+  );
+  const paginate = useLocalPaginator(setPaginationState);
+
   const handleBack = () => navigate(collectionListUrl());
 
   const [selectedChannel] = useLocalStorage("collectionListChannel", "");
@@ -255,8 +258,7 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
 
         const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
           data?.collection?.products?.pageInfo,
-          paginationState,
-          params
+          paginationState
         );
 
         return (

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -59,16 +59,6 @@ export enum SaleDetailsPageTab {
   variants = "variants"
 }
 
-export function saleDetailsPageTab(tab: string): SaleDetailsPageTab {
-  return tab === SaleDetailsPageTab.products
-    ? SaleDetailsPageTab.products
-    : tab === SaleDetailsPageTab.collections
-    ? SaleDetailsPageTab.collections
-    : tab === SaleDetailsPageTab.categories
-    ? SaleDetailsPageTab.categories
-    : SaleDetailsPageTab.variants;
-}
-
 export interface SaleDetailsPageProps
   extends Pick<ListProps, Exclude<keyof ListProps, "onRowClick">>,
     TabListActions<

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -52,14 +52,6 @@ export enum VoucherDetailsPageTab {
   products = "products"
 }
 
-export function voucherDetailsPageTab(tab: string): VoucherDetailsPageTab {
-  return tab === VoucherDetailsPageTab.products
-    ? VoucherDetailsPageTab.products
-    : tab === VoucherDetailsPageTab.collections
-    ? VoucherDetailsPageTab.collections
-    : VoucherDetailsPageTab.categories;
-}
-
 export interface VoucherDetailsPageFormData extends MetadataFormData {
   applyOncePerCustomer: boolean;
   applyOncePerOrder: boolean;

--- a/src/discounts/index.tsx
+++ b/src/discounts/index.tsx
@@ -6,8 +6,6 @@ import { useIntl } from "react-intl";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
-import { saleDetailsPageTab } from "./components/SaleDetailsPage";
-import { voucherDetailsPageTab } from "./components/VoucherDetailsPage";
 import {
   saleAddPath,
   SaleCreateUrlQueryParams,
@@ -41,11 +39,8 @@ const SaleDetailsView: React.FC<RouteComponentProps<{ id: string }>> = ({
   match,
   location
 }) => {
-  const { activeTab, ...qs } = parseQs(location.search.substr(1));
-  const params: SaleUrlQueryParams = {
-    ...qs,
-    activeTab: saleDetailsPageTab(activeTab)
-  };
+  const qs = parseQs(location.search.substr(1));
+  const params: SaleUrlQueryParams = qs;
 
   return (
     <SaleDetailsViewComponent
@@ -76,11 +71,9 @@ const VoucherDetailsView: React.FC<RouteComponentProps<{ id: string }>> = ({
   match,
   location
 }) => {
-  const { activeTab, ...qs } = parseQs(location.search.substr(1));
-  const params: VoucherUrlQueryParams = {
-    ...qs,
-    activeTab: voucherDetailsPageTab(activeTab)
-  };
+  const qs = parseQs(location.search.substr(1));
+  const params: VoucherUrlQueryParams = qs;
+
   return (
     <VoucherDetailsViewComponent
       id={decodeURIComponent(match.params.id)}

--- a/src/discounts/urls.ts
+++ b/src/discounts/urls.ts
@@ -12,8 +12,6 @@ import {
   Sort,
   TabActionDialog
 } from "../types";
-import { SaleDetailsPageTab } from "./components/SaleDetailsPage";
-import { VoucherDetailsPageTab } from "./components/VoucherDetailsPage";
 
 export const discountSection = "/discounts/";
 
@@ -60,10 +58,7 @@ export type SaleUrlDialog =
   | "unassign-variant"
   | "remove"
   | ChannelsAction;
-export type SaleUrlQueryParams = Pagination &
-  BulkAction &
-  Dialog<SaleUrlDialog> &
-  ActiveTab<SaleDetailsPageTab>;
+export type SaleUrlQueryParams = BulkAction & Dialog<SaleUrlDialog>;
 export type SaleCreateUrlQueryParams = Dialog<ChannelsAction>;
 export const saleUrl = (id: string, params?: SaleUrlQueryParams) =>
   salePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
@@ -117,10 +112,7 @@ export type VoucherUrlDialog =
   | "unassign-product"
   | "remove"
   | ChannelsAction;
-export type VoucherUrlQueryParams = Pagination &
-  BulkAction &
-  Dialog<VoucherUrlDialog> &
-  ActiveTab<VoucherDetailsPageTab>;
+export type VoucherUrlQueryParams = BulkAction & Dialog<VoucherUrlDialog>;
 export type VoucherCreateUrlQueryParams = Dialog<ChannelsAction>;
 export const voucherUrl = (id: string, params?: VoucherUrlQueryParams) =>
   voucherPath(encodeURIComponent(id)) + "?" + stringifyQs(params);

--- a/src/hooks/useLocalPaginator.ts
+++ b/src/hooks/useLocalPaginator.ts
@@ -14,6 +14,11 @@ export interface PaginationState {
   last?: number;
 }
 
+/**
+ * Local pagination state.
+ * @param paginateBy Number of items per page.
+ * @returns Pagination state and setter.
+ */
 export function useLocalPaginationState(
   paginateBy: number
 ): [PaginationState, (paginationState: PaginationState) => void] {
@@ -44,6 +49,39 @@ export function useLocalPaginationState(
   }, [paginateBy]);
 
   return [state, setPaginationState];
+}
+
+/**
+ * Local pagination state persisted as long as section is not changed.
+ * @param paginateBy Number of items per page.
+ * @param section Section name. When changed, pagination state is reset.
+ * @returns Pagination state and setter.
+ */
+export function useSectionLocalPaginationState(
+  paginateBy: number,
+  section: string
+): [PaginationState, (paginationState: PaginationState) => void] {
+  const [paginationSection, setPaginationSection] = useState(section);
+  const [paginationState, setPaginationState] = useLocalPaginationState(
+    paginateBy
+  );
+
+  useEffect(() => {
+    if (section !== paginationSection) {
+      setPaginationState({});
+    }
+  }, [section]);
+
+  useEffect(() => {
+    if (section !== paginationSection) {
+      setPaginationSection(section);
+    }
+  }, [paginationState]);
+
+  return [
+    section === paginationSection ? paginationState : {},
+    setPaginationState
+  ];
 }
 
 function useLocalPaginator(

--- a/src/hooks/useNavigator.ts
+++ b/src/hooks/useNavigator.ts
@@ -16,7 +16,7 @@ function useNavigator(): UseNavigatorResult {
 
   return (
     url: string,
-    { replace = false, preserveQs = false, resetScroll = true } = {}
+    { replace = false, preserveQs = false, resetScroll = false } = {}
   ) => {
     const targetUrl = preserveQs ? url + search : url;
     if (replace) {

--- a/src/hooks/usePaginator.ts
+++ b/src/hooks/usePaginator.ts
@@ -52,7 +52,7 @@ function usePaginator() {
             after: pageInfo.endCursor,
             before: undefined
           }),
-        { replace: true }
+        { replace: true, resetScroll: true }
       );
 
     const loadPreviousPage = () =>
@@ -63,7 +63,7 @@ function usePaginator() {
             after: undefined,
             before: pageInfo.startCursor
           }),
-        { replace: true }
+        { replace: true, resetScroll: true }
       );
 
     const newPageInfo = pageInfo

--- a/src/shipping/urls.ts
+++ b/src/shipping/urls.ts
@@ -34,8 +34,7 @@ export type ShippingZoneUrlQueryParams = Dialog<ShippingZoneUrlDialog> &
   SingleAction &
   Partial<{
     type: ShippingMethodTypeEnum;
-  }> &
-  Pagination;
+  }>;
 export const shippingZoneUrl = (
   id: string,
   params?: ShippingZoneUrlQueryParams
@@ -50,8 +49,7 @@ export type ShippingRateUrlDialog =
 
 export type ShippingRateUrlQueryParams = Dialog<ShippingRateUrlDialog> &
   SingleAction &
-  BulkAction &
-  Pagination;
+  BulkAction;
 export type ShippingRateCreateUrlDialog = ZipCodeRangeActions | ChannelsAction;
 export type ShippingRateCreateUrlQueryParams = Dialog<
   ShippingRateCreateUrlDialog

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -9,11 +9,11 @@ import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { PAGINATE_BY } from "@saleor/config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useChannels from "@saleor/hooks/useChannels";
+import useLocalPaginator, {
+  useLocalPaginationState
+} from "@saleor/hooks/useLocalPaginator";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, {
-  createPaginationState
-} from "@saleor/hooks/usePaginator";
 import { sectionNames } from "@saleor/intl";
 import { commonMessages } from "@saleor/intl";
 import {
@@ -81,9 +81,11 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
-  const paginate = usePaginator();
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const [paginationState, setPaginationState] = useLocalPaginationState(
+    PAGINATE_BY
+  );
+  const paginate = useLocalPaginator(setPaginationState);
 
   const { data, loading, refetch } = useShippingZone({
     displayLoader: true,
@@ -111,8 +113,7 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
 
   const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
     rate?.excludedProducts.pageInfo,
-    paginationState,
-    params
+    paginationState
   );
 
   const [

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -4,9 +4,9 @@ import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { PAGINATE_BY } from "@saleor/config";
+import { useLocalPaginationState } from "@saleor/hooks/useLocalPaginator";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import { createPaginationState } from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
 import { commonMessages } from "@saleor/intl";
 import { getById } from "@saleor/orders/components/OrderReturnPage/utils";
@@ -61,7 +61,7 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
   const intl = useIntl();
   const shop = useShop();
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const [paginationState] = useLocalPaginationState(PAGINATE_BY);
 
   const { result: searchWarehousesOpts, loadMore, search } = useWarehouseSearch(
     {

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -9,11 +9,11 @@ import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { PAGINATE_BY } from "@saleor/config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useChannels from "@saleor/hooks/useChannels";
+import useLocalPaginator, {
+  useLocalPaginationState
+} from "@saleor/hooks/useLocalPaginator";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, {
-  createPaginationState
-} from "@saleor/hooks/usePaginator";
 import { sectionNames } from "@saleor/intl";
 import { commonMessages } from "@saleor/intl";
 import {
@@ -81,9 +81,11 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
-  const paginate = usePaginator();
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const [paginationState, setPaginationState] = useLocalPaginationState(
+    PAGINATE_BY
+  );
+  const paginate = useLocalPaginator(setPaginationState);
 
   const { data, loading, refetch } = useShippingZone({
     displayLoader: true,
@@ -160,8 +162,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
 
   const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
     rate?.excludedProducts.pageInfo,
-    paginationState,
-    params
+    paginationState
   );
 
   const [


### PR DESCRIPTION
I want to merge this change because... 

1. It sets auto-scroll to top:
- 🔴  disabled when actions changing URL are performed (e.g. closing dialogs)
- 🔴  disabled when pagination with "local" (react state) state persisting is used (lists in category details, lists in collection details, etc.)
- 🟢  enabled when pagination with "global" (query params) state persisting is used (product list, order list, etc.)

2. changes "global" pagination to "local" pagination in pages where it wasn't used yet, but should as lists are just a part of page (category details, collection details, etc.)

<!-- Please mention all relevant issue numbers. -->
PR to review: https://github.com/saleor/saleor-dashboard/pull/1644

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> main

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
