### PR TITLE
Add test for creating product type with gift card kind

### DIFF
--- a/cypress/elements/productTypes/productTypeDetails.js
+++ b/cypress/elements/productTypes/productTypeDetails.js
@@ -4,5 +4,6 @@ export const PRODUCT_TYPE_DETAILS = {
   assignProductAttributeButton: '[data-test-id="assignProductsAttributes"]',
   assignVariantAttributeButton: '[data-test-id="assignVariantsAttributes"]',
   hasVariantsButton: '[name="hasVariants"]',
-  shippingWeightInput: '[name="weight"]'
+  shippingWeightInput: '[name="weight"]',
+  giftCardKindCheckbox: '[data-test-id="product-type-kind-option-GIFT_CARD"]'
 };

--- a/cypress/integration/configuration/productTypes.js
+++ b/cypress/integration/configuration/productTypes.js
@@ -15,7 +15,7 @@ import filterTests from "../../support/filterTests";
 import { createProductType } from "../../support/pages/productTypePage";
 
 filterTests({ definedTags: ["all"] }, () => {
-  describe("Tests for product types", () => {
+  describe("As an admin I want to manage product types", () => {
     const startsWith = "ProductType";
 
     before(() => {

--- a/cypress/integration/configuration/productTypes.js
+++ b/cypress/integration/configuration/productTypes.js
@@ -34,13 +34,14 @@ filterTests({ definedTags: ["all"] }, () => {
     it("Create product type without shipping required", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
-      createProductType(name, false)
+      createProductType({ name })
         .then(productType => {
           getProductType(productType.id);
         })
         .then(productType => {
           expect(productType.name).to.be.eq(name);
           expect(productType.isShippingRequired).to.be.false;
+          expect(productType.kind).to.be.eq("NORMAL");
         });
     });
 
@@ -48,7 +49,7 @@ filterTests({ definedTags: ["all"] }, () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const shippingWeight = 10;
 
-      createProductType(name, shippingWeight)
+      createProductType({ name, shippingWeight })
         .then(productType => {
           getProductType(productType.id);
         })
@@ -56,6 +57,21 @@ filterTests({ definedTags: ["all"] }, () => {
           expect(productType.name).to.be.eq(name);
           expect(productType.isShippingRequired).to.be.true;
           expect(productType.weight.value).to.eq(shippingWeight);
+          expect(productType.kind).to.be.eq("NORMAL");
+        });
+    });
+
+    it("Create product type with gift card kind", () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+
+      createProductType({ name, giftCard: true })
+        .then(productType => {
+          getProductType(productType.id);
+        })
+        .then(productType => {
+          expect(productType.name).to.be.eq(name);
+          expect(productType.isShippingRequired).to.be.false;
+          expect(productType.kind).to.be.eq("GIFT_CARD");
         });
     });
 
@@ -89,7 +105,7 @@ filterTests({ definedTags: ["all"] }, () => {
             productTypeDetailsUrl(productType.id)
           )
             .get(PRODUCT_TYPE_DETAILS.hasVariantsButton)
-            .click()
+            .click({ force: true })
             .get(PRODUCT_TYPE_DETAILS.assignVariantAttributeButton)
             .click()
             .addAliasToGraphRequest("AssignProductAttribute")

--- a/cypress/integration/configuration/productTypes.js
+++ b/cypress/integration/configuration/productTypes.js
@@ -31,7 +31,7 @@ filterTests({ definedTags: ["all"] }, () => {
         .softExpectSkeletonIsVisible();
     });
 
-    it("Create product type without shipping required", () => {
+    it("As an admin I should be able to create product type without shipping required", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createProductType({ name })
@@ -45,7 +45,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Create product type with shipping required", () => {
+    it("As an admin I should be able to create product type with shipping required", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const shippingWeight = 10;
 
@@ -61,7 +61,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Create product type with gift card kind", () => {
+    it("As an admin I should be able to create product type with gift card kind", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createProductType({ name, giftCard: true })
@@ -75,7 +75,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Update product type with product attribute", () => {
+    it("As an admin I should be able to update product type with product attribute", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createTypeProduct({ name })
@@ -96,7 +96,7 @@ filterTests({ definedTags: ["all"] }, () => {
         });
     });
 
-    it("Update product type with variant attribute", () => {
+    it("As an admin I should be able to update product type with variant attribute", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 
       createTypeProduct({ name, hasVariants: false })

--- a/cypress/support/api/requests/ProductType.js
+++ b/cypress/support/api/requests/ProductType.js
@@ -97,6 +97,7 @@ export function getProductType(productTypeId) {
     productType(id:"${productTypeId}"){
       id
       name
+      kind
       isShippingRequired
       weight{
         value

--- a/cypress/support/pages/productTypePage.js
+++ b/cypress/support/pages/productTypePage.js
@@ -2,12 +2,15 @@ import { PRODUCT_TYPE_DETAILS } from "../../elements/productTypes/productTypeDet
 import { PRODUCT_TYPES_LIST } from "../../elements/productTypes/productTypesList";
 import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
 
-export function createProductType(name, shippingWeight) {
+export function createProductType({ name, shippingWeight, giftCard = false }) {
   cy.get(PRODUCT_TYPES_LIST.addProductTypeButton)
     .click()
     .waitForProgressBarToNotBeVisible()
     .get(PRODUCT_TYPE_DETAILS.nameInput)
     .type(name);
+  if (giftCard) {
+    cy.get(PRODUCT_TYPE_DETAILS.giftCardKindCheckbox).click();
+  }
   if (shippingWeight) {
     cy.get(PRODUCT_TYPE_DETAILS.isShippingRequired)
       .click()


### PR DESCRIPTION
I want to merge this change because I added test for creating product type with gift card kind
<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
