### PR TITLE
ConfirmButtonTransitionState' was not found error #1653

### DIFF
--- a/src/components/ConfirmButton.tsx
+++ b/src/components/ConfirmButton.tsx
@@ -6,7 +6,7 @@ import {
 } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
-export { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+export type { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 
 export interface ConfirmButtonProps
   extends Omit<MacawConfirmButtonProps, "labels"> {


### PR DESCRIPTION
It solves `ConfirmButtonTransitionState' was not found in '@saleor/macaw-ui #1653`

I want to merge this change because...a minor change

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
![image](https://user-images.githubusercontent.com/1001052/144567493-88bf1331-88ab-4c9e-89dc-9e947a291595.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
