### PR TITLE
Fix initial discount calculation on draft order line

### DIFF
--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from "react";
+
+export function useUpdateEffect(fn: () => void, depArr: any[]) {
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    if (mounted.current) {
+      return fn();
+    }
+    mounted.current = true;
+  }, depArr);
+}
+
+export default useUpdateEffect;

--- a/src/orders/components/OrderDiscountCommonModal/OrderDiscountCommonModal.tsx
+++ b/src/orders/components/OrderDiscountCommonModal/OrderDiscountCommonModal.tsx
@@ -14,6 +14,7 @@ import ConfirmButton, {
 import PriceField from "@saleor/components/PriceField";
 import RadioGroupField from "@saleor/components/RadioGroupField";
 import { Money } from "@saleor/fragments/types/Money";
+import { useUpdateEffect } from "@saleor/hooks/useUpdateEffect";
 import { buttonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/macaw-ui";
 import { DiscountValueTypeEnum } from "@saleor/types/globalTypes";
@@ -258,7 +259,7 @@ const OrderDiscountCommonModal: React.FC<OrderDiscountCommonModalProps> = ({
     setValue(recalculatedValue);
   };
 
-  useEffect(handleValueConversion, [calculationMode]);
+  useUpdateEffect(handleValueConversion, [calculationMode]);
 
   const dialogTitle =
     modalType === ORDER_LINE_DISCOUNT


### PR DESCRIPTION
I want to merge this change because it fixes the initial discount calculation

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
