### PR TITLE
Allow empty attribute to be included in variant creation

### DIFF
--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -117,9 +117,7 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
       variables: {
         input: {
           attributes: prepareAttributesInput({
-            attributes: formData.attributes.filter(
-              attribute => attribute.value?.length && attribute.value[0] !== ""
-            ),
+            attributes: formData.attributes,
             updatedFileAttributes
           }),
           product: productId,


### PR DESCRIPTION
I want to merge this change because it fixes an issue that made it impossible to pass empty attribute in variant creation.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
