### PR TITLE
fix(SingleSelectField): dont allow to select option when it is disabled

### DIFF
--- a/src/components/SingleSelectField/SingleSelectField.tsx
+++ b/src/components/SingleSelectField/SingleSelectField.tsx
@@ -10,6 +10,7 @@ import {
 import { SelectProps } from "@material-ui/core/Select";
 import { makeStyles } from "@saleor/macaw-ui";
 import classNames from "classnames";
+import clsx from "clsx";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -31,6 +32,9 @@ const useStyles = makeStyles(
     },
     paper: {
       maxHeight: `calc(${singleSelectFieldItemHeight}px * 10 + ${singleSelectFieldItemHeight}px * 0.5)`
+    },
+    disabledMenuItem: {
+      pointerEvents: "none"
     }
   }),
   { name: "SingleSelectField" }
@@ -127,6 +131,7 @@ export const SingleSelectField: React.FC<SingleSelectFieldProps> = props => {
           choices.map(choice => (
             <MenuItem
               disabled={choice.disabled}
+              className={clsx(choice.disabled && classes.disabledMenuItem)}
               data-test-id={"select-field-option-" + choice.value}
               value={choice.value}
               key={choice.value}


### PR DESCRIPTION
I want to merge this change because I want to fix SingleSelectField disabled prop

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

before:

https://user-images.githubusercontent.com/50200782/154258470-760e5b3a-aa7b-462b-9469-fa903ea7bbf3.mov

after:

https://user-images.githubusercontent.com/50200782/154258481-7c9f3404-58cb-43ec-a87f-b1983decc3ae.mov

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
