### PR TITLE
Bump Saleor SDK to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5354,9 +5354,9 @@
       }
     },
     "@saleor/sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.1.tgz",
-      "integrity": "sha512-25b4R2tlBp1Mf0vybOFE5lSOsbL6aeCGOfWhVxRKtvKfxlEFrpMiLyQBuZSgZvd0Qrgc7Xmj7214lBwNqfeMgQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.3.tgz",
+      "integrity": "sha512-gg/7e729PfT4t6SgpmOpNhzC9umytcci0pBUB+f8DxfluRgml0HJcZgKPDOH8AKap6taXZHR8o9kotT0FahOJw==",
       "requires": {
         "cross-fetch": "^3.1.4",
         "jwt-decode": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
     "@saleor/macaw-ui": "^0.3.1-1",
-    "@saleor/sdk": "^0.4.1",
+    "@saleor/sdk": "^0.4.3",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",
     "@uiw/react-color-hue": "0.0.34",


### PR DESCRIPTION
I want to merge this change because it bumps SDK version to 0.4.3 (with applied changes from https://github.com/saleor/saleor-sdk/pull/154).

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
