### PR TITLE
Don't render delete button if user doesn't have an avatar

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6818,17 +6818,17 @@
     "context": "section header",
     "string": "Preferences"
   },
+  "src_dot_staff_dot_components_dot_StaffProperties_dot_1473195966": {
+    "context": "avatar change button",
+    "string": "Change"
+  },
   "src_dot_staff_dot_components_dot_StaffProperties_dot_2650522200": {
     "context": "section header",
     "string": "Staff Member Information"
   },
-  "src_dot_staff_dot_components_dot_StaffProperties_dot_2771097267": {
-    "context": "button",
-    "string": "Change photo"
-  },
-  "src_dot_staff_dot_components_dot_StaffProperties_dot_457748370": {
-    "context": "button",
-    "string": "Delete photo"
+  "src_dot_staff_dot_components_dot_StaffProperties_dot_3645414921": {
+    "context": "avatar delete button",
+    "string": "Delete"
   },
   "src_dot_staff_dot_components_dot_UserStatus_dot_userDisableInstruction": {
     "string": "If you want to disable this User please uncheck the box below."

--- a/src/staff/components/StaffProperties/StaffProperties.tsx
+++ b/src/staff/components/StaffProperties/StaffProperties.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import SVG from "react-inlinesvg";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { getUserInitials, maybe } from "../../../misc";
+import { getUserInitials } from "../../../misc";
 import { StaffMemberDetails_user } from "../../types/StaffMemberDetails";
 
 const useStyles = makeStyles(

--- a/src/staff/components/StaffProperties/StaffProperties.tsx
+++ b/src/staff/components/StaffProperties/StaffProperties.tsx
@@ -128,6 +128,8 @@ const StaffProperties: React.FC<StaffPropertiesProps> = props => {
   const clickImgInput = () => imgInputAnchor.current.click();
   const formErrors = getFormErrors(["id"], errors || []);
 
+  const hasAvatar = !!staffMember?.avatar?.url;
+
   return (
     <Card className={className}>
       <CardTitle
@@ -140,10 +142,10 @@ const StaffProperties: React.FC<StaffPropertiesProps> = props => {
         <div className={classes.root}>
           <div>
             <div className={classes.avatar}>
-              {maybe(() => staffMember.avatar.url) ? (
+              {hasAvatar ? (
                 <img
                   className={classes.avatarImage}
-                  src={maybe(() => staffMember.avatar.url)}
+                  src={staffMember.avatar.url}
                 />
               ) : (
                 <div className={classes.avatarDefault}>
@@ -158,19 +160,23 @@ const StaffProperties: React.FC<StaffPropertiesProps> = props => {
                     className={classes.avatarActionText}
                   >
                     <FormattedMessage
-                      defaultMessage="Change photo"
-                      description="button"
+                      defaultMessage="Change"
+                      description="avatar change button"
                     />
                   </Typography>
-                  <Typography
-                    onClick={onImageDelete}
-                    className={classes.avatarActionText}
-                  >
-                    <FormattedMessage
-                      defaultMessage="Delete photo"
-                      description="button"
-                    />
-                  </Typography>
+                  {hasAvatar && (
+                    <>
+                      <Typography
+                        onClick={onImageDelete}
+                        className={classes.avatarActionText}
+                      >
+                        <FormattedMessage
+                          defaultMessage="Delete"
+                          description="avatar delete button"
+                        />
+                      </Typography>
+                    </>
+                  )}
                   <input
                     className={classes.fileField}
                     id="fileUpload"

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -81,7 +81,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
 
   return (
     <TypedStaffMemberDetailsQuery displayLoader variables={{ id }}>
-      {({ data, loading }) => {
+      {({ data, loading, refetch }) => {
         const staffMember = data?.user;
 
         if (staffMember === null) {
@@ -111,6 +111,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
               status: "success",
               text: intl.formatMessage(commonMessages.savedChanges)
             });
+            refetch();
           } else {
             notify({
               status: "error",
@@ -126,6 +127,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
               text: intl.formatMessage(commonMessages.savedChanges)
             });
             navigate(staffMemberDetailsUrl(id));
+            refetch();
           }
         };
 


### PR DESCRIPTION
I want to merge this change because it doesn't render "delete" button if user doesn't have an avatar + changed messages according to new design.

3.1 PR: https://github.com/saleor/saleor-dashboard/pull/1803

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://stable.staging.saleor.cloud/graphql/
