### PR TITLE
Shipping zones button fix

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1560,13 +1560,17 @@
     "context": "add shipping zone title",
     "string": "Add Shipping Zones"
   },
+  "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_allSelectedMessage": {
+    "context": "all selected zones card message",
+    "string": "All available shipping zones have been selected"
+  },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_subtitle": {
     "context": "card subtitle",
     "string": "Select Shipping Zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels."
   },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_title": {
     "context": "title",
-    "string": "{zonesCount} Shipping Zones"
+    "string": "{zonesCount} / {totalCount} Shipping Zones"
   },
   "src_dot_channels_dot_pages_dot_ChannelsListPage_dot_2754800034": {
     "context": "alert",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1566,7 +1566,7 @@
   },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_subtitle": {
     "context": "card subtitle",
-    "string": "Select shipping zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels."
+    "string": "Select shipping zones that will be supplied via this channel. You can assign shipping zones to multiple channels."
   },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_title": {
     "context": "title",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1566,11 +1566,11 @@
   },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_subtitle": {
     "context": "card subtitle",
-    "string": "Select Shipping Zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels."
+    "string": "Select shipping zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels."
   },
   "src_dot_channels_dot_components_dot_ShippingZonesCard_dot_title": {
     "context": "title",
-    "string": "{zonesCount} / {totalCount} Shipping Zones"
+    "string": "{zonesCount} / {totalCount} shipping zones"
   },
   "src_dot_channels_dot_pages_dot_ChannelsListPage_dot_2754800034": {
     "context": "alert",

--- a/src/apps/views/AppDetails/AppDetails.tsx
+++ b/src/apps/views/AppDetails/AppDetails.tsx
@@ -1,3 +1,4 @@
+import NotFoundPage from "@saleor/components/NotFoundPage";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import getAppErrorMessage from "@saleor/utils/errors/app";

--- a/src/apps/views/AppDetails/AppDetails.tsx
+++ b/src/apps/views/AppDetails/AppDetails.tsx
@@ -28,7 +28,7 @@ interface AppDetailsProps {
 }
 
 export const AppDetails: React.FC<AppDetailsProps> = ({ id, params }) => {
-  const { data, loading, refetch } = useAppDetails({
+  const { data, loading, refetch, error } = useAppDetails({
     displayLoader: true,
     variables: { id }
   });

--- a/src/apps/views/AppDetails/AppDetails.tsx
+++ b/src/apps/views/AppDetails/AppDetails.tsx
@@ -1,4 +1,3 @@
-import NotFoundPage from "@saleor/components/NotFoundPage";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import getAppErrorMessage from "@saleor/utils/errors/app";
@@ -28,7 +27,7 @@ interface AppDetailsProps {
 }
 
 export const AppDetails: React.FC<AppDetailsProps> = ({ id, params }) => {
-  const { data, loading, refetch, error } = useAppDetails({
+  const { data, loading, refetch } = useAppDetails({
     displayLoader: true,
     variables: { id }
   });

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.stories.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.stories.tsx
@@ -25,7 +25,8 @@ const baseProps = {
   fetchMoreShippingZones: {
     loading: false,
     hasMore: false,
-    onFetchMore: () => undefined
+    onFetchMore: () => undefined,
+    totalCount: 0
   },
   shippingZones: [],
   shippingZonesChoices: shippingZones as ChannelShippingZones

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   subtitle: {
     defaultMessage:
-      "Select Shipping Zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels.",
+      "Select shipping zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels.",
     description: "card subtitle"
   },
   allSelectedMessage: {

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -6,6 +6,7 @@ import {
   Typography
 } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
+import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -38,26 +39,6 @@ const useStyles = makeStyles(
     }
   }),
   { name: "ShippingZonesCard" }
-);
-
-const useExpanderStyles = makeStyles(
-  () => ({
-    // empty expanded needed for mui to use root styles
-    expanded: {},
-    root: {
-      boxShadow: "none",
-
-      "&:before": {
-        content: "none"
-      },
-
-      "&$expanded": {
-        margin: 0,
-        border: "none"
-      }
-    }
-  }),
-  { name: "ShippingZonesCardExpander" }
 );
 
 type ShippingZonesCardProps = ShippingZonesProps;

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -24,8 +24,41 @@ const messages = defineMessages({
     defaultMessage:
       "Select Shipping Zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels.",
     description: "card subtitle"
+  },
+  allSelectedMessage: {
+    defaultMessage: "All available shipping zones have been selected",
+    description: "all selected zones card message"
   }
 });
+
+const useStyles = makeStyles(
+  theme => ({
+    infoMessage: {
+      padding: theme.spacing(3)
+    }
+  }),
+  { name: "ShippingZonesCard" }
+);
+
+const useExpanderStyles = makeStyles(
+  () => ({
+    // empty expanded needed for mui to use root styles
+    expanded: {},
+    root: {
+      boxShadow: "none",
+
+      "&:before": {
+        content: "none"
+      },
+
+      "&$expanded": {
+        margin: 0,
+        border: "none"
+      }
+    }
+  }),
+  { name: "ShippingZonesCardExpander" }
+);
 
 type ShippingZonesCardProps = ShippingZonesProps;
 
@@ -37,6 +70,7 @@ const ShippingZonesCard: React.FC<ShippingZonesCardProps> = props => {
   } = props;
 
   const expanderClasses = useExpanderStyles({});
+  const classes = useStyles();
   const intl = useIntl();
 
   const hasMoreZonesToBeSelected = totalCount !== shippingZones.length;
@@ -48,7 +82,10 @@ const ShippingZonesCard: React.FC<ShippingZonesCardProps> = props => {
         <Typography>{intl.formatMessage(messages.subtitle)}</Typography>
       </CardContent>
       <Accordion classes={expanderClasses}>
-        <ShippingZonesListHeader shippingZones={shippingZones} />
+        <ShippingZonesListHeader
+          shippingZones={shippingZones}
+          totalCount={totalCount}
+        />
         <Divider />
         {shippingZones.map(zone => (
           <ShippingZoneItem zone={zone} onDelete={removeShippingZone} />

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -92,7 +92,15 @@ const ShippingZonesCard: React.FC<ShippingZonesCardProps> = props => {
         ))}
         {hasMoreZonesToBeSelected ? (
           <ShippingZonesCardListFooter {...props} />
-        ) : null}
+        ) : (
+          <Typography
+            color="textSecondary"
+            variant="subtitle1"
+            className={classes.infoMessage}
+          >
+            {intl.formatMessage(messages.allSelectedMessage)}
+          </Typography>
+        )}
       </Accordion>
     </Card>
   );

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   subtitle: {
     defaultMessage:
-      "Select shipping zones that will be supplied via this channel. You can assign Shipping Zones to multiple channels.",
+      "Select shipping zones that will be supplied via this channel. You can assign shipping zones to multiple channels.",
     description: "card subtitle"
   },
   allSelectedMessage: {

--- a/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(
 
 const messages = defineMessages({
   title: {
-    defaultMessage: "{zonesCount} / {totalCount} Shipping Zones",
+    defaultMessage: "{zonesCount} / {totalCount} shipping zones",
     description: "title"
   }
 });

--- a/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
@@ -41,17 +41,19 @@ const useStyles = makeStyles(
 
 const messages = defineMessages({
   title: {
-    defaultMessage: "{zonesCount} Shipping Zones",
+    defaultMessage: "{zonesCount} / {totalCount} Shipping Zones",
     description: "title"
   }
 });
 
 interface ShippingZonesListHeaderProps {
   shippingZones: ChannelShippingZones;
+  totalCount: number;
 }
 
 const ShippingZonesListHeader: React.FC<ShippingZonesListHeaderProps> = ({
-  shippingZones
+  shippingZones,
+  totalCount
 }) => {
   const classes = useStyles({});
   const intl = useIntl();
@@ -61,7 +63,8 @@ const ShippingZonesListHeader: React.FC<ShippingZonesListHeaderProps> = ({
       <AccordionSummary expandIcon={<IconChevronDown />} classes={classes}>
         <Typography variant="subtitle2" color="textSecondary">
           {intl.formatMessage(messages.title, {
-            zonesCount: shippingZones.length
+            zonesCount: shippingZones.length,
+            totalCount
           })}
         </Typography>
       </AccordionSummary>

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
@@ -42,7 +42,8 @@ const props: ChannelDetailsPageProps = {
   fetchMoreShippingZones: {
     loading: false,
     hasMore: false,
-    onFetchMore: () => undefined
+    onFetchMore: () => undefined,
+    totalCount: 0
   }
 };
 


### PR DESCRIPTION
I want to merge this change because it shows the user more clearly how many zones has been selected. The submitted "bug" isn't a bug - it's just a confusion caused by a button not appearing when all available zones are selected. 

3.1 PR: https://github.com/saleor/saleor-dashboard/pull/1804

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/13994677/147237390-c73586d1-96e5-4117-ab2c-b6f1b31db600.png)

After:
![image](https://user-images.githubusercontent.com/13994677/147237446-523aad79-e695-4a2b-bade-65d7ff481875.png)
![image](https://user-images.githubusercontent.com/13994677/147237486-838abab5-393d-4832-ab3e-5b8029fbbe76.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
