### PR TITLE
Fix double "dashboard" part in link hrefs

### DIFF
--- a/src/auth/views/ResetPassword.tsx
+++ b/src/auth/views/ResetPassword.tsx
@@ -53,7 +53,7 @@ const ResetPasswordView: React.FC = () => {
           <ResetPasswordPage
             disabled={requestPasswordResetOpts.loading}
             error={error}
-            onBack={() => navigate(APP_MOUNT_URI)}
+            onBack={() => navigate("/")}
             onSubmit={handleSubmit}
           />
         );

--- a/src/auth/views/ResetPasswordSuccess.tsx
+++ b/src/auth/views/ResetPasswordSuccess.tsx
@@ -1,4 +1,3 @@
-import { APP_MOUNT_URI } from "@saleor/config";
 import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 
@@ -7,7 +6,7 @@ import ResetPasswordSuccessPage from "../components/ResetPasswordSuccessPage";
 const ResetPasswordSuccessView: React.FC = () => {
   const navigate = useNavigator();
 
-  return <ResetPasswordSuccessPage onBack={() => navigate(APP_MOUNT_URI)} />;
+  return <ResetPasswordSuccessPage onBack={() => navigate("/")} />;
 };
 ResetPasswordSuccessView.displayName = "ResetPasswordSuccessView";
 export default ResetPasswordSuccessView;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -292,7 +292,7 @@ export function getUserInitials(user?: User) {
 }
 
 export function createHref(url: string) {
-  return urlJoin(APP_MOUNT_URI, url);
+  return urlJoin("/", APP_MOUNT_URI, url);
 }
 
 interface AnyEvent {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -2,11 +2,9 @@ import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import moment from "moment-timezone";
 import { MutationFunction, MutationResult } from "react-apollo";
 import { IntlShape } from "react-intl";
-import urlJoin from "url-join";
 
 import { StatusType } from "./components/StatusChip/types";
 import { StatusLabelProps } from "./components/StatusLabel";
-import { APP_MOUNT_URI } from "./config";
 import { AddressType, AddressTypeInput } from "./customers/types";
 import {
   commonStatusMessages,
@@ -289,10 +287,6 @@ export function getUserInitials(user?: User) {
         : user.email.slice(0, 2)
       ).toUpperCase()
     : undefined;
-}
-
-export function createHref(url: string) {
-  return urlJoin("/", APP_MOUNT_URI, url);
 }
 
 interface AnyEvent {

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { customerUrl } from "../../../customers/urls";
-import { createHref, maybe } from "../../../misc";
+import { maybe } from "../../../misc";
 import { OrderDetails_order } from "../../types/OrderDetails";
 
 const useStyles = makeStyles(
@@ -193,7 +193,7 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
               <div>
                 <Link
                   underline={false}
-                  href={createHref(customerUrl(user.id))}
+                  href={customerUrl(user.id)}
                   onClick={onProfileView}
                 >
                   <FormattedMessage

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -13,7 +13,7 @@ import SingleAutocompleteSelectField, {
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import { makeStyles } from "@saleor/macaw-ui";
-import { createHref, maybe } from "@saleor/misc";
+import { maybe } from "@saleor/misc";
 import { productTypeUrl } from "@saleor/productTypes/urls";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -133,7 +133,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
               <FormattedMessage defaultMessage="Product Type" />
             </Typography>
             <Link
-              href={createHref(productTypeUrl(productType?.id) ?? "")}
+              href={productTypeUrl(productType?.id)}
               disabled={!productType?.id}
             >
               {productType?.name ?? "..."}


### PR DESCRIPTION
I want to merge this change because it fixes redirects to `/dashboard/dashboard/something`.

**PR intended to be tested with API branch:** 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
