### PR TITLE
Disable form change check in variant creation

### DIFF
--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -153,7 +153,6 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
         formErrors,
         disabled: formDisabled,
         handlers,
-        hasChanged,
         submit
       }) => (
         <Container>
@@ -256,7 +255,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
             </div>
           </Grid>
           <Savebar
-            disabled={disabled || formDisabled || !onSubmit || !hasChanged}
+            disabled={disabled || formDisabled || !onSubmit}
             labels={{
               confirm: intl.formatMessage(messages.saveVariant),
               delete: intl.formatMessage(messages.deleteVariant)


### PR DESCRIPTION
I want to merge this change because... saving variant (during creation) should not be blocked without any attribute or without SKU assigned - so without anything assigned.

Related subtask: https://app.clickup.com/t/2549495/SALEOR-5111

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
