### PR TITLE
Run e2e test manually and every night

### DIFF
--- a/.github/workflows/manually-run-e2e.yml
+++ b/.github/workflows/manually-run-e2e.yml
@@ -1,0 +1,111 @@
+name: E2E
+
+on:
+  pull_request:
+    types: [reopened, synchronize, labeled, opened]
+    branches: ["*"]
+  workflow_dispatch:
+    branches: ["*"]
+jobs:
+  cypress-run:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && (((github.event.action == 'labeled') && (github.event.label.name == 'run e2e')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+      - name: Cypress run full spec
+        if: ${{ steps.api_uri.outputs.custom_api_uri == 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+          CYPRESS_MAILHOG: ${{ secrets.CYPRESS_MAILHOG }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+      - name: Cypress run allEnvs spec
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:allEnv
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+  cypress-run-critical:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && ((github.event.label.name != 'run e2e') || !(contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for CYPRESS_API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: CYPRESS_API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+      - name: Cypress run critical
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:critical
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/.github/workflows/manually-run-e2e.yml
+++ b/.github/workflows/manually-run-e2e.yml
@@ -1,4 +1,4 @@
-name: E2E
+name: Manually run e2e
 
 on:
   pull_request:

--- a/.github/workflows/run-e2e-at-night.yml
+++ b/.github/workflows/run-e2e-at-night.yml
@@ -1,0 +1,111 @@
+name: E2E
+
+on:
+  pull_request:
+    types: [reopened, synchronize, labeled, opened]
+    branches: ["*"]
+  workflow_dispatch:
+    branches: ["*"]
+jobs:
+  cypress-run:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && (((github.event.action == 'labeled') && (github.event.label.name == 'run e2e')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+      - name: Cypress run full spec
+        if: ${{ steps.api_uri.outputs.custom_api_uri == 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+          CYPRESS_MAILHOG: ${{ secrets.CYPRESS_MAILHOG }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+      - name: Cypress run allEnvs spec
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:allEnv
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
+  cypress-run-critical:
+    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && ((github.event.label.name != 'run e2e') || !(contains(github.event.pull_request.labels.*.name, 'run e2e')))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get API_URI
+        id: api_uri
+        # Search for CYPRESS_API_URI in PR description and use default if not defined
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          prefix: CYPRESS_API_URI=
+          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
+          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
+        run: |
+          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+      - name: Cypress run critical
+        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+        with:
+          build: npm run build
+          start: npx local-web-server --spa index.html
+          wait-on: http://localhost:9000/
+          wait-on-timeout: 120
+          command: npm run cy:run:critical
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/.github/workflows/run-e2e-at-night.yml
+++ b/.github/workflows/run-e2e-at-night.yml
@@ -2,7 +2,7 @@ name: Run e2e at night
 
 on:
   schedule:
-    - cron: "00 15 * * *"
+    - cron: "40 16 * * *"
 
 jobs:
   cypress-run-stable:

--- a/.github/workflows/run-e2e-at-night.yml
+++ b/.github/workflows/run-e2e-at-night.yml
@@ -1,109 +1,54 @@
-name: E2E
+name: Run e2e at night
 
 on:
-  pull_request:
-    types: [reopened, synchronize, labeled, opened]
-    branches: ["*"]
-  workflow_dispatch:
-    branches: ["*"]
+  schedule:
+    - cron: "00 15 * * *"
+
 jobs:
-  cypress-run:
-    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && (((github.event.action == 'labeled') && (github.event.label.name == 'run e2e')) || ((github.event.action != 'labeled') && contains(github.event.pull_request.labels.*.name, 'run e2e')))
+  cypress-run-stable:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      - name: Get API_URI
-        id: api_uri
-        # Search for API_URI in PR description and use default if not defined
-        env:
-          pull_request_body: ${{ github.event.pull_request.body }}
-          prefix: API_URI=
-          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
-          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
-        run: |
-          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
+        with:
+          ref: 3.0
       - name: Cypress run full spec
-        if: ${{ steps.api_uri.outputs.custom_api_uri == 'https://qa.staging.saleor.cloud/graphql/' }}
         uses: cypress-io/github-action@v2
         env:
           API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
           APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
-          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
           CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
           CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
           CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
           CYPRESS_MAILHOG: ${{ secrets.CYPRESS_MAILHOG }}
         with:
-          build: npm run build
-          start: npx local-web-server --spa index.html
-          wait-on: http://localhost:9000/
-          wait-on-timeout: 120
+          command: npm run cy:run:stable
       - uses: actions/upload-artifact@v1
         if: ${{ failure() }}
         with:
           name: cypress-videos
           path: cypress/videos
 
-      - name: Cypress run allEnvs spec
-        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
-        uses: cypress-io/github-action@v2
-        env:
-          API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
-          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
-          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
-          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
-          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
-          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
-          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
-        with:
-          build: npm run build
-          start: npx local-web-server --spa index.html
-          wait-on: http://localhost:9000/
-          wait-on-timeout: 120
-          command: npm run cy:run:allEnv
-      - uses: actions/upload-artifact@v1
-        if: ${{ failure() }}
-        with:
-          name: cypress-videos
-          path: cypress/videos
-
-  cypress-run-critical:
-    if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard' && ((github.event.label.name != 'run e2e') || !(contains(github.event.pull_request.labels.*.name, 'run e2e')))
+  cypress-run-qa:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      - name: Get API_URI
-        id: api_uri
-        # Search for CYPRESS_API_URI in PR description and use default if not defined
-        env:
-          pull_request_body: ${{ github.event.pull_request.body }}
-          prefix: CYPRESS_API_URI=
-          pattern: (http|https)://[a-zA-Z0-9.-]+/graphql/?
-          fallback_uri: ${{ secrets.CYPRESS_API_URI }}
-        run: |
-          echo "::set-output name=custom_api_uri::$(echo $pull_request_body | grep -Eo "$prefix$pattern" | sed s/$prefix// | head -n 1 | { read custom_uri; if [ -z "$custom_uri" ]; then echo "$fallback_uri"; else echo "$custom_uri"; fi })"
-      - name: Cypress run critical
-        if: ${{ steps.api_uri.outputs.custom_api_uri != 'https://qa.staging.saleor.cloud/graphql/' }}
+        with:
+          ref: main
+      - name: Cypress run full spec
         uses: cypress-io/github-action@v2
         env:
           API_URI: ${{ steps.api_uri.outputs.custom_api_uri }}
           APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
-          CYPRESS_baseUrl: ${{ secrets.CYPRESS_BASEURL }}
           CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
           CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
           CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+          CYPRESS_MAILHOG: ${{ secrets.CYPRESS_MAILHOG }}
         with:
-          build: npm run build
-          start: npx local-web-server --spa index.html
-          wait-on: http://localhost:9000/
-          wait-on-timeout: 120
-          command: npm run cy:run:critical
+          command: npm run cy:run:qa
       - uses: actions/upload-artifact@v1
         if: ${{ failure() }}
         with:

--- a/.github/workflows/run-e2e-at-night.yml
+++ b/.github/workflows/run-e2e-at-night.yml
@@ -3,6 +3,8 @@ name: Run e2e at night
 on:
   schedule:
     - cron: "40 16 * * *"
+  workflow_dispatch:
+    branches: ["3.0"]
 
 jobs:
   cypress-run-stable:

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -22,6 +22,7 @@ const graphql = require("graphql-request");
 
 module.exports = async (on, config) => {
   // make env variables visible for cypress
+  // process.env.SALEOR_URL = "https://stable.staging.saleor.cloud/dashboard/";
   config.env.API_URI = process.env.API_URI;
   config.env.APP_MOUNT_URI = process.env.APP_MOUNT_URI;
   config.env.mailHogUrl = process.env.CYPRESS_MAILHOG;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.0.0-b.29",
+  "version": "3.0.0-b.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -255,6 +255,8 @@
     "cy:run:dashboard": "cypress run --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "cy:run:record": "npm run cy:run -- --record",
     "cy:open": "cypress open",
+    "cy:run:stable": "cypress run --env tags=all --config baseUrl=https://stable.staging.saleor.cloud/dashboard/  --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
+    "cy:run:qa": "cypress run --env tags=all --config baseUrl=https://qa.staging.saleor.cloud/dashboard/  --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "cy:run:critical": "cypress run --env tags=critical --spec 'cypress/integration/navigation.js','cypress/integration/products/*.js','cypress/integration/checkout/*.js' --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "cy:run:allEnv": "cypress run --env tags=all --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "test:e2e:run": "start-server-and-test start http://localhost:9000 cy:run",


### PR DESCRIPTION
I want to merge this change because I want to run e2e test manually and every night 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
