### PR TITLE
Fix menu reordering in navigation

### DIFF
--- a/src/navigation/components/MenuDetailsPage/tree.test.ts
+++ b/src/navigation/components/MenuDetailsPage/tree.test.ts
@@ -1,7 +1,1154 @@
 import { menu } from "../../fixtures";
 import { MenuDetails_menu_items } from "../../types/MenuDetails";
 import { TreeOperation } from "../MenuItems";
-import { computeTree } from "./tree";
+import { computeRelativeTree } from "./tree";
+
+const relativeOutput: MenuDetails_menu_items[][] = [
+  // no moves
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves one in root
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    }
+  ],
+  // moves two in root
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    }
+  ],
+  // empty move
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves every
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    },
+
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    }
+  ],
+  // moves children
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child outside
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQX==",
+        name: "Glasses"
+      },
+      children: [],
+      collection: null,
+      id: "1glasses",
+      level: 0,
+      name: "Glasses",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child outside and puts it in location
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OA==",
+        name: "Groceries"
+      },
+      children: [],
+      collection: null,
+      id: "3groceries",
+      level: 0,
+      name: "Groceries",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQX==",
+        name: "Glasses"
+      },
+      children: [],
+      collection: null,
+      id: "1glasses",
+      level: 0,
+      name: "Glasses",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child inside
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves child inside then outside then changes index
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ],
+  // moves item as last child and moves it up
+  [
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6Nw==",
+        name: "Accessories"
+      },
+      children: [
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OAX==",
+            name: "Jewelry"
+          },
+          children: [],
+          collection: null,
+          id: "0jewelry",
+          level: 0,
+          name: "Jewelry",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OA==",
+            name: "Groceries"
+          },
+          children: [],
+          collection: null,
+          id: "3groceries",
+          level: 0,
+          name: "Groceries",
+          page: null,
+          url: null
+        },
+        {
+          __typename: "MenuItem",
+          category: {
+            __typename: "Category",
+            id: "Q2F0ZWdvcnk6OQX==",
+            name: "Glasses"
+          },
+          children: [],
+          collection: null,
+          id: "1glasses",
+          level: 0,
+          name: "Glasses",
+          page: null,
+          url: null
+        }
+      ],
+      collection: null,
+      id: "2accessories",
+      level: 0,
+      name: "Accessories",
+      page: null,
+      url: null
+    },
+    {
+      __typename: "MenuItem",
+      category: {
+        __typename: "Category",
+        id: "Q2F0ZWdvcnk6OQ==",
+        name: "Apparel"
+      },
+      children: [],
+      collection: null,
+      id: "4apparel",
+      level: 0,
+      name: "Apparel",
+      page: null,
+      url: null
+    }
+  ]
+];
+
+const secondTestTable: TreeOperation[][] = [
+  // no moves
+  [],
+  // moves one in root
+  [{ id: "4apparel", sortOrder: -1, type: "move" }],
+  // moves two in root
+  [
+    { id: "2accessories", sortOrder: 2, type: "move" },
+    { id: "4apparel", sortOrder: -1, type: "move" }
+  ],
+  // empty move
+  [
+    { id: "2accessories", sortOrder: 0, type: "move" },
+    { id: "4apparel", sortOrder: 0, type: "move" }
+  ],
+  // move every
+  [
+    { id: "2accessories", sortOrder: 1, type: "move" },
+    { id: "4apparel", sortOrder: -2, type: "move" },
+    { id: "3groceries", sortOrder: -1, type: "move" }
+  ],
+  // moves children
+  [
+    {
+      id: "1glasses",
+      sortOrder: -1,
+      type: "move",
+      parentId: "2accessories"
+    }
+  ],
+  // moves children outside
+  [
+    {
+      id: "1glasses",
+      sortOrder: 3,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "1glasses",
+      sortOrder: 0 - 3,
+      type: "move"
+    }
+  ],
+  // moves children outside and puts it in a location
+  [
+    {
+      id: "1glasses",
+      sortOrder: 3,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "1glasses",
+      sortOrder: 2 - 3,
+      type: "move"
+    }
+  ],
+  // moves child inside
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move",
+      simulatedMove: true
+    },
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0 - 2,
+      type: "move"
+    }
+  ],
+  // moves child inside, moves it and puts it back
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: 1,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: 1,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      sortOrder: -2,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  // moves item as last child and moves it up
+  [
+    {
+      id: "3groceries",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 1,
+      type: "move"
+    }
+  ]
+];
+
+const testTable: TreeOperation[][] = [
+  [],
+  [
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "4apparel",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    {
+      id: "4apparel",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "0jewelry",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "0jewelry", parentId: "1glasses", sortOrder: 0, type: "move" },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 2, type: "move" }
+  ],
+  [
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "3groceries", sortOrder: 0, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "3groceries",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "2accessories", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 2, type: "move" },
+    { id: "1glasses", sortOrder: 3, type: "move" },
+    { id: "4apparel", sortOrder: 0, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "2accessories", sortOrder: 0, type: "move" },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "1glasses",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "0jewelry", sortOrder: 0, type: "move" },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 0,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "0jewelry",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "1glasses",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "4apparel",
+      parentId: "2accessories",
+      sortOrder: 2,
+      type: "move"
+    },
+    {
+      id: "3groceries",
+      parentId: "0jewelry",
+      sortOrder: 0,
+      type: "move"
+    },
+    { id: "4apparel", parentId: "1glasses", sortOrder: 0, type: "move" },
+    { id: "1glasses", sortOrder: 1, type: "move" },
+    { id: "0jewelry", sortOrder: 1, type: "move" },
+    {
+      id: "2accessories",
+      parentId: "4apparel",
+      sortOrder: 0,
+      type: "move"
+    }
+  ],
+  [{ id: "2accessories", type: "remove" }],
+  [
+    { id: "2accessories", type: "remove" },
+    { id: "4apparel", sortOrder: 0, type: "move" },
+    { id: "3groceries", type: "remove" }
+  ]
+];
 
 // Readability FTW
 function innerTreeToString(
@@ -23,163 +1170,67 @@ function treeToString(tree: MenuDetails_menu_items[]): string {
 }
 
 describe("Properly computes trees", () => {
-  const testTable: TreeOperation[][] = [
-    [],
-    [
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "4apparel",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      {
-        id: "4apparel",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "0jewelry",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "0jewelry", parentId: "1glasses", sortOrder: 0, type: "move" },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 2, type: "move" }
-    ],
-    [
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "1glasses", parentId: "0jewelry", sortOrder: 0, type: "move" },
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "3groceries", sortOrder: 0, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "3groceries",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "2accessories", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 2, type: "move" },
-      { id: "1glasses", sortOrder: 3, type: "move" },
-      { id: "4apparel", sortOrder: 0, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "2accessories", sortOrder: 0, type: "move" },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "1glasses",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "0jewelry", sortOrder: 0, type: "move" },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 0,
-        type: "move"
-      },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "0jewelry",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "1glasses",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "4apparel",
-        parentId: "2accessories",
-        sortOrder: 2,
-        type: "move"
-      },
-      {
-        id: "3groceries",
-        parentId: "0jewelry",
-        sortOrder: 0,
-        type: "move"
-      },
-      { id: "4apparel", parentId: "1glasses", sortOrder: 0, type: "move" },
-      { id: "1glasses", sortOrder: 1, type: "move" },
-      { id: "0jewelry", sortOrder: 1, type: "move" },
-      {
-        id: "2accessories",
-        parentId: "4apparel",
-        sortOrder: 0,
-        type: "move"
-      }
-    ],
-    [{ id: "2accessories", type: "remove" }],
-    [
-      { id: "2accessories", type: "remove" },
-      { id: "4apparel", sortOrder: 0, type: "move" },
-      { id: "3groceries", type: "remove" }
-    ]
-  ];
-
   testTable.forEach(testData =>
     it("#", () => {
-      const computedTree = computeTree(menu.items, testData);
+      const computedTree = computeRelativeTree(menu.items, testData);
       expect(treeToString(computedTree)).toMatchSnapshot();
     })
   );
+});
+
+describe("Properly computes relative trees", () => {
+  it("doesn't move anything", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[0]);
+    expect(computedTree).toEqual(relativeOutput[0]);
+  });
+
+  it("moves one root element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[1]);
+    expect(computedTree).toEqual(relativeOutput[1]);
+  });
+
+  it("moves two root element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[2]);
+    expect(computedTree).toEqual(relativeOutput[2]);
+  });
+
+  it("empty moves", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[3]);
+    expect(computedTree).toEqual(relativeOutput[3]);
+  });
+
+  it("moves every element", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[4]);
+    expect(computedTree).toEqual(relativeOutput[4]);
+  });
+
+  it("moves children", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[5]);
+    expect(computedTree).toEqual(relativeOutput[5]);
+  });
+
+  it("moves child outside", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[6]);
+    expect(computedTree).toEqual(relativeOutput[6]);
+  });
+
+  it("moves child outside and puts it in a location", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[7]);
+    expect(computedTree).toEqual(relativeOutput[7]);
+  });
+
+  it("moves child inside", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[8]);
+    expect(computedTree).toEqual(relativeOutput[8]);
+  });
+
+  it("moves child inside then outside then changes index", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[9]);
+    expect(computedTree).toEqual(relativeOutput[9]);
+  });
+
+  it("moves item as last child and moves it up", () => {
+    const computedTree = computeRelativeTree(menu.items, secondTestTable[10]);
+    expect(computedTree).toEqual(relativeOutput[10]);
+  });
 });

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -21,7 +21,7 @@ const NODE_MARGIN = 40;
 export interface MenuItemsProps {
   canUndo: boolean;
   items: MenuDetails_menu_items[];
-  onChange: (operation: TreeOperation) => void;
+  onChange: (operations: TreeOperation[]) => void;
   onItemAdd: () => void;
   onItemClick: (id: string, type: MenuItemType) => void;
   onItemEdit: (id: string) => void;
@@ -181,10 +181,12 @@ const Node: React.FC<NodeRendererProps> = props => {
           className={classes.deleteButton}
           variant="secondary"
           onClick={() =>
-            node.onChange({
-              id: node.id as any,
-              type: "remove"
-            })
+            node.onChange([
+              {
+                id: node.id,
+                type: "remove"
+              }
+            ])
           }
         >
           <DeleteIcon />
@@ -245,6 +247,7 @@ const MenuItems: React.FC<MenuItemsProps> = props => {
                 marginLeft: NODE_MARGIN * (path.length - 1)
               }
             })}
+            maxDepth={5}
             isVirtualized={false}
             rowHeight={NODE_HEIGHT}
             treeData={items.map(item =>

--- a/src/navigation/components/MenuItems/__snapshots__/tree.test.ts.snap
+++ b/src/navigation/components/MenuItems/__snapshots__/tree.test.ts.snap
@@ -1,28 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Properly computes diffs # 1`] = `
-Object {
-  "id": "1glasses",
-  "parentId": "0jewelry",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "1glasses",
+    "parentId": "0jewelry",
+    "sortOrder": 0,
+    "type": "move",
+  },
+]
 `;
 
 exports[`Properly computes diffs # 2`] = `
-Object {
-  "id": "1glasses",
-  "parentId": "2accessories",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "1glasses",
+    "parentId": "2accessories",
+    "sortOrder": -1,
+    "type": "move",
+  },
+]
 `;
 
 exports[`Properly computes diffs # 3`] = `
-Object {
-  "id": "2accessories",
-  "parentId": "4apparel",
-  "sortOrder": 0,
-  "type": "move",
-}
+Array [
+  Object {
+    "id": "2accessories",
+    "parentId": "4apparel",
+    "sortOrder": 0,
+    "type": "move",
+  },
+]
 `;

--- a/src/navigation/components/MenuItems/tree.ts
+++ b/src/navigation/components/MenuItems/tree.ts
@@ -10,6 +10,7 @@ export interface TreeOperation {
   type: TreeOperationType;
   parentId?: string;
   sortOrder?: number;
+  simulatedMove?: boolean;
 }
 
 export const unknownTypeError = Error("Unknown type");
@@ -64,11 +65,11 @@ export function getItemId(item: MenuDetails_menu_items): string {
 export function getDiff(
   originalTree: TreeItem[],
   newTree: TreeItem[]
-): TreeOperation {
+): TreeOperation[] {
   const originalMap = treeToMap(originalTree, "root");
   const newMap = treeToMap(newTree, "root");
 
-  const diff: TreeOperation[] = Object.keys(newMap).map(key => {
+  const diff: TreeOperation[] = Object.keys(newMap).flatMap(key => {
     const originalNode = originalMap[key];
     const newNode = newMap[key];
 
@@ -76,23 +77,56 @@ export function getDiff(
 
     if (patch.length > 0) {
       const addedNode = patch.find(operation => operation.type === "add");
+      const removedNode = patch.find(operation => operation.type === "remove");
+
       if (!!addedNode) {
+        const changedParent = originalNode.length !== newNode.length;
+        const sortOrder = removedNode
+          ? addedNode.newPos - removedNode.oldPos
+          : addedNode.newPos;
+
+        // This exists because backend doesn't recongize the position of the new node
+        // when it's moved from child to parent and/or up
+        // We have to make an additional move so that backend can sort the new tree correctly
+        // because without it the new node goes to the end of the parent node array by default
+        // SimulatedMove is removed before submit
+        if (changedParent && sortOrder !== originalNode.length) {
+          return [
+            {
+              id: addedNode.items[0],
+              parentId: key === "root" ? undefined : key,
+              sortOrder: newNode.length - 1,
+              type: "move" as TreeOperationType,
+              simulatedMove: true
+            },
+            {
+              id: addedNode.items[0],
+              parentId: key === "root" ? undefined : key,
+              sortOrder:
+                sortOrder - newNode.length < 0
+                  ? sortOrder - newNode.length + 1
+                  : sortOrder - newNode.length - 1,
+              type: "move" as TreeOperationType
+            }
+          ];
+        }
+
         return {
           id: addedNode.items[0],
           parentId: key === "root" ? undefined : key,
-          sortOrder: addedNode.newPos,
+          sortOrder,
           type: "move" as TreeOperationType
         };
       }
     }
   });
 
-  return diff.find(d => !!d);
+  return diff.filter(d => !!d);
 }
 
 export function getNodeData(
   item: MenuDetails_menu_items,
-  onChange: (operation: TreeOperation) => void,
+  onChange: (operations: TreeOperation[]) => void,
   onClick: (id: string, type: MenuItemType) => void,
   onEdit: (id: string) => void
 ): TreeItem {


### PR DESCRIPTION
I want to merge this change because it changes the way menu reordering works on the frontend. Frontend used to send absolute indexes - this PR changes it to send relative indexes according to the moves.

Cherry pick of https://github.com/saleor/saleor-dashboard/pull/1861

Task linked: https://app.clickup.com/t/2549495/SALEOR-5772

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-2647-fix-menu-item-reordering-3-1.api.saleor.rocks/graphql/
