### PR TITLE
Use variant prices in add product modal

### DIFF
--- a/src/components/DiscountedPrice/DiscountedPrice.tsx
+++ b/src/components/DiscountedPrice/DiscountedPrice.tsx
@@ -17,7 +17,7 @@ const DiscountedPrice: React.FC<DiscountedPriceProps> = ({
 
   return (
     <>
-      <Typography className={classes.strike}>
+      <Typography className={classes.strike} color="textSecondary">
         <Money money={regularPrice} />
       </Typography>
       <Money money={discountedPrice} />

--- a/src/components/DiscountedPrice/DiscountedPrice.tsx
+++ b/src/components/DiscountedPrice/DiscountedPrice.tsx
@@ -1,0 +1,27 @@
+import { Typography } from "@material-ui/core";
+import React from "react";
+import Money, { IMoney } from "../Money";
+import { useStyles } from "./styles";
+
+interface DiscountedPriceProps {
+  regularPrice: IMoney;
+  discountedPrice: IMoney;
+}
+
+const DiscountedPrice: React.FC<DiscountedPriceProps> = ({
+  regularPrice,
+  discountedPrice
+}) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Typography className={classes.strike}>
+        <Money money={regularPrice} />
+      </Typography>
+      <Money money={discountedPrice} />
+    </>
+  );
+};
+
+export default DiscountedPrice;

--- a/src/components/DiscountedPrice/DiscountedPrice.tsx
+++ b/src/components/DiscountedPrice/DiscountedPrice.tsx
@@ -1,5 +1,6 @@
 import { Typography } from "@material-ui/core";
 import React from "react";
+
 import Money, { IMoney } from "../Money";
 import { useStyles } from "./styles";
 

--- a/src/components/DiscountedPrice/styles.ts
+++ b/src/components/DiscountedPrice/styles.ts
@@ -1,0 +1,12 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    strike: {
+      textDecoration: "line-through",
+      color: theme.palette.grey[400],
+      fontSize: "smaller"
+    }
+  }),
+  { name: "DiscountedPrice" }
+);

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -281,6 +281,9 @@ export const fragmentOrderDetails = gql`
       name
       currencyCode
       slug
+      defaultCountry {
+        code
+      }
     }
     isPaid
   }

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -469,6 +469,11 @@ export interface OrderDetailsFragment_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDetailsFragment_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDetailsFragment_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -476,6 +481,7 @@ export interface OrderDetailsFragment_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDetailsFragment_channel_defaultCountry;
 }
 
 export interface OrderDetailsFragment {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -360,7 +360,7 @@ export function addressToAddressInput<T>(
   const { id, __typename, ...rest } = address;
   return {
     ...rest,
-    country: findInEnum(address?.country?.code, CountryCode)
+    country: findInEnum(address.country.code, CountryCode)
   };
 }
 

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -13,6 +13,7 @@ import {
   orderStatusMessages,
   paymentStatusMessages
 } from "./intl";
+import { OrderDetails_order_shippingAddress } from "./orders/types/OrderDetails";
 import {
   MutationResultAdditionalProps,
   PartialMutationProviderOutput,
@@ -351,6 +352,16 @@ export function findInEnum<TEnum extends {}>(needle: string, haystack: TEnum) {
   }
 
   throw new Error(`Key ${needle} not found in enum`);
+}
+
+export function addressToAddressInput<T>(
+  address: T & OrderDetails_order_shippingAddress
+): AddressInput {
+  const { id, __typename, ...rest } = address;
+  return {
+    ...rest,
+    country: findInEnum(address?.country?.code, CountryCode)
+  };
 }
 
 export function findValueInEnum<TEnum extends {}>(

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -2,6 +2,7 @@ import DiscountedPrice from "@saleor/components/DiscountedPrice/DiscountedPrice"
 import Money from "@saleor/components/Money";
 import { SearchOrderVariant_search_edges_node_variants_pricing } from "@saleor/orders/types/SearchOrderVariant";
 import * as React from "react";
+
 import { useStyles } from "./styles";
 
 interface OrderPriceLabelProps {

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -15,10 +15,6 @@ const useStyles = makeStyles(theme => ({
     alignItems: "flex-end",
     justifyContent: "flex-end"
   },
-  subtitle: {
-    color: theme.palette.grey[500],
-    paddingRight: theme.spacing(1)
-  },
   strike: {
     textDecoration: "line-through",
     color: theme.palette.grey[400],

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(
 const OrderPriceLabel: React.FC<OrderPriceLabelProps> = ({ pricing }) => {
   const classes = useStyles();
 
-  if (!!pricing.onSale) {
+  if (pricing.onSale) {
     const { price, priceUndiscounted } = pricing;
     return (
       <div className={classes.percentDiscountLabelContainer}>

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -1,0 +1,47 @@
+import { Typography } from "@material-ui/core";
+import { makeStyles } from "@saleor/macaw-ui";
+import Money from "@saleor/components/Money";
+import * as React from "react";
+import { SearchOrderVariant_search_edges_node_variants_pricing } from "@saleor/orders/types/SearchOrderVariant";
+
+interface OrderPriceLabelProps {
+  pricing: SearchOrderVariant_search_edges_node_variants_pricing;
+}
+
+const useStyles = makeStyles(theme => ({
+  percentDiscountLabelContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    justifyContent: "flex-end"
+  },
+  subtitle: {
+    color: theme.palette.grey[500],
+    paddingRight: theme.spacing(1)
+  },
+  strike: {
+    textDecoration: "line-through",
+    color: theme.palette.grey[400],
+    fontSize: "smaller"
+  }
+}));
+
+const OrderPriceLabel: React.FC<OrderPriceLabelProps> = ({ pricing }) => {
+  const classes = useStyles();
+
+  if (!!pricing.onSale) {
+    const { price, priceUndiscounted } = pricing;
+    return (
+      <div className={classes.percentDiscountLabelContainer}>
+        <Typography className={classes.strike}>
+          <Money money={priceUndiscounted.gross} />
+        </Typography>
+        <Money money={price.gross} />
+      </div>
+    );
+  }
+
+  return <Money money={pricing.priceUndiscounted.gross} />;
+};
+
+export default OrderPriceLabel;

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -1,26 +1,29 @@
 import { Typography } from "@material-ui/core";
-import { makeStyles } from "@saleor/macaw-ui";
 import Money from "@saleor/components/Money";
-import * as React from "react";
+import { makeStyles } from "@saleor/macaw-ui";
 import { SearchOrderVariant_search_edges_node_variants_pricing } from "@saleor/orders/types/SearchOrderVariant";
+import * as React from "react";
 
 interface OrderPriceLabelProps {
   pricing: SearchOrderVariant_search_edges_node_variants_pricing;
 }
 
-const useStyles = makeStyles(theme => ({
-  percentDiscountLabelContainer: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-end",
-    justifyContent: "flex-end"
-  },
-  strike: {
-    textDecoration: "line-through",
-    color: theme.palette.grey[400],
-    fontSize: "smaller"
-  }
-}));
+const useStyles = makeStyles(
+  theme => ({
+    percentDiscountLabelContainer: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "flex-end",
+      justifyContent: "flex-end"
+    },
+    strike: {
+      textDecoration: "line-through",
+      color: theme.palette.grey[400],
+      fontSize: "smaller"
+    }
+  }),
+  { name: "OrderPriceLabel" }
+);
 
 const OrderPriceLabel: React.FC<OrderPriceLabelProps> = ({ pricing }) => {
   const classes = useStyles();

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -1,29 +1,12 @@
-import { Typography } from "@material-ui/core";
+import DiscountedPrice from "@saleor/components/DiscountedPrice/DiscountedPrice";
 import Money from "@saleor/components/Money";
-import { makeStyles } from "@saleor/macaw-ui";
 import { SearchOrderVariant_search_edges_node_variants_pricing } from "@saleor/orders/types/SearchOrderVariant";
 import * as React from "react";
+import { useStyles } from "./styles";
 
 interface OrderPriceLabelProps {
   pricing: SearchOrderVariant_search_edges_node_variants_pricing;
 }
-
-const useStyles = makeStyles(
-  theme => ({
-    percentDiscountLabelContainer: {
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "flex-end",
-      justifyContent: "flex-end"
-    },
-    strike: {
-      textDecoration: "line-through",
-      color: theme.palette.grey[400],
-      fontSize: "smaller"
-    }
-  }),
-  { name: "OrderPriceLabel" }
-);
 
 const OrderPriceLabel: React.FC<OrderPriceLabelProps> = ({ pricing }) => {
   const classes = useStyles();
@@ -32,10 +15,10 @@ const OrderPriceLabel: React.FC<OrderPriceLabelProps> = ({ pricing }) => {
     const { price, priceUndiscounted } = pricing;
     return (
       <div className={classes.percentDiscountLabelContainer}>
-        <Typography className={classes.strike}>
-          <Money money={priceUndiscounted.gross} />
-        </Typography>
-        <Money money={price.gross} />
+        <DiscountedPrice
+          discountedPrice={price.gross}
+          regularPrice={priceUndiscounted.gross}
+        />
       </div>
     );
   }

--- a/src/orders/components/OrderPriceLabel/styles.ts
+++ b/src/orders/components/OrderPriceLabel/styles.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    percentDiscountLabelContainer: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "flex-end",
+      justifyContent: "flex-end"
+    }
+  }),
+  { name: "OrderPriceLabel" }
+);

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -16,7 +16,6 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
-import Money from "@saleor/components/Money";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import TableCellAvatar from "@saleor/components/TableCellAvatar";
 import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -36,6 +36,7 @@ import {
   SearchOrderVariant_search_edges_node,
   SearchOrderVariant_search_edges_node_variants
 } from "../../types/SearchOrderVariant";
+import OrderPriceLabel from "../OrderPriceLabel/OrderPriceLabel";
 
 const useStyles = makeStyles(
   theme => ({
@@ -363,9 +364,7 @@ const OrderProductAddDialog: React.FC<OrderProductAddDialogProps> = props => {
                             </div>
                           </TableCell>
                           <TableCell className={classes.textRight}>
-                            {variant?.channelListings[0]?.price && (
-                              <Money money={variant.channelListings[0].price} />
-                            )}
+                            <OrderPriceLabel pricing={variant.pricing} />
                           </TableCell>
                         </TableRow>
                       ))}

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -825,7 +825,11 @@ export const order = (placeholder: string): OrderDetails_order => ({
     currencyCode: "USD",
     id: "123454",
     isActive: true,
-    name: "Default Channel"
+    name: "Default Channel",
+    defaultCountry: {
+      code: "CA",
+      __typename: "CountryDisplay"
+    }
   },
   created: "2018-09-11T09:37:28.185874+00:00",
   customerNote: "Lorem ipsum dolor sit amet",
@@ -1401,7 +1405,11 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
     currencyCode: "USD",
     id: "123454",
     isActive: true,
-    name: "Default Channel"
+    name: "Default Channel",
+    defaultCountry: {
+      code: "CA",
+      __typename: "CountryDisplay"
+    }
   },
   created: "2018-09-20T23:23:39.811428+00:00",
   customerNote: "Lorem ipsum dolor sit",
@@ -1673,7 +1681,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjAy",
         name: "500ml",
-        sku: "93855755"
+        sku: "93855755",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
@@ -1711,7 +1739,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjAz",
         name: "1l",
-        sku: "43226647"
+        sku: "43226647",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
@@ -1749,7 +1797,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjA0",
         name: "2l",
-        sku: "80884671"
+        sku: "80884671",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       }
     ]
   },
@@ -1798,7 +1866,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjEx",
         name: "500ml",
-        sku: "43200242"
+        sku: "43200242",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
@@ -1836,7 +1924,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjEy",
         name: "1l",
-        sku: "79129513"
+        sku: "79129513",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
@@ -1874,7 +1982,27 @@ export const orderLineSearch = (
         ],
         id: "UHJvZHVjdFZhcmlhbnQ6MjEz",
         name: "2l",
-        sku: "75799450"
+        sku: "75799450",
+        pricing: {
+          __typename: "VariantPricingInfo",
+          onSale: false,
+          price: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          },
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            gross: {
+              amount: 1,
+              currency: "USD",
+              __typename: "Money"
+            }
+          }
+        }
       }
     ]
   }

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -164,11 +164,14 @@ export const useOrderQuery = makeQuery<OrderDetails, OrderDetailsVariables>(
 );
 
 export const searchOrderVariant = gql`
+  ${fragmentMoney}
+
   query SearchOrderVariant(
     $channel: String!
     $first: Int!
     $query: String!
     $after: String
+    $address: AddressInput
   ) {
     search: products(
       first: $first
@@ -187,6 +190,19 @@ export const searchOrderVariant = gql`
             id
             name
             sku
+            pricing(address: $address) {
+              priceUndiscounted {
+                gross {
+                  ...Money
+                }
+              }
+              price {
+                gross {
+                  ...Money
+                }
+              }
+              onSale
+            }
             channelListings {
               channel {
                 id

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -478,6 +478,11 @@ export interface FulfillOrder_orderFulfill_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface FulfillOrder_orderFulfill_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface FulfillOrder_orderFulfill_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -485,6 +490,7 @@ export interface FulfillOrder_orderFulfill_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: FulfillOrder_orderFulfill_order_channel_defaultCountry;
 }
 
 export interface FulfillOrder_orderFulfill_order {

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -476,6 +476,11 @@ export interface OrderCancel_orderCancel_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderCancel_orderCancel_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderCancel_orderCancel_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderCancel_orderCancel_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderCancel_orderCancel_order_channel_defaultCountry;
 }
 
 export interface OrderCancel_orderCancel_order {

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -476,6 +476,11 @@ export interface OrderCapture_orderCapture_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderCapture_orderCapture_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderCapture_orderCapture_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderCapture_orderCapture_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderCapture_orderCapture_order_channel_defaultCountry;
 }
 
 export interface OrderCapture_orderCapture_order {

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -476,6 +476,11 @@ export interface OrderConfirm_orderConfirm_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderConfirm_orderConfirm_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderConfirm_orderConfirm_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderConfirm_orderConfirm_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderConfirm_orderConfirm_order_channel_defaultCountry;
 }
 
 export interface OrderConfirm_orderConfirm_order {

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -469,6 +469,11 @@ export interface OrderDetails_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDetails_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDetails_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -476,6 +481,7 @@ export interface OrderDetails_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDetails_order_channel_defaultCountry;
 }
 
 export interface OrderDetails_order {

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -476,6 +476,11 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDiscountAdd_orderDiscountAdd_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDiscountAdd_orderDiscountAdd_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDiscountAdd_orderDiscountAdd_order_channel_defaultCountry;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order {

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -476,6 +476,11 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDiscountDelete_orderDiscountDelete_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDiscountDelete_orderDiscountDelete_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDiscountDelete_orderDiscountDelete_order_channel_defaultCountry;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order {

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -476,6 +476,11 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDiscountUpdate_orderDiscountUpdate_order_channel_defaultCountry;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order {

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -476,6 +476,11 @@ export interface OrderDraftCancel_draftOrderDelete_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDraftCancel_draftOrderDelete_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDraftCancel_draftOrderDelete_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDraftCancel_draftOrderDelete_order_channel_defaultCountry;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order {

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -476,6 +476,11 @@ export interface OrderDraftFinalize_draftOrderComplete_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDraftFinalize_draftOrderComplete_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDraftFinalize_draftOrderComplete_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDraftFinalize_draftOrderComplete_order_channel_defaultCountry;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order {

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -476,6 +476,11 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderDraftUpdate_draftOrderUpdate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderDraftUpdate_draftOrderUpdate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderDraftUpdate_draftOrderUpdate_order_channel_defaultCountry;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order {

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -476,6 +476,11 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderFulfillmentCancel_orderFulfillmentCancel_order_channel_defaultCountry;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order {

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -571,6 +571,11 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   status: JobStatusEnum;
 }
 
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -578,6 +583,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_channel_defaultCountry;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order {

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -476,6 +476,11 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   status: JobStatusEnum;
 }
 
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_channel_defaultCountry;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order {

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -476,6 +476,11 @@ export interface OrderLineDelete_orderLineDelete_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderLineDelete_orderLineDelete_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderLineDelete_orderLineDelete_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderLineDelete_orderLineDelete_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderLineDelete_orderLineDelete_order_channel_defaultCountry;
 }
 
 export interface OrderLineDelete_orderLineDelete_order {

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -476,6 +476,11 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_invoices 
   status: JobStatusEnum;
 }
 
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderLineDiscountRemove_orderLineDiscountRemove_order_channel_defaultCountry;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order {

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -476,6 +476,11 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_invoices 
   status: JobStatusEnum;
 }
 
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel_defaultCountry;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order {

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -476,6 +476,11 @@ export interface OrderLineUpdate_orderLineUpdate_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderLineUpdate_orderLineUpdate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderLineUpdate_orderLineUpdate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderLineUpdate_orderLineUpdate_order_channel_defaultCountry;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order {

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -476,6 +476,11 @@ export interface OrderLinesAdd_orderLinesCreate_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderLinesAdd_orderLinesCreate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderLinesAdd_orderLinesCreate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderLinesAdd_orderLinesCreate_order_channel_defaultCountry;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order {

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -476,6 +476,11 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderMarkAsPaid_orderMarkAsPaid_order_channel_defaultCountry;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order {

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -476,6 +476,11 @@ export interface OrderRefund_orderRefund_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderRefund_orderRefund_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderRefund_orderRefund_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderRefund_orderRefund_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderRefund_orderRefund_order_channel_defaultCountry;
 }
 
 export interface OrderRefund_orderRefund_order {

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -484,6 +484,11 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -491,6 +496,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderShippingMethodUpdate_orderUpdateShipping_order_channel_defaultCountry;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order {

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -476,6 +476,11 @@ export interface OrderUpdate_orderUpdate_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderUpdate_orderUpdate_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderUpdate_orderUpdate_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderUpdate_orderUpdate_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderUpdate_orderUpdate_order_channel_defaultCountry;
 }
 
 export interface OrderUpdate_orderUpdate_order {

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -476,6 +476,11 @@ export interface OrderVoid_orderVoid_order_invoices {
   status: JobStatusEnum;
 }
 
+export interface OrderVoid_orderVoid_order_channel_defaultCountry {
+  __typename: "CountryDisplay";
+  code: string;
+}
+
 export interface OrderVoid_orderVoid_order_channel {
   __typename: "Channel";
   isActive: boolean;
@@ -483,6 +488,7 @@ export interface OrderVoid_orderVoid_order_channel {
   name: string;
   currencyCode: string;
   slug: string;
+  defaultCountry: OrderVoid_orderVoid_order_channel_defaultCountry;
 }
 
 export interface OrderVoid_orderVoid_order {

--- a/src/orders/types/SearchOrderVariant.ts
+++ b/src/orders/types/SearchOrderVariant.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { AddressInput } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL query operation: SearchOrderVariant
 // ====================================================
@@ -10,6 +12,35 @@
 export interface SearchOrderVariant_search_edges_node_thumbnail {
   __typename: "Image";
   url: string;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted {
+  __typename: "TaxedMoney";
+  gross: SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted_gross;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing_price_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing_price {
+  __typename: "TaxedMoney";
+  gross: SearchOrderVariant_search_edges_node_variants_pricing_price_gross;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing {
+  __typename: "VariantPricingInfo";
+  priceUndiscounted: SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted | null;
+  price: SearchOrderVariant_search_edges_node_variants_pricing_price | null;
+  onSale: boolean | null;
 }
 
 export interface SearchOrderVariant_search_edges_node_variants_channelListings_channel {
@@ -37,6 +68,7 @@ export interface SearchOrderVariant_search_edges_node_variants {
   id: string;
   name: string;
   sku: string;
+  pricing: SearchOrderVariant_search_edges_node_variants_pricing | null;
   channelListings: SearchOrderVariant_search_edges_node_variants_channelListings[] | null;
 }
 
@@ -76,4 +108,5 @@ export interface SearchOrderVariantVariables {
   first: number;
   query: string;
   after?: string | null;
+  address?: AddressInput | null;
 }

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -1,7 +1,7 @@
 import { IMoney, subtractMoney } from "@saleor/components/Money";
 import { FormsetData } from "@saleor/hooks/useFormset";
 import { addressToAddressInput } from "@saleor/misc";
-import { AddressInput } from "@saleor/types/globalTypes";
+import { AddressInput, CountryCode } from "@saleor/types/globalTypes";
 
 import {
   LineItemData,
@@ -211,14 +211,16 @@ export function mergeRepeatedOrderLines(
   }, Array<OrderDetails_order_fulfillments_lines>());
 }
 
-export const getVariantSearchAddress = (order: OrderDetails_order) => {
-  if (!!order.shippingAddress) {
+export const getVariantSearchAddress = (
+  order: OrderDetails_order
+): AddressInput => {
+  if (order.shippingAddress) {
     return addressToAddressInput(order.shippingAddress);
   }
 
-  if (!!order.billingAddress) {
+  if (order.billingAddress) {
     return addressToAddressInput(order.billingAddress);
   }
 
-  return { country: order.channel.defaultCountry.code } as AddressInput;
+  return { country: order.channel.defaultCountry.code as CountryCode };
 };

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -1,5 +1,7 @@
 import { IMoney, subtractMoney } from "@saleor/components/Money";
 import { FormsetData } from "@saleor/hooks/useFormset";
+import { addressToAddressInput } from "@saleor/misc";
+import { AddressInput } from "@saleor/types/globalTypes";
 
 import {
   LineItemData,
@@ -208,3 +210,15 @@ export function mergeRepeatedOrderLines(
     return prev;
   }, Array<OrderDetails_order_fulfillments_lines>());
 }
+
+export const getVariantSearchAddress = (order: OrderDetails_order) => {
+  if (!!order.shippingAddress) {
+    return addressToAddressInput(order.shippingAddress);
+  }
+
+  if (!!order.billingAddress) {
+    return addressToAddressInput(order.billingAddress);
+  }
+
+  return { country: order.channel.defaultCountry.code } as AddressInput;
+};

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@saleor/orders/components/OrderCustomerChangeDialog/form";
 import OrderCustomerChangeDialog from "@saleor/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog";
 import { OrderDetails } from "@saleor/orders/types/OrderDetails";
+import { getVariantSearchAddress } from "@saleor/orders/utils/data";
 import { OrderDiscountProvider } from "@saleor/products/components/OrderDiscountProviders/OrderDiscountProvider";
 import { OrderLineDiscountProvider } from "@saleor/products/components/OrderDiscountProviders/OrderLineDiscountProvider";
 import useCustomerSearch from "@saleor/searches/useCustomerSearch";
@@ -73,7 +74,11 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     search: variantSearch,
     result: variantSearchOpts
   } = useOrderVariantSearch({
-    variables: { ...DEFAULT_INITIAL_SEARCH_DATA, channel: order.channel.slug }
+    variables: {
+      ...DEFAULT_INITIAL_SEARCH_DATA,
+      channel: order.channel.slug,
+      address: getVariantSearchAddress(order)
+    }
   });
 
   const {


### PR DESCRIPTION
I want to merge this change because I want to change pricing from channel to variant. 

3.1 PR: https://github.com/saleor/saleor-dashboard/pull/1698

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
New "sale" price labels
![image](https://user-images.githubusercontent.com/13994677/146794850-885e6a4f-5e01-4321-a021-cc1c427e1312.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
