### PR TITLE
Add new tests for product types

### DIFF
--- a/cypress/elements/shared/button-selectors.js
+++ b/cypress/elements/shared/button-selectors.js
@@ -10,7 +10,8 @@ export const BUTTON_SELECTORS = {
   deleteButton: '[data-test="button-bar-delete"]',
   expandIcon: '[data-test-id="expand-icon"]',
   nextPaginationButton: '[data-test="button-pagination-next"]',
-  deleteIcon: '[data-test-id="deleteIcon"]',
+  deleteIcon: '[data-test-id="delete-icon"]',
   showMoreButton: '[data-test-id="showMoreButton"]',
-  button: "button"
+  button: "button",
+  deleteAssignedItemsConsentCheckbox: '[name="delete-assigned-items-consent"]'
 };

--- a/cypress/elements/shared/sharedElements.js
+++ b/cypress/elements/shared/sharedElements.js
@@ -21,7 +21,8 @@ export const SHARED_ELEMENTS = {
   filters: {
     filterGroupActivateCheckbox: '[data-test="filterGroupActive"]',
     filterRow: '[data-test="channel-availability-item"]'
-  }
+  },
+  warningDialog: '[data-test-id="warning-dialog"]'
 };
 
 export const selectorWithDataValue = value => `[data-value="${value}"]`;

--- a/cypress/integration/configuration/productTypes.js
+++ b/cypress/integration/configuration/productTypes.js
@@ -4,24 +4,38 @@
 import faker from "faker";
 
 import { PRODUCT_TYPE_DETAILS } from "../../elements/productTypes/productTypeDetails";
+import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
+import { SHARED_ELEMENTS } from "../../elements/shared/sharedElements";
 import { productTypeDetailsUrl, urlList } from "../../fixtures/urlList";
 import { createAttribute } from "../../support/api/requests/Attribute";
+import { createCategory } from "../../support/api/requests/Category";
 import {
+  assignAttribute,
   createTypeProduct,
   getProductType
 } from "../../support/api/requests/ProductType";
-import { deleteProductsStartsWith } from "../../support/api/utils/products/productsUtils";
+import { getProductDetails } from "../../support/api/requests/storeFront/ProductDetails";
+import { getDefaultChannel } from "../../support/api/utils/channelsUtils";
+import {
+  createProductInChannel,
+  deleteProductsStartsWith
+} from "../../support/api/utils/products/productsUtils";
 import filterTests from "../../support/filterTests";
 import { createProductType } from "../../support/pages/productTypePage";
 
 filterTests({ definedTags: ["all"] }, () => {
   describe("Tests for product types", () => {
-    const startsWith = "ProductType";
+    const startsWith = "productType";
+    let category;
+    let channel;
+    let attribute;
 
     before(() => {
       cy.clearSessionData().loginUserViaRequest();
       deleteProductsStartsWith(startsWith);
-      createAttribute({ name: startsWith });
+      createAttribute({ name: startsWith }).then(resp => (attribute = resp));
+      createCategory(startsWith).then(resp => (category = resp));
+      getDefaultChannel().then(resp => (channel = resp));
     });
 
     beforeEach(() => {
@@ -100,6 +114,113 @@ filterTests({ definedTags: ["all"] }, () => {
         })
         .then(productType => {
           expect(productType.variantAttributes[0].name).to.eq(startsWith);
+        });
+    });
+
+    it("Delete product type", () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+
+      createTypeProduct({ name, hasVariants: false }).then(productType => {
+        cy.visitAndWaitForProgressBarToDisappear(
+          productTypeDetailsUrl(productType.id)
+        )
+          .get(BUTTON_SELECTORS.deleteButton)
+          .click()
+          .addAliasToGraphRequest("ProductTypeDelete")
+          .get(SHARED_ELEMENTS.warningDialog)
+          .find(BUTTON_SELECTORS.deleteButton)
+          .click()
+          .waitForRequestAndCheckIfNoErrors("@ProductTypeDelete");
+        getProductType(productType.id).should("be.null");
+      });
+    });
+
+    it("Delete product type with assigned product", () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+      let productType;
+
+      createTypeProduct({ name, hasVariants: false })
+        .then(productTypeResp => {
+          productType = productTypeResp;
+          createProductInChannel({
+            name,
+            channelId: channel.id,
+            categoryId: category.id,
+            productTypeId: productType.id
+          });
+        })
+        .then(({ product }) => {
+          cy.visitAndWaitForProgressBarToDisappear(
+            productTypeDetailsUrl(productType.id)
+          )
+            .get(BUTTON_SELECTORS.deleteButton)
+            .click()
+            .addAliasToGraphRequest("ProductTypeDelete")
+            .get(SHARED_ELEMENTS.warningDialog)
+            .find(BUTTON_SELECTORS.deleteButton)
+            .should("not.be.enabled")
+            .get(BUTTON_SELECTORS.deleteAssignedItemsConsentCheckbox)
+            .click()
+            .get(SHARED_ELEMENTS.warningDialog)
+            .find(BUTTON_SELECTORS.deleteButton)
+            .click()
+            .waitForRequestAndCheckIfNoErrors("@ProductTypeDelete");
+          getProductType(productType.id).should("be.null");
+          getProductDetails(product.id)
+            .its("body.data.product")
+            .should("be.null");
+        });
+    });
+
+    it("Remove variant attribute from product type", () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+      let productType;
+
+      createTypeProduct({ name, hasVariants: true })
+        .then(productTypeResp => {
+          productType = productTypeResp;
+          assignAttribute(productType.id, attribute.id);
+        })
+        .then(() => {
+          cy.visitAndWaitForProgressBarToDisappear(
+            productTypeDetailsUrl(productType.id)
+          )
+            .get(BUTTON_SELECTORS.deleteIcon)
+            .click()
+            .addAliasToGraphRequest("UnassignProductAttribute")
+            .get(BUTTON_SELECTORS.submit)
+            .click()
+            .wait("@UnassignProductAttribute");
+          getProductType(productType.id);
+        })
+        .then(productType => {
+          expect(productType.variantAttributes).to.be.empty;
+        });
+    });
+
+    it("Remove variant attribute from product type", () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+      let productType;
+
+      createTypeProduct({ name, hasVariants: false })
+        .then(productTypeResp => {
+          productType = productTypeResp;
+          assignAttribute(productType.id, attribute.id, "PRODUCT");
+        })
+        .then(() => {
+          cy.visitAndWaitForProgressBarToDisappear(
+            productTypeDetailsUrl(productType.id)
+          )
+            .get(BUTTON_SELECTORS.deleteIcon)
+            .click()
+            .addAliasToGraphRequest("UnassignProductAttribute")
+            .get(BUTTON_SELECTORS.submit)
+            .click()
+            .wait("@UnassignProductAttribute");
+          getProductType(productType.id);
+        })
+        .then(productType => {
+          expect(productType.variantAttributes).to.be.empty;
         });
     });
   });

--- a/cypress/integration/configuration/productTypes.js
+++ b/cypress/integration/configuration/productTypes.js
@@ -24,7 +24,7 @@ import filterTests from "../../support/filterTests";
 import { createProductType } from "../../support/pages/productTypePage";
 
 filterTests({ definedTags: ["all"] }, () => {
-  describe("Tests for product types", () => {
+  describe("As an admin I want to manage product types", () => {
     const startsWith = "productType";
     let category;
     let channel;
@@ -45,7 +45,7 @@ filterTests({ definedTags: ["all"] }, () => {
         .softExpectSkeletonIsVisible();
     });
 
-    it("Create product type without shipping required", () => {
+    it("As an admin I want to create product type without shipping required", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createProductType(name, false)
@@ -58,7 +58,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Create product type with shipping required", () => {
+    it("As an admin I want to create product type with shipping required", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const shippingWeight = 10;
 
@@ -73,7 +73,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Update product type with product attribute", () => {
+    it("As an admin I want to update product type with product attribute", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createTypeProduct({ name })
@@ -94,7 +94,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Update product type with variant attribute", () => {
+    it("As an admin I want to update product type with variant attribute", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createTypeProduct({ name, hasVariants: false })
@@ -117,7 +117,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Delete product type", () => {
+    it("As an admin I want to delete product type", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createTypeProduct({ name, hasVariants: false }).then(productType => {
@@ -135,7 +135,7 @@ filterTests({ definedTags: ["all"] }, () => {
       });
     });
 
-    it("Delete product type with assigned product", () => {
+    it("As an admin I want to delete product type with assigned product", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       let productType;
 
@@ -172,7 +172,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Remove variant attribute from product type", () => {
+    it("As an admin I want to remove variant attribute from product type", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       let productType;
 
@@ -198,7 +198,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Remove variant attribute from product type", () => {
+    it("As an admin I want to remove variant attribute from product type", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       let productType;
 

--- a/cypress/support/api/requests/Attribute.js
+++ b/cypress/support/api/requests/Attribute.js
@@ -27,7 +27,7 @@ export function createAttribute({
           }
         }
       }
-      attributeErrors{
+      errors{
         field
         message
       }

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -113,12 +113,16 @@ export function createProduct({
     attributeValue,
     `values:["${attributeValue}"]`
   );
+  const attributes = getValueWithDefault(
+    attributeId,
+    `attributes:[{
+    id:"${attributeId}"
+    ${attributeValuesLine}
+  }]`
+  );
   const mutation = `mutation{
     productCreate(input:{
-      attributes:[{
-        id:"${attributeId}"
-        ${attributeValuesLine}
-      }]
+      ${attributes}
       name:"${name}"
       slug:"${name}"
       seo:{title:"${name}" description:""}

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -116,9 +116,9 @@ export function createProduct({
   const attributes = getValueWithDefault(
     attributeId,
     `attributes:[{
-    id:"${attributeId}"
-    ${attributeValuesLine}
-  }]`
+      id:"${attributeId}"
+      ${attributeValuesLine}
+    }]`
   );
   const mutation = `mutation{
     productCreate(input:{

--- a/cypress/support/api/requests/ProductType.js
+++ b/cypress/support/api/requests/ProductType.js
@@ -143,3 +143,22 @@ export function setProductTypeAsDigital(productTypeId, isDigital = true) {
    }`;
   return cy.sendRequestWithQuery(mutation);
 }
+
+export function assignAttribute(
+  productTypeId,
+  attributeId,
+  attributeType = "VARIANT"
+) {
+  const mutation = `mutation{
+    productAttributeAssign(productTypeId:"${productTypeId}" operations:{
+      id:"${attributeId}"
+      type: ${attributeType}
+    }){
+      errors{
+        field
+        message
+      }
+    }
+  }`;
+  return cy.sendRequestWithQuery(mutation);
+}

--- a/cypress/support/api/requests/ProductType.js
+++ b/cypress/support/api/requests/ProductType.js
@@ -150,7 +150,7 @@ export function assignAttribute(
   attributeType = "VARIANT"
 ) {
   const mutation = `mutation{
-    productAttributeAssign(productTypeId:"${productTypeId}" operations:{
+    productAttributeAssign(productTypeId:"${productTypeId}", operations:{
       id:"${attributeId}"
       type: ${attributeType}
     }){

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -265,7 +265,7 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
         }
         productListToolbar={
           <IconButton
-            data-test-id="deleteIcon"
+            data-test-id="delete-icon"
             color="primary"
             onClick={() =>
               openModal("delete-products", {

--- a/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
+++ b/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
@@ -92,7 +92,7 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
 
   return (
     <Modal open={isOpen}>
-      <div className={classes.centerContainer}>
+      <div className={classes.centerContainer} data-test-id="warning-dialog">
         <Card className={classes.content}>
           <ModalTitle
             title={intl.formatMessage(baseMessages.title, {

--- a/src/permissionGroups/components/PermissionGroupList/PermissionGroupList.tsx
+++ b/src/permissionGroups/components/PermissionGroupList/PermissionGroupList.tsx
@@ -149,7 +149,7 @@ const PermissionGroupList: React.FC<PermissionGroupListProps> = props => {
                     {permissionGroup.userCanManage && (
                       <IconButton
                         variant="secondary"
-                        data-test-id="deleteIcon"
+                        data-test-id="delete-icon"
                         color="primary"
                         onClick={stopPropagation(() =>
                           onDelete(permissionGroup.id)

--- a/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -190,6 +190,7 @@ const ProductTypeAttributes: React.FC<ProductTypeAttributesProps> = props => {
                   </TableCell>
                   <TableCell className={classes.colAction}>
                     <IconButton
+                      data-test-id="delete-icon"
                       disabled={disabled}
                       variant="secondary"
                       onClick={stopPropagation(() =>


### PR DESCRIPTION
I want to merge this change because I added tests for product types

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
