### PR TITLE
Always run critical tests on 3.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cypress-run:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && (((github.event.action == 'labeled') && (github.event.label.name == 'run e2e')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'run e2e')))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -19,12 +19,11 @@ jobs:
         # Search for CYPRESS_API_URI in PR description and use default if not defined
         env:
           pull_request_body: ${{ github.event.pull_request.body }}
-          prefix: CYPRESS_API_URI=
+          prefix: API_URI=
           pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
           fallback_uri: ${{ secrets.CYPRESS_API_URI }}
         run: |
           echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
-
       - name: Cypress run full spec
         if: ${{ steps.api_uri.outputs.custom_api_uri == 'https://qa.staging.saleor.cloud/graphql/' }}
         uses: cypress-io/github-action@v2
@@ -65,6 +64,46 @@ jobs:
           wait-on: http://localhost:9000/
           wait-on-timeout: 120
           command: npm run cy:run:allEnv
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+  cypress-run-critical:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && ((github.event.label.name != 'run e2e') || !(contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for CYPRESS_API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: CYPRESS_API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+      - name: Cypress run critical
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:critical
       - uses: actions/upload-artifact@v1
         if: ${{ failure() }}
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,10 @@ name: E2E
 
 on:
   pull_request:
-    types: [reopened, synchronize, labeled]
+    types: [reopened, synchronize, labeled, opened]
     branches: ["*"]
-
+  workflow_dispatch:
+    branches: ["*"]
 jobs:
   cypress-run:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && (((github.event.action == 'labeled') && (github.event.label.name == 'run e2e')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'run e2e')))


### PR DESCRIPTION
I want to merge this change because I want to always run critical tests on 3.0

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
