### PR TITLE
Redirect user back to the first landing page after external login

### DIFF
--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -42,6 +42,11 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     setRequestedExternalPluginId
   ] = useLocalStorage("requestedExternalPluginId", null);
 
+  const [fallbackUri, setFallbackUri] = useLocalStorage(
+    "externalLoginFallbackUri",
+    null
+  );
+
   const handleSubmit = async (data: LoginFormData) => {
     const result = await login(data.email, data.password);
     const errors = result?.errors || [];
@@ -50,6 +55,8 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
   };
 
   const handleRequestExternalAuthentication = async (pluginId: string) => {
+    setFallbackUri(location.pathname);
+
     const result = await requestLoginByExternalPlugin(pluginId, {
       redirectUri: urlJoin(
         window.location.origin,
@@ -70,7 +77,8 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
       state
     });
     if (result && !result?.errors?.length) {
-      navigate(APP_DEFAULT_URI);
+      navigate(fallbackUri ?? APP_DEFAULT_URI);
+      setFallbackUri(null);
     }
   };
 

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -77,7 +77,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
       state
     });
     if (result && !result?.errors?.length) {
-      navigate(fallbackUri ?? APP_DEFAULT_URI);
+      navigate(fallbackUri ?? "/");
       setFallbackUri(null);
     }
   };


### PR DESCRIPTION
I want to merge this change because it redirects the user back to the subpage they first landed on.

3.1 PR to review: https://github.com/saleor/saleor-dashboard/pull/1742

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
