### PR TITLE
Add tests for content attributes for 3.1

### DIFF
--- a/cypress/integration/configuration/attributes/createContentAttribute.js
+++ b/cypress/integration/configuration/attributes/createContentAttribute.js
@@ -6,7 +6,10 @@ import faker from "faker";
 import { ATTRIBUTES_DETAILS } from "../../../elements/attribute/attributes_details";
 import { ATTRIBUTES_LIST } from "../../../elements/attribute/attributes_list";
 import { urlList } from "../../../fixtures/urlList";
-import { getAttribute } from "../../../support/api/requests/Attribute";
+import {
+  createAttribute,
+  getAttribute
+} from "../../../support/api/requests/Attribute";
 import { deleteAttributesStartsWith } from "../../../support/api/utils/attributes/attributeUtils";
 import { expectCorrectDataInAttribute } from "../../../support/api/utils/attributes/checkAttributeData";
 import filterTests from "../../../support/filterTests";
@@ -20,7 +23,9 @@ filterTests({ definedTags: ["all"] }, () => {
       "MULTISELECT",
       "FILE",
       "RICH_TEXT",
-      "BOOLEAN"
+      "BOOLEAN",
+      "DATE",
+      "DATE_TIME"
     ];
     const attributeReferenceType = ["PRODUCT", "PAGE"];
     const attributeNumericType = [
@@ -43,6 +48,7 @@ filterTests({ definedTags: ["all"] }, () => {
         .get(ATTRIBUTES_DETAILS.pageTypeAttributeCheckbox)
         .click();
     });
+
     attributesTypes.forEach(attributeType => {
       it(`should create ${attributeType} attribute`, () => {
         const attributeName = `${startsWith}${faker.datatype.number()}`;

--- a/cypress/integration/configuration/attributes/deleteAndUpdateContentAttribute.js
+++ b/cypress/integration/configuration/attributes/deleteAndUpdateContentAttribute.js
@@ -1,0 +1,62 @@
+// / <reference types="cypress"/>
+// / <reference types="../../../support"/>
+
+import faker from "faker";
+
+import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
+import { attributeDetailsUrl } from "../../../fixtures/urlList";
+import {
+  createAttribute,
+  getAttribute
+} from "../../../support/api/requests/Attribute";
+import { deleteAttributesStartsWith } from "../../../support/api/utils/attributes/attributeUtils";
+import filterTests from "../../../support/filterTests";
+import { fillUpAttributeNameAndCode } from "../../../support/pages/attributesPage";
+
+filterTests({ definedTags: ["all"] }, () => {
+  describe("Delete and update content attribute", () => {
+    const startsWith = "AttrContDel";
+    let attribute;
+
+    before(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      deleteAttributesStartsWith(startsWith);
+    });
+
+    beforeEach(() => {
+      cy.clearSessionData().loginUserViaRequest();
+      createAttribute({
+        name: `${startsWith}${faker.datatype.number()}`,
+        type: "PAGE_TYPE"
+      }).then(attributeResp => {
+        attribute = attributeResp;
+      });
+    });
+
+    it("should delete attribute", () => {
+      cy.visit(attributeDetailsUrl(attribute.id))
+        .get(BUTTON_SELECTORS.deleteButton)
+        .click()
+        .addAliasToGraphRequest("AttributeDelete")
+        .get(BUTTON_SELECTORS.submit)
+        .click()
+        .waitForRequestAndCheckIfNoErrors("@AttributeDelete");
+      getAttribute(attribute.id).should("be.null");
+    });
+
+    it("should update attribute", () => {
+      const attributeUpdatedName = `${startsWith}${faker.datatype.number()}`;
+
+      cy.visit(attributeDetailsUrl(attribute.id));
+      fillUpAttributeNameAndCode(attributeUpdatedName);
+      cy.addAliasToGraphRequest("AttributeUpdate")
+        .get(BUTTON_SELECTORS.confirm)
+        .click()
+        .waitForRequestAndCheckIfNoErrors("@AttributeUpdate");
+      getAttribute(attribute.id).then(attributeResp => {
+        expect(attributeResp.name).to.eq(attributeUpdatedName);
+        expect(attributeResp.slug).to.eq(attributeUpdatedName);
+      });
+    });
+  });
+});

--- a/cypress/support/api/requests/Attribute.js
+++ b/cypress/support/api/requests/Attribute.js
@@ -27,7 +27,7 @@ export function createAttribute({
           }
         }
       }
-      attributeErrors{
+      errors{
         field
         message
       }


### PR DESCRIPTION
I want to merge this change because I added tests for content attributes for 3.1

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
