### PR TITLE
Fix menu reordering in navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.0.0-b.30",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
+++ b/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
@@ -12,7 +12,6 @@ import { Backlink } from "@saleor/macaw-ui";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { maybe } from "../../../misc";
 import { MenuDetails_menu } from "../../types/MenuDetails";
 import { MenuItemType } from "../MenuItemDialog";
 import MenuItems, { TreeOperation } from "../MenuItems";
@@ -55,7 +54,7 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
   const intl = useIntl();
 
   const initialForm: MenuDetailsFormData = {
-    name: maybe(() => menu.name, "")
+    name: menu?.name ?? ""
   };
 
   const [treeOperations, setTreeOperations] = React.useState<TreeOperation[]>(
@@ -79,9 +78,7 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
   };
 
   const handleChange = (operations: TreeOperation[]) => {
-    if (!!operations) {
-      setTreeOperations([...treeOperations, ...operations]);
-    }
+    setTreeOperations([...treeOperations, ...operations]);
   };
 
   return (
@@ -113,9 +110,11 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
               <CardSpacer />
               <MenuItems
                 canUndo={treeOperations.length > 0}
-                items={maybe(() =>
-                  computeRelativeTree(menu.items, [...treeOperations])
-                )}
+                items={
+                  menu?.items
+                    ? computeRelativeTree(menu.items, treeOperations)
+                    : []
+                }
                 onChange={handleChange}
                 onItemAdd={onItemAdd}
                 onItemClick={onItemClick}
@@ -123,6 +122,7 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
                 onUndo={() =>
                   setTreeOperations(operations => {
                     if (operations.length > 1) {
+                      // Undo of a simulated move needs removal of 2 moves instead of one
                       if (operations[operations.length - 2].simulatedMove) {
                         return operations.slice(0, operations.length - 2);
                       }

--- a/src/navigation/components/MenuDetailsPage/tree.test.ts
+++ b/src/navigation/components/MenuDetailsPage/tree.test.ts
@@ -1,7 +1,1154 @@
 import { menu } from "../../fixtures";
 import { MenuDetails_menu_items } from "../../types/MenuDetails";
 import { TreeOperation } from "../MenuItems";
-import { computeTree } from "./tree";
+import { computeRelativeTree } from "./tree";
+
+const relativeOutput: MenuDetails_menu_items[][] = [
+  // no moves
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves one in root
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    }
+  ],
+  // moves two in root
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    }
+  ],
+  // empty move
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves every
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    }
+  ],
+  // moves children
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child outside
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQX==",
+        name: "Glasses"
+      },
+      children: [],
+      collection: null,
+      id: "1glasses",
+      level: 0,
+      name: "Glasses",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child outside and puts it in location
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQX==",
+        name: "Glasses"
+      },
+      children: [],
+      collection: null,
+      id: "1glasses",
+      level: 0,
+      name: "Glasses",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child inside
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child inside then outside then changes index
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves item as last child and moves it up
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ]
+];
+
+const secondTestTable: TreeOperation[][] = [
+  // no moves
+  [],
+  // moves one in root
+  [{ id: "4apparel", sortOrder: -1, type: "move" }],
+  // moves two in root
+  [
+    { id: "2accessories", sortOrder: 2, type: "move" },
+    { id: "4apparel", sortOrder: -1, type: "move" }
+  ],
+  // empty move
+  [
+    { id: "2accessories", sortOrder: 0, type: "move" },
+    { id: "4apparel", sortOrder: 0, type: "move" }
+  ],
+  // move every
+  [
+    { id: "2accessories", sortOrder: 1, type: "move" },
+    { id: "4apparel", sortOrder: -2, type: "move" },
+    { id: "3groceries", sortOrder: -1, type: "move" }
+  ],
+  // moves children
+  [
+    {
+      id: "1glasses",
+      sortOrder: -1,
+      type: "move",
+      parentId: "2accessories"
+    }
+  ],
+  // moves children outside
+  [
+    {
+      id: "1glasses",
+      sortOrder: 3,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "1glasses",
+      sortOrder: 0 - 3,
+      type: "move"
+    }
+  ],
+  // moves children outside and puts it in a location
+  [
+    {
+      id: "1glasses",
+      sortOrder: 3,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "1glasses",
+      sortOrder: 2 - 3,
+      type: "move"
+    }
+  ],
+  // moves child inside
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0 - 2,
+      type: "move"
+    }
+  ],
+  // moves child inside, moves it and puts it back
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: 1,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: 1,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: -2,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  // moves item as last child and moves it up
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 1,
+      type: "move"
+    }
+  ]
+];
+
+const testTable: TreeOperation[][] = [
+  [],
+  [
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "4apparel",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    {
+      id: "4apparel",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "0jewelry",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "0jewelry", parentId: "1glasses", sortOrder: 0, type: "move" },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 2, type: "move" }
+  ],
+  [
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "3groceries", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "2accessories", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 2, type: "move" },
+    { id: "1glasses", sortOrder: 3, type: "move" },
+    { id: "4apparel", sortOrder: 0, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "2accessories", sortOrder: 0, type: "move" },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "1glasses",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "0jewelry",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "4apparel", parentId: "1glasses", sortOrder: 0, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "4apparel",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [{ id: "2accessories", type: "remove" }],
+  [
+    { id: "2accessories", type: "remove" },
+    { id: "4apparel", sortOrder: 0, type: "move" },
+    { id: "3groceries", type: "remove" }
+  ]
+];
 
 // Readability FTW
 function innerTreeToString(
@@ -23,163 +1170,67 @@ function treeToString(tree: MenuDetails_menu_items[]): string {
 }
 
 describe("Properly computes trees", () => {
-  const testTable: TreeOperation[][] = [
-    [],
-    [
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "4apparel",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      {
-        id: "4apparel",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "0jewelry",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "0jewelry", parentId: "1glasses", sortOrder: 0, type: "move" },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 2, type: "move" }
-    ],
-    [
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "3groceries", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "2accessories", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 2, type: "move" },
-      { id: "1glasses", sortOrder: 3, type: "move" },
-      { id: "4apparel", sortOrder: 0, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "2accessories", sortOrder: 0, type: "move" },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "1glasses",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "0jewelry",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "4apparel", parentId: "1glasses", sortOrder: 0, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "4apparel",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [{ id: "2accessories", type: "remove" }],
-    [
-      { id: "2accessories", type: "remove" },
-      { id: "4apparel", sortOrder: 0, type: "move" },
-      { id: "3groceries", type: "remove" }
-    ]
-  ];
-
   testTable.forEach(testData =>
     it("#", () => {
-      const computedTree = computeTree(menu.items, testData);
+      const computedTree = computeRelativeTree(menu.items, testData);
       expect(treeToString(computedTree)).toMatchSnapshot();
     })
   );
+});
+
+describe("Properly computes relative trees", () => {
+  it("doesn't move anything", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[0]);
+    expect(computedTree).toEqual(relativeOutput[0]);
+  });
+
+  it("moves one root element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[1]);
+    expect(computedTree).toEqual(relativeOutput[1]);
+  });
+
+  it("moves two root element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[2]);
+    expect(computedTree).toEqual(relativeOutput[2]);
+  });
+
+  it("empty moves", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[3]);
+    expect(computedTree).toEqual(relativeOutput[3]);
+  });
+
+  it("moves every element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[4]);
+    expect(computedTree).toEqual(relativeOutput[4]);
+  });
+
+  it("moves children", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[5]);
+    expect(computedTree).toEqual(relativeOutput[5]);
+  });
+
+  it("moves child outside", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[6]);
+    expect(computedTree).toEqual(relativeOutput[6]);
+  });
+
+  it("moves child outside and puts it in a location", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[7]);
+    expect(computedTree).toEqual(relativeOutput[7]);
+  });
+
+  it("moves child inside", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[8]);
+    expect(computedTree).toEqual(relativeOutput[8]);
+  });
+
+  it("moves child inside then outside then changes index", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[9]);
+    expect(computedTree).toEqual(relativeOutput[9]);
+  });
+
+  it("moves item as last child and moves it up", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[10]);
+    expect(computedTree).toEqual(relativeOutput[10]);
+  });
 });

--- a/src/navigation/components/MenuDetailsPage/tree.ts
+++ b/src/navigation/components/MenuDetailsPage/tree.ts
@@ -133,7 +133,6 @@ export function computeRelativeTree(
     (acc, operation) => executeRelativeOperation(acc, operation),
     // // FIXME: 😡
     JSON.parse(JSON.stringify(tree))
-    // tree
   );
   return newTree;
 }

--- a/src/navigation/components/MenuDetailsPage/tree.ts
+++ b/src/navigation/components/MenuDetailsPage/tree.ts
@@ -45,23 +45,28 @@ function removeNode(
   return newTree;
 }
 
-function insertNode(
-  tree: MenuDetails_menu_items[],
-  path: number[],
-  node: MenuDetails_menu_items,
-  position: number
-): MenuDetails_menu_items[] {
+function insertNode({
+  tree,
+  path,
+  node,
+  position
+}: {
+  tree: MenuDetails_menu_items[];
+  path: number[];
+  node: MenuDetails_menu_items;
+  position: number;
+}): MenuDetails_menu_items[] {
   if (path.length === 0) {
     return [...tree.slice(0, position), node, ...tree.slice(position)];
   }
 
   if (path[0] in tree) {
-    tree[path[0]].children = insertNode(
-      tree[path[0]].children,
-      path.slice(1),
+    tree[path[0]].children = insertNode({
+      tree: tree[path[0]].children,
+      path: path.slice(1),
       node,
       position
-    );
+    });
   }
   return tree;
 }
@@ -106,12 +111,12 @@ function permuteRelativeNode(
 
   const position = sourcePath[sourcePath.length - 1];
 
-  const treeAfterInsertion = insertNode(
-    treeAfterRemoval,
-    targetPath,
+  const treeAfterInsertion = insertNode({
+    tree: treeAfterRemoval,
+    path: targetPath,
     node,
-    position + permutation.sortOrder
-  );
+    position: position + permutation.sortOrder
+  });
 
   return treeAfterInsertion;
 }
@@ -131,7 +136,6 @@ export function computeRelativeTree(
 ) {
   const newTree = operations.reduce(
     (acc, operation) => executeRelativeOperation(acc, operation),
-    // // FIXME: 😡
     JSON.parse(JSON.stringify(tree))
   );
   return newTree;

--- a/src/navigation/components/MenuDetailsPage/tree.ts
+++ b/src/navigation/components/MenuDetailsPage/tree.ts
@@ -89,46 +89,51 @@ function removeNodeAndChildren(
   return removeNode(tree, sourcePath);
 }
 
-function permuteNode(
+function permuteRelativeNode(
   tree: MenuDetails_menu_items[],
   permutation: TreeOperation
 ): MenuDetails_menu_items[] {
   const sourcePath = findNode(tree, permutation.id);
   const node = getNode(tree, sourcePath);
 
+  const hasParent = !!permutation.parentId;
+
   const treeAfterRemoval = removeNode(tree, sourcePath);
 
-  const targetPath = permutation.parentId
+  const targetPath = hasParent
     ? findNode(treeAfterRemoval, permutation.parentId)
     : [];
+
+  const position = sourcePath[sourcePath.length - 1];
 
   const treeAfterInsertion = insertNode(
     treeAfterRemoval,
     targetPath,
     node,
-    permutation.sortOrder
+    position + permutation.sortOrder
   );
 
   return treeAfterInsertion;
 }
 
-function executeOperation(
+function executeRelativeOperation(
   tree: MenuDetails_menu_items[],
   operation: TreeOperation
 ): MenuDetails_menu_items[] {
   return operation.type === "move"
-    ? permuteNode(tree, operation)
+    ? permuteRelativeNode(tree, operation)
     : removeNodeAndChildren(tree, operation);
 }
 
-export function computeTree(
+export function computeRelativeTree(
   tree: MenuDetails_menu_items[],
   operations: TreeOperation[]
 ) {
   const newTree = operations.reduce(
-    (acc, operation) => executeOperation(acc, operation),
-    // FIXME: 😡
+    (acc, operation) => executeRelativeOperation(acc, operation),
+    // // FIXME: 😡
     JSON.parse(JSON.stringify(tree))
+    // tree
   );
   return newTree;
 }

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -247,6 +247,7 @@ const MenuItems: React.FC<MenuItemsProps> = props => {
                 marginLeft: NODE_MARGIN * (path.length - 1)
               }
             })}
+            maxDepth={5}
             isVirtualized={false}
             rowHeight={NODE_HEIGHT}
             treeData={items.map(item =>

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -21,7 +21,7 @@ const NODE_MARGIN = 40;
 export interface MenuItemsProps {
   canUndo: boolean;
   items: MenuDetails_menu_items[];
-  onChange: (operation: TreeOperation) => void;
+  onChange: (operations: TreeOperation[]) => void;
   onItemAdd: () => void;
   onItemClick: (id: string, type: MenuItemType) => void;
   onItemEdit: (id: string) => void;
@@ -181,10 +181,12 @@ const Node: React.FC<NodeRendererProps> = props => {
           className={classes.deleteButton}
           variant="secondary"
           onClick={() =>
-            node.onChange({
-              id: node.id as any,
-              type: "remove"
-            })
+            node.onChange([
+              {
+                id: node.id as any,
+                type: "remove"
+              }
+            ])
           }
         >
           <DeleteIcon />
@@ -253,16 +255,15 @@ const MenuItems: React.FC<MenuItemsProps> = props => {
             theme={{
               nodeContentRenderer: Node as any
             }}
-            onChange={newTree =>
-              onChange(
-                getDiff(
-                  items.map(item =>
-                    getNodeData(item, onChange, onItemClick, onItemEdit)
-                  ),
-                  newTree as TreeItem[]
-                )
-              )
-            }
+            onChange={newTree => {
+              const diff = getDiff(
+                items.map(item =>
+                  getNodeData(item, onChange, onItemClick, onItemEdit)
+                ),
+                newTree as TreeItem[]
+              );
+              onChange(diff);
+            }}
             placeholderRenderer={Placeholder as any}
           />
         )}

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -255,15 +255,16 @@ const MenuItems: React.FC<MenuItemsProps> = props => {
             theme={{
               nodeContentRenderer: Node as any
             }}
-            onChange={newTree => {
-              const diff = getDiff(
-                items.map(item =>
-                  getNodeData(item, onChange, onItemClick, onItemEdit)
-                ),
-                newTree as TreeItem[]
-              );
-              onChange(diff);
-            }}
+            onChange={newTree =>
+              onChange(
+                getDiff(
+                  items.map(item =>
+                    getNodeData(item, onChange, onItemClick, onItemEdit)
+                  ),
+                  newTree as TreeItem[]
+                )
+              )
+            }
             placeholderRenderer={Placeholder as any}
           />
         )}

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -183,7 +183,7 @@ const Node: React.FC<NodeRendererProps> = props => {
           onClick={() =>
             node.onChange([
               {
-                id: node.id as any,
+                id: node.id,
                 type: "remove"
               }
             ])

--- a/src/navigation/components/MenuItems/__snapshots__/tree.test.ts.snap
+++ b/src/navigation/components/MenuItems/__snapshots__/tree.test.ts.snap
@@ -1,28 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Properly computes diffs # 1`] = `
-Object {
-  "id": "1glasses",
-  "parentId": "0jewelry",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "1glasses",
+    "parentId": "0jewelry",
+    "sortOrder": 0,
+    "type": "move",
+  },
+]
 `;
 
 exports[`Properly computes diffs # 2`] = `
-Object {
-  "id": "1glasses",
-  "parentId": "2accessories",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "1glasses",
+    "parentId": "2accessories",
+    "sortOrder": -1,
+    "type": "move",
+  },
+]
 `;
 
 exports[`Properly computes diffs # 3`] = `
-Object {
-  "id": "2accessories",
-  "parentId": "4apparel",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "2accessories",
+    "parentId": "4apparel",
+    "sortOrder": 0,
+    "type": "move",
+  },
+]
 `;

--- a/src/navigation/components/MenuItems/tree.ts
+++ b/src/navigation/components/MenuItems/tree.ts
@@ -139,7 +139,7 @@ export function getNodeData(
     onChange,
     onClick: () => onClick(getItemId(item), getItemType(item)),
     onEdit: () => onEdit(item.id),
-    title: `${item.name} ${item.id}`
+    title: item.name
   };
 }
 


### PR DESCRIPTION
I want to merge this change because it changes the way menu reordering works on the frontend. Frontend used to send absolute indexes - this PR changes it to send relative indexes according to the moves. 

3.1 PR: https://github.com/saleor/saleor-dashboard/pull/1871

Task linked: https://app.clickup.com/t/2549495/SALEOR-5772

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-2647-fix-menu-item-reordering.api.saleor.rocks/graphql/
