### PR TITLE
Add tests for pages for 3.1

### DIFF
--- a/cypress/fixtures/urlList.js
+++ b/cypress/fixtures/urlList.js
@@ -49,6 +49,8 @@ export const giftCardDetailsUrl = giftCardId =>
 
 export const menuDetailsUrl = menuId => `${urlList.navigation}${menuId}`;
 
+export const pageDetailsUrl = pageId => `${urlList.pages}${pageId}`;
+
 export const pageTypeDetailsUrl = pageTypeId =>
   `${urlList.pageTypes}${pageTypeId}`;
 


### PR DESCRIPTION
I want to merge this change because I added tests for pages

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
