### PR TITLE
Fix order settings button being disabled

### DIFF
--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -44,12 +44,12 @@ function useOrderSettingsForm(
   shop: ShopOrderSettingsFragment,
   onSubmit: (data: OrderSettingsFormData) => SubmitPromise
 ): UseOrderSettingsFormResult {
-  const [changed, setChanged] = React.useState(false);
-
-  const { data, handleChange, formId } = useForm(
+  const { data, handleChange, formId, hasChanged, setChanged } = useForm(
     getOrderSeettingsFormData(orderSettings, shop),
     undefined,
-    { confirmLeave: true }
+    {
+      confirmLeave: true
+    }
   );
 
   const handleFormSubmit = useHandleFormSubmit({
@@ -63,7 +63,7 @@ function useOrderSettingsForm(
   return {
     change: handleChange,
     data,
-    hasChanged: changed,
+    hasChanged,
     submit
   };
 }


### PR DESCRIPTION
I want to merge this change because it fixes always disabled button on Order Settings page

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
