### PR TITLE
Add api error log in notifications

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2549,6 +2549,14 @@
     "context": "weight",
     "string": "{value} {unit}"
   },
+  "src_dot_components_dot_messages_dot_hideError": {
+    "context": "hide error log label in notification",
+    "string": "Hide log"
+  },
+  "src_dot_components_dot_messages_dot_seeError": {
+    "context": "see error log label in notification",
+    "string": "See error log"
+  },
   "src_dot_configuration": {
     "context": "configuration section name",
     "string": "Configuration"
@@ -2850,6 +2858,9 @@
   },
   "src_dot_date": {
     "string": "Date"
+  },
+  "src_dot_defaultErrorTitle": {
+    "string": "Something went wrong"
   },
   "src_dot_delete": {
     "context": "button",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5332,9 +5332,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.3.1-1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.1-1.tgz",
-      "integrity": "sha512-RBi5QY8J+Y2rX9fm3ERXV+KywgbCmoeWcU/Snt0pI2P3f6JuT7x4eCVJ+Z1atLy4gOmoqeI2kB0EqeIel59ZFQ==",
+      "version": "github:saleor/macaw-ui#fcacd65a292a91c0183deeaef2444477f331ad44",
+      "from": "github:saleor/macaw-ui#fcacd65",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "^0.3.1-1",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#fcacd65",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -31,7 +31,8 @@ export async function handleQueryAuthError(
     } else {
       notify({
         status: "error",
-        text: intl.formatMessage(commonMessages.somethingWentWrong)
+        apiMessage: error.networkError.message,
+        title: intl.formatMessage(commonMessages.defaultErrorTitle)
       });
     }
   } else if (
@@ -41,7 +42,8 @@ export async function handleQueryAuthError(
   ) {
     notify({
       status: "error",
-      text: intl.formatMessage(commonMessages.somethingWentWrong)
+      apiMessage: error.networkError.message,
+      title: intl.formatMessage(commonMessages.defaultErrorTitle)
     });
   }
 }

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -31,8 +31,7 @@ export async function handleQueryAuthError(
     } else {
       notify({
         status: "error",
-        apiMessage: error.networkError.message,
-        title: intl.formatMessage(commonMessages.defaultErrorTitle)
+        apiMessage: error.networkError.message
       });
     }
   } else if (
@@ -40,10 +39,11 @@ export async function handleQueryAuthError(
       err => err.extensions?.exception?.code === "PermissionDenied"
     )
   ) {
-    notify({
-      status: "error",
-      apiMessage: error.networkError.message,
-      title: intl.formatMessage(commonMessages.defaultErrorTitle)
+    error.graphQLErrors.map(graphQLError => {
+      notify({
+        status: "error",
+        apiMessage: graphQLError.message
+      });
     });
   }
 }

--- a/src/components/messages/MessageManagerProvider.tsx
+++ b/src/components/messages/MessageManagerProvider.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_NOTIFICATION_SHOW_TIME } from "@saleor/config";
+import { commonMessages } from "@saleor/intl";
 import { Notification } from "@saleor/macaw-ui";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
@@ -114,7 +115,11 @@ const MessageManagerProvider = ({ children }) => {
                     }
                   : {})}
                 onClose={notification.close}
-                title={notification.message.title}
+                title={
+                  notification.message.apiMessage && !notification.message.title
+                    ? intl.formatMessage(commonMessages.defaultErrorTitle)
+                    : notification.message.title
+                }
                 type={notification.message.status || "info"}
                 content={notification.message.text}
                 apiMessage={

--- a/src/components/messages/MessageManagerProvider.tsx
+++ b/src/components/messages/MessageManagerProvider.tsx
@@ -1,10 +1,12 @@
 import { DEFAULT_NOTIFICATION_SHOW_TIME } from "@saleor/config";
 import { Notification } from "@saleor/macaw-ui";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useIntl } from "react-intl";
 import { TransitionGroup } from "react-transition-group";
 
 import { INotification, ITimer, MessageContext } from ".";
 import Container from "./Container";
+import { messages as notificationMessages } from "./messages";
 import { useStyles } from "./styles";
 import Transition from "./Transition";
 
@@ -12,6 +14,7 @@ const MessageManagerProvider = ({ children }) => {
   const classes = useStyles();
   const timersArr = useRef<ITimer[]>([]);
   const [notifications, setNotifications] = useState<INotification[]>([]);
+  const intl = useIntl();
 
   useEffect(() => {
     const timersArrRef = timersArr.current;
@@ -114,6 +117,17 @@ const MessageManagerProvider = ({ children }) => {
                 title={notification.message.title}
                 type={notification.message.status || "info"}
                 content={notification.message.text}
+                apiMessage={
+                  notification.message.apiMessage && {
+                    apiMessageContent: notification.message.apiMessage,
+                    hideApiLabel: intl.formatMessage(
+                      notificationMessages.hideError
+                    ),
+                    showApiLabel: intl.formatMessage(
+                      notificationMessages.seeError
+                    )
+                  }
+                }
                 {...(!!notification.message.actionBtn
                   ? {
                       action: {

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -9,9 +9,10 @@ export interface IMessage {
   autohide?: number;
   expandText?: string;
   title?: string;
-  text: React.ReactNode;
+  text?: React.ReactNode;
   onUndo?: () => void;
   status?: Status;
+  apiMessage?: string;
 }
 
 export interface INotification {

--- a/src/components/messages/messages.ts
+++ b/src/components/messages/messages.ts
@@ -1,0 +1,12 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  seeError: {
+    defaultMessage: "See error log",
+    description: "see error log label in notification"
+  },
+  hideError: {
+    defaultMessage: "Hide log",
+    description: "hide error log label in notification"
+  }
+});

--- a/src/hooks/makeMutation.ts
+++ b/src/hooks/makeMutation.ts
@@ -59,9 +59,11 @@ function makeMutation<TData, TVariables>(
             text: intl.formatMessage(commonMessages.sessionExpired)
           });
         } else if (!hasError(err, GqlErrors.LimitReachedException)) {
-          notify({
-            status: "error",
-            text: intl.formatMessage(commonMessages.somethingWentWrong)
+          err.graphQLErrors.map(graphQLError => {
+            notify({
+              status: "error",
+              apiMessage: graphQLError.message
+            });
           });
         }
         if (onError) {

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -96,6 +96,9 @@ export const commonMessages = defineMessages({
   somethingWentWrong: {
     defaultMessage: "Saleor ran into an unexpected problem"
   },
+  defaultErrorTitle: {
+    defaultMessage: "Something went wrong"
+  },
   startDate: {
     defaultMessage: "Start Date"
   },

--- a/src/mutations.tsx
+++ b/src/mutations.tsx
@@ -41,7 +41,8 @@ export function TypedMutation<TData, TVariables>(
           if (err.networkError) {
             notify({
               status: "error",
-              text: intl.formatMessage(commonMessages.somethingWentWrong)
+              apiMessage: err.networkError.message,
+              title: intl.formatMessage(commonMessages.defaultErrorTitle)
             });
           }
           if (hasError(err, GqlErrors.ReadOnlyException)) {
@@ -58,7 +59,8 @@ export function TypedMutation<TData, TVariables>(
           } else if (!hasError(err, GqlErrors.LimitReachedException)) {
             notify({
               status: "error",
-              text: intl.formatMessage(commonMessages.somethingWentWrong)
+              apiMessage: err.networkError.message,
+              title: intl.formatMessage(commonMessages.defaultErrorTitle)
             });
           }
           if (onError) {

--- a/src/mutations.tsx
+++ b/src/mutations.tsx
@@ -41,8 +41,7 @@ export function TypedMutation<TData, TVariables>(
           if (err.networkError) {
             notify({
               status: "error",
-              apiMessage: err.networkError.message,
-              title: intl.formatMessage(commonMessages.defaultErrorTitle)
+              apiMessage: err.networkError.message
             });
           }
           if (hasError(err, GqlErrors.ReadOnlyException)) {
@@ -57,10 +56,11 @@ export function TypedMutation<TData, TVariables>(
               text: intl.formatMessage(commonMessages.sessionExpired)
             });
           } else if (!hasError(err, GqlErrors.LimitReachedException)) {
-            notify({
-              status: "error",
-              apiMessage: err.networkError.message,
-              title: intl.formatMessage(commonMessages.defaultErrorTitle)
+            err.graphQLErrors.map(graphQLError => {
+              notify({
+                status: "error",
+                apiMessage: graphQLError.message
+              });
             });
           }
           if (onError) {


### PR DESCRIPTION
I want to merge this change because it adds error logs from api in notifications if the error is unhandled. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
