### PR TITLE
Add product type link in product details view 

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -65,7 +65,7 @@ const Link: React.FC<LinkProps> = props => {
       [classes.disabled]: disabled
     }),
     onClick: event => {
-      if (disabled) {
+      if (disabled || !onClick) {
         return;
       }
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -3,6 +3,7 @@ import { TypographyProps } from "@material-ui/core/Typography";
 import { makeStyles } from "@saleor/macaw-ui";
 import classNames from "classnames";
 import React from "react";
+import { Link as RouterLink } from "react-router-dom";
 
 const useStyles = makeStyles(
   theme => ({
@@ -19,6 +20,9 @@ const useStyles = makeStyles(
     underline: {
       textDecoration: "underline"
     },
+    noUnderline: {
+      textDecoration: "none"
+    },
     disabled: {
       cursor: "default",
       color: theme.palette.textHighlighted.inactive
@@ -27,11 +31,14 @@ const useStyles = makeStyles(
   { name: "Link" }
 );
 
+const isExternalURL = url => /^https?:\/\//.test(url);
+
 interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string;
   color?: "primary" | "secondary";
   underline?: boolean;
   typographyProps?: TypographyProps;
-  onClick: () => void;
+  onClick?: () => void;
   disabled?: boolean;
 }
 
@@ -43,32 +50,47 @@ const Link: React.FC<LinkProps> = props => {
     underline = false,
     onClick,
     disabled,
+    href,
     ...linkProps
   } = props;
 
   const classes = useStyles(props);
 
-  return (
-    <Typography
-      component="a"
-      className={classNames(className, {
-        [classes.root]: true,
-        [classes[color]]: true,
-        [classes.underline]: underline,
-        [classes.disabled]: disabled
-      })}
-      onClick={event => {
-        if (disabled) {
-          return;
-        }
+  const commonLinkProps = {
+    className: classNames(className, {
+      [classes.root]: true,
+      [classes[color]]: true,
+      [classes.underline]: underline,
+      [classes.noUnderline]: !underline,
+      [classes.disabled]: disabled
+    }),
+    onClick: event => {
+      if (disabled) {
+        return;
+      }
 
-        event.preventDefault();
-        onClick();
-      }}
-      {...linkProps}
-    >
-      {children}
-    </Typography>
+      event.preventDefault();
+      onClick();
+    },
+    ...linkProps
+  };
+
+  return (
+    <>
+      {!!href && !isExternalURL(href) ? (
+        <RouterLink to={disabled ? undefined : href} {...commonLinkProps}>
+          {children}
+        </RouterLink>
+      ) : (
+        <Typography
+          component="a"
+          href={disabled ? undefined : href}
+          {...commonLinkProps}
+        >
+          {children}
+        </Typography>
+      )}
+    </>
   );
 };
 Link.displayName = "Link";

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import packageInfo from "../package.json";
 import { SearchVariables } from "./hooks/makeSearch";
 import { ListSettings, ListViews, Pagination } from "./types";
 
-export const APP_MOUNT_URI = process.env.APP_MOUNT_URI;
+export const APP_MOUNT_URI = process.env.APP_MOUNT_URI || "/";
 export const APP_DEFAULT_URI = "/";
 export const API_URI = process.env.API_URI;
 export const SW_INTERVAL = parseInt(process.env.SW_INTERVAL, 0);

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -292,7 +292,7 @@ export function getUserInitials(user?: User) {
 }
 
 export function createHref(url: string) {
-  return urlJoin(APP_MOUNT_URI, url);
+  return !APP_MOUNT_URI ? url : urlJoin(APP_MOUNT_URI, url);
 }
 
 interface AnyEvent {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -292,7 +292,7 @@ export function getUserInitials(user?: User) {
 }
 
 export function createHref(url: string) {
-  return !APP_MOUNT_URI ? url : urlJoin(APP_MOUNT_URI, url);
+  return urlJoin(APP_MOUNT_URI, url);
 }
 
 interface AnyEvent {

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -3,6 +3,7 @@ import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import { FormSpacer } from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
+import Link from "@saleor/components/Link";
 import MultiAutocompleteSelectField, {
   MultiAutocompleteChoiceType
 } from "@saleor/components/MultiAutocompleteSelectField";
@@ -11,8 +12,10 @@ import SingleAutocompleteSelectField, {
 } from "@saleor/components/SingleAutocompleteSelectField";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { ChangeEvent } from "@saleor/hooks/useForm";
+import useNavigator from "@saleor/hooks/useNavigator";
 import { makeStyles } from "@saleor/macaw-ui";
 import { maybe } from "@saleor/misc";
+import { productTypeUrl } from "@saleor/productTypes/urls";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
 import React from "react";
@@ -93,6 +96,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
 
   const classes = useStyles(props);
   const intl = useIntl();
+  const navigate = useNavigator();
 
   const formErrors = getFormErrors(
     ["productType", "category", "collections"],
@@ -130,7 +134,14 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
             <Typography className={classes.label} variant="caption">
               <FormattedMessage defaultMessage="Product Type" />
             </Typography>
-            <Typography>{maybe(() => productType.name, "...")}</Typography>
+            <Link
+              onClick={() =>
+                navigate(productTypeUrl(productType?.id), { resetScroll: true })
+              }
+              disabled={productType?.id === undefined}
+            >
+              {productType?.name ?? "..."}
+            </Link>
             <CardSpacer />
             <Typography className={classes.label} variant="caption">
               <FormattedMessage defaultMessage="Product Type" />

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -138,7 +138,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
               onClick={() =>
                 navigate(productTypeUrl(productType?.id), { resetScroll: true })
               }
-              disabled={productType?.id === undefined}
+              disabled={!productType?.id}
             >
               {productType?.name ?? "..."}
             </Link>

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -14,7 +14,7 @@ import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragme
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import useNavigator from "@saleor/hooks/useNavigator";
 import { makeStyles } from "@saleor/macaw-ui";
-import { maybe } from "@saleor/misc";
+import { createHref, maybe } from "@saleor/misc";
 import { productTypeUrl } from "@saleor/productTypes/urls";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -138,6 +138,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
               onClick={() =>
                 navigate(productTypeUrl(productType?.id), { resetScroll: true })
               }
+              href={createHref(productTypeUrl(productType?.id))}
               disabled={!productType?.id}
             >
               {productType?.name ?? "..."}

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -12,7 +12,6 @@ import SingleAutocompleteSelectField, {
 } from "@saleor/components/SingleAutocompleteSelectField";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { ChangeEvent } from "@saleor/hooks/useForm";
-import useNavigator from "@saleor/hooks/useNavigator";
 import { makeStyles } from "@saleor/macaw-ui";
 import { createHref, maybe } from "@saleor/misc";
 import { productTypeUrl } from "@saleor/productTypes/urls";
@@ -96,7 +95,6 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
 
   const classes = useStyles(props);
   const intl = useIntl();
-  const navigate = useNavigator();
 
   const formErrors = getFormErrors(
     ["productType", "category", "collections"],
@@ -135,9 +133,6 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
               <FormattedMessage defaultMessage="Product Type" />
             </Typography>
             <Link
-              onClick={() =>
-                navigate(productTypeUrl(productType?.id), { resetScroll: true })
-              }
               href={createHref(productTypeUrl(productType?.id) ?? "")}
               disabled={!productType?.id}
             >

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -138,7 +138,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
               onClick={() =>
                 navigate(productTypeUrl(productType?.id), { resetScroll: true })
               }
-              href={createHref(productTypeUrl(productType?.id))}
+              href={createHref(productTypeUrl(productType?.id) ?? "")}
               disabled={!productType?.id}
             >
               {productType?.name ?? "..."}

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
@@ -17,6 +17,7 @@ const channels = createChannelsData(channelsList);
 
 import * as _useNavigator from "@saleor/hooks/useNavigator";
 import Adapter from "enzyme-adapter-react-16";
+import { MemoryRouter } from "react-router-dom";
 
 configure({ adapter: new Adapter() });
 
@@ -86,9 +87,11 @@ describe("Product details page", () => {
   useNavigator.mockImplementation();
   it("can select empty option on attribute", () => {
     const component = mount(
-      <Wrapper>
-        <ProductUpdatePage {...props} />
-      </Wrapper>
+      <MemoryRouter>
+        <Wrapper>
+          <ProductUpdatePage {...props} />
+        </Wrapper>
+      </MemoryRouter>
     );
     expect(component.find(selectors.dropdown).exists()).toBeFalsy();
 

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
@@ -15,10 +15,13 @@ import ProductUpdatePage, { ProductUpdatePageProps } from "./ProductUpdatePage";
 const product = productFixture(placeholderImage);
 const channels = createChannelsData(channelsList);
 
+import * as _useNavigator from "@saleor/hooks/useNavigator";
 import Adapter from "enzyme-adapter-react-16";
+
 configure({ adapter: new Adapter() });
 
 const onSubmit = jest.fn();
+const useNavigator = jest.spyOn(_useNavigator, "default");
 
 const props: ProductUpdatePageProps = {
   ...listActionsProps,
@@ -80,6 +83,7 @@ const selectors = {
 };
 
 describe("Product details page", () => {
+  useNavigator.mockImplementation();
   it("can select empty option on attribute", () => {
     const component = mount(
       <Wrapper>


### PR DESCRIPTION
I want to merge this change because it

- adds product type link in product details view
- improves link component for using `href`

Changes should not affect links in other parts of dashboard with the exception of added `text-decoration: none` if underline is false or undefined in props.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/41952692/149318136-12b493d9-f0d7-440b-b4ef-7cc22714937c.png)

After:
![image](https://user-images.githubusercontent.com/41952692/149318327-3489c2f5-2496-4c26-9cb3-a3df0c6f2d2f.png)



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
