### PR TITLE
Add tests for shipping method for 3.1

### DIFF
--- a/cypress/elements/shipping/shipping-rate-details.js
+++ b/cypress/elements/shipping/shipping-rate-details.js
@@ -8,8 +8,8 @@ export const SHIPPING_RATE_DETAILS = {
     min: '[name="min"]',
     max: '[name="max"]'
   },
-  maxWeightInput: '[name="maxValue"]',
-  minWeightInput: '[name="minValue"]',
+  maxWeightInput: '[name*="maxValue"]',
+  minWeightInput: '[name*="minValue"]',
   minDeliveryTimeInput: '[name="minDays"]',
   maxDeliveryTimeInput: '[name="maxDays"]'
 };

--- a/cypress/elements/shipping/shipping-zone-details.js
+++ b/cypress/elements/shipping/shipping-zone-details.js
@@ -1,5 +1,6 @@
 export const SHIPPING_ZONE_DETAILS = {
   assignCountryButton: "[data-test-id='assign-country']",
+  descriptionInput: "[name='description']",
   submitAssignCountry: "[type='submit']",
   searchInput: "[name='query']",
   tableRow: "[class*='MuiTableRow']",

--- a/cypress/fixtures/urlList.js
+++ b/cypress/fixtures/urlList.js
@@ -18,6 +18,7 @@ export const urlList = {
   pageTypes: "page-types/",
   permissionsGroups: "permission-groups/",
   plugins: "plugins/",
+  priceRate: "price/",
   products: "products/",
   productTypes: "product-types/",
   sales: "discounts/sales/",
@@ -78,6 +79,9 @@ export const userDetailsUrl = userId => `${urlList.staffMembers}${userId}`;
 
 export const weightRateUrl = (shippingZoneId, weightRateId) =>
   `${urlList.shippingMethods}${shippingZoneId}/${urlList.weightRete}${weightRateId}`;
+
+export const priceRateUrl = (shippingZoneId, priceRateId) =>
+  `${urlList.shippingMethods}${shippingZoneId}/${urlList.priceRate}${priceRateId}`;
 
 export const warehouseDetailsUrl = warehouseId =>
   `${urlList.warehouses}${warehouseId}`;

--- a/cypress/integration/configuration/shippingMethods/editShippingMethod.js
+++ b/cypress/integration/configuration/shippingMethods/editShippingMethod.js
@@ -1,0 +1,95 @@
+// / <reference types="cypress"/>
+// / <reference types="../../../support"/>
+
+import faker from "faker";
+
+import { priceRateUrl } from "../../../fixtures/urlList";
+import {
+  addChannelToShippingMethod,
+  createShippingRate,
+  createShippingZone,
+  getShippingZone
+} from "../../../support/api/requests/ShippingMethod";
+import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
+import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
+import filterTests from "../../../support/filterTests";
+import {
+  fillUpShippingRate,
+  saveRateAfterUpdate
+} from "../../../support/pages/shippingMethodPage";
+
+filterTests({ definedTags: ["all"] }, () => {
+  describe("Edit shipping method", () => {
+    const startsWith = "EditShipping-";
+    const name = `${startsWith}${faker.datatype.number()}`;
+    const price = 10;
+
+    let defaultChannel;
+    let shippingZone;
+    let shippingMethod;
+
+    before(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      deleteShippingStartsWith(startsWith);
+
+      getDefaultChannel()
+        .then(channel => {
+          defaultChannel = channel;
+          createShippingZone(name, "US", defaultChannel.id);
+        })
+        .then(shippingZoneResp => {
+          shippingZone = shippingZoneResp;
+        });
+    });
+
+    beforeEach(() => {
+      const rateName = `${startsWith}${faker.datatype.number()}`;
+
+      cy.clearSessionData().loginUserViaRequest();
+      createShippingRate({
+        name: rateName,
+        shippingZone: shippingZone.id
+      }).then(({ shippingMethod: shippingResp }) => {
+        shippingMethod = shippingResp;
+        addChannelToShippingMethod(shippingMethod.id, defaultChannel.id, 1);
+      });
+    });
+
+    it("Update shipping rate", () => {
+      const updatedRateName = `${startsWith}Updated`;
+      const deliveryTime = { min: 1, max: 7 };
+
+      cy.visit(priceRateUrl(shippingZone.id, shippingMethod.id));
+      fillUpShippingRate({
+        rateName: updatedRateName,
+        price,
+        deliveryTime
+      });
+      saveRateAfterUpdate();
+      getShippingZone(shippingZone.id).then(({ shippingMethods }) => {
+        expect(shippingMethods).to.have.length(1);
+        chai
+          .softExpect(shippingMethods[0].minimumDeliveryDays)
+          .to.be.eq(deliveryTime.min);
+        chai
+          .softExpect(shippingMethods[0].maximumDeliveryDays)
+          .to.be.eq(deliveryTime.max);
+        chai
+          .softExpect(shippingMethods[0].channelListings[0].price.amount)
+          .to.be.eq(price);
+      });
+    });
+
+    it("Delete shipping rate", () => {
+      cy.visit(
+        priceRateUrl(shippingZone.id, shippingMethod.id)
+      ).deleteElementWithReqAlias("DeleteShippingRate");
+      getShippingZone(shippingZone.id).then(({ shippingMethods }) => {
+        const deletedShipping = shippingMethods.find(
+          element => element.id === shippingMethod.id
+        );
+        expect(deletedShipping).to.be.not.ok;
+      });
+    });
+  });
+});

--- a/cypress/integration/configuration/shippingMethods/editShippingZone.js
+++ b/cypress/integration/configuration/shippingMethods/editShippingZone.js
@@ -1,0 +1,79 @@
+// / <reference types="cypress"/>
+// / <reference types="../../../support"/>
+
+import faker from "faker";
+
+import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
+import { shippingZoneDetailsUrl } from "../../../fixtures/urlList";
+import {
+  createShippingZone,
+  getShippingZone
+} from "../../../support/api/requests/ShippingMethod";
+import { createWarehouse } from "../../../support/api/requests/Warehouse";
+import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
+import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
+import filterTests from "../../../support/filterTests";
+import { fillUpShippingZoneData } from "../../../support/pages/shippingMethodPage";
+
+filterTests({ definedTags: ["all"] }, () => {
+  describe("Edit shipping zone", () => {
+    const startsWith = "EditShipping-";
+    const name = `${startsWith}${faker.datatype.number()}`;
+
+    let defaultChannel;
+    let shippingZone;
+    let plAddress;
+
+    before(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      deleteShippingStartsWith(startsWith);
+
+      getDefaultChannel()
+        .then(channel => {
+          defaultChannel = channel;
+          cy.fixture("addresses");
+        })
+        .then(addresses => {
+          plAddress = addresses.plAddress;
+          createWarehouse({ name, address: plAddress });
+        });
+    });
+
+    beforeEach(() => {
+      const rateName = `${startsWith}${faker.datatype.number()}`;
+
+      cy.clearSessionData().loginUserViaRequest();
+      createShippingZone(name, "US", defaultChannel.id).then(
+        shippingZoneResp => {
+          shippingZone = shippingZoneResp;
+        }
+      );
+    });
+
+    it("Update shipping zone", () => {
+      const updatedName = `${startsWith}Updated`;
+
+      cy.visit(shippingZoneDetailsUrl(shippingZone.id));
+      fillUpShippingZoneData({
+        channelName: defaultChannel.name,
+        country: "Poland",
+        shippingName: updatedName,
+        warehouseName: name
+      });
+      getShippingZone(shippingZone.id).then(shippingZone => {
+        chai.softExpect(shippingZone.channels).to.have.length(0);
+        chai.softExpect(shippingZone.name).to.eq(updatedName);
+        chai.softExpect(shippingZone.description).to.eq(updatedName);
+        chai.softExpect(shippingZone.warehouses[0].name).to.eq(name);
+        expect(shippingZone.countries.find(el => el.code === "PL")).to.be.ok;
+      });
+    });
+
+    it("Delete shipping zone", () => {
+      cy.visit(
+        shippingZoneDetailsUrl(shippingZone.id)
+      ).deleteElementWithReqAlias("DeleteShippingZone");
+      getShippingZone(shippingZone.id).should("be.null");
+    });
+  });
+});

--- a/cypress/support/api/requests/ShippingMethod.js
+++ b/cypress/support/api/requests/ShippingMethod.js
@@ -137,6 +137,14 @@ export function getShippingZone(shippingZoneId) {
     shippingZone(id:"${shippingZoneId}"){
       id
       name
+      description
+      warehouses{
+        name
+        id
+      }
+      countries{
+        code
+      }
       channels{
         name
         id
@@ -144,6 +152,25 @@ export function getShippingZone(shippingZoneId) {
       shippingMethods{
         id
         name
+        minimumDeliveryDays
+        maximumDeliveryDays
+        minimumOrderWeight{
+          value
+        }
+        maximumOrderWeight{
+          value
+        }
+        channelListings{
+          price{
+            amount
+          }
+          minimumOrderPrice{
+            amount
+          }
+          maximumOrderPrice{
+            amount
+          }
+        }
       }
     }
   }`;

--- a/cypress/support/api/utils/shippingUtils.js
+++ b/cypress/support/api/utils/shippingUtils.js
@@ -42,7 +42,7 @@ export function createShipping({
 }
 export function createShippingRate({ name, shippingZoneId }) {
   return shippingMethodRequest
-    .createShippingRate({ name, shippingZoneId })
+    .createShippingRate({ name, shippingZone: shippingZoneId })
     .its("body.data.shippingPriceCreate.shippingMethod");
 }
 

--- a/cypress/support/customCommands/sharedElementsOperations/confirmationMessages.js
+++ b/cypress/support/customCommands/sharedElementsOperations/confirmationMessages.js
@@ -1,12 +1,5 @@
 import { SHARED_ELEMENTS } from "../../../elements/shared/sharedElements";
 
-// export function confirmationMessageShouldDisappear() {
-//   cy.get(SHARED_ELEMENTS.notificationSuccess)
-//     .should("be.visible")
-//     .get(SHARED_ELEMENTS.notificationSuccess)
-//     .should("not.exist");
-// }
-
 Cypress.Commands.add("confirmationMessageShouldDisappear", () => {
   cy.get(SHARED_ELEMENTS.notificationSuccess)
     .should("be.visible")

--- a/cypress/support/customCommands/sharedElementsOperations/deleteElement.js
+++ b/cypress/support/customCommands/sharedElementsOperations/deleteElement.js
@@ -1,0 +1,11 @@
+import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
+
+Cypress.Commands.add("deleteElementWithReqAlias", alias =>
+  cy
+    .get(BUTTON_SELECTORS.deleteButton)
+    .click()
+    .addAliasToGraphRequest(alias)
+    .get(BUTTON_SELECTORS.submit)
+    .click()
+    .waitForRequestAndCheckIfNoErrors(`@${alias}`)
+);

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -49,5 +49,6 @@ declare namespace Cypress {
     findElementOnTable(elementName: string): Chainable<any>;
     searchInTable(query: string): Chainable<any>;
     waitForRequestAndCheckIfNoErrors(alias: string): Chainable<any>;
+    deleteElementWithReqAlias(alias: string): Chainable<any>;
   }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -10,6 +10,7 @@ import "./customCommands/sharedElementsOperations/confirmationMessages.js";
 import "./customCommands/sharedElementsOperations/progressBar.js";
 import "./customCommands/sharedElementsOperations/selects.js";
 import "./customCommands/sharedElementsOperations/tables";
+import "./customCommands/sharedElementsOperations/deleteElement";
 import "cypress-mailhog";
 import "cypress-file-upload";
 

--- a/cypress/support/pages/shippingMethodPage.js
+++ b/cypress/support/pages/shippingMethodPage.js
@@ -10,10 +10,25 @@ export function createShippingZone(
   country,
   channelName
 ) {
-  cy.get(SHIPPING_ZONES_LIST.addShippingZone)
-    .click()
-    .get(SHIPPING_ZONE_DETAILS.nameInput)
-    .type(shippingName)
+  cy.get(SHIPPING_ZONES_LIST.addShippingZone).click();
+  fillUpShippingZoneData({
+    shippingName,
+    warehouseName,
+    country,
+    channelName
+  });
+}
+
+export function fillUpShippingZoneData({
+  shippingName,
+  warehouseName,
+  country,
+  channelName
+}) {
+  cy.get(SHIPPING_ZONE_DETAILS.nameInput)
+    .clearAndType(shippingName)
+    .get(SHIPPING_ZONE_DETAILS.descriptionInput)
+    .clearAndType(shippingName)
     .get(SHIPPING_ZONE_DETAILS.assignCountryButton)
     .click()
     .get(SHIPPING_ZONE_DETAILS.searchInput)
@@ -32,7 +47,8 @@ export function createShippingZone(
     .type(warehouseName)
     .get(SHIPPING_ZONE_DETAILS.autocompleteContentDialog)
     .scrollTo("bottom");
-  cy.contains(SHIPPING_ZONE_DETAILS.option, warehouseName)
+  return cy
+    .contains(SHIPPING_ZONE_DETAILS.option, warehouseName)
     .click({ force: true })
     .get(SHIPPING_ZONE_DETAILS.channelSelector)
     .click()
@@ -80,13 +96,26 @@ export function enterAndFillUpShippingRate({
   weightLimits,
   deliveryTime
 }) {
-  cy.get(rateOption)
-    .click()
-    .waitForProgressBarToNotBeVisible()
+  cy.get(rateOption).click();
+  fillUpShippingRate({
+    rateName,
+    price,
+    weightLimits,
+    deliveryTime
+  });
+}
+
+export function fillUpShippingRate({
+  rateName,
+  price,
+  weightLimits,
+  deliveryTime
+}) {
+  cy.waitForProgressBarToNotBeVisible()
     .get(SHARED_ELEMENTS.richTextEditor.empty)
     .should("exist")
     .get(SHIPPING_RATE_DETAILS.inputName)
-    .type(rateName);
+    .clearAndType(rateName);
   if (deliveryTime) {
     fillUpDeliveryTime(deliveryTime);
   }
@@ -94,7 +123,7 @@ export function enterAndFillUpShippingRate({
     fillUpWeightLimits(weightLimits);
   }
   cy.get(SHIPPING_RATE_DETAILS.priceInput).each($priceInput => {
-    cy.wrap($priceInput).type(price);
+    cy.wrap($priceInput).clearAndType(price);
   });
 }
 
@@ -132,6 +161,15 @@ export function saveRate() {
     .its("response.body.0.data.shippingZone");
 }
 
+export function saveRateAfterUpdate() {
+  return cy
+    .addAliasToGraphRequest("ShippingMethodChannelListingUpdate")
+    .get(BUTTON_SELECTORS.confirm)
+    .click()
+    .confirmationMessageShouldDisappear()
+    .waitForRequestAndCheckIfNoErrors(`@ShippingMethodChannelListingUpdate`);
+}
+
 export function fillUpWeightLimits({ max, min }) {
   cy.get(SHIPPING_RATE_DETAILS.minWeightInput)
     .type(min)
@@ -141,9 +179,9 @@ export function fillUpWeightLimits({ max, min }) {
 
 export function fillUpDeliveryTime({ min, max }) {
   cy.get(SHIPPING_RATE_DETAILS.minDeliveryTimeInput)
-    .type(min)
+    .clearAndType(min)
     .get(SHIPPING_RATE_DETAILS.maxDeliveryTimeInput)
-    .type(max);
+    .clearAndType(max);
 }
 
 export const rateOptions = {


### PR DESCRIPTION
I want to merge this change because I want to add tests for shipping method to main branch

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
