### PR TITLE
Add product type link in product details view (#1724)

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -3,6 +3,7 @@ import { TypographyProps } from "@material-ui/core/Typography";
 import { makeStyles } from "@saleor/macaw-ui";
 import classNames from "classnames";
 import React from "react";
+import { Link as RouterLink } from "react-router-dom";
 
 const useStyles = makeStyles(
   theme => ({
@@ -19,6 +20,9 @@ const useStyles = makeStyles(
     underline: {
       textDecoration: "underline"
     },
+    noUnderline: {
+      textDecoration: "none"
+    },
     disabled: {
       cursor: "default",
       color: theme.palette.textHighlighted.inactive
@@ -27,11 +31,14 @@ const useStyles = makeStyles(
   { name: "Link" }
 );
 
+const isExternalURL = url => /^https?:\/\//.test(url);
+
 interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string;
   color?: "primary" | "secondary";
   underline?: boolean;
   typographyProps?: TypographyProps;
-  onClick: () => void;
+  onClick?: () => void;
   disabled?: boolean;
 }
 
@@ -43,32 +50,47 @@ const Link: React.FC<LinkProps> = props => {
     underline = false,
     onClick,
     disabled,
+    href,
     ...linkProps
   } = props;
 
   const classes = useStyles(props);
 
-  return (
-    <Typography
-      component="a"
-      className={classNames(className, {
-        [classes.root]: true,
-        [classes[color]]: true,
-        [classes.underline]: underline,
-        [classes.disabled]: disabled
-      })}
-      onClick={event => {
-        if (disabled) {
-          return;
-        }
+  const commonLinkProps = {
+    className: classNames(className, {
+      [classes.root]: true,
+      [classes[color]]: true,
+      [classes.underline]: underline,
+      [classes.noUnderline]: !underline,
+      [classes.disabled]: disabled
+    }),
+    onClick: event => {
+      if (disabled || !onClick) {
+        return;
+      }
 
-        event.preventDefault();
-        onClick();
-      }}
-      {...linkProps}
-    >
-      {children}
-    </Typography>
+      event.preventDefault();
+      onClick();
+    },
+    ...linkProps
+  };
+
+  return (
+    <>
+      {!!href && !isExternalURL(href) ? (
+        <RouterLink to={disabled ? undefined : href} {...commonLinkProps}>
+          {children}
+        </RouterLink>
+      ) : (
+        <Typography
+          component="a"
+          href={disabled ? undefined : href}
+          {...commonLinkProps}
+        >
+          {children}
+        </Typography>
+      )}
+    </>
   );
 };
 Link.displayName = "Link";

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import packageInfo from "../package.json";
 import { SearchVariables } from "./hooks/makeSearch";
 import { ListSettings, ListViews, Pagination } from "./types";
 
-export const APP_MOUNT_URI = process.env.APP_MOUNT_URI;
+export const APP_MOUNT_URI = process.env.APP_MOUNT_URI || "/";
 export const APP_DEFAULT_URI = "/";
 export const API_URI = process.env.API_URI;
 export const SW_INTERVAL = parseInt(process.env.SW_INTERVAL, 0);

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -3,6 +3,7 @@ import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import { FormSpacer } from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
+import Link from "@saleor/components/Link";
 import MultiAutocompleteSelectField, {
   MultiAutocompleteChoiceType
 } from "@saleor/components/MultiAutocompleteSelectField";
@@ -12,7 +13,8 @@ import SingleAutocompleteSelectField, {
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import { makeStyles } from "@saleor/macaw-ui";
-import { maybe } from "@saleor/misc";
+import { createHref, maybe } from "@saleor/misc";
+import { productTypeUrl } from "@saleor/productTypes/urls";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
 import React from "react";
@@ -130,7 +132,12 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
             <Typography className={classes.label} variant="caption">
               <FormattedMessage defaultMessage="Product Type" />
             </Typography>
-            <Typography>{maybe(() => productType.name, "...")}</Typography>
+            <Link
+              href={createHref(productTypeUrl(productType?.id) ?? "")}
+              disabled={!productType?.id}
+            >
+              {productType?.name ?? "..."}
+            </Link>
             <CardSpacer />
             <Typography className={classes.label} variant="caption">
               <FormattedMessage defaultMessage="Product Type" />

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
@@ -15,10 +15,14 @@ import ProductUpdatePage, { ProductUpdatePageProps } from "./ProductUpdatePage";
 const product = productFixture(placeholderImage);
 const channels = createChannelsData(channelsList);
 
+import * as _useNavigator from "@saleor/hooks/useNavigator";
 import Adapter from "enzyme-adapter-react-16";
+import { MemoryRouter } from "react-router-dom";
+
 configure({ adapter: new Adapter() });
 
 const onSubmit = jest.fn();
+const useNavigator = jest.spyOn(_useNavigator, "default");
 
 const props: ProductUpdatePageProps = {
   ...listActionsProps,
@@ -81,11 +85,14 @@ const selectors = {
 };
 
 describe("Product details page", () => {
+  useNavigator.mockImplementation();
   it("can select empty option on attribute", () => {
     const component = mount(
-      <Wrapper>
-        <ProductUpdatePage {...props} />
-      </Wrapper>
+      <MemoryRouter>
+        <Wrapper>
+          <ProductUpdatePage {...props} />
+        </Wrapper>
+      </MemoryRouter>
     );
     expect(component.find(selectors.dropdown).exists()).toBeFalsy();
 


### PR DESCRIPTION
Cherry pick of #1724 

* add link to product type in product details

* fix tests

* Apply CR suggestion

Co-authored-by: Wojciech Mista <wojciech.mista@saleor.io>

* improve Link component

* Fix tests - add memory router

* fix undefined value in createHref

* fix onclick when it is not provided

* Fix undefined app mount uri

* fix undefined api uri in ci/cd tests

* remove onclick from product type link

Co-authored-by: Wojciech Mista <wojciech.mista@saleor.io>

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.1

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
