### PR TITLE
Fix attributeValueDelete mutation error - required first/last value

### DIFF
--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -307,7 +307,8 @@ export const handleDeleteMultipleAttributeValues = async (
 
       if (fileValueUnused) {
         return deleteAttributeValue({
-          id: existingAttribute.values[0].id
+          id: existingAttribute.values[0].id,
+          firstValues: 20
         });
       }
     })


### PR DESCRIPTION
I want to merge this change because it fixes an error with attributeValueDelete mutation where `first` or `last` value is required for proper pagination of `choices` field.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
