### PR TITLE
Update password reset pages

### DIFF
--- a/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
@@ -42,9 +42,15 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
 
         return (
           <>
+            <Typography variant="h3" className={classes.header}>
+              <FormattedMessage
+                defaultMessage="Set up new password"
+                description="page title"
+              />
+            </Typography>
             {!!error && <div className={classes.panel}>{error}</div>}
-            <Typography>
-              <FormattedMessage defaultMessage="Please set up a new password." />
+            <Typography variant="caption" color="textSecondary">
+              <FormattedMessage defaultMessage="Please set up a new password for your account. Repeat your new password to make sure you will be able to remember it." />
             </Typography>
             <FormSpacer />
             <TextField

--- a/src/auth/components/ResetPasswordPage/ResetPasswordPage.stories.tsx
+++ b/src/auth/components/ResetPasswordPage/ResetPasswordPage.stories.tsx
@@ -9,6 +9,7 @@ import ResetPasswordPage, { ResetPasswordPageProps } from "./ResetPasswordPage";
 const props: ResetPasswordPageProps = {
   disabled: false,
   error: undefined,
+  onBack: () => undefined,
   onSubmit: () => undefined
 };
 storiesOf("Views / Authentication / Reset password", module)

--- a/src/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
@@ -36,7 +36,7 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = props => {
           </Typography>
           {!!error && <div className={classes.panel}>{error}</div>}
           <Typography variant="caption" color="textSecondary">
-            <FormattedMessage defaultMessage="Provide us with an email - if we find it in out database we will send you a link to reset your password. You should be able to find it in your inbox in next couple of minutes." />
+            <FormattedMessage defaultMessage="Provide us with an email - if we find it in our database we will send you a link to reset your password. You should be able to find it in your inbox in the next couple of minutes." />
           </Typography>
           <FormSpacer />
           <TextField

--- a/src/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
@@ -2,7 +2,7 @@ import { TextField, Typography } from "@material-ui/core";
 import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { commonMessages } from "@saleor/intl";
-import { Button } from "@saleor/macaw-ui";
+import { ArrowRightIcon, Button, IconButton } from "@saleor/macaw-ui";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -14,11 +14,12 @@ export interface ResetPasswordPageFormData {
 export interface ResetPasswordPageProps {
   disabled: boolean;
   error: string;
+  onBack: () => void;
   onSubmit: (data: ResetPasswordPageFormData) => void;
 }
 
 const ResetPasswordPage: React.FC<ResetPasswordPageProps> = props => {
-  const { disabled, error, onSubmit } = props;
+  const { disabled, error, onBack, onSubmit } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
@@ -27,9 +28,15 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = props => {
     <Form initial={{ email: "" }} onSubmit={onSubmit}>
       {({ change: handleChange, data, submit: handleSubmit }) => (
         <>
+          <IconButton className={classes.backBtn} onClick={onBack}>
+            <ArrowRightIcon className={classes.arrow} />
+          </IconButton>
+          <Typography variant="h3" className={classes.header}>
+            <FormattedMessage defaultMessage="Reset password" />
+          </Typography>
           {!!error && <div className={classes.panel}>{error}</div>}
-          <Typography>
-            <FormattedMessage defaultMessage="Forgot your password? Don't worry, we'll reset it for you." />
+          <Typography variant="caption" color="textSecondary">
+            <FormattedMessage defaultMessage="Provide us with an email - if we find it in out database we will send you a link to reset your password. You should be able to find it in your inbox in next couple of minutes." />
           </Typography>
           <FormSpacer />
           <TextField
@@ -54,7 +61,7 @@ const ResetPasswordPage: React.FC<ResetPasswordPageProps> = props => {
             type="submit"
           >
             <FormattedMessage
-              defaultMessage="Send Instructions"
+              defaultMessage="Send an email with reset link"
               description="password reset, button"
             />
           </Button>

--- a/src/auth/components/ResetPasswordSuccessPage/ResetPasswordSuccessPage.tsx
+++ b/src/auth/components/ResetPasswordSuccessPage/ResetPasswordSuccessPage.tsx
@@ -20,6 +20,9 @@ const ResetPasswordSuccessPage: React.FC<ResetPasswordSuccessPageProps> = props 
 
   return (
     <>
+      <Typography variant="h3" className={classes.header}>
+        <FormattedMessage defaultMessage="Reset password" />
+      </Typography>
       <Typography>
         <FormattedMessage defaultMessage="Success! In a few minutes you’ll receive a message with instructions on how to reset your password." />
       </Typography>

--- a/src/auth/components/styles.ts
+++ b/src/auth/components/styles.ts
@@ -2,6 +2,12 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 const useStyles = makeStyles(
   theme => ({
+    arrow: {
+      transform: "rotate(180deg)"
+    },
+    backBtn: {
+      marginBottom: theme.spacing(3)
+    },
     buttonContainer: {
       display: "flex",
       justifyContent: "flex-end"

--- a/src/auth/views/ResetPassword.tsx
+++ b/src/auth/views/ResetPassword.tsx
@@ -53,6 +53,7 @@ const ResetPasswordView: React.FC = () => {
           <ResetPasswordPage
             disabled={requestPasswordResetOpts.loading}
             error={error}
+            onBack={() => navigate(APP_MOUNT_URI)}
             onSubmit={handleSubmit}
           />
         );

--- a/src/auth/views/ResetPasswordSuccess.tsx
+++ b/src/auth/views/ResetPasswordSuccess.tsx
@@ -1,3 +1,4 @@
+import { APP_MOUNT_URI } from "@saleor/config";
 import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 
@@ -6,7 +7,7 @@ import ResetPasswordSuccessPage from "../components/ResetPasswordSuccessPage";
 const ResetPasswordSuccessView: React.FC = () => {
   const navigate = useNavigator();
 
-  return <ResetPasswordSuccessPage onBack={() => navigate("/")} />;
+  return <ResetPasswordSuccessPage onBack={() => navigate(APP_MOUNT_URI)} />;
 };
 ResetPasswordSuccessView.displayName = "ResetPasswordSuccessView";
 export default ResetPasswordSuccessView;


### PR DESCRIPTION
I want to merge this change because it updates design on password recorery pages.

**PR intended to be tested with API branch:** 3.0

### Screenshots
<img width="1411" alt="Zrzut ekranu 2021-12-22 o 15 46 17" src="https://user-images.githubusercontent.com/6833443/147112392-d0c124dc-2571-4ede-bf93-392eb5cc4e15.png">
<img width="1407" alt="Zrzut ekranu 2021-12-22 o 15 47 03" src="https://user-images.githubusercontent.com/6833443/147112403-f1a05f35-6b8d-4e54-95cb-c09b1562b26e.png">
te

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
