### PR TITLE
Add items response in updateMetadata mutation

### DIFF
--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -20,7 +20,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethodType" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "ShippingMethod" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingMethodType" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -15,9 +15,29 @@ export interface UpdateMetadata_updateMetadata_errors {
   field: string | null;
 }
 
+export interface UpdateMetadata_updateMetadata_item_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_updateMetadata_item_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_updateMetadata_item {
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingMethodType" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
+  metadata: (UpdateMetadata_updateMetadata_item_metadata | null)[];
+  privateMetadata: (UpdateMetadata_updateMetadata_item_privateMetadata | null)[];
+  id: string;
+}
+
 export interface UpdateMetadata_updateMetadata {
   __typename: "UpdateMetadata";
   errors: UpdateMetadata_updateMetadata_errors[];
+  item: UpdateMetadata_updateMetadata_item | null;
 }
 
 export interface UpdateMetadata_deleteMetadata_errors {
@@ -39,7 +59,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethodType" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "ShippingMethod" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingMethodType" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -15,9 +15,29 @@ export interface UpdatePrivateMetadata_updatePrivateMetadata_errors {
   field: string | null;
 }
 
+export interface UpdatePrivateMetadata_updatePrivateMetadata_item_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdatePrivateMetadata_updatePrivateMetadata_item_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdatePrivateMetadata_updatePrivateMetadata_item {
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingMethodType" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
+  metadata: (UpdatePrivateMetadata_updatePrivateMetadata_item_metadata | null)[];
+  privateMetadata: (UpdatePrivateMetadata_updatePrivateMetadata_item_privateMetadata | null)[];
+  id: string;
+}
+
 export interface UpdatePrivateMetadata_updatePrivateMetadata {
   __typename: "UpdatePrivateMetadata";
   errors: UpdatePrivateMetadata_updatePrivateMetadata_errors[];
+  item: UpdatePrivateMetadata_updatePrivateMetadata_item | null;
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_errors {
@@ -39,7 +59,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethodType" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "ShippingMethod" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingMethodType" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/updateMetadata.ts
+++ b/src/utils/metadata/updateMetadata.ts
@@ -24,6 +24,12 @@ const updateMetadata = gql`
       errors {
         ...MetadataErrorFragment
       }
+      item {
+        ...MetadataFragment
+        ... on Node {
+          id
+        }
+      }
     }
     deleteMetadata(id: $id, keys: $keysToDelete) {
       errors {

--- a/src/utils/metadata/updateMetadata.ts
+++ b/src/utils/metadata/updateMetadata.ts
@@ -61,6 +61,12 @@ const updatePrivateMetadata = gql`
       errors {
         ...MetadataErrorFragment
       }
+      item {
+        ...MetadataFragment
+        ... on Node {
+          id
+        }
+      }
     }
     deletePrivateMetadata(id: $id, keys: $keysToDelete) {
       errors {


### PR DESCRIPTION
I want to merge this change because it adds `items` field in updateMetadata mutation, just like in deleteMetadata.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
