### PR TITLE
Run cypress nightly

### DIFF
--- a/.github/workflows/run-e2e-at-night.yml
+++ b/.github/workflows/run-e2e-at-night.yml
@@ -1,0 +1,32 @@
+name: Cypress nightly tests
+on:
+  pull_request:
+    types: [reopened, synchronize, labeled, opened]
+    branches: ["*"]
+  schedule:
+  - cron: '00 02 * * *'
+    
+jobs:
+  nightly:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cypress nightly tests 🌃
+        uses: cypress-io/github-action@v2
+        env:
+          API_URI: https://qa.staging.saleor.cloud/graphql/
+          APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
+          CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
+          CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
+          CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+          CYPRESS_MAILHOG: ${{ secrets.CYPRESS_MAILHOG }}
+        with:
+          command: npm run cy:run:qa
+      - uses: actions/upload-artifact@v1
+        if: ${{ failure() }}
+        with:
+          name: cypress-videos
+          path: cypress/videos
+

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "start": "npm run generate-fragment-types && webpack-dev-server -d",
     "storybook": "start-storybook -p 3000 -c src/storybook/",
     "cy:run": "cypress run",
+    "cy:run:qa": "cypress run --env tags=all --config baseUrl=https://qa.staging.saleor.cloud/dashboard/  --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "cy:run:dashboard": "cypress run --record --key 1fe833f5-fca4-4454-ac55-943815b91c6c",
     "cy:run:record": "npm run cy:run -- --record",
     "cy:open": "cypress open",


### PR DESCRIPTION
I want to merge this change because I want to run cypress nightly

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
