### PR TITLE
Allow no attribute values in variant creator

### DIFF
--- a/src/attributes/fixtures.ts
+++ b/src/attributes/fixtures.ts
@@ -90,6 +90,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "author",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -152,6 +153,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "box-size",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -250,6 +252,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "brand",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -294,6 +297,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "candy-box-size",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -374,6 +378,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "coffee-genre",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -436,6 +441,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "collar",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -516,6 +522,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "color",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -578,6 +585,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "cover",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -712,6 +720,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "flavor",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -774,6 +783,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "language",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -836,6 +846,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       slug: "publisher",
       type: AttributeTypeEnum.PRODUCT_TYPE,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       unit: null,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
@@ -899,6 +910,7 @@ export const attributes: Array<AttributeList_attributes_edges_node &
       type: AttributeTypeEnum.PRODUCT_TYPE,
       unit: null,
       inputType: AttributeInputTypeEnum.DROPDOWN,
+      valueRequired: false,
       choices: {
         __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
         pageInfo: {

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -163,6 +163,7 @@ export const productVariantAttributesFragment = gql`
         id
         name
         inputType
+        valueRequired
         unit
         choices(
           first: $firstValues

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -132,6 +132,7 @@ export interface Product_productType_variantAttributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: Product_productType_variantAttributes_choices | null;
 }

--- a/src/fragments/types/ProductVariantAttributesFragment.ts
+++ b/src/fragments/types/ProductVariantAttributesFragment.ts
@@ -132,6 +132,7 @@ export interface ProductVariantAttributesFragment_productType_variantAttributes 
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: ProductVariantAttributesFragment_productType_variantAttributes_choices | null;
 }

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreator.stories.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreator.stories.tsx
@@ -59,6 +59,7 @@ const stock: Stock = {
 
 const dataAttributes = selectedAttributes.map(attribute => ({
   id: attribute.id,
+  valueRequired: attribute.valueRequired,
   values: attribute.choices.edges
     .map(value => ({
       slug: value.node.slug,

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
@@ -47,7 +47,9 @@ function canHitNext(
   switch (step) {
     case ProductVariantCreatorStep.values:
       return (
-        data.attributes.every(attribute => attribute.values.length > 0) &&
+        data.attributes.every(
+          attribute => !attribute.valueRequired || attribute.values.length > 0
+        ) &&
         (variantsLeft === null || getVariantsNumber(data) <= variantsLeft)
       );
     case ProductVariantCreatorStep.prices:

--- a/src/products/components/ProductVariantCreatorPage/__snapshots__/reducer.test.ts.snap
+++ b/src/products/components/ProductVariantCreatorPage/__snapshots__/reducer.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -42,6 +43,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -79,6 +81,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -650,6 +653,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -687,6 +691,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -724,6 +729,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -1295,6 +1301,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -1332,6 +1339,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -1369,6 +1377,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -1440,6 +1449,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -1477,6 +1487,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -1514,6 +1525,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -2036,6 +2048,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -2073,6 +2086,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -2110,6 +2124,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -2587,6 +2602,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -2624,6 +2640,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -2661,6 +2678,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -3183,6 +3201,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -3220,6 +3239,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -3257,6 +3277,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",
@@ -3696,6 +3717,7 @@ Object {
   "attributes": Array [
     Object {
       "id": "attr-1",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-1-1",
@@ -3733,6 +3755,7 @@ Object {
     },
     Object {
       "id": "attr-2",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-2-2",
@@ -3770,6 +3793,7 @@ Object {
     },
     Object {
       "id": "attr-4",
+      "valueRequired": false,
       "values": Array [
         Object {
           "slug": "val-4-1",

--- a/src/products/components/ProductVariantCreatorPage/createVariants.ts
+++ b/src/products/components/ProductVariantCreatorPage/createVariants.ts
@@ -10,7 +10,7 @@ import {
 
 interface CreateVariantAttributeValueInput {
   attributeId: string;
-  attributeValueSlug: string;
+  attributeValueSlug: string | null;
   attributeBooleanValue: boolean | null;
 }
 
@@ -100,7 +100,12 @@ function createVariant(
     attributes: attributes.map(attribute => ({
       id: attribute.attributeId,
       ...(attribute.attributeBooleanValue === null
-        ? { values: [attribute.attributeValueSlug] }
+        ? {
+            values:
+              attribute.attributeValueSlug === null
+                ? []
+                : [attribute.attributeValueSlug]
+          }
         : { boolean: attribute.attributeBooleanValue })
     })),
     channelListings: price,
@@ -116,6 +121,18 @@ function addAttributeToVariant(
   attribute: Attribute,
   variant: CreateVariantInput
 ): CreateVariantInput[] {
+  if (attribute.values.length === 0) {
+    return [
+      [
+        ...variant,
+        {
+          attributeId: attribute.id,
+          attributeValueSlug: null,
+          attributeBooleanValue: null
+        }
+      ]
+    ];
+  }
   return attribute.values.map(attributeValue => [
     ...variant,
     {

--- a/src/products/components/ProductVariantCreatorPage/createVariants.ts
+++ b/src/products/components/ProductVariantCreatorPage/createVariants.ts
@@ -1,4 +1,7 @@
-import { ProductVariantBulkCreateInput } from "@saleor/types/globalTypes";
+import {
+  BulkAttributeValueInput,
+  ProductVariantBulkCreateInput
+} from "@saleor/types/globalTypes";
 
 import {
   Attribute,
@@ -81,6 +84,23 @@ function getPriceFromMode(
   }
 }
 
+function getAttributeFromAttributeValueInput({
+  attributeId,
+  attributeBooleanValue,
+  attributeValueSlug
+}: CreateVariantAttributeValueInput): BulkAttributeValueInput {
+  if (attributeBooleanValue === null) {
+    return {
+      id: attributeId,
+      values: attributeValueSlug === null ? [] : [attributeValueSlug]
+    };
+  }
+  return {
+    id: attributeId,
+    boolean: attributeBooleanValue
+  };
+}
+
 function createVariant(
   data: ProductVariantCreateFormData,
   attributes: CreateVariantInput
@@ -97,17 +117,7 @@ function createVariant(
   );
 
   return {
-    attributes: attributes.map(attribute => ({
-      id: attribute.attributeId,
-      ...(attribute.attributeBooleanValue === null
-        ? {
-            values:
-              attribute.attributeValueSlug === null
-                ? []
-                : [attribute.attributeValueSlug]
-          }
-        : { boolean: attribute.attributeBooleanValue })
-    })),
+    attributes: attributes.map(getAttributeFromAttributeValueInput),
     channelListings: price,
     sku: "",
     stocks: stocks.map((quantity, stockIndex) => ({

--- a/src/products/components/ProductVariantCreatorPage/fixtures.ts
+++ b/src/products/components/ProductVariantCreatorPage/fixtures.ts
@@ -18,6 +18,7 @@ export const channels: ChannelPriceData[] = [
 export const attributes = [
   {
     id: "attr-1",
+    valueRequired: false,
     values: Array(9)
       .fill(0)
       .map((_, index) => ({
@@ -39,6 +40,7 @@ export const attributes = [
   },
   {
     id: "attr-2",
+    valueRequired: false,
     values: Array(6)
       .fill(0)
       .map((_, index) => ({
@@ -60,6 +62,7 @@ export const attributes = [
   },
   {
     id: "attr-3",
+    valueRequired: false,
     values: Array(4)
       .fill(0)
       .map((_, index) => ({
@@ -81,6 +84,7 @@ export const attributes = [
   },
   {
     id: "attr-4",
+    valueRequired: false,
     values: Array(11)
       .fill(0)
       .map((_, index) => ({
@@ -130,14 +134,17 @@ export const secondStep: ProductVariantCreateFormData = {
   attributes: [
     {
       id: attributes[0].id,
+      valueRequired: attributes[0].valueRequired,
       values: []
     },
     {
       id: attributes[1].id,
+      valueRequired: attributes[1].valueRequired,
       values: []
     },
     {
       id: attributes[3].id,
+      valueRequired: attributes[3].valueRequired,
       values: []
     }
   ]
@@ -148,14 +155,17 @@ export const thirdStep: ProductVariantCreateFormData = {
   attributes: [
     {
       id: attributes[0].id,
+      valueRequired: attributes[0].valueRequired,
       values: [0, 6].map(index => attributes[0].values[index])
     },
     {
       id: attributes[1].id,
+      valueRequired: attributes[1].valueRequired,
       values: [1, 3].map(index => attributes[1].values[index])
     },
     {
       id: attributes[3].id,
+      valueRequired: attributes[3].valueRequired,
       values: [0, 4].map(index => attributes[3].values[index])
     }
   ],

--- a/src/products/components/ProductVariantCreatorPage/form.ts
+++ b/src/products/components/ProductVariantCreatorPage/form.ts
@@ -29,6 +29,7 @@ export interface Stock {
 }
 export interface Attribute {
   id: string;
+  valueRequired: boolean;
   values: Array<AttributeValue<Partial<AttributeValueFragment>>>;
 }
 export interface ProductVariantCreateFormData {
@@ -52,6 +53,7 @@ export const createInitialForm = (
   return {
     attributes: attributes.map(attribute => ({
       id: attribute.id,
+      valueRequired: attribute.valueRequired,
       values: []
     })),
     price: {

--- a/src/products/components/ProductVariantCreatorPage/reducer.ts
+++ b/src/products/components/ProductVariantCreatorPage/reducer.ts
@@ -94,6 +94,7 @@ function selectValue(
   const updatedAttributes = add(
     {
       id: attributeId,
+      valueRequired: attribute.valueRequired,
       values
     },
     remove(attribute, prevState.attributes, (a, b) => a.id === b.id)
@@ -417,9 +418,21 @@ function deleteVariant(
   state: ProductVariantCreateFormData,
   variantIndex: number
 ): ProductVariantCreateFormData {
+  const variants = removeAtIndex(state.variants, variantIndex);
+
   return {
     ...state,
-    variants: removeAtIndex(state.variants, variantIndex)
+    variants: variants.length
+      ? variants
+      : createVariants({
+          ...state,
+          attributes: state.attributes.map(attribute => ({
+            id: attribute.id,
+            valueRequired: attribute.valueRequired,
+            values: []
+          })),
+          variants
+        })
   };
 }
 

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -472,6 +472,7 @@ export const product: (
         id: "isdugfhud",
         name: "Attachment",
         inputType: AttributeInputTypeEnum.DROPDOWN,
+        valueRequired: false,
         unit: null,
         choices: {
           __typename: "AttributeValueCountableConnection",
@@ -512,6 +513,7 @@ export const product: (
         id: "pta18161",
         name: "Color",
         inputType: AttributeInputTypeEnum.DROPDOWN,
+        valueRequired: false,
         unit: null,
         choices: {
           __typename: "AttributeValueCountableConnection",

--- a/src/products/types/CreateMultipleVariantsData.ts
+++ b/src/products/types/CreateMultipleVariantsData.ts
@@ -132,6 +132,7 @@ export interface CreateMultipleVariantsData_product_productType_variantAttribute
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: CreateMultipleVariantsData_product_productType_variantAttributes_choices | null;
 }

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -132,6 +132,7 @@ export interface ProductDetails_product_productType_variantAttributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: ProductDetails_product_productType_variantAttributes_choices | null;
 }

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -139,6 +139,7 @@ export interface ProductUpdate_productUpdate_product_productType_variantAttribut
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: ProductUpdate_productUpdate_product_productType_variantAttributes_choices | null;
 }

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -139,6 +139,7 @@ export interface SimpleProductUpdate_productUpdate_product_productType_variantAt
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
   choices: SimpleProductUpdate_productUpdate_product_productType_variantAttributes_choices | null;
 }


### PR DESCRIPTION
I want to merge this change because... it allows creating variants without any attribute values assigned in variant creator.

<!-- Please mention all relevant issue numbers. -->
Backend: https://github.com/saleor/saleor/pull/8905

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
1. When values for none attribute set:
<img width="761" alt="Zrzut ekranu 2022-01-5 o 18 35 29" src="https://user-images.githubusercontent.com/9825562/148267116-2c0c488f-a312-4a52-b3ce-1b2f44a1f059.png">
2. When values for first attribute set:
<img width="765" alt="Zrzut ekranu 2022-01-5 o 18 35 18" src="https://user-images.githubusercontent.com/9825562/148267114-dc06fcba-5f29-4eb1-87a9-1e0539746a14.png">
3. When values for second attribute set:
<img width="764" alt="Zrzut ekranu 2022-01-5 o 18 35 43" src="https://user-images.githubusercontent.com/9825562/148267118-3cdd2497-d9d8-4611-96ed-40eded415105.png">
4. When values for all attributes set:
<img width="903" alt="Zrzut ekranu 2022-01-5 o 19 00 21" src="https://user-images.githubusercontent.com/9825562/148267121-86c91b28-7f0f-4632-8432-dec90c5eaaee.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
