### PR TITLE
Add tests for allowing orders to fulfill without stock

### DIFF
--- a/cypress/elements/orders/order-fulfill-selectors.js
+++ b/cypress/elements/orders/order-fulfill-selectors.js
@@ -1,0 +1,3 @@
+export const ORDER_FULFILL_SELECTORS = {
+  fulfillOrderButton: '[data-test-id="quantity-to-fulfill"]'
+};

--- a/cypress/elements/orders/order-selectors.js
+++ b/cypress/elements/orders/order-selectors.js
@@ -1,0 +1,3 @@
+export const ORDER_SELECTORS = {
+  fulfillOrderButton: '[data-test-id="fulfill-order-button"]'
+};

--- a/cypress/fixtures/urlList.js
+++ b/cypress/fixtures/urlList.js
@@ -48,6 +48,8 @@ export const customerDetailsUrl = customerId =>
 
 export const menuDetailsUrl = menuId => `${urlList.navigation}${menuId}`;
 
+export const orderDetailsUrl = orderId => `${urlList.orders}${orderId}`;
+
 export const pageDetailsUrl = pageId => `${urlList.pages}${pageId}`;
 
 export const pageTypeDetailsUrl = pageTypeId =>

--- a/cypress/integration/orders/fulfillOrdersWithoutStock.js
+++ b/cypress/integration/orders/fulfillOrdersWithoutStock.js
@@ -1,0 +1,116 @@
+// / <reference types="cypress"/>
+// / <reference types="../../support"/>
+
+import faker from "faker";
+
+import { ORDERS_SELECTORS } from "../../elements/orders/orders-selectors";
+import { urlList } from "../../fixtures/urlList";
+import { ONE_PERMISSION_USERS } from "../../fixtures/users";
+import {
+  createCustomer,
+  deleteCustomersStartsWith
+} from "../../support/api/requests/Customer";
+import { updateOrdersSettings } from "../../support/api/requests/Order";
+import { getDefaultChannel } from "../../support/api/utils/channelsUtils";
+import * as productsUtils from "../../support/api/utils/products/productsUtils";
+import {
+  createShipping,
+  deleteShippingStartsWith
+} from "../../support/api/utils/shippingUtils";
+import filterTests from "../../support/filterTests";
+import { selectChannelInPicker } from "../../support/pages/channelsPage";
+
+filterTests({ definedTags: ["all"] }, () => {
+  describe("Orders", () => {
+    const startsWith = "CyOrders-";
+    const randomName = startsWith + faker.datatype.number();
+
+    let customer;
+    let defaultChannel;
+    let warehouse;
+    let shippingMethod;
+    let variantsList;
+    let address;
+
+    before(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      deleteCustomersStartsWith(startsWith);
+      deleteShippingStartsWith(startsWith);
+      productsUtils.deleteProductsStartsWith(startsWith);
+
+      updateOrdersSettings();
+      getDefaultChannel()
+        .then(channel => {
+          defaultChannel = channel;
+        })
+        .then(() => {
+          cy.fixture("addresses");
+        })
+        .then(addresses => {
+          address = addresses.plAddress;
+          createCustomer(
+            `${randomName}@example.com`,
+            randomName,
+            address,
+            true
+          );
+        })
+        .then(customerResp => {
+          customer = customerResp.body.data.customerCreate.user;
+          createShipping({
+            channelId: defaultChannel.id,
+            name: randomName,
+            address
+          });
+        })
+        .then(
+          ({
+            warehouse: warehouseResp,
+            shippingMethod: shippingMethodResp
+          }) => {
+            shippingMethod = shippingMethodResp;
+            warehouse = warehouseResp;
+            productsUtils.createTypeAttributeAndCategoryForProduct({
+              name: randomName
+            });
+          }
+        )
+        .then(
+          ({
+            productType: productTypeResp,
+            attribute: attributeResp,
+            category: categoryResp
+          }) => {
+            productsUtils.createProductInChannel({
+              name: randomName,
+              channelId: defaultChannel.id,
+              warehouseId: warehouse.id,
+              quantityInWarehouse: 0,
+              productTypeId: productTypeResp.id,
+              attributeId: attributeResp.id,
+              categoryId: categoryResp.id
+            });
+          }
+        )
+        .then(({ variantsList: variantsResp }) => {
+          variantsList = variantsResp;
+        });
+    });
+
+    beforeEach(() => {
+      cy.clearSessionData().loginUserViaRequest(
+        "auth",
+        ONE_PERMISSION_USERS.order
+      );
+    });
+
+    it("should create order with selected channel", () => {
+      cy.clearSessionData().loginUserViaRequest();
+      cy.visit(urlList.orders)
+        .get(ORDERS_SELECTORS.createOrder)
+        .click();
+      selectChannelInPicker(defaultChannel.name);
+      cy.pause();
+    });
+  });
+});

--- a/cypress/support/api/requests/Order.js
+++ b/cypress/support/api/requests/Order.js
@@ -79,6 +79,7 @@ export function completeOrder(orderId) {
       order{
         id
         number
+        status
         lines{
           id
         }
@@ -131,7 +132,13 @@ export function getOrder(orderId) {
   cy.sendRequestWithQuery(query).its("body.data.order");
 }
 
-export function fulfillOrder({ orderId, warehouse, quantity, linesId }) {
+export function fulfillOrder({
+  orderId,
+  warehouse,
+  quantity,
+  linesId,
+  allowStockToBeExceeded = false
+}) {
   const lines = linesId.reduce((lines, lineId) => {
     const line = `{orderLineId:"${lineId.id}"
       stocks:{
@@ -144,6 +151,7 @@ export function fulfillOrder({ orderId, warehouse, quantity, linesId }) {
   const mutation = `mutation fulfill{
   orderFulfill(order:"${orderId}" input:{
     lines:[${lines}]
+    allowStockToBeExceeded: ${true}
   }){
     errors{
       field

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -236,6 +236,13 @@ export function getVariant(id, channel, auth = "auth") {
     productVariant(id:"${id}" channel:"${channel}"){
       id
       name
+      quantityAvailable
+      stocks{
+        quantity
+        warehouse{
+          id
+        }
+      }
       pricing{
         onSale
         discount{
@@ -273,4 +280,25 @@ export function updateVariantPrice({ variantId, channelId, price }) {
     }
   }`;
   return cy.sendRequestWithQuery(mutation);
+}
+
+export function updateVariantStock({
+  variantId,
+  warehouseId,
+  quantityInWarehouse
+}) {
+  const mutation = `mutation{
+    productVariantStocksUpdate(variantId:"${variantId}" stocks:{
+      warehouse:"${warehouseId}"
+      quantity:${quantityInWarehouse}
+    }){
+      errors{
+        field
+        message
+      }
+    }
+  }`;
+  return cy
+    .sendRequestWithQuery(mutation)
+    .its("body.data.productVariantStocksUpdate");
 }

--- a/cypress/support/pages/orderPage.js
+++ b/cypress/support/pages/orderPage.js
@@ -1,0 +1,26 @@
+import { ORDER_FULFILL_SELECTORS } from "../../elements/orders/order-fulfill-selectors";
+import { ORDER_SELECTORS } from "../../elements/orders/order-selectors";
+import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
+
+export function fulfillOrder(quantityToFulfill = 1) {
+  return cy
+    .get(ORDER_SELECTORS.fulfillOrderButton)
+    .click()
+    .get(ORDER_FULFILL_SELECTORS.fulfillOrderButton)
+    .type(quantityToFulfill)
+    .addAliasToGraphRequest("FulfillOrder")
+    .get(BUTTON_SELECTORS.confirm)
+    .click();
+}
+
+export function fulfillOrderWithInsufficientStock(quantityToFulfill = 1) {
+  fulfillOrder(quantityToFulfill)
+    .wait("@FulfillOrder")
+    .its("response.body.data.orderFulfill.errors")
+    .then(errors => expect(errors[0].code).to.eq("INSUFFICIENT_STOCK"));
+  return cy
+    .get(BUTTON_SELECTORS.submit)
+    .click()
+    .wait("@FulfillOrder")
+    .its("response.body.data.orderFulfill");
+}

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -408,6 +408,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
                                 key={warehouseStock.id}
                               >
                                 <TextField
+                                  data-test-id="quantity-to-fulfill"
                                   type="number"
                                   inputProps={{
                                     className: classNames(

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -74,7 +74,11 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
                 </div>
               </Tooltip>
             ) : (
-              <Button variant="primary" onClick={onFulfill}>
+              <Button
+                variant="primary"
+                onClick={onFulfill}
+                data-test-id="fulfill-order-button"
+              >
                 {intl.formatMessage(messages.fulfillButton)}
               </Button>
             )}


### PR DESCRIPTION
I want to merge this change because I added tests for fulfilling orders with products without stock

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
