### PR TITLE
Create change warehouse dialog

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4250,6 +4250,34 @@
   "src_dot_orders_dot_components_dot_OrderCannotCancelOrderDialog_dot_775268031": {
     "string": "There are still fulfillments created for this order. Cancel the fulfillments first before you cancel the order."
   },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_currentSelection": {
+    "context": "label for currently selected warehouse",
+    "string": "currently selected"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_dialogDescription": {
+    "context": "change warehouse dialog description",
+    "string": "Choose warehouse you want to fulfill this order from"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_dialogTitle": {
+    "context": "change warehouse dialog title",
+    "string": "Change warehouse"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_productUnavailable": {
+    "context": "warehouse label when one product is unavailable",
+    "string": "{productName} is unavailable at this location"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_productsUnavailable": {
+    "context": "warehouse label when multiple products are unavailable",
+    "string": "{productCount} products are unavailable at this location"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_searchFieldPlaceholder": {
+    "context": "change warehouse dialog search placeholder",
+    "string": "Search warehouses"
+  },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_warehouseListLabel": {
+    "context": "change warehouse dialog warehouse list label",
+    "string": "Warehouses A to Z"
+  },
   "src_dot_orders_dot_components_dot_OrderChannelSectionCard_dot_1243773440": {
     "context": "section header",
     "string": "Sales channel"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4262,13 +4262,13 @@
     "context": "change warehouse dialog title",
     "string": "Change warehouse"
   },
+  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_multipleProductsUnavailable": {
+    "context": "warehouse label when multiple products are unavailable",
+    "string": "{productCount} products are unavailable at this location"
+  },
   "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_productUnavailable": {
     "context": "warehouse label when one product is unavailable",
     "string": "{productName} is unavailable at this location"
-  },
-  "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_productsUnavailable": {
-    "context": "warehouse label when multiple products are unavailable",
-    "string": "{productCount} products are unavailable at this location"
   },
   "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_searchFieldPlaceholder": {
     "context": "change warehouse dialog search placeholder",

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -78,11 +78,23 @@ export const fragmentOrderLine = gql`
   fragment OrderLineFragment on OrderLine {
     id
     isShippingRequired
+    allocations {
+      warehouse {
+        id
+      }
+    }
     variant {
       id
       quantityAvailable
       preorder {
         endDate
+      }
+      stocks {
+        warehouse {
+          id
+        }
+        quantity
+        quantityAllocated
       }
     }
     productName

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -79,6 +79,7 @@ export const fragmentOrderLine = gql`
     id
     isShippingRequired
     allocations {
+      quantity
       warehouse {
         id
       }

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -79,6 +79,7 @@ export const fragmentOrderLine = gql`
     id
     isShippingRequired
     allocations {
+      id
       quantity
       warehouse {
         id
@@ -91,6 +92,7 @@ export const fragmentOrderLine = gql`
         endDate
       }
       stocks {
+        id
         warehouse {
           id
         }

--- a/src/fragments/types/FulfillmentFragment.ts
+++ b/src/fragments/types/FulfillmentFragment.ts
@@ -16,6 +16,7 @@ export interface FulfillmentFragment_lines_orderLine_allocations_warehouse {
 
 export interface FulfillmentFragment_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: FulfillmentFragment_lines_orderLine_allocations_warehouse;
 }
@@ -32,6 +33,7 @@ export interface FulfillmentFragment_lines_orderLine_variant_stocks_warehouse {
 
 export interface FulfillmentFragment_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: FulfillmentFragment_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/fragments/types/FulfillmentFragment.ts
+++ b/src/fragments/types/FulfillmentFragment.ts
@@ -16,6 +16,7 @@ export interface FulfillmentFragment_lines_orderLine_allocations_warehouse {
 
 export interface FulfillmentFragment_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: FulfillmentFragment_lines_orderLine_allocations_warehouse;
 }
 

--- a/src/fragments/types/FulfillmentFragment.ts
+++ b/src/fragments/types/FulfillmentFragment.ts
@@ -9,9 +9,31 @@ import { DiscountValueTypeEnum, FulfillmentStatus } from "./../../types/globalTy
 // GraphQL fragment: FulfillmentFragment
 // ====================================================
 
+export interface FulfillmentFragment_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillmentFragment_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: FulfillmentFragment_lines_orderLine_allocations_warehouse;
+}
+
 export interface FulfillmentFragment_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface FulfillmentFragment_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillmentFragment_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: FulfillmentFragment_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface FulfillmentFragment_lines_orderLine_variant {
@@ -19,6 +41,7 @@ export interface FulfillmentFragment_lines_orderLine_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: FulfillmentFragment_lines_orderLine_variant_preorder | null;
+  stocks: (FulfillmentFragment_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface FulfillmentFragment_lines_orderLine_unitDiscount {
@@ -73,6 +96,7 @@ export interface FulfillmentFragment_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: FulfillmentFragment_lines_orderLine_allocations[] | null;
   variant: FulfillmentFragment_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -213,6 +213,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations_w
 
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDetailsFragment_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -229,6 +230,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant_stock
 
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -340,6 +342,7 @@ export interface OrderDetailsFragment_lines_allocations_warehouse {
 
 export interface OrderDetailsFragment_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDetailsFragment_lines_allocations_warehouse;
 }
@@ -356,6 +359,7 @@ export interface OrderDetailsFragment_lines_variant_stocks_warehouse {
 
 export interface OrderDetailsFragment_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDetailsFragment_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -206,9 +206,31 @@ export interface OrderDetailsFragment_events {
   lines: (OrderDetailsFragment_events_lines | null)[] | null;
 }
 
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDetailsFragment_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant {
@@ -216,6 +238,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDetailsFragment_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDetailsFragment_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_unitDiscount {
@@ -270,6 +293,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDetailsFragment_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDetailsFragment_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -308,9 +332,31 @@ export interface OrderDetailsFragment_fulfillments {
   warehouse: OrderDetailsFragment_fulfillments_warehouse | null;
 }
 
+export interface OrderDetailsFragment_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetailsFragment_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDetailsFragment_lines_allocations_warehouse;
+}
+
 export interface OrderDetailsFragment_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDetailsFragment_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetailsFragment_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDetailsFragment_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDetailsFragment_lines_variant {
@@ -318,6 +364,7 @@ export interface OrderDetailsFragment_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDetailsFragment_lines_variant_preorder | null;
+  stocks: (OrderDetailsFragment_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDetailsFragment_lines_unitDiscount {
@@ -372,6 +419,7 @@ export interface OrderDetailsFragment_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDetailsFragment_lines_allocations[] | null;
   variant: OrderDetailsFragment_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -213,6 +213,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations_w
 
 export interface OrderDetailsFragment_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDetailsFragment_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -339,6 +340,7 @@ export interface OrderDetailsFragment_lines_allocations_warehouse {
 
 export interface OrderDetailsFragment_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDetailsFragment_lines_allocations_warehouse;
 }
 

--- a/src/fragments/types/OrderLineFragment.ts
+++ b/src/fragments/types/OrderLineFragment.ts
@@ -16,6 +16,7 @@ export interface OrderLineFragment_allocations_warehouse {
 
 export interface OrderLineFragment_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineFragment_allocations_warehouse;
 }
 

--- a/src/fragments/types/OrderLineFragment.ts
+++ b/src/fragments/types/OrderLineFragment.ts
@@ -9,9 +9,31 @@ import { DiscountValueTypeEnum } from "./../../types/globalTypes";
 // GraphQL fragment: OrderLineFragment
 // ====================================================
 
+export interface OrderLineFragment_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineFragment_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineFragment_allocations_warehouse;
+}
+
 export interface OrderLineFragment_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineFragment_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineFragment_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineFragment_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineFragment_variant {
@@ -19,6 +41,7 @@ export interface OrderLineFragment_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineFragment_variant_preorder | null;
+  stocks: (OrderLineFragment_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineFragment_unitDiscount {
@@ -73,6 +96,7 @@ export interface OrderLineFragment {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineFragment_allocations[] | null;
   variant: OrderLineFragment_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/fragments/types/OrderLineFragment.ts
+++ b/src/fragments/types/OrderLineFragment.ts
@@ -16,6 +16,7 @@ export interface OrderLineFragment_allocations_warehouse {
 
 export interface OrderLineFragment_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineFragment_allocations_warehouse;
 }
@@ -32,6 +33,7 @@ export interface OrderLineFragment_variant_stocks_warehouse {
 
 export interface OrderLineFragment_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineFragment_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/hooks/makeQuery.ts
+++ b/src/hooks/makeQuery.ts
@@ -20,7 +20,7 @@ import useNotifier from "./useNotifier";
 const getPermissionKey = (permission: string) =>
   `PERMISSION_${permission}` as PrefixedPermissions;
 
-const allPermissions = Object.keys(PermissionEnum).reduce(
+export const allPermissions = Object.keys(PermissionEnum).reduce(
   (prev, code) => ({
     ...prev,
     [getPermissionKey(code)]: false

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -508,3 +508,6 @@ export const combinedMultiAutocompleteChoices = (
   selected: MultiAutocompleteChoiceType[],
   choices: MultiAutocompleteChoiceType[]
 ) => uniqBy([...selected, ...choices], "value");
+
+export type WithOptional<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.stories.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.stories.tsx
@@ -1,0 +1,45 @@
+import { MockedProvider, MockedResponse } from "@apollo/react-testing";
+import { allPermissions } from "@saleor/hooks/makeQuery";
+import { order, warehouseSearch } from "@saleor/orders/fixtures";
+import { searchWarehouses } from "@saleor/searches/useWarehouseSearch";
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import OrderChangeWarehouseDialog, { OrderChangeWarehouseDialogProps } from ".";
+
+const props: OrderChangeWarehouseDialogProps = {
+  open: true,
+  lines: order("abc").lines,
+  currentWarehouse: null,
+  onConfirm: () => null,
+  onClose: () => null
+};
+
+const mocks: MockedResponse[] = [
+  {
+    request: {
+      query: searchWarehouses,
+      variables: {
+        first: 20,
+        after: null,
+        query: "",
+        ...allPermissions
+      }
+    },
+    result: {
+      data: { search: warehouseSearch }
+    }
+  }
+];
+
+storiesOf(
+  "Orders / Order details fulfillment warehouse selection modal",
+  module
+)
+  .addDecorator(Decorator)
+  .add("default", () => (
+    <MockedProvider mocks={mocks}>
+      <OrderChangeWarehouseDialog {...props} />
+    </MockedProvider>
+  ));

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -82,7 +82,11 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
     onClose();
   };
 
-  React.useEffect(loadMore, [!bottomShadow]);
+  React.useEffect(() => {
+    if (!bottomShadow) {
+      loadMore();
+    }
+  }, [bottomShadow]);
 
   return (
     <Dialog fullWidth open={open}>

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -89,7 +89,7 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
   }, [bottomShadow]);
 
   return (
-    <Dialog fullWidth open={open}>
+    <Dialog fullWidth open={open} onClose={onClose}>
       <ScrollShadow variant="top" show={topShadow}>
         <DialogHeader onClose={onClose}>
           <FormattedMessage {...messages.dialogTitle} />

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -26,6 +26,7 @@ import {
   useElementScroll
 } from "@saleor/macaw-ui";
 import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
+import { SearchWarehouses_search_edges_node } from "@saleor/searches/types/SearchWarehouses";
 import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import { WarehouseList_warehouses_edges_node } from "@saleor/warehouses/types/WarehouseList";
@@ -71,7 +72,10 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
   });
   const filteredWarehouses = mapEdgesToItems(warehousesOpts?.data?.search);
 
-  const isLineAvailableInWarehouse = (line, warehouse) => {
+  const isLineAvailableInWarehouse = (
+    line: OrderDetails_order_lines,
+    warehouse: SearchWarehouses_search_edges_node
+  ) => {
     if (
       line.variant.stocks.find(stock => stock.warehouse.id === warehouse.id)
     ) {
@@ -79,7 +83,10 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
     }
     return false;
   };
-  const getAvailableQuantity = (line, warehouse) => {
+  const getAvailableQuantity = (
+    line: OrderDetails_order_lines,
+    warehouse: SearchWarehouses_search_edges_node
+  ) => {
     const warehouseStock = line.variant?.stocks?.find(
       stock => stock.warehouse.id === warehouse.id
     );

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -139,11 +139,8 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
         {filteredWarehouses ? (
           <RadioGroup value={selectedWarehouseId} onChange={handleChange}>
             {filteredWarehouses.map(warehouse => {
-              const unavailableLines = [];
-              lines.map(line =>
-                isLineAvailableInWarehouse(line, warehouse)
-                  ? undefined
-                  : unavailableLines.push(line)
+              const unavailableLines = lines.filter(line =>
+                !isLineAvailableInWarehouse(line, warehouse)
               );
               const allLinesAvailable = unavailableLines.length === 0;
               return (

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {
   Dialog,
   DialogActions,

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -163,7 +163,7 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
                                       }
                                     )
                                   : intl.formatMessage(
-                                      messages.productsUnavailable,
+                                      messages.multipleProductsUnavailable,
                                       { productCount: unavailableLines.length }
                                     )}
                               </Typography>

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -26,7 +26,6 @@ import {
   useElementScroll
 } from "@saleor/macaw-ui";
 import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
-import { SearchWarehouses_search_edges_node } from "@saleor/searches/types/SearchWarehouses";
 import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import { WarehouseList_warehouses_edges_node } from "@saleor/warehouses/types/WarehouseList";
@@ -36,6 +35,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { getById } from "../OrderReturnPage/utils";
 import { changeWarehouseDialogMessages as messages } from "./messages";
 import { useStyles } from "./styles";
+import { isLineAvailableInWarehouse } from "./utils";
 
 export interface OrderChangeWarehouseDialogProps {
   open: boolean;
@@ -71,36 +71,6 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
     }
   });
   const filteredWarehouses = mapEdgesToItems(warehousesOpts?.data?.search);
-
-  const isLineAvailableInWarehouse = (
-    line: OrderDetails_order_lines,
-    warehouse: SearchWarehouses_search_edges_node
-  ) => {
-    if (
-      line.variant.stocks.find(stock => stock.warehouse.id === warehouse.id)
-    ) {
-      return line.quantityToFulfill <= getAvailableQuantity(line, warehouse);
-    }
-    return false;
-  };
-  const getAvailableQuantity = (
-    line: OrderDetails_order_lines,
-    warehouse: SearchWarehouses_search_edges_node
-  ) => {
-    const warehouseStock = line.variant?.stocks?.find(
-      stock => stock.warehouse.id === warehouse.id
-    );
-    const warehouseAllocation = line.allocations.find(
-      allocation => allocation.warehouse.id === warehouse.id
-    );
-    const allocatedQuantityForLine = warehouseAllocation?.quantity || 0;
-    const availableQuantity =
-      warehouseStock?.quantity -
-      warehouseStock?.quantityAllocated +
-      allocatedQuantityForLine;
-
-    return availableQuantity;
-  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedWarehouseId(e.target.value);

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -13,7 +13,6 @@ import {
 } from "@material-ui/core";
 import Debounce from "@saleor/components/Debounce";
 import Skeleton from "@saleor/components/Skeleton";
-import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
 import {
   Button,
@@ -28,20 +27,20 @@ import {
 import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
 import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import { mapEdgesToItems } from "@saleor/utils/maps";
-import { WarehouseList_warehouses_edges_node } from "@saleor/warehouses/types/WarehouseList";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { getById } from "../OrderReturnPage/utils";
 import { changeWarehouseDialogMessages as messages } from "./messages";
 import { useStyles } from "./styles";
+import { Warehouse } from "./types";
 import { isLineAvailableInWarehouse } from "./utils";
 
 export interface OrderChangeWarehouseDialogProps {
   open: boolean;
   lines: OrderDetails_order_lines[];
-  currentWarehouse: WarehouseList_warehouses_edges_node;
-  onConfirm: (warehouse: WarehouseList_warehouses_edges_node) => void;
+  currentWarehouse: Warehouse;
+  onConfirm: (warehouse: Warehouse) => void;
   onClose();
 }
 
@@ -60,9 +59,9 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
   const bottomShadow = isScrolledToBottom(anchor, position, 20) === false;
 
   const [query, setQuery] = React.useState<string>("");
-  const [selectedWarehouseId, setSelectedWarehouseId] = useStateFromProps<
-    string
-  >(currentWarehouse?.id);
+  const [selectedWarehouseId, setSelectedWarehouseId] = React.useState<string>(
+    currentWarehouse?.id
+  );
   const { result: warehousesOpts, loadMore, search } = useWarehouseSearch({
     variables: {
       after: null,
@@ -79,7 +78,7 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
     const selectedWarehouse = filteredWarehouses.find(
       getById(selectedWarehouseId)
     );
-    onConfirm(selectedWarehouse as any);
+    onConfirm(selectedWarehouse);
     onClose();
   };
 

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -168,7 +168,7 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
               );
               const allLinesAvailable = unavailableLines.length === 0;
               return (
-                <TableRow>
+                <TableRow key={warehouse.id}>
                   <TableCell className={classes.warehouseCell}>
                     <div>
                       <FormControlLabel

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -139,8 +139,8 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
         {filteredWarehouses ? (
           <RadioGroup value={selectedWarehouseId} onChange={handleChange}>
             {filteredWarehouses.map(warehouse => {
-              const unavailableLines = lines.filter(line =>
-                !isLineAvailableInWarehouse(line, warehouse)
+              const unavailableLines = lines.filter(
+                line => !isLineAvailableInWarehouse(line, warehouse)
               );
               const allLinesAvailable = unavailableLines.length === 0;
               return (

--- a/src/orders/components/OrderChangeWarehouseDialog/index.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./OrderChangeWarehouseDialog";
+export * from "./OrderChangeWarehouseDialog";

--- a/src/orders/components/OrderChangeWarehouseDialog/messages.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/messages.ts
@@ -1,0 +1,39 @@
+import { defineMessage } from "react-intl";
+
+export const changeWarehouseDialogMessages = defineMessage({
+  dialogTitle: {
+    defaultMessage: "Change warehouse",
+    description: "change warehouse dialog title",
+    id: "test998798722"
+  },
+  dialogDescription: {
+    defaultMessage: "Choose warehouse you want to fulfill this order from",
+    description: "change warehouse dialog description",
+    id: "test1092831290"
+  },
+  searchFieldPlaceholder: {
+    defaultMessage: "Search warehouses",
+    description: "change warehouse dialog search placeholder",
+    id: "test9817298112"
+  },
+  warehouseListLabel: {
+    defaultMessage: "Warehouses A to Z",
+    description: "change warehouse dialog warehouse list label",
+    id: "test278728"
+  },
+  productUnavailable: {
+    defaultMessage: "{productName} is unavailable at this location",
+    description: "warehouse label when one product is unavailable",
+    id: "test2787282"
+  },
+  productsUnavailable: {
+    defaultMessage: "{productCount} products are unavailable at this location",
+    description: "warehouse label when multiple products are unavailable",
+    id: "test2787283"
+  },
+  currentSelection: {
+    defaultMessage: "currently selected",
+    description: "label for currently selected warehouse",
+    id: "test129009213"
+  }
+});

--- a/src/orders/components/OrderChangeWarehouseDialog/messages.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/messages.ts
@@ -21,7 +21,7 @@ export const changeWarehouseDialogMessages = defineMessages({
     defaultMessage: "{productName} is unavailable at this location",
     description: "warehouse label when one product is unavailable"
   },
-  productsUnavailable: {
+  multipleProductsUnavailable: {
     defaultMessage: "{productCount} products are unavailable at this location",
     description: "warehouse label when multiple products are unavailable"
   },

--- a/src/orders/components/OrderChangeWarehouseDialog/messages.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/messages.ts
@@ -3,37 +3,30 @@ import { defineMessage } from "react-intl";
 export const changeWarehouseDialogMessages = defineMessage({
   dialogTitle: {
     defaultMessage: "Change warehouse",
-    description: "change warehouse dialog title",
-    id: "test998798722"
+    description: "change warehouse dialog title"
   },
   dialogDescription: {
     defaultMessage: "Choose warehouse you want to fulfill this order from",
-    description: "change warehouse dialog description",
-    id: "test1092831290"
+    description: "change warehouse dialog description"
   },
   searchFieldPlaceholder: {
     defaultMessage: "Search warehouses",
-    description: "change warehouse dialog search placeholder",
-    id: "test9817298112"
+    description: "change warehouse dialog search placeholder"
   },
   warehouseListLabel: {
     defaultMessage: "Warehouses A to Z",
-    description: "change warehouse dialog warehouse list label",
-    id: "test278728"
+    description: "change warehouse dialog warehouse list label"
   },
   productUnavailable: {
     defaultMessage: "{productName} is unavailable at this location",
-    description: "warehouse label when one product is unavailable",
-    id: "test2787282"
+    description: "warehouse label when one product is unavailable"
   },
   productsUnavailable: {
     defaultMessage: "{productCount} products are unavailable at this location",
-    description: "warehouse label when multiple products are unavailable",
-    id: "test2787283"
+    description: "warehouse label when multiple products are unavailable"
   },
   currentSelection: {
     defaultMessage: "currently selected",
-    description: "label for currently selected warehouse",
-    id: "test129009213"
+    description: "label for currently selected warehouse"
   }
 });

--- a/src/orders/components/OrderChangeWarehouseDialog/messages.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/messages.ts
@@ -1,6 +1,6 @@
-import { defineMessage } from "react-intl";
+import { defineMessages } from "react-intl";
 
-export const changeWarehouseDialogMessages = defineMessage({
+export const changeWarehouseDialogMessages = defineMessages({
   dialogTitle: {
     defaultMessage: "Change warehouse",
     description: "change warehouse dialog title"

--- a/src/orders/components/OrderChangeWarehouseDialog/styles.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/styles.ts
@@ -1,0 +1,44 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    container: {
+      paddingTop: 0
+    },
+    radioLabelContainer: {
+      display: "flex",
+      flexDirection: "column"
+    },
+    searchBox: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2)
+    },
+    searchInput: {
+      paddingTop: theme.spacing(2),
+      paddingBottom: theme.spacing(2)
+    },
+    supportHeader: {
+      textTransform: "uppercase",
+      color: theme.palette.saleor.main[3],
+      fontWeight: 500,
+      letterSpacing: "0.1em",
+      fontSize: "12px",
+      lineHeight: "160%"
+    },
+    warehouseCell: {
+      paddingLeft: 0
+    },
+    helpText: {
+      display: "inline",
+      fontSize: "12px",
+      lineHeight: "160%",
+      color: theme.palette.saleor.main[3]
+    },
+    supportText: {
+      fontSize: "14px",
+      lineHeight: "160%",
+      color: theme.palette.saleor.main[3]
+    }
+  }),
+  { name: "OrderChangeWarehouseDialog" }
+);

--- a/src/orders/components/OrderChangeWarehouseDialog/types.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/types.ts
@@ -1,0 +1,7 @@
+import { WithOptional } from "@saleor/misc";
+import { WarehouseList_warehouses_edges_node } from "@saleor/warehouses/types/WarehouseList";
+
+export type Warehouse = WithOptional<
+  WarehouseList_warehouses_edges_node,
+  "shippingZones"
+>;

--- a/src/orders/components/OrderChangeWarehouseDialog/utils.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/utils.ts
@@ -1,0 +1,30 @@
+import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
+import { SearchWarehouses_search_edges_node } from "@saleor/searches/types/SearchWarehouses";
+
+export const isLineAvailableInWarehouse = (
+  line: OrderDetails_order_lines,
+  warehouse: SearchWarehouses_search_edges_node
+) => {
+  if (line.variant.stocks.find(stock => stock.warehouse.id === warehouse.id)) {
+    return line.quantityToFulfill <= getAvailableQuantity(line, warehouse);
+  }
+  return false;
+};
+export const getAvailableQuantity = (
+  line: OrderDetails_order_lines,
+  warehouse: SearchWarehouses_search_edges_node
+) => {
+  const warehouseStock = line.variant?.stocks?.find(
+    stock => stock.warehouse.id === warehouse.id
+  );
+  const warehouseAllocation = line.allocations.find(
+    allocation => allocation.warehouse.id === warehouse.id
+  );
+  const allocatedQuantityForLine = warehouseAllocation?.quantity || 0;
+  const availableQuantity =
+    warehouseStock?.quantity -
+    warehouseStock?.quantityAllocated +
+    allocatedQuantityForLine;
+
+  return availableQuantity;
+};

--- a/src/orders/components/OrderChangeWarehouseDialog/utils.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/utils.ts
@@ -1,9 +1,10 @@
 import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
-import { SearchWarehouses_search_edges_node } from "@saleor/searches/types/SearchWarehouses";
+
+import { Warehouse } from "./types";
 
 export const isLineAvailableInWarehouse = (
   line: OrderDetails_order_lines,
-  warehouse: SearchWarehouses_search_edges_node
+  warehouse: Warehouse
 ) => {
   if (line.variant.stocks.find(stock => stock.warehouse.id === warehouse.id)) {
     return line.quantityToFulfill <= getAvailableQuantity(line, warehouse);
@@ -12,7 +13,7 @@ export const isLineAvailableInWarehouse = (
 };
 export const getAvailableQuantity = (
   line: OrderDetails_order_lines,
-  warehouse: SearchWarehouses_search_edges_node
+  warehouse: Warehouse
 ) => {
   const warehouseStock = line.variant?.stocks?.find(
     stock => stock.warehouse.id === warehouse.id

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1074,6 +1074,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
             quantityToFulfill: 0,
             allocations: [
               {
+                id: "allocation_test_id",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1129,6 +1130,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
               preorder: null,
               stocks: [
                 {
+                  id: "stock_test_id1",
                   warehouse: {
                     id:
                       "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1139,6 +1141,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
                   __typename: "Stock"
                 },
                 {
+                  id: "stock_test_id2",
                   warehouse: {
                     id:
                       "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1177,6 +1180,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
             quantityToFulfill: 0,
             allocations: [
               {
+                id: "allocation_test_id",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1232,6 +1236,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
               preorder: null,
               stocks: [
                 {
+                  id: "stock_test_id1",
                   warehouse: {
                     id:
                       "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1242,6 +1247,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
                   __typename: "Stock"
                 },
                 {
+                  id: "stock_test_id2",
                   warehouse: {
                     id:
                       "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1288,6 +1294,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
       quantityToFulfill: 3,
       allocations: [
         {
+          id: "allocation_test_id",
           warehouse: {
             id:
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1343,6 +1350,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
         preorder: null,
         stocks: [
           {
+            id: "stock_test_id1",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1353,6 +1361,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
             __typename: "Stock"
           },
           {
+            id: "stock_test_id2",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1376,6 +1385,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
       quantityToFulfill: 0,
       allocations: [
         {
+          id: "allocation_test_id",
           warehouse: {
             id:
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1432,6 +1442,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
         preorder: null,
         stocks: [
           {
+            id: "stock_test_id1",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1442,6 +1453,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
             __typename: "Stock"
           },
           {
+            id: "stock_test_id2",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1604,6 +1616,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
       quantityToFulfill: 2,
       allocations: [
         {
+          id: "allocation_test_id",
           warehouse: {
             id:
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1659,6 +1672,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
         preorder: null,
         stocks: [
           {
+            id: "stock_test_id1",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1669,6 +1683,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
             __typename: "Stock"
           },
           {
+            id: "stock_test_id2",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1692,6 +1707,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
       quantityToFulfill: 2,
       allocations: [
         {
+          id: "allocation_test_id",
           warehouse: {
             id:
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1747,6 +1763,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
         preorder: null,
         stocks: [
           {
+            id: "stock_test_id1",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1757,6 +1774,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
             __typename: "Stock"
           },
           {
+            id: "stock_test_id2",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1079,6 +1079,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
                     "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                   __typename: "Warehouse"
                 },
+                quantity: 1,
                 __typename: "Allocation"
               }
             ],
@@ -1181,6 +1182,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
                     "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                   __typename: "Warehouse"
                 },
+                quantity: 1,
                 __typename: "Allocation"
               }
             ],
@@ -1291,6 +1293,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
             __typename: "Warehouse"
           },
+          quantity: 1,
           __typename: "Allocation"
         }
       ],
@@ -1378,6 +1381,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
             __typename: "Warehouse"
           },
+          quantity: 1,
           __typename: "Allocation"
         }
       ],
@@ -1605,6 +1609,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
             __typename: "Warehouse"
           },
+          quantity: 1,
           __typename: "Allocation"
         }
       ],
@@ -1692,6 +1697,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
               "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
             __typename: "Warehouse"
           },
+          quantity: 1,
           __typename: "Allocation"
         }
       ],

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -3,6 +3,7 @@ import { InvoiceFragment } from "@saleor/fragments/types/InvoiceFragment";
 import { OrderSettingsFragment } from "@saleor/fragments/types/OrderSettingsFragment";
 import { ShopOrderSettingsFragment } from "@saleor/fragments/types/ShopOrderSettingsFragment";
 import { SearchCustomers_search_edges_node } from "@saleor/searches/types/SearchCustomers";
+import { SearchWarehouses_search } from "@saleor/searches/types/SearchWarehouses";
 import { warehouseForPickup, warehouseList } from "@saleor/warehouses/fixtures";
 import { MessageDescriptor } from "react-intl";
 
@@ -1071,6 +1072,16 @@ export const order = (placeholder: string): OrderDetails_order => ({
             quantity: 2,
             quantityFulfilled: 2,
             quantityToFulfill: 0,
+            allocations: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                  __typename: "Warehouse"
+                },
+                __typename: "Allocation"
+              }
+            ],
             thumbnail: {
               __typename: "Image" as "Image",
               url: placeholder
@@ -1114,7 +1125,29 @@ export const order = (placeholder: string): OrderDetails_order => ({
               __typename: "ProductVariant",
               id: "dsfsfuhb",
               quantityAvailable: 10,
-              preorder: null
+              preorder: null,
+              stocks: [
+                {
+                  warehouse: {
+                    id:
+                      "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                    __typename: "Warehouse"
+                  },
+                  quantity: 166,
+                  quantityAllocated: 0,
+                  __typename: "Stock"
+                },
+                {
+                  warehouse: {
+                    id:
+                      "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                    __typename: "Warehouse"
+                  },
+                  quantity: 166,
+                  quantityAllocated: 0,
+                  __typename: "Stock"
+                }
+              ]
             }
           },
           quantity: 1
@@ -1141,6 +1174,16 @@ export const order = (placeholder: string): OrderDetails_order => ({
             quantity: 2,
             quantityFulfilled: 2,
             quantityToFulfill: 0,
+            allocations: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                  __typename: "Warehouse"
+                },
+                __typename: "Allocation"
+              }
+            ],
             thumbnail: {
               __typename: "Image" as "Image",
               url: placeholder
@@ -1184,7 +1227,29 @@ export const order = (placeholder: string): OrderDetails_order => ({
               __typename: "ProductVariant",
               id: "dsfsfuhb",
               quantityAvailable: 10,
-              preorder: null
+              preorder: null,
+              stocks: [
+                {
+                  warehouse: {
+                    id:
+                      "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                    __typename: "Warehouse"
+                  },
+                  quantity: 166,
+                  quantityAllocated: 0,
+                  __typename: "Stock"
+                },
+                {
+                  warehouse: {
+                    id:
+                      "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                    __typename: "Warehouse"
+                  },
+                  quantity: 166,
+                  quantityAllocated: 0,
+                  __typename: "Stock"
+                }
+              ]
             }
           },
           quantity: 1
@@ -1219,6 +1284,16 @@ export const order = (placeholder: string): OrderDetails_order => ({
       quantity: 3,
       quantityFulfilled: 0,
       quantityToFulfill: 3,
+      allocations: [
+        {
+          warehouse: {
+            id:
+              "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+            __typename: "Warehouse"
+          },
+          __typename: "Allocation"
+        }
+      ],
       thumbnail: {
         __typename: "Image" as "Image",
         url: placeholder
@@ -1262,7 +1337,29 @@ export const order = (placeholder: string): OrderDetails_order => ({
         __typename: "ProductVariant",
         id: "dsfsfuhb",
         quantityAvailable: 10,
-        preorder: null
+        preorder: null,
+        stocks: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          },
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          }
+        ]
       }
     },
     {
@@ -1274,6 +1371,16 @@ export const order = (placeholder: string): OrderDetails_order => ({
       quantity: 2,
       quantityFulfilled: 2,
       quantityToFulfill: 0,
+      allocations: [
+        {
+          warehouse: {
+            id:
+              "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+            __typename: "Warehouse"
+          },
+          __typename: "Allocation"
+        }
+      ],
       thumbnail: {
         __typename: "Image" as "Image",
         url: placeholder
@@ -1318,7 +1425,29 @@ export const order = (placeholder: string): OrderDetails_order => ({
         __typename: "ProductVariant",
         id: "dsfsfuhb",
         quantityAvailable: 10,
-        preorder: null
+        preorder: null,
+        stocks: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          },
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          }
+        ]
       }
     }
   ],
@@ -1469,6 +1598,16 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
       quantity: 2,
       quantityFulfilled: 0,
       quantityToFulfill: 2,
+      allocations: [
+        {
+          warehouse: {
+            id:
+              "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+            __typename: "Warehouse"
+          },
+          __typename: "Allocation"
+        }
+      ],
       thumbnail: {
         __typename: "Image" as "Image",
         url: placeholder
@@ -1512,7 +1651,29 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
         __typename: "ProductVariant",
         id: "dsfsfuhb",
         quantityAvailable: 10,
-        preorder: null
+        preorder: null,
+        stocks: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          },
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          }
+        ]
       }
     },
     {
@@ -1524,6 +1685,16 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
       quantity: 2,
       quantityFulfilled: 0,
       quantityToFulfill: 2,
+      allocations: [
+        {
+          warehouse: {
+            id:
+              "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+            __typename: "Warehouse"
+          },
+          __typename: "Allocation"
+        }
+      ],
       thumbnail: {
         __typename: "Image" as "Image",
         url: placeholder
@@ -1567,7 +1738,29 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
         __typename: "ProductVariant",
         id: "dsfsfuhb",
         quantityAvailable: 10,
-        preorder: null
+        preorder: null,
+        stocks: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          },
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+              __typename: "Warehouse"
+            },
+            quantity: 166,
+            quantityAllocated: 0,
+            __typename: "Stock"
+          }
+        ]
       }
     }
   ],
@@ -2085,4 +2278,106 @@ export const shopOrderSettings: ShopOrderSettingsFragment = {
   __typename: "Shop",
   fulfillmentAutoApprove: true,
   fulfillmentAllowUnpaid: true
+};
+
+export const warehouseSearch: SearchWarehouses_search = {
+  edges: [
+    {
+      node: {
+        id: "V2FyZWhvdXNlOmJiZTEwZjk1LTQyYjAtNDRlMS04Yjc5LWU5MjllMmViYTRjMQ==",
+        name: "CyVou-97803",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjdhOGViNThhLTYwN2QtNGMxNC04ODVmLTBiMWU3ZDcyMTIyNQ==",
+        name: "CyWarehouse72715",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjY2NWIxZWFmLTU5MDYtNGE0Mi1iYWVkLTc1ODQ3YWNhMWI1NQ==",
+        name: "CyWarehouseCheckout70441",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjdkNmVmNmFkLWY4NTMtNGVmNS1iMzQ5LTUyY2I2N2U3NmIwZQ==",
+        name: "CyWeightRates-78849",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjcwZjMyYTUyLWVlODQtNGExYi1iMjgzLTgwYjllMzgyNDlkNg==",
+        name: "EditShipping-82885",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+        name: "Europe for click and collect",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+        name: "Oceania",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjNiZDM0YjEyLTllNDktNDMwZC1iM2QyLTRkYmRhMjM1MGUyOQ==",
+        name: "ProductsWithoutSkuInOrder",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOmU4M2U2NjQ2LTFhYjctNGNmNC05N2M4LTFiZjI2NGE2NjQ4Yw==",
+        name: "StocksThreshold",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOmJkMmQ1NDFjLWQwMjMtNDAwNi05YmRjLWZhZTA4OWZlNzZiYg==",
+        name: "UpdateProductsSku59844",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    },
+    {
+      node: {
+        id: "V2FyZWhvdXNlOjgzNDMwMzI4LTI2YWItNDNkZS1hNzdhLTVmNGNhMTljMDJhNg==",
+        name: "WithoutShipmentCheckout-4505",
+        __typename: "Warehouse"
+      },
+      __typename: "WarehouseCountableEdge"
+    }
+  ],
+  pageInfo: {
+    endCursor:
+      "WyJXaXRob3V0U2hpcG1lbnRDaGVja291dC00NTA1IiwgIldpdGhvdXRTaGlwbWVudENoZWNrb3V0LTQ1MDUiXQ==",
+    hasNextPage: false,
+    hasPreviousPage: true,
+    startCursor: "WyJDeVZvdS05NzgwMyIsICJDeVZvdS05NzgwMyJd",
+    __typename: "PageInfo"
+  },
+  __typename: "WarehouseCountableConnection"
 };

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -215,9 +215,31 @@ export interface FulfillOrder_orderFulfill_order_events {
   lines: (FulfillOrder_orderFulfill_order_events_lines | null)[] | null;
 }
 
+export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant {
@@ -225,6 +247,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_va
   id: string;
   quantityAvailable: number | null;
   preorder: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_unitDiscount {
@@ -279,6 +302,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -317,9 +341,31 @@ export interface FulfillOrder_orderFulfill_order_fulfillments {
   warehouse: FulfillOrder_orderFulfill_order_fulfillments_warehouse | null;
 }
 
+export interface FulfillOrder_orderFulfill_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillOrder_orderFulfill_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: FulfillOrder_orderFulfill_order_lines_allocations_warehouse;
+}
+
 export interface FulfillOrder_orderFulfill_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface FulfillOrder_orderFulfill_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface FulfillOrder_orderFulfill_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: FulfillOrder_orderFulfill_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface FulfillOrder_orderFulfill_order_lines_variant {
@@ -327,6 +373,7 @@ export interface FulfillOrder_orderFulfill_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: FulfillOrder_orderFulfill_order_lines_variant_preorder | null;
+  stocks: (FulfillOrder_orderFulfill_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface FulfillOrder_orderFulfill_order_lines_unitDiscount {
@@ -381,6 +428,7 @@ export interface FulfillOrder_orderFulfill_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: FulfillOrder_orderFulfill_order_lines_allocations[] | null;
   variant: FulfillOrder_orderFulfill_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -222,6 +222,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_al
 
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -348,6 +349,7 @@ export interface FulfillOrder_orderFulfill_order_lines_allocations_warehouse {
 
 export interface FulfillOrder_orderFulfill_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: FulfillOrder_orderFulfill_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -222,6 +222,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_al
 
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -238,6 +239,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_va
 
 export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -349,6 +351,7 @@ export interface FulfillOrder_orderFulfill_order_lines_allocations_warehouse {
 
 export interface FulfillOrder_orderFulfill_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: FulfillOrder_orderFulfill_order_lines_allocations_warehouse;
 }
@@ -365,6 +368,7 @@ export interface FulfillOrder_orderFulfill_order_lines_variant_stocks_warehouse 
 
 export interface FulfillOrder_orderFulfill_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: FulfillOrder_orderFulfill_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -220,6 +220,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allo
 
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderCancel_orderCancel_order_lines_allocations_warehouse {
 
 export interface OrderCancel_orderCancel_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderCancel_orderCancel_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -220,6 +220,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allo
 
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_vari
 
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderCancel_orderCancel_order_lines_allocations_warehouse {
 
 export interface OrderCancel_orderCancel_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderCancel_orderCancel_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderCancel_orderCancel_order_lines_variant_stocks_warehouse {
 
 export interface OrderCancel_orderCancel_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderCancel_orderCancel_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -213,9 +213,31 @@ export interface OrderCancel_orderCancel_order_events {
   lines: (OrderCancel_orderCancel_order_events_lines | null)[] | null;
 }
 
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_vari
   id: string;
   quantityAvailable: number | null;
   preorder: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderCancel_orderCancel_order_fulfillments {
   warehouse: OrderCancel_orderCancel_order_fulfillments_warehouse | null;
 }
 
+export interface OrderCancel_orderCancel_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCancel_orderCancel_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderCancel_orderCancel_order_lines_allocations_warehouse;
+}
+
 export interface OrderCancel_orderCancel_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderCancel_orderCancel_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCancel_orderCancel_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderCancel_orderCancel_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderCancel_orderCancel_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderCancel_orderCancel_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderCancel_orderCancel_order_lines_variant_preorder | null;
+  stocks: (OrderCancel_orderCancel_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderCancel_orderCancel_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderCancel_orderCancel_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderCancel_orderCancel_order_lines_allocations[] | null;
   variant: OrderCancel_orderCancel_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -220,6 +220,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_al
 
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_va
 
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderCapture_orderCapture_order_lines_allocations_warehouse {
 
 export interface OrderCapture_orderCapture_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderCapture_orderCapture_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderCapture_orderCapture_order_lines_variant_stocks_warehouse 
 
 export interface OrderCapture_orderCapture_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderCapture_orderCapture_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -213,9 +213,31 @@ export interface OrderCapture_orderCapture_order_events {
   lines: (OrderCapture_orderCapture_order_events_lines | null)[] | null;
 }
 
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_va
   id: string;
   quantityAvailable: number | null;
   preorder: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderCapture_orderCapture_order_fulfillments {
   warehouse: OrderCapture_orderCapture_order_fulfillments_warehouse | null;
 }
 
+export interface OrderCapture_orderCapture_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCapture_orderCapture_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderCapture_orderCapture_order_lines_allocations_warehouse;
+}
+
 export interface OrderCapture_orderCapture_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderCapture_orderCapture_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderCapture_orderCapture_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderCapture_orderCapture_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderCapture_orderCapture_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderCapture_orderCapture_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderCapture_orderCapture_order_lines_variant_preorder | null;
+  stocks: (OrderCapture_orderCapture_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderCapture_orderCapture_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderCapture_orderCapture_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderCapture_orderCapture_order_lines_allocations[] | null;
   variant: OrderCapture_orderCapture_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -220,6 +220,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_al
 
 export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderCapture_orderCapture_order_lines_allocations_warehouse {
 
 export interface OrderCapture_orderCapture_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderCapture_orderCapture_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -213,9 +213,31 @@ export interface OrderConfirm_orderConfirm_order_events {
   lines: (OrderConfirm_orderConfirm_order_events_lines | null)[] | null;
 }
 
+export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_va
   id: string;
   quantityAvailable: number | null;
   preorder: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderConfirm_orderConfirm_order_fulfillments {
   warehouse: OrderConfirm_orderConfirm_order_fulfillments_warehouse | null;
 }
 
+export interface OrderConfirm_orderConfirm_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderConfirm_orderConfirm_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderConfirm_orderConfirm_order_lines_allocations_warehouse;
+}
+
 export interface OrderConfirm_orderConfirm_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderConfirm_orderConfirm_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderConfirm_orderConfirm_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderConfirm_orderConfirm_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderConfirm_orderConfirm_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderConfirm_orderConfirm_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderConfirm_orderConfirm_order_lines_variant_preorder | null;
+  stocks: (OrderConfirm_orderConfirm_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderConfirm_orderConfirm_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderConfirm_orderConfirm_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderConfirm_orderConfirm_order_lines_allocations[] | null;
   variant: OrderConfirm_orderConfirm_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -220,6 +220,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_al
 
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderConfirm_orderConfirm_order_lines_allocations_warehouse {
 
 export interface OrderConfirm_orderConfirm_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderConfirm_orderConfirm_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -220,6 +220,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_al
 
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_va
 
 export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderConfirm_orderConfirm_order_lines_allocations_warehouse {
 
 export interface OrderConfirm_orderConfirm_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderConfirm_orderConfirm_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderConfirm_orderConfirm_order_lines_variant_stocks_warehouse 
 
 export interface OrderConfirm_orderConfirm_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderConfirm_orderConfirm_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -213,6 +213,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine_allocations_war
 
 export interface OrderDetails_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDetails_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -339,6 +340,7 @@ export interface OrderDetails_order_lines_allocations_warehouse {
 
 export interface OrderDetails_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDetails_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -206,9 +206,31 @@ export interface OrderDetails_order_events {
   lines: (OrderDetails_order_events_lines | null)[] | null;
 }
 
+export interface OrderDetails_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetails_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDetails_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDetails_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDetails_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetails_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDetails_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDetails_order_fulfillments_lines_orderLine_variant {
@@ -216,6 +238,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDetails_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDetails_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDetails_order_fulfillments_lines_orderLine_unitDiscount {
@@ -270,6 +293,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDetails_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDetails_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -308,9 +332,31 @@ export interface OrderDetails_order_fulfillments {
   warehouse: OrderDetails_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDetails_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetails_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDetails_order_lines_allocations_warehouse;
+}
+
 export interface OrderDetails_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDetails_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDetails_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDetails_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDetails_order_lines_variant {
@@ -318,6 +364,7 @@ export interface OrderDetails_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDetails_order_lines_variant_preorder | null;
+  stocks: (OrderDetails_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDetails_order_lines_unitDiscount {
@@ -372,6 +419,7 @@ export interface OrderDetails_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDetails_order_lines_allocations[] | null;
   variant: OrderDetails_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -213,6 +213,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine_allocations_war
 
 export interface OrderDetails_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDetails_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -229,6 +230,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine_variant_stocks_
 
 export interface OrderDetails_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDetails_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -340,6 +342,7 @@ export interface OrderDetails_order_lines_allocations_warehouse {
 
 export interface OrderDetails_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDetails_order_lines_allocations_warehouse;
 }
@@ -356,6 +359,7 @@ export interface OrderDetails_order_lines_variant_stocks_warehouse {
 
 export interface OrderDetails_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDetails_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -213,9 +213,31 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_events {
   lines: (OrderDiscountAdd_orderDiscountAdd_order_events_lines | null)[] | null;
 }
 
+export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments {
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_warehouse;
+}
+
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountAdd_orderDiscountAdd_order_lines_variant_preorder | null;
+  stocks: (OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountAdd_orderDiscountAdd_order_lines_allocations[] | null;
   variant: OrderDiscountAdd_orderDiscountAdd_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_wareh
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks_wa
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_wareh
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountAdd_orderDiscountAdd_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant_sto
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -213,9 +213,31 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_events {
   lines: (OrderDiscountDelete_orderDiscountDelete_order_events_lines | null)[] | null;
 }
 
+export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments {
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountDelete_orderDiscountDelete_order_lines_allocations_warehouse;
+}
+
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountDelete_orderDiscountDelete_order_lines_variant_preorder | null;
+  stocks: (OrderDiscountDelete_orderDiscountDelete_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountDelete_orderDiscountDelete_order_lines_allocations[] | null;
   variant: OrderDiscountDelete_orderDiscountDelete_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountDelete_orderDiscountDelete_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_sto
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -213,9 +213,31 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_events {
   lines: (OrderDiscountUpdate_orderDiscountUpdate_order_events_lines | null)[] | null;
 }
 
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments {
   warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations_warehouse;
+}
+
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_preorder | null;
+  stocks: (OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDiscountUpdate_orderDiscountUpdate_order_lines_allocations[] | null;
   variant: OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -220,6 +220,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations_wareh
 
 export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftCancel_draftOrderDelete_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -220,6 +220,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations_wareh
 
 export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftCancel_draftOrderDelete_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks_wa
 
 export interface OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -213,9 +213,31 @@ export interface OrderDraftCancel_draftOrderDelete_order_events {
   lines: (OrderDraftCancel_draftOrderDelete_order_events_lines | null)[] | null;
 }
 
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments {
   warehouse: OrderDraftCancel_draftOrderDelete_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftCancel_draftOrderDelete_order_lines_allocations_warehouse;
+}
+
 export interface OrderDraftCancel_draftOrderDelete_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftCancel_draftOrderDelete_order_lines_variant_preorder | null;
+  stocks: (OrderDraftCancel_draftOrderDelete_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftCancel_draftOrderDelete_order_lines_allocations[] | null;
   variant: OrderDraftCancel_draftOrderDelete_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -220,6 +220,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations_w
 
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant_stock
 
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -213,9 +213,31 @@ export interface OrderDraftFinalize_draftOrderComplete_order_events {
   lines: (OrderDraftFinalize_draftOrderComplete_order_events_lines | null)[] | null;
 }
 
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments {
   warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftFinalize_draftOrderComplete_order_lines_allocations_warehouse;
+}
+
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftFinalize_draftOrderComplete_order_lines_variant_preorder | null;
+  stocks: (OrderDraftFinalize_draftOrderComplete_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftFinalize_draftOrderComplete_order_lines_allocations[] | null;
   variant: OrderDraftFinalize_draftOrderComplete_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -220,6 +220,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations_w
 
 export interface OrderDraftFinalize_draftOrderComplete_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftFinalize_draftOrderComplete_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_wareh
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_wareh
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks_wa
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -213,9 +213,31 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_events {
   lines: (OrderDraftUpdate_draftOrderUpdate_order_events_lines | null)[] | null;
 }
 
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments {
   warehouse: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderDraftUpdate_draftOrderUpdate_order_lines_allocations_warehouse;
+}
+
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderDraftUpdate_draftOrderUpdate_order_lines_variant_preorder | null;
+  stocks: (OrderDraftUpdate_draftOrderUpdate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderDraftUpdate_draftOrderUpdate_order_lines_allocations[] | null;
   variant: OrderDraftUpdate_draftOrderUpdate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderFulfillmentApprove.ts
+++ b/src/orders/types/OrderFulfillmentApprove.ts
@@ -213,9 +213,31 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_events {
   lines: (OrderFulfillmentApprove_orderFulfillmentApprove_order_events_lines | null)[] | null;
 }
 
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_warehouse | null;
 }
 
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations_warehouse;
+}
+
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_var
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_preorder | null;
+  stocks: (OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations[] | null;
   variant: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderFulfillmentApprove.ts
+++ b/src/orders/types/OrderFulfillmentApprove.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_all
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_var
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderFulfillmentApprove.ts
+++ b/src/orders/types/OrderFulfillmentApprove.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_all
 
 export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_alloc
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_varia
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_alloc
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -213,9 +213,31 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events {
   lines: (OrderFulfillmentCancel_orderFulfillmentCancel_order_events_lines | null)[] | null;
 }
 
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
   warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_warehouse | null;
 }
 
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations_warehouse;
+}
+
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_varia
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_preorder | null;
+  stocks: (OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_allocations[] | null;
   variant: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -23,6 +23,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -472,6 +474,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -16,9 +16,31 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_e
   addressType: AddressTypeEnum | null;
 }
 
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant {
@@ -26,6 +48,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_preorder | null;
+  stocks: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_unitDiscount {
@@ -80,6 +103,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations[] | null;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   lines: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_events_lines | null)[] | null;
 }
 
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant {
@@ -325,6 +371,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -417,9 +465,31 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_warehouse | null;
 }
 
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations_warehouse;
+}
+
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant {
@@ -427,6 +497,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_preorder | null;
+  stocks: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_unitDiscount {
@@ -481,6 +552,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations[] | null;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -23,6 +23,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_allocations_warehouse;
 }
@@ -39,6 +40,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -474,6 +478,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_allocations_warehouse;
 }
@@ -490,6 +495,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -213,9 +213,31 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   lines: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_events_lines | null)[] | null;
 }
 
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_warehouse | null;
 }
 
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations_warehouse;
+}
+
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   id: string;
   quantityAvailable: number | null;
   preorder: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_preorder | null;
+  stocks: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations[] | null;
   variant: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -220,6 +220,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -220,6 +220,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
 
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
 
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines_allocations_warehou
 
 export interface OrderLineDelete_orderLineDelete_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDelete_orderLineDelete_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines_variant_stocks_ware
 
 export interface OrderLineDelete_orderLineDelete_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDelete_orderLineDelete_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -220,6 +220,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
 
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines_allocations_warehou
 
 export interface OrderLineDelete_orderLineDelete_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDelete_orderLineDelete_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -213,9 +213,31 @@ export interface OrderLineDelete_orderLineDelete_order_events {
   lines: (OrderLineDelete_orderLineDelete_order_events_lines | null)[] | null;
 }
 
+export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments {
   warehouse: OrderLineDelete_orderLineDelete_order_fulfillments_warehouse | null;
 }
 
+export interface OrderLineDelete_orderLineDelete_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDelete_orderLineDelete_order_lines_allocations_warehouse;
+}
+
 export interface OrderLineDelete_orderLineDelete_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDelete_orderLineDelete_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDelete_orderLineDelete_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDelete_orderLineDelete_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDelete_orderLineDelete_order_lines_variant_preorder | null;
+  stocks: (OrderLineDelete_orderLineDelete_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDelete_orderLineDelete_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDelete_orderLineDelete_order_lines_allocations[] | null;
   variant: OrderLineDelete_orderLineDelete_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -220,6 +220,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_all
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -220,6 +220,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_all
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_var
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -213,9 +213,31 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_events {
   lines: (OrderLineDiscountRemove_orderLineDiscountRemove_order_events_lines | null)[] | null;
 }
 
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
   warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_warehouse | null;
 }
 
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations_warehouse;
+}
+
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_var
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_preorder | null;
+  stocks: (OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_allocations[] | null;
   variant: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -213,9 +213,31 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_events {
   lines: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_events_lines | null)[] | null;
 }
 
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations_warehouse;
+}
+
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_var
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_preorder | null;
+  stocks: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations[] | null;
   variant: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_all
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_var
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_all
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
 
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehou
 
 export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -213,9 +213,31 @@ export interface OrderLineUpdate_orderLineUpdate_order_events {
   lines: (OrderLineUpdate_orderLineUpdate_order_events_lines | null)[] | null;
 }
 
+export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments {
   warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehouse;
+}
+
 export interface OrderLineUpdate_orderLineUpdate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLineUpdate_orderLineUpdate_order_lines_variant_preorder | null;
+  stocks: (OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLineUpdate_orderLineUpdate_order_lines_allocations[] | null;
   variant: OrderLineUpdate_orderLineUpdate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
 
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
 
 export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehou
 
 export interface OrderLineUpdate_orderLineUpdate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLineUpdate_orderLineUpdate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks_ware
 
 export interface OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLineUpdate_orderLineUpdate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -220,6 +220,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
 
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
 
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehous
 
 export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks_wareh
 
 export interface OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -220,6 +220,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
 
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehous
 
 export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -213,9 +213,31 @@ export interface OrderLinesAdd_orderLinesCreate_order_events {
   lines: (OrderLinesAdd_orderLinesCreate_order_events_lines | null)[] | null;
 }
 
+export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments {
   warehouse: OrderLinesAdd_orderLinesCreate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderLinesAdd_orderLinesCreate_order_lines_allocations_warehouse;
+}
+
 export interface OrderLinesAdd_orderLinesCreate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderLinesAdd_orderLinesCreate_order_lines_variant_preorder | null;
+  stocks: (OrderLinesAdd_orderLinesCreate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderLinesAdd_orderLinesCreate_order_lines_allocations[] | null;
   variant: OrderLinesAdd_orderLinesCreate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -220,6 +220,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehou
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks_ware
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -213,9 +213,31 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_events {
   lines: (OrderMarkAsPaid_orderMarkAsPaid_order_events_lines | null)[] | null;
 }
 
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
   id: string;
   quantityAvailable: number | null;
   preorder: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments {
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_warehouse | null;
 }
 
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehouse;
+}
+
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_preorder | null;
+  stocks: (OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations[] | null;
   variant: OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -220,6 +220,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehou
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderMarkAsPaid_orderMarkAsPaid_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -220,6 +220,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allo
 
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderRefund_orderRefund_order_lines_allocations_warehouse {
 
 export interface OrderRefund_orderRefund_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderRefund_orderRefund_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -220,6 +220,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allo
 
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_vari
 
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderRefund_orderRefund_order_lines_allocations_warehouse {
 
 export interface OrderRefund_orderRefund_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderRefund_orderRefund_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderRefund_orderRefund_order_lines_variant_stocks_warehouse {
 
 export interface OrderRefund_orderRefund_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderRefund_orderRefund_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -213,9 +213,31 @@ export interface OrderRefund_orderRefund_order_events {
   lines: (OrderRefund_orderRefund_order_events_lines | null)[] | null;
 }
 
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_vari
   id: string;
   quantityAvailable: number | null;
   preorder: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderRefund_orderRefund_order_fulfillments {
   warehouse: OrderRefund_orderRefund_order_fulfillments_warehouse | null;
 }
 
+export interface OrderRefund_orderRefund_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderRefund_orderRefund_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderRefund_orderRefund_order_lines_allocations_warehouse;
+}
+
 export interface OrderRefund_orderRefund_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderRefund_orderRefund_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderRefund_orderRefund_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderRefund_orderRefund_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderRefund_orderRefund_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderRefund_orderRefund_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderRefund_orderRefund_order_lines_variant_preorder | null;
+  stocks: (OrderRefund_orderRefund_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderRefund_orderRefund_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderRefund_orderRefund_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderRefund_orderRefund_order_lines_allocations[] | null;
   variant: OrderRefund_orderRefund_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -277,9 +277,31 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_events {
   lines: (OrderShippingMethodUpdate_orderUpdateShipping_order_events_lines | null)[] | null;
 }
 
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant {
@@ -287,6 +309,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
   id: string;
   quantityAvailable: number | null;
   preorder: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_unitDiscount {
@@ -341,6 +364,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -379,9 +403,31 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_warehouse | null;
 }
 
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations_warehouse;
+}
+
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant {
@@ -389,6 +435,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_varia
   id: string;
   quantityAvailable: number | null;
   preorder: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_preorder | null;
+  stocks: (OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_unitDiscount {
@@ -443,6 +490,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations[] | null;
   variant: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -284,6 +284,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -300,6 +301,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -411,6 +413,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_alloc
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations_warehouse;
 }
@@ -427,6 +430,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_varia
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -284,6 +284,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -410,6 +411,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_alloc
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allo
 
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_vari
 
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderUpdate_orderUpdate_order_lines_allocations_warehouse {
 
 export interface OrderUpdate_orderUpdate_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderUpdate_orderUpdate_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderUpdate_orderUpdate_order_lines_variant_stocks_warehouse {
 
 export interface OrderUpdate_orderUpdate_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderUpdate_orderUpdate_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -220,6 +220,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allo
 
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderUpdate_orderUpdate_order_lines_allocations_warehouse {
 
 export interface OrderUpdate_orderUpdate_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderUpdate_orderUpdate_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -213,9 +213,31 @@ export interface OrderUpdate_orderUpdate_order_events {
   lines: (OrderUpdate_orderUpdate_order_events_lines | null)[] | null;
 }
 
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_vari
   id: string;
   quantityAvailable: number | null;
   preorder: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderUpdate_orderUpdate_order_fulfillments {
   warehouse: OrderUpdate_orderUpdate_order_fulfillments_warehouse | null;
 }
 
+export interface OrderUpdate_orderUpdate_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderUpdate_orderUpdate_order_lines_allocations_warehouse;
+}
+
 export interface OrderUpdate_orderUpdate_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderUpdate_orderUpdate_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderUpdate_orderUpdate_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderUpdate_orderUpdate_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderUpdate_orderUpdate_order_lines_variant_preorder | null;
+  stocks: (OrderUpdate_orderUpdate_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderUpdate_orderUpdate_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderUpdate_orderUpdate_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderUpdate_orderUpdate_order_lines_allocations[] | null;
   variant: OrderUpdate_orderUpdate_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -220,6 +220,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocati
 
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
 
@@ -346,6 +347,7 @@ export interface OrderVoid_orderVoid_order_lines_allocations_warehouse {
 
 export interface OrderVoid_orderVoid_order_lines_allocations {
   __typename: "Allocation";
+  quantity: number;
   warehouse: OrderVoid_orderVoid_order_lines_allocations_warehouse;
 }
 

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -220,6 +220,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocati
 
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations_warehouse;
 }
@@ -236,6 +237,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_
 
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;
@@ -347,6 +349,7 @@ export interface OrderVoid_orderVoid_order_lines_allocations_warehouse {
 
 export interface OrderVoid_orderVoid_order_lines_allocations {
   __typename: "Allocation";
+  id: string;
   quantity: number;
   warehouse: OrderVoid_orderVoid_order_lines_allocations_warehouse;
 }
@@ -363,6 +366,7 @@ export interface OrderVoid_orderVoid_order_lines_variant_stocks_warehouse {
 
 export interface OrderVoid_orderVoid_order_lines_variant_stocks {
   __typename: "Stock";
+  id: string;
   warehouse: OrderVoid_orderVoid_order_lines_variant_stocks_warehouse;
   quantity: number;
   quantityAllocated: number;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -213,9 +213,31 @@ export interface OrderVoid_orderVoid_order_events {
   lines: (OrderVoid_orderVoid_order_events_lines | null)[] | null;
 }
 
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations {
+  __typename: "Allocation";
+  warehouse: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations_warehouse;
+}
+
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant {
@@ -223,6 +245,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant 
   id: string;
   quantityAvailable: number | null;
   preorder: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_preorder | null;
+  stocks: (OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant_stocks | null)[] | null;
 }
 
 export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitDiscount {
@@ -277,6 +300,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_allocations[] | null;
   variant: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
   productSku: string | null;
@@ -315,9 +339,31 @@ export interface OrderVoid_orderVoid_order_fulfillments {
   warehouse: OrderVoid_orderVoid_order_fulfillments_warehouse | null;
 }
 
+export interface OrderVoid_orderVoid_order_lines_allocations_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderVoid_orderVoid_order_lines_allocations {
+  __typename: "Allocation";
+  warehouse: OrderVoid_orderVoid_order_lines_allocations_warehouse;
+}
+
 export interface OrderVoid_orderVoid_order_lines_variant_preorder {
   __typename: "PreorderData";
   endDate: any | null;
+}
+
+export interface OrderVoid_orderVoid_order_lines_variant_stocks_warehouse {
+  __typename: "Warehouse";
+  id: string;
+}
+
+export interface OrderVoid_orderVoid_order_lines_variant_stocks {
+  __typename: "Stock";
+  warehouse: OrderVoid_orderVoid_order_lines_variant_stocks_warehouse;
+  quantity: number;
+  quantityAllocated: number;
 }
 
 export interface OrderVoid_orderVoid_order_lines_variant {
@@ -325,6 +371,7 @@ export interface OrderVoid_orderVoid_order_lines_variant {
   id: string;
   quantityAvailable: number | null;
   preorder: OrderVoid_orderVoid_order_lines_variant_preorder | null;
+  stocks: (OrderVoid_orderVoid_order_lines_variant_stocks | null)[] | null;
 }
 
 export interface OrderVoid_orderVoid_order_lines_unitDiscount {
@@ -379,6 +426,7 @@ export interface OrderVoid_orderVoid_order_lines {
   __typename: "OrderLine";
   id: string;
   isShippingRequired: boolean;
+  allocations: OrderVoid_orderVoid_order_lines_allocations[] | null;
   variant: OrderVoid_orderVoid_order_lines_variant | null;
   productName: string;
   productSku: string | null;

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -106,6 +106,7 @@ export type OrderUrlDialog =
   | "cancel"
   | "cancel-fulfillment"
   | "capture"
+  | "change-warehouse"
   | "customer-change"
   | "edit-customer-addresses"
   | "edit-billing-address"

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -535,6 +535,7 @@ describe("Get the total value of all replaced products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -623,6 +624,7 @@ describe("Get the total value of all replaced products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -711,6 +713,7 @@ describe("Get the total value of all replaced products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -805,6 +808,7 @@ describe("Get the total value of all replaced products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -898,6 +902,7 @@ describe("Get the total value of all replaced products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -991,6 +996,7 @@ describe("Get the total value of all replaced products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -1084,6 +1090,7 @@ describe("Get the total value of all replaced products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -1177,6 +1184,7 @@ describe("Get the total value of all replaced products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -1404,6 +1412,7 @@ describe("Get the total value of all selected products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -1492,6 +1501,7 @@ describe("Get the total value of all selected products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -1580,6 +1590,7 @@ describe("Get the total value of all selected products", () => {
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
               __typename: "Warehouse"
             },
+            quantity: 1,
             __typename: "Allocation"
           }
         ],
@@ -1674,6 +1685,7 @@ describe("Get the total value of all selected products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -1767,6 +1779,7 @@ describe("Get the total value of all selected products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -1860,6 +1873,7 @@ describe("Get the total value of all selected products", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -2081,6 +2095,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -2174,6 +2189,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],
@@ -2267,6 +2283,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
                 __typename: "Warehouse"
               },
+              quantity: 1,
               __typename: "Allocation"
             }
           ],

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -528,11 +528,43 @@ describe("Get the total value of all replaced products", () => {
       {
         id: "1",
         isShippingRequired: false,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
           quantityAvailable: 50,
           preorder: null,
-          __typename: "ProductVariant"
+          __typename: "ProductVariant",
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ]
         },
         productName: "Lake Tunes",
         productSku: "lake-tunes-mp3",
@@ -584,10 +616,42 @@ describe("Get the total value of all replaced products", () => {
       {
         id: "2",
         isShippingRequired: false,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
           quantityAvailable: 50,
           preorder: null,
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ],
           __typename: "ProductVariant"
         },
         productName: "Lake Tunes",
@@ -640,10 +704,42 @@ describe("Get the total value of all replaced products", () => {
       {
         id: "3",
         isShippingRequired: true,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6Mjg2",
           quantityAvailable: 50,
           preorder: null,
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ],
           __typename: "ProductVariant"
         },
         productName: "T-shirt",
@@ -702,10 +798,42 @@ describe("Get the total value of all replaced products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -763,10 +891,42 @@ describe("Get the total value of all replaced products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -824,10 +984,42 @@ describe("Get the total value of all replaced products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ3",
           isShippingRequired: true,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6Mjg2",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "T-shirt",
@@ -885,10 +1077,42 @@ describe("Get the total value of all replaced products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -946,10 +1170,42 @@ describe("Get the total value of all replaced products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -1141,10 +1397,42 @@ describe("Get the total value of all selected products", () => {
       {
         id: "1",
         isShippingRequired: false,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
           quantityAvailable: 50,
           preorder: null,
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ],
           __typename: "ProductVariant"
         },
         productName: "Lake Tunes",
@@ -1197,10 +1485,42 @@ describe("Get the total value of all selected products", () => {
       {
         id: "2",
         isShippingRequired: false,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
           quantityAvailable: 50,
           preorder: null,
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ],
           __typename: "ProductVariant"
         },
         productName: "Lake Tunes",
@@ -1253,10 +1573,42 @@ describe("Get the total value of all selected products", () => {
       {
         id: "3",
         isShippingRequired: true,
+        allocations: [
+          {
+            warehouse: {
+              id:
+                "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+              __typename: "Warehouse"
+            },
+            __typename: "Allocation"
+          }
+        ],
         variant: {
           id: "UHJvZHVjdFZhcmlhbnQ6Mjg2",
           quantityAvailable: 50,
           preorder: null,
+          stocks: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            },
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                __typename: "Warehouse"
+              },
+              quantity: 166,
+              quantityAllocated: 0,
+              __typename: "Stock"
+            }
+          ],
           __typename: "ProductVariant"
         },
         productName: "T-shirt",
@@ -1315,10 +1667,42 @@ describe("Get the total value of all selected products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -1376,10 +1760,42 @@ describe("Get the total value of all selected products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -1437,10 +1853,42 @@ describe("Get the total value of all selected products", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ3",
           isShippingRequired: true,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6Mjg2",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "T-shirt",
@@ -1626,10 +2074,42 @@ describe("Merge repeated order lines of fulfillment lines", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -1687,10 +2167,42 @@ describe("Merge repeated order lines of fulfillment lines", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ1",
           isShippingRequired: false,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6MzE3",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "Lake Tunes",
@@ -1748,10 +2260,42 @@ describe("Merge repeated order lines of fulfillment lines", () => {
         orderLine: {
           id: "T3JkZXJMaW5lOjQ3",
           isShippingRequired: true,
+          allocations: [
+            {
+              warehouse: {
+                id:
+                  "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
+                __typename: "Warehouse"
+              },
+              __typename: "Allocation"
+            }
+          ],
           variant: {
             id: "UHJvZHVjdFZhcmlhbnQ6Mjg2",
             quantityAvailable: 50,
             preorder: null,
+            stocks: [
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              },
+              {
+                warehouse: {
+                  id:
+                    "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
+                  __typename: "Warehouse"
+                },
+                quantity: 166,
+                quantityAllocated: 0,
+                __typename: "Stock"
+              }
+            ],
             __typename: "ProductVariant"
           },
           productName: "T-shirt",

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -530,6 +530,7 @@ describe("Get the total value of all replaced products", () => {
         isShippingRequired: false,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -546,6 +547,7 @@ describe("Get the total value of all replaced products", () => {
           __typename: "ProductVariant",
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -556,6 +558,7 @@ describe("Get the total value of all replaced products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -619,6 +622,7 @@ describe("Get the total value of all replaced products", () => {
         isShippingRequired: false,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -634,6 +638,7 @@ describe("Get the total value of all replaced products", () => {
           preorder: null,
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -644,6 +649,7 @@ describe("Get the total value of all replaced products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -708,6 +714,7 @@ describe("Get the total value of all replaced products", () => {
         isShippingRequired: true,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -723,6 +730,7 @@ describe("Get the total value of all replaced products", () => {
           preorder: null,
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -733,6 +741,7 @@ describe("Get the total value of all replaced products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -803,6 +812,7 @@ describe("Get the total value of all replaced products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -818,6 +828,7 @@ describe("Get the total value of all replaced products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -828,6 +839,7 @@ describe("Get the total value of all replaced products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -897,6 +909,7 @@ describe("Get the total value of all replaced products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -912,6 +925,7 @@ describe("Get the total value of all replaced products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -922,6 +936,7 @@ describe("Get the total value of all replaced products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -991,6 +1006,7 @@ describe("Get the total value of all replaced products", () => {
           isShippingRequired: true,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1006,6 +1022,7 @@ describe("Get the total value of all replaced products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1016,6 +1033,7 @@ describe("Get the total value of all replaced products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1085,6 +1103,7 @@ describe("Get the total value of all replaced products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1100,6 +1119,7 @@ describe("Get the total value of all replaced products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1110,6 +1130,7 @@ describe("Get the total value of all replaced products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1179,6 +1200,7 @@ describe("Get the total value of all replaced products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1194,6 +1216,7 @@ describe("Get the total value of all replaced products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1204,6 +1227,7 @@ describe("Get the total value of all replaced products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1407,6 +1431,7 @@ describe("Get the total value of all selected products", () => {
         isShippingRequired: false,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1422,6 +1447,7 @@ describe("Get the total value of all selected products", () => {
           preorder: null,
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1432,6 +1458,7 @@ describe("Get the total value of all selected products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1496,6 +1523,7 @@ describe("Get the total value of all selected products", () => {
         isShippingRequired: false,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1511,6 +1539,7 @@ describe("Get the total value of all selected products", () => {
           preorder: null,
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1521,6 +1550,7 @@ describe("Get the total value of all selected products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1585,6 +1615,7 @@ describe("Get the total value of all selected products", () => {
         isShippingRequired: true,
         allocations: [
           {
+            id: "allocation_test_id",
             warehouse: {
               id:
                 "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1600,6 +1631,7 @@ describe("Get the total value of all selected products", () => {
           preorder: null,
           stocks: [
             {
+              id: "stock_test_id1",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1610,6 +1642,7 @@ describe("Get the total value of all selected products", () => {
               __typename: "Stock"
             },
             {
+              id: "stock_test_id2",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1680,6 +1713,7 @@ describe("Get the total value of all selected products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1695,6 +1729,7 @@ describe("Get the total value of all selected products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1705,6 +1740,7 @@ describe("Get the total value of all selected products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1774,6 +1810,7 @@ describe("Get the total value of all selected products", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1789,6 +1826,7 @@ describe("Get the total value of all selected products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1799,6 +1837,7 @@ describe("Get the total value of all selected products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -1868,6 +1907,7 @@ describe("Get the total value of all selected products", () => {
           isShippingRequired: true,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -1883,6 +1923,7 @@ describe("Get the total value of all selected products", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -1893,6 +1934,7 @@ describe("Get the total value of all selected products", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -2090,6 +2132,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -2105,6 +2148,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -2115,6 +2159,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -2184,6 +2229,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
           isShippingRequired: false,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -2199,6 +2245,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -2209,6 +2256,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",
@@ -2278,6 +2326,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
           isShippingRequired: true,
           allocations: [
             {
+              id: "allocation_test_id",
               warehouse: {
                 id:
                   "V2FyZWhvdXNlOjk1NWY0ZDk2LWRmNTAtNGY0Zi1hOTM4LWM5MTYzYTA4YTViNg==",
@@ -2293,6 +2342,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
             preorder: null,
             stocks: [
               {
+                id: "stock_test_id1",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjc4OGUyMGRlLTlmYTAtNDI5My1iZDk2LWUwM2RjY2RhMzc0ZQ==",
@@ -2303,6 +2353,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
                 __typename: "Stock"
               },
               {
+                id: "stock_test_id2",
                 warehouse: {
                   id:
                     "V2FyZWhvdXNlOjczYzI0OGNmLTliNzAtNDlmMi1hMDRlLTM4ZTYxMmQ5MDYwMQ==",

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -4,6 +4,7 @@ import { useCustomerAddressesQuery } from "@saleor/customers/queries";
 import useNavigator from "@saleor/hooks/useNavigator";
 import OrderCannotCancelOrderDialog from "@saleor/orders/components/OrderCannotCancelOrderDialog";
 import OrderChangeWarehouseDialog from "@saleor/orders/components/OrderChangeWarehouseDialog";
+import { Warehouse } from "@saleor/orders/components/OrderChangeWarehouseDialog/types";
 import { OrderCustomerAddressesEditDialogOutput } from "@saleor/orders/components/OrderCustomerAddressesEditDialog/types";
 import OrderFulfillmentApproveDialog from "@saleor/orders/components/OrderFulfillmentApproveDialog";
 import OrderInvoiceEmailSendDialog from "@saleor/orders/components/OrderInvoiceEmailSendDialog";
@@ -19,7 +20,6 @@ import {
 import { PartialMutationProviderOutput } from "@saleor/types";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import { useWarehouseList } from "@saleor/warehouses/queries";
-import { WarehouseList_warehouses_edges_node } from "@saleor/warehouses/types/WarehouseList";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -111,13 +111,13 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
 
   const warehouses = mapEdgesToItems(warehousesData?.warehouses);
 
-  // @TODO this is wip
-  // exact logic for determining default
-  // warehouse will be added in future PR
   const [fulfillmentWarehouse, setFulfillmentWarehouse] = React.useState<
-    WarehouseList_warehouses_edges_node
+    Warehouse
   >(null);
   React.useEffect(() => {
+    // @TODO this is wip
+    // exact logic for determining default
+    // warehouse will be added in future PR
     setFulfillmentWarehouse(warehouses?.[0]);
   }, [warehousesData, warehousesLoading]);
 

--- a/src/searches/useWarehouseSearch.ts
+++ b/src/searches/useWarehouseSearch.ts
@@ -13,6 +13,7 @@ export const searchWarehouses = gql`
     search: warehouses(
       after: $after
       first: $first
+      sortBy: { direction: ASC, field: NAME }
       filter: { search: $query }
     ) {
       edges {


### PR DESCRIPTION
I want to merge this change because it adds dialog for changing warehouse in order details view.

This change can't really be tested now because modal will be opened by clicking on warehouse button in order detail view. This button is yet to be implemented in future PR.

You can open modal manually by adding `?action=change-warehouse` in the url in order details view.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.1

### Screenshots
![image](https://user-images.githubusercontent.com/41952692/153298763-fc0c0e7c-f094-4912-adf0-fcab08a58018.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
