### PR TITLE
Redirect user to created variant after variant create

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6746,6 +6746,10 @@
     "context": "window title",
     "string": "Create Variants"
   },
+  "src_dot_products_dot_views_dot_variantCreatedSuccess": {
+    "context": "variant created success message",
+    "string": "Variant created"
+  },
   "src_dot_properties": {
     "string": "Properties"
   },

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -9,6 +9,7 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { useFileUploadMutation } from "@saleor/files/mutations";
 import useNavigator from "@saleor/hooks/useNavigator";
+import useNotifier from "@saleor/hooks/useNotifier";
 import useShop from "@saleor/hooks/useShop";
 import usePageSearch from "@saleor/searches/usePageSearch";
 import useProductSearch from "@saleor/searches/useProductSearch";
@@ -21,7 +22,7 @@ import {
 } from "@saleor/utils/metadata/updateMetadata";
 import { useWarehouseList } from "@saleor/warehouses/queries";
 import { warehouseAddPath } from "@saleor/warehouses/urls";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 
 import { weight } from "../../misc";
@@ -39,6 +40,7 @@ import {
   ProductVariantAddUrlQueryParams,
   productVariantEditUrl
 } from "../urls";
+import { variantCreateMessages as messages } from "./messages";
 import { createVariantReorderHandler } from "./ProductUpdate/handlers";
 
 interface ProductVariantCreateProps {
@@ -51,6 +53,8 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
   params
 }) => {
   const navigate = useNavigator();
+  const notify = useNotifier();
+
   const shop = useShop();
   const intl = useIntl();
   const warehouses = useWarehouseList({
@@ -59,6 +63,11 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
       first: 50
     }
   });
+
+  const [
+    productVariantCreateComplete,
+    setProductVariantCreateComplete
+  ] = useState(false);
 
   const { data, loading: productLoading } = useProductVariantCreateQuery({
     displayLoader: true,
@@ -135,6 +144,10 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
     });
     const id = result.data?.productVariantCreate?.productVariant?.id;
 
+    if (id) {
+      setProductVariantCreateComplete(true);
+    }
+
     return id || null;
   };
   const handleSubmit = createMetadataCreateHandler(
@@ -152,6 +165,23 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
         id: attribute.id
       })
     );
+
+  const handleProductVariantCreateSuccess = (variantId: string) => {
+    notify({
+      status: "success",
+      text: intl.formatMessage(messages.variantCreatedSuccess)
+    });
+    navigate(productVariantEditUrl(productId, variantId));
+  };
+
+  useEffect(() => {
+    const id =
+      variantCreateResult.data?.productVariantCreate?.productVariant?.id;
+
+    if (id && productVariantCreateComplete) {
+      handleProductVariantCreateSuccess(id);
+    }
+  }, [productVariantCreateComplete]);
 
   const {
     loadMore: loadMorePages,

--- a/src/products/views/messages.ts
+++ b/src/products/views/messages.ts
@@ -1,0 +1,8 @@
+import { defineMessages } from "react-intl";
+
+export const variantCreateMessages = defineMessages({
+  variantCreatedSuccess: {
+    defaultMessage: "Variant created",
+    description: "variant created success message"
+  }
+});


### PR DESCRIPTION
I want to merge this change because it redirects user to the created variant after variant creation.

3.0 reviewed PR: https://github.com/saleor/saleor-dashboard/pull/1771

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
