### PR TITLE
Disable save in product create & edit when product name is empty (#1551)

### DIFF
--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -327,16 +327,35 @@ function useProductCreateForm(
   const data = getData();
   const submit = () => onSubmit(data);
 
-  const disabled =
-    (!opts.selectedProductType?.hasVariants &&
-      (data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      ) ||
-        !data.category)) ||
-    (data.isPreorder &&
+  const shouldEnableSave = () => {
+    if (!data.name || !data.productType) {
+      return false;
+    }
+
+    if (
+      data.isPreorder &&
       data.hasPreorderEndDate &&
-      !!form.errors.preorderEndDateTime);
+      !!form.errors.preorderEndDateTime
+    ) {
+      return false;
+    }
+
+    if (opts.selectedProductType?.hasVariants) {
+      return true;
+    }
+
+    const hasInvalidChannelListingPrices = data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    );
+
+    if (hasInvalidChannelListingPrices) {
+      return false;
+    }
+    return true;
+  };
+
+  const disabled = !shouldEnableSave();
 
   return {
     change: handleChange,

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -386,15 +386,35 @@ function useProductUpdateForm(
   const submit = async () =>
     handleFormSubmit(getSubmitData(), handleSubmit, setChanged);
 
-  const disabled =
-    (!opts.hasVariants &&
-      data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      )) ||
-    (data.isPreorder &&
+  const shouldEnableSave = () => {
+    if (!data.name) {
+      return false;
+    }
+
+    if (
+      data.isPreorder &&
       data.hasPreorderEndDate &&
-      !!form.errors.preorderEndDateTime);
+      !!form.errors.preorderEndDateTime
+    ) {
+      return false;
+    }
+
+    if (opts.hasVariants) {
+      return true;
+    }
+
+    const hasInvalidChannelListingPrices = data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    );
+
+    if (hasInvalidChannelListingPrices) {
+      return false;
+    }
+    return true;
+  };
+
+  const disabled = !shouldEnableSave();
 
   return {
     change: handleChange,


### PR DESCRIPTION
Cherry pick of #1551 
**SKU validation is deleted because SKU field is not required in 3.1**

* disable save in product edit & create when name is empty

* code review refactor

* Fix disabled button

Co-authored-by: Magdalena Markusik <magdalena@markusik.com>

* fix incorrect logic

* fix incorrect logic

* fix disable form on product variant

Co-authored-by: Magdalena Markusik <magdalena@markusik.com>



<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
