### PR TITLE
EditorJS initialisation fixes

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -37,8 +37,8 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
 
   React.useEffect(
     () => {
-      if (data !== undefined) {
-        editor.current = new EditorJS({
+      if (data !== undefined && !editor.current) {
+        const editorjs = new EditorJS({
           data,
           holder: editorContainer.current,
           logLevel: "ERROR" as LogLevels,
@@ -51,6 +51,8 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
             // const undo = new Undo({ editor });
             // undo.initialize(data);
 
+            editor.current = editorjs;
+
             if (onReady) {
               onReady();
             }
@@ -60,7 +62,12 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
         });
       }
 
-      return editor.current?.destroy;
+      return () => {
+        if (editor.current) {
+          editor.current.destroy();
+        }
+        editor.current = null;
+      };
     },
     // Rerender editor only if changed from undefined to defined state
     [data === undefined]

--- a/src/components/RichTextEditor/RichTextEditorContent.tsx
+++ b/src/components/RichTextEditor/RichTextEditorContent.tsx
@@ -67,18 +67,29 @@ const RichTextEditorContent: React.FC<RichTextEditorContentProps> = ({
   const editorContainer = React.useRef<HTMLDivElement>();
   React.useEffect(
     () => {
-      if (data) {
-        editor.current = new EditorJS({
+      if (data !== undefined && !editor.current) {
+        const editorjs = new EditorJS({
           data,
           holder: editorContainer.current,
           logLevel: "ERROR" as LogLevels,
-          onReady,
+          onReady: () => {
+            editor.current = editorjs;
+
+            if (onReady) {
+              onReady();
+            }
+          },
           readOnly: true,
           tools
         });
       }
 
-      return editor.current?.destroy;
+      return () => {
+        if (editor.current) {
+          editor.current.destroy();
+        }
+        editor.current = null;
+      };
     },
     // Rerender editor only if changed from undefined to defined state
     [data === undefined]

--- a/src/translations/components/TranslationFields/TranslationFields.tsx
+++ b/src/translations/components/TranslationFields/TranslationFields.tsx
@@ -222,6 +222,13 @@ const TranslationFields: React.FC<TranslationFieldsProps> = props => {
                         onDiscard={onDiscard}
                         onSubmit={data => onSubmit(field, data)}
                       />
+                    ) : // FIXME
+                    // For now this is the only way to fix the issue
+                    // of initializing the editor with fetched data.
+                    // Without this the editor doesn't get the saved data
+                    // and is empty
+                    disabled ? (
+                      <Skeleton />
                     ) : (
                       <TranslationFieldsRich
                         resetKey={richTextResetKey}


### PR DESCRIPTION
I want to merge this change because it fixes editorjs issues in dashboard:

- Product update description can be edited
- Entering from a link, translation editor receives data and displays it in the input

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
