### PR TITLE
Fix order line overflowing texts

### DIFF
--- a/src/orders/components/OrderFulfilledProductsCard/styles.ts
+++ b/src/orders/components/OrderFulfilledProductsCard/styles.ts
@@ -7,6 +7,12 @@ const useStyles = makeStyles(
       padding: theme.spacing(2, 3)
     },
     table: {
+      "& td, & th": {
+        "&:not(:first-child):not(:last-child)": {
+          paddingLeft: theme.spacing(1),
+          paddingRight: theme.spacing(1)
+        }
+      },
       tableLayout: "fixed"
     },
     infoLabel: {

--- a/src/orders/components/OrderProductsCardElements/OrderProductsCardHeader.tsx
+++ b/src/orders/components/OrderProductsCardElements/OrderProductsCardHeader.tsx
@@ -14,20 +14,20 @@ const useStyles = makeStyles(
     },
     colPrice: {
       textAlign: "right",
-      width: 120
+      width: 150
     },
     colQuantity: {
       textAlign: "center",
-      width: 120
+      width: 110
     },
     colSku: {
       textAlign: "right",
       textOverflow: "ellipsis",
-      width: 120
+      width: 140
     },
     colTotal: {
       textAlign: "right",
-      width: 120
+      width: 150
     },
     infoLabel: {
       display: "inline-block"
@@ -56,40 +56,49 @@ const TableHeader = () => {
   const classes = useStyles({});
 
   return (
-    <TableHead>
-      <TableRow>
-        <TableCell className={classes.colName}>
-          <FormattedMessage
-            defaultMessage="Product"
-            description="product name"
-          />
-        </TableCell>
-        <TableCell className={classes.colSku}>
-          <FormattedMessage
-            defaultMessage="SKU"
-            description="ordered product sku"
-          />
-        </TableCell>
-        <TableCell className={classes.colQuantity}>
-          <FormattedMessage
-            defaultMessage="Quantity"
-            description="ordered product quantity"
-          />
-        </TableCell>
-        <TableCell className={classes.colPrice}>
-          <FormattedMessage
-            defaultMessage="Price"
-            description="product price"
-          />
-        </TableCell>
-        <TableCell className={classes.colTotal}>
-          <FormattedMessage
-            defaultMessage="Total"
-            description="order line total price"
-          />
-        </TableCell>
-      </TableRow>
-    </TableHead>
+    <>
+      <colgroup>
+        <col className={classes.colName} />
+        <col className={classes.colSku} />
+        <col className={classes.colQuantity} />
+        <col className={classes.colPrice} />
+        <col className={classes.colTotal} />
+      </colgroup>
+      <TableHead>
+        <TableRow>
+          <TableCell className={classes.colName}>
+            <FormattedMessage
+              defaultMessage="Product"
+              description="product name"
+            />
+          </TableCell>
+          <TableCell className={classes.colSku}>
+            <FormattedMessage
+              defaultMessage="SKU"
+              description="ordered product sku"
+            />
+          </TableCell>
+          <TableCell className={classes.colQuantity}>
+            <FormattedMessage
+              defaultMessage="Quantity"
+              description="ordered product quantity"
+            />
+          </TableCell>
+          <TableCell className={classes.colPrice}>
+            <FormattedMessage
+              defaultMessage="Price"
+              description="product price"
+            />
+          </TableCell>
+          <TableCell className={classes.colTotal}>
+            <FormattedMessage
+              defaultMessage="Total"
+              description="order line total price"
+            />
+          </TableCell>
+        </TableRow>
+      </TableHead>
+    </>
   );
 };
 

--- a/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
+++ b/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
@@ -17,28 +17,22 @@ import { orderProductsCardElementsMessages as messages } from "./messages";
 
 const useStyles = makeStyles(
   theme => ({
-    colName: {
-      width: "auto"
-    },
+    colName: {},
     colNameLabel: {
       marginLeft: AVATAR_MARGIN
     },
     colPrice: {
-      textAlign: "right",
-      width: 120
+      textAlign: "right"
     },
     colQuantity: {
-      textAlign: "center",
-      width: 120
+      textAlign: "center"
     },
     colSku: {
       textAlign: "right",
-      textOverflow: "ellipsis",
-      width: 120
+      textOverflow: "ellipsis"
     },
     colTotal: {
-      textAlign: "right",
-      width: 120
+      textAlign: "right"
     },
     infoLabel: {
       display: "inline-block"
@@ -55,9 +49,6 @@ const useStyles = makeStyles(
     },
     statusBar: {
       paddingTop: 0
-    },
-    table: {
-      tableLayout: "fixed"
     }
   }),
   { name: "TableLine" }

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -19,6 +19,12 @@ const useStyles = makeStyles(
       padding: theme.spacing(2, 3)
     },
     table: {
+      "& td, & th": {
+        "&:not(:first-child):not(:last-child)": {
+          paddingLeft: theme.spacing(1),
+          paddingRight: theme.spacing(1)
+        }
+      },
       tableLayout: "fixed"
     }
   }),


### PR DESCRIPTION
I want to merge this change because it fixes overflowing values in order line tables.

**PR intended to be tested with API branch:** 3.0

### Screenshots
Before:
![image (17)](https://user-images.githubusercontent.com/6833443/150796038-81768eb3-0cad-41f2-b194-39030ea2bd21.png)
After:
<img width="871" alt="Zrzut ekranu 2022-01-24 o 14 55 32" src="https://user-images.githubusercontent.com/6833443/150795956-38055ff7-ba49-4fae-93c6-c5fdef777108.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
