### PR TITLE
Rename ExpansionPanel components to Accordion

### DIFF
--- a/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
+++ b/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
@@ -1,8 +1,4 @@
-import {
-  ExpansionPanel,
-  ExpansionPanelSummary,
-  Typography
-} from "@material-ui/core";
+import { Accordion, AccordionSummary, Typography } from "@material-ui/core";
 import { ChannelData } from "@saleor/channels/utils";
 import { Messages } from "@saleor/components/ChannelsAvailabilityCard/types";
 import IconChevronDown from "@saleor/icons/ChevronDown";
@@ -119,8 +115,8 @@ const ChannelWithVariantsAvailabilityItemWrapper: React.FC<ChannelAvailabilityIt
     : messages.variantCountLabel;
 
   return (
-    <ExpansionPanel classes={expanderClasses}>
-      <ExpansionPanelSummary
+    <Accordion classes={expanderClasses}>
+      <AccordionSummary
         expandIcon={<IconChevronDown />}
         classes={summaryClasses}
       >
@@ -129,9 +125,9 @@ const ChannelWithVariantsAvailabilityItemWrapper: React.FC<ChannelAvailabilityIt
           <Label text={intl.formatMessage(variantsLabel, { variantsCount })} />
           <Label text={commonChannelMessages.availableDateText} />
         </div>
-      </ExpansionPanelSummary>
+      </AccordionSummary>
       {children}
-    </ExpansionPanel>
+    </Accordion>
   );
 };
 

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -1,8 +1,8 @@
 import placeholderImage from "@assets/images/placeholder60x60.png";
 import {
+  Accordion,
+  AccordionSummary,
   Divider,
-  ExpansionPanel,
-  ExpansionPanelSummary,
   Typography
 } from "@material-ui/core";
 import { ChannelData } from "@saleor/channels/utils";
@@ -157,12 +157,12 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
           placeholderImage;
 
         return (
-          <ExpansionPanel
+          <Accordion
             classes={expanderClasses}
             data-test-id="expand-channel-row"
             key={channelId}
           >
-            <ExpansionPanelSummary
+            <AccordionSummary
               expandIcon={<IconChevronDown />}
               classes={summaryClasses}
             >
@@ -194,7 +194,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                 </div>
                 <Divider />
               </div>
-            </ExpansionPanelSummary>
+            </AccordionSummary>
             {allVariants.map(({ id: variantId, name }) => (
               <React.Fragment key={variantId}>
                 <div
@@ -217,7 +217,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                 <Divider />
               </React.Fragment>
             ))}
-          </ExpansionPanel>
+          </Accordion>
         );
       })}
     </>

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.tsx
@@ -1,8 +1,8 @@
 import {
+  Accordion,
   Card,
   CardContent,
   Divider,
-  ExpansionPanel,
   Typography
 } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
@@ -67,7 +67,7 @@ const ShippingZonesCard: React.FC<ShippingZonesCardProps> = props => {
       <CardContent>
         <Typography>{intl.formatMessage(messages.subtitle)}</Typography>
       </CardContent>
-      <ExpansionPanel classes={expanderClasses}>
+      <Accordion classes={expanderClasses}>
         <ShippingZonesListHeader shippingZones={shippingZones} />
         <Divider />
         {shippingZones.map(zone => (
@@ -76,7 +76,7 @@ const ShippingZonesCard: React.FC<ShippingZonesCardProps> = props => {
         {hasMoreZonesToBeSelected ? (
           <ShippingZonesCardListFooter {...props} />
         ) : null}
-      </ExpansionPanel>
+      </Accordion>
     </Card>
   );
 };

--- a/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
@@ -1,4 +1,4 @@
-import { ExpansionPanelSummary, Typography } from "@material-ui/core";
+import { AccordionSummary, Typography } from "@material-ui/core";
 import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import { ChannelShippingZones } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import IconChevronDown from "@saleor/icons/ChevronDown";
@@ -58,13 +58,13 @@ const ShippingZonesListHeader: React.FC<ShippingZonesListHeaderProps> = ({
 
   return (
     <div className={classes.container}>
-      <ExpansionPanelSummary expandIcon={<IconChevronDown />} classes={classes}>
+      <AccordionSummary expandIcon={<IconChevronDown />} classes={classes}>
         <Typography variant="subtitle2" color="textSecondary">
           {intl.formatMessage(messages.title, {
             zonesCount: shippingZones.length
           })}
         </Typography>
-      </ExpansionPanelSummary>
+      </AccordionSummary>
       <HorizontalSpacer spacing={1.5} />
     </div>
   );

--- a/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemWrapper.tsx
+++ b/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemWrapper.tsx
@@ -1,8 +1,4 @@
-import {
-  ExpansionPanel,
-  ExpansionPanelSummary,
-  Typography
-} from "@material-ui/core";
+import { Accordion, AccordionSummary, Typography } from "@material-ui/core";
 import { ChannelData } from "@saleor/channels/utils";
 import IconChevronDown from "@saleor/icons/ChevronDown";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -76,19 +72,16 @@ const ChannelContentWrapper: React.FC<ChannelContentWrapperProps> = ({
   const { name } = data;
 
   return (
-    <ExpansionPanel
-      classes={expanderClasses}
-      data-test="channel-availability-item"
-    >
-      <ExpansionPanelSummary
+    <Accordion classes={expanderClasses} data-test="channel-availability-item">
+      <AccordionSummary
         expandIcon={<IconChevronDown />}
         classes={summaryClasses}
       >
         <Typography>{name}</Typography>
         <Typography variant="caption">{messages.availableDateText}</Typography>
-      </ExpansionPanelSummary>
+      </AccordionSummary>
       {children}
-    </ExpansionPanel>
+    </Accordion>
   );
 };
 

--- a/src/components/Filter/FilterContent/FilterContent.tsx
+++ b/src/components/Filter/FilterContent/FilterContent.tsx
@@ -1,6 +1,6 @@
 import {
-  ExpansionPanel,
-  ExpansionPanelSummary,
+  Accordion,
+  AccordionSummary,
   makeStyles,
   Paper,
   Typography
@@ -208,13 +208,13 @@ const FilterContent: React.FC<FilterContentProps> = ({
             const currentFilter = getFilterFromCurrentData(filter);
 
             return (
-              <ExpansionPanel
+              <Accordion
                 key={filter.name}
                 classes={expanderClasses}
                 data-test="channel-availability-item"
                 expanded={filter.name === openedFilter?.name}
               >
-                <ExpansionPanelSummary
+                <AccordionSummary
                   expandIcon={<IconChevronDown />}
                   classes={summaryClasses}
                   onClick={() => handleFilterOpen(filter)}
@@ -227,7 +227,7 @@ const FilterContent: React.FC<FilterContentProps> = ({
                       }
                     />
                   )}
-                </ExpansionPanelSummary>
+                </AccordionSummary>
                 {currentFilter?.active && (
                   <FilterErrorsList
                     errors={errors?.[filter.name]}
@@ -260,7 +260,7 @@ const FilterContent: React.FC<FilterContentProps> = ({
                     filter={currentFilter}
                   />
                 )}
-              </ExpansionPanel>
+              </Accordion>
             );
           })}
       </form>

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -1,7 +1,7 @@
 import {
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Typography
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
@@ -22,7 +22,7 @@ const useStyles = makeStyles(
       width: 8
     },
     panel: {
-      "& .MuiExpansionPanelDetails-root": {
+      "& .MuiAccordionDetails-root": {
         padding: 0,
         paddingTop: theme.spacing(2)
       },
@@ -40,13 +40,13 @@ const useStyles = makeStyles(
       width: "100%"
     },
     panelExpander: {
-      "&.MuiExpansionPanelSummary-root.Mui-expanded": {
+      "&.MuiAccordionSummary-root.Mui-expanded": {
         minHeight: 0
       },
-      "&> .MuiExpansionPanelSummary-content": {
+      "&> .MuiAccordionSummary-content": {
         margin: 0
       },
-      "&> .MuiExpansionPanelSummary-expandIcon": {
+      "&> .MuiAccordionSummary-expandIcon": {
         padding: 0,
         position: "absolute",
         right: theme.spacing(20)
@@ -93,8 +93,8 @@ export const TimelineEvent: React.FC<TimelineEventProps> = props => {
     <div className={classes.root}>
       <span className={classes.dot} />
       {children ? (
-        <ExpansionPanel className={classes.panel} elevation={0}>
-          <ExpansionPanelSummary
+        <Accordion className={classes.panel} elevation={0}>
+          <AccordionSummary
             className={classes.panelExpander}
             expandIcon={<ExpandMoreIcon />}
           >
@@ -103,11 +103,11 @@ export const TimelineEvent: React.FC<TimelineEventProps> = props => {
               date={date}
               titleElements={titleElements}
             />
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
+          </AccordionSummary>
+          <AccordionDetails>
             <Typography>{children}</Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
+          </AccordionDetails>
+        </Accordion>
       ) : (
         <TimelineEventHeader
           title={title}

--- a/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
+++ b/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
@@ -1,8 +1,8 @@
 import {
+  Accordion,
+  AccordionSummary,
   CardContent,
   Divider,
-  ExpansionPanel,
-  ExpansionPanelSummary,
   Typography
 } from "@material-ui/core";
 import Skeleton from "@saleor/components/Skeleton";
@@ -138,8 +138,8 @@ const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAva
 
   return (
     <CardContainer>
-      <ExpansionPanel classes={expanderClasses}>
-        <ExpansionPanelSummary
+      <Accordion classes={expanderClasses}>
+        <AccordionSummary
           expandIcon={<IconChevronDown />}
           classes={summaryClasses}
           data-test-id="channels-variant-availability-summary"
@@ -150,7 +150,7 @@ const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAva
               availableChannelsCount: allAvailableChannelsListings.length
             })}
           </Typography>
-        </ExpansionPanelSummary>
+        </AccordionSummary>
 
         {channelListings.map(({ channel }) => (
           <React.Fragment key={channel.id}>
@@ -170,7 +170,7 @@ const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAva
             </CardContent>
           </React.Fragment>
         ))}
-      </ExpansionPanel>
+      </Accordion>
     </CardContainer>
   );
 };


### PR DESCRIPTION
I want to merge this change because in MUI v4 Expansion Panel components:

- ExpansionPanel
- ExpansionPanelSummary
- ExpansionPanelActions
- ExpansionPanelDetails

have been renamed to Accordion.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
