### PR TITLE
Refactor order cards headers

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4246,6 +4246,42 @@
   "src_dot_orders_dot_components_dot_OrderCannotCancelOrderDialog_dot_775268031": {
     "string": "There are still fulfillments created for this order. Cancel the fulfillments first before you cancel the order."
   },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_cancelled": {
+    "context": "cancelled fulfillment, section header",
+    "string": "Cancelled ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_fulfilled": {
+    "context": "section header",
+    "string": "Fulfilled ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_fulfilledFrom": {
+    "context": "fulfilled fulfillment, section header",
+    "string": "Fulfilled from {warehouseName}"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_refunded": {
+    "context": "refunded fulfillment, section header",
+    "string": "Refunded ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_refundedAndReturned": {
+    "context": "cancelled fulfillment, section header",
+    "string": "Refunded and Returned ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_replaced": {
+    "context": "refunded fulfillment, section header",
+    "string": "Replaced ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_returned": {
+    "context": "refunded fulfillment, section header",
+    "string": "Returned ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_unfulfilled": {
+    "context": "section header",
+    "string": "Unfulfilled ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderCardTitle_dot_waitingForApproval": {
+    "context": "unapproved fulfillment, section header",
+    "string": "Waiting for approval ({quantity})"
+  },
   "src_dot_orders_dot_components_dot_OrderChangeWarehouseDialog_dot_currentSelection": {
     "context": "label for currently selected warehouse",
     "string": "currently selected"
@@ -5303,41 +5339,13 @@
     "context": "button",
     "string": "Set maximal quantities"
   },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_cancelled": {
-    "context": "cancelled fulfillment, section header",
-    "string": "Cancelled ({quantity})"
-  },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_description": {
     "context": "product no longer exists error description",
     "string": "This product is no longer in database so it can’t be replaced, nor returned"
   },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_fulfilled": {
-    "context": "section header",
-    "string": "Fulfilled ({quantity})"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_fulfilledFrom": {
-    "context": "fulfilled fulfillment, section header",
-    "string": "Fulfilled from {warehouseName}"
-  },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_improperValue": {
     "context": "error message",
     "string": "Improper value"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_refunded": {
-    "context": "refunded fulfillment, section header",
-    "string": "Refunded ({quantity})"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_refundedAndReturned": {
-    "context": "cancelled fulfillment, section header",
-    "string": "Refunded and Returned ({quantity})"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_replaced": {
-    "context": "refunded fulfillment, section header",
-    "string": "Replaced ({quantity})"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_returned": {
-    "context": "refunded fulfillment, section header",
-    "string": "Returned ({quantity})"
   },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_title": {
     "context": "product no longer exists error title",
@@ -5350,14 +5358,6 @@
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_titleUnfulfilled": {
     "context": "section header",
     "string": "Unfulfilled Items"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_unfulfilled": {
-    "context": "section header",
-    "string": "Unfulfilled"
-  },
-  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_waitingForApproval": {
-    "context": "unapproved fulfillment, section header",
-    "string": "Waiting for approval ({quantity})"
   },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_appTitle": {
     "context": "page header with order number",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5332,9 +5332,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.3.1-1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.1-1.tgz",
-      "integrity": "sha512-RBi5QY8J+Y2rX9fm3ERXV+KywgbCmoeWcU/Snt0pI2P3f6JuT7x4eCVJ+Z1atLy4gOmoqeI2kB0EqeIel59ZFQ==",
+      "version": "github:saleor/macaw-ui#fe25825230d5c894e9d0985890d20d07d5b24683",
+      "from": "github:saleor/macaw-ui#pull/116/head",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5332,8 +5332,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:saleor/macaw-ui#fe25825230d5c894e9d0985890d20d07d5b24683",
-      "from": "github:saleor/macaw-ui#pull/116/head",
+      "version": "github:saleor/macaw-ui#e19c9ec3c2ea78344717b81c0ab4bce02d70299a",
+      "from": "github:saleor/macaw-ui#add-circle-indicators",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5332,8 +5332,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:saleor/macaw-ui#e19c9ec3c2ea78344717b81c0ab4bce02d70299a",
-      "from": "github:saleor/macaw-ui#add-circle-indicators",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.2.tgz",
+      "integrity": "sha512-h8hyIkGRnWHzUVSVKjAZYMGojL2qmWRiKLe4taAa0SWr2Xps/SxWEFPgdWJGxTUWTKe0qnqXc6IcJmvwQU23+A==",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:saleor/macaw-ui#add-circle-indicators",
+    "@saleor/macaw-ui": "^0.3.2",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "^0.3.1-1",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#pull/116/head",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:saleor/macaw-ui#pull/116/head",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#add-circle-indicators",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -147,9 +147,11 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
       toolbar={toolbar}
       title={
         <div className={classes.title}>
-          <div className={classes.indicator}>
-            {withStatus && <CircleIndicator color={selectStatus(status)} />}
-          </div>
+          {withStatus && (
+            <div className={classes.indicator}>
+              <CircleIndicator color={selectStatus(status)} />
+            </div>
+          )}
           <HorizontalSpacer spacing={2} />
           <Typography className={classes.cardHeader}>
             {intl.formatMessage(messageForStatus, {

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -1,6 +1,7 @@
 import { Typography } from "@material-ui/core";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import DefaultCardTitle from "@saleor/components/CardTitle";
-import { makeStyles, Pill } from "@saleor/macaw-ui";
+import { CircleIndicator, makeStyles } from "@saleor/macaw-ui";
 import { StatusType } from "@saleor/types";
 import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import camelCase from "lodash/camelCase";
@@ -32,6 +33,10 @@ const useStyles = makeStyles(
       lineHeight: "29px",
       letterSpacing: "0.02em",
       textAlign: "left"
+    },
+    indicator: {
+      display: "flex",
+      alignItems: "center"
     }
   }),
   { name: "OrderCardTitle" }
@@ -109,7 +114,7 @@ const selectStatus = (status: CardTitleStatus) => {
     case FulfillmentStatus.CANCELED:
       return StatusType.ERROR;
     default:
-      return StatusType.WARNING;
+      return StatusType.ERROR;
   }
 };
 
@@ -137,37 +142,21 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
     0
   );
 
-  const title = (
-    <div className={classes.title}>
-      <Typography className={classes.cardHeader}>
-        {intl.formatMessage(messageForStatus, {
-          fulfillmentName,
-          quantity: totalQuantity
-        })}
-      </Typography>
-      {!!warehouseName && (
-        <Typography className={classes.warehouseName} variant="caption">
-          <FormattedMessage
-            {...messages.fulfilledFrom}
-            values={{
-              warehouseName
-            }}
-          />
-        </Typography>
-      )}
-    </div>
-  );
-
   return (
     <DefaultCardTitle
       toolbar={toolbar}
       title={
         <div className={classes.title}>
-          {withStatus ? (
-            <Pill label={title} color={selectStatus(status)} />
-          ) : (
-            title
-          )}
+          <div className={classes.indicator}>
+            {withStatus && <CircleIndicator color={selectStatus(status)}/>}
+          </div>
+          <HorizontalSpacer spacing={2} />
+          <Typography className={classes.cardHeader}>
+            {intl.formatMessage(messageForStatus, {
+              fulfillmentName,
+              quantity: totalQuantity
+            })}
+          </Typography>
           {!!warehouseName && (
             <Typography className={classes.warehouseName} variant="caption">
               <FormattedMessage

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -75,7 +75,7 @@ type CardTitleLines = Array<{
   quantity: number;
 }>;
 
-interface CardTitleProps {
+interface OrderCardTitleProps {
   lines?: CardTitleLines;
   fulfillmentOrder?: number;
   status: CardTitleStatus;
@@ -106,7 +106,7 @@ const selectStatus = (status: CardTitleStatus) => {
   }
 };
 
-const CardTitle: React.FC<CardTitleProps> = ({
+const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
   lines = [],
   fulfillmentOrder,
   status,
@@ -170,4 +170,5 @@ const CardTitle: React.FC<CardTitleProps> = ({
   );
 };
 
-export default CardTitle;
+OrderCardTitle.displayName = "OrderCardTitle";
+export default OrderCardTitle;

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -25,9 +25,16 @@ const useStyles = makeStyles(
       alignSelf: "center",
       color: theme.palette.text.secondary,
       margin: `auto ${theme.spacing(1)} auto auto`
+    },
+    cardHeader: {
+      fontSize: "24px",
+      fontWeight: 500,
+      lineHeight: "29px",
+      letterSpacing: "0.02em",
+      textAlign: "left"
     }
   }),
-  { name: "CardTitle" }
+  { name: "OrderCardTitle" }
 );
 
 const messages = defineMessages({
@@ -60,7 +67,7 @@ const messages = defineMessages({
     description: "unapproved fulfillment, section header"
   },
   unfulfilled: {
-    defaultMessage: "Unfulfilled",
+    defaultMessage: "Unfulfilled ({quantity})",
     description: "section header"
   },
   fulfilledFrom: {
@@ -131,17 +138,24 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
   );
 
   const title = (
-    <>
-      {intl.formatMessage(messageForStatus, {
-        fulfillmentName,
-        quantity: totalQuantity
-      })}
-      {fulfillmentName && (
-        <Typography className={classes.orderNumber} variant="body1">
-          {fulfillmentName}
+    <div className={classes.title}>
+      <Typography className={classes.cardHeader}>
+        {intl.formatMessage(messageForStatus, {
+          fulfillmentName,
+          quantity: totalQuantity
+        })}
+      </Typography>
+      {!!warehouseName && (
+        <Typography className={classes.warehouseName} variant="caption">
+          <FormattedMessage
+            {...messages.fulfilledFrom}
+            values={{
+              warehouseName
+            }}
+          />
         </Typography>
       )}
-    </>
+    </div>
   );
 
   return (

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles(
     title: {
       width: "100%",
       display: "flex",
-      justifyContent: "space-between"
+      justifyContent: "flex-start"
     },
     orderNumber: {
       display: "inline",
@@ -148,7 +148,7 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
       title={
         <div className={classes.title}>
           <div className={classes.indicator}>
-            {withStatus && <CircleIndicator color={selectStatus(status)}/>}
+            {withStatus && <CircleIndicator color={selectStatus(status)} />}
           </div>
           <HorizontalSpacer spacing={2} />
           <Typography className={classes.cardHeader}>

--- a/src/orders/components/OrderCardTitle/index.ts
+++ b/src/orders/components/OrderCardTitle/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./OrderCardTitle";
+export * from "./OrderCardTitle";

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -139,10 +139,10 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
         {filteredWarehouses ? (
           <RadioGroup value={selectedWarehouseId} onChange={handleChange}>
             {filteredWarehouses.map(warehouse => {
-              const unavailableLines = lines.filter(
+              const unavailableLines = lines?.filter(
                 line => !isLineAvailableInWarehouse(line, warehouse)
               );
-              const allLinesAvailable = unavailableLines.length === 0;
+              const someLinesUnavailable = unavailableLines?.length > 0;
               return (
                 <TableRow key={warehouse.id}>
                   <TableCell className={classes.warehouseCell}>
@@ -153,7 +153,7 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
                         label={
                           <div className={classes.radioLabelContainer}>
                             {warehouse.name}
-                            {!allLinesAvailable && (
+                            {someLinesUnavailable && (
                               <Typography className={classes.supportText}>
                                 {unavailableLines.length === 1
                                   ? intl.formatMessage(

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -27,6 +27,7 @@ import {
   OrderDetails_order,
   OrderDetails_shop
 } from "../../types/OrderDetails";
+import { Warehouse } from "../OrderChangeWarehouseDialog/types";
 import OrderCustomer from "../OrderCustomer";
 import OrderCustomerNote from "../OrderCustomerNote";
 import OrderDraftDetails from "../OrderDraftDetails/OrderDraftDetails";
@@ -64,6 +65,7 @@ export interface OrderDetailsPageProps extends UserPermissionProps {
   }>;
   disabled: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
+  selectedWarehouse: Warehouse;
   onOrderLineAdd?: () => void;
   onOrderLineChange?: (
     id: string,
@@ -90,6 +92,7 @@ export interface OrderDetailsPageProps extends UserPermissionProps {
   onInvoiceClick(invoiceId: string);
   onInvoiceGenerate();
   onInvoiceSend(invoiceId: string);
+  onWarehouseChange();
   onSubmit(data: MetadataFormData): SubmitPromise;
 }
 
@@ -114,6 +117,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     order,
     shop,
     saveButtonBarState,
+    selectedWarehouse,
     userPermissions,
     onBack,
     onBillingAddressEdit,
@@ -137,6 +141,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     onOrderLineChange,
     onOrderLineRemove,
     onShippingMethodEdit,
+    onWarehouseChange,
     onSubmit
   } = props;
   const classes = useStyles(props);
@@ -243,6 +248,8 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
                     notAllowedToFulfillUnpaid={notAllowedToFulfillUnpaid}
                     lines={unfulfilled}
                     onFulfill={onOrderFulfill}
+                    onWarehouseChange={onWarehouseChange}
+                    selectedWarehouse={selectedWarehouse}
                   />
                 ) : (
                   <>

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -65,7 +65,7 @@ export interface OrderDetailsPageProps extends UserPermissionProps {
   }>;
   disabled: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
-  selectedWarehouse: Warehouse;
+  selectedWarehouse?: Warehouse;
   onOrderLineAdd?: () => void;
   onOrderLineChange?: (
     id: string,
@@ -92,7 +92,7 @@ export interface OrderDetailsPageProps extends UserPermissionProps {
   onInvoiceClick(invoiceId: string);
   onInvoiceGenerate();
   onInvoiceSend(invoiceId: string);
-  onWarehouseChange();
+  onWarehouseChange?();
   onSubmit(data: MetadataFormData): SubmitPromise;
 }
 

--- a/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
@@ -10,9 +10,9 @@ import React from "react";
 import { renderCollection } from "../../../misc";
 import { FulfillmentStatus } from "../../../types/globalTypes";
 import { OrderDetails_order_fulfillments } from "../../types/OrderDetails";
+import OrderCardTitle from "../OrderCardTitle";
 import TableHeader from "../OrderProductsCardElements/OrderProductsCardHeader";
 import TableLine from "../OrderProductsCardElements/OrderProductsTableRow";
-import CardTitle from "../OrderReturnPage/OrderReturnRefundItemsCard/CardTitle";
 import ActionButtons from "./ActionButtons";
 import ExtraInfoLines from "./ExtraInfoLines";
 import useStyles from "./styles";
@@ -65,7 +65,7 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
   return (
     <>
       <Card>
-        <CardTitle
+        <OrderCardTitle
           withStatus
           lines={fulfillment?.lines}
           fulfillmentOrder={fulfillment?.fulfillmentOrder}

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -23,9 +23,9 @@ import {
 import React, { CSSProperties } from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
+import OrderCardTitle from "../../OrderCardTitle";
 import { FormsetQuantityData, FormsetReplacementData } from "../form";
 import { getById } from "../utils";
-import CardTitle from "./CardTitle";
 import MaximalButton from "./MaximalButton";
 import ProductErrorCell from "./ProductErrorCell";
 
@@ -118,7 +118,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
 
   return (
     <Card>
-      <CardTitle
+      <OrderCardTitle
         orderNumber={order?.number}
         lines={lines}
         fulfillmentOrder={fulfillment?.fulfillmentOrder}

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles(
       borderRadius: "4px",
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(1),
-      paddingRight: theme.spacing(1),
+      paddingRight: theme.spacing(0.5),
       paddingLeft: theme.spacing(1.5),
       "&:hover": {
         backgroundColor: theme.palette.saleor.active[5],

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -1,14 +1,16 @@
 import { Card, CardActions, TableBody, Typography } from "@material-ui/core";
 import CardSpacer from "@saleor/components/CardSpacer";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
+import Skeleton from "@saleor/components/Skeleton";
 import { commonMessages } from "@saleor/intl";
-import { Button, makeStyles } from "@saleor/macaw-ui";
+import { Button, ChevronIcon, makeStyles } from "@saleor/macaw-ui";
 import { renderCollection } from "@saleor/misc";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { OrderDetails_order_lines } from "../../types/OrderDetails";
 import OrderCardTitle from "../OrderCardTitle";
+import { Warehouse } from "../OrderChangeWarehouseDialog/types";
 import TableHeader from "../OrderProductsCardElements/OrderProductsCardHeader";
 import TableLine from "../OrderProductsCardElements/OrderProductsTableRow";
 
@@ -26,6 +28,21 @@ const useStyles = makeStyles(
         }
       },
       tableLayout: "fixed"
+    },
+    toolbar: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      cursor: "pointer",
+      borderRadius: "4px",
+      paddingTop: theme.spacing(1),
+      paddingBottom: theme.spacing(1),
+      paddingRight: theme.spacing(1),
+      paddingLeft: theme.spacing(1.5),
+      "&:hover": {
+        backgroundColor: theme.palette.saleor.active[5],
+        color: theme.palette.saleor.active[1]
+      }
     }
   }),
   { name: "OrderUnfulfilledItems" }
@@ -36,6 +53,8 @@ interface OrderUnfulfilledProductsCardProps {
   notAllowedToFulfillUnpaid: boolean;
   lines: OrderDetails_order_lines[];
   onFulfill: () => void;
+  selectedWarehouse: Warehouse;
+  onWarehouseChange: () => null;
 }
 
 const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> = props => {
@@ -43,7 +62,9 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
     showFulfillmentAction,
     notAllowedToFulfillUnpaid,
     lines,
-    onFulfill
+    onFulfill,
+    selectedWarehouse,
+    onWarehouseChange
   } = props;
   const classes = useStyles({});
 
@@ -54,7 +75,17 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
   return (
     <>
       <Card>
-        <OrderCardTitle lines={lines} withStatus status="unfulfilled" />
+        <OrderCardTitle
+          lines={lines}
+          withStatus
+          status="unfulfilled"
+          toolbar={
+            <div className={classes.toolbar} onClick={onWarehouseChange}>
+              {selectedWarehouse?.name ?? <Skeleton />}
+              <ChevronIcon />
+            </div>
+          }
+        />
         <ResponsiveTable className={classes.table}>
           <TableHeader />
           <TableBody>

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -59,7 +59,7 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
           <TableHeader />
           <TableBody>
             {renderCollection(lines, line => (
-              <TableLine isOrderLine line={line} />
+              <TableLine key={line.id} isOrderLine line={line} />
             ))}
           </TableBody>
         </ResponsiveTable>

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -54,7 +54,7 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
   return (
     <>
       <Card>
-        <OrderCardTitle withStatus status="unfulfilled" />
+        <OrderCardTitle lines={lines} withStatus status="unfulfilled" />
         <ResponsiveTable className={classes.table}>
           <TableHeader />
           <TableBody>

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -8,9 +8,9 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { OrderDetails_order_lines } from "../../types/OrderDetails";
+import OrderCardTitle from "../OrderCardTitle";
 import TableHeader from "../OrderProductsCardElements/OrderProductsCardHeader";
 import TableLine from "../OrderProductsCardElements/OrderProductsTableRow";
-import CardTitle from "../OrderReturnPage/OrderReturnRefundItemsCard/CardTitle";
 
 const useStyles = makeStyles(
   theme => ({
@@ -54,7 +54,7 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
   return (
     <>
       <Card>
-        <CardTitle withStatus status="unfulfilled" />
+        <OrderCardTitle withStatus status="unfulfilled" />
         <ResponsiveTable className={classes.table}>
           <TableHeader />
           <TableBody>

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -95,9 +95,9 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
           </TableBody>
         </ResponsiveTable>
         {showFulfillmentAction && (
-          <CardActions>
+          <CardActions className={classes.actions}>
             <Button
-              variant="tertiary"
+              variant="primary"
               onClick={onFulfill}
               disabled={notAllowedToFulfillUnpaid}
             >

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -117,11 +117,12 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
 
   React.useEffect(() => {
     const warehousesAvailability = warehouses?.map(warehouse => {
-      let linesAvailable = 0;
-
       if (!order?.lines) {
         return undefined;
       }
+
+      let linesAvailable = 0;
+
       order.lines.forEach(line => {
         if (
           line?.variant?.stocks?.find(

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -138,9 +138,11 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
       };
     });
 
-    const defaultWarehouse = warehousesAvailability?.reduce((prev, curr) =>
-      curr.linesAvailable > prev.linesAvailable ? curr : prev
-    ).warehouse;
+    const defaultWarehouse = order?.lines
+      ? warehousesAvailability?.reduce((prev, curr) =>
+          curr.linesAvailable > prev.linesAvailable ? curr : prev
+        ).warehouse
+      : undefined;
     setFulfillmentWarehouse(defaultWarehouse);
   }, [warehousesData, warehousesLoading]);
 

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -121,24 +121,17 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
         return undefined;
       }
 
-      let linesAvailable = 0;
-
-      order.lines.forEach(line => {
-        if (
-          line?.variant?.stocks?.find(
-            stock => stock.warehouse.id === warehouse.id
-          )
-        ) {
-          linesAvailable += 1;
-        }
-      });
+      const linesAvailable = order.lines.filter(line =>
+        line?.variant?.stocks?.find(
+          stock => stock.warehouse.id === warehouse.id
+        )
+      ).length;
 
       return {
         warehouse,
         linesAvailable
       };
     });
-
     const defaultWarehouse = order?.lines
       ? warehousesAvailability?.reduce((prev, curr) =>
           curr.linesAvailable > prev.linesAvailable ? curr : prev

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -114,11 +114,34 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
   const [fulfillmentWarehouse, setFulfillmentWarehouse] = React.useState<
     Warehouse
   >(null);
+
   React.useEffect(() => {
-    // @TODO this is wip
-    // exact logic for determining default
-    // warehouse will be added in future PR
-    setFulfillmentWarehouse(warehouses?.[0]);
+    const warehousesAvailability = warehouses?.map(warehouse => {
+      let linesAvailable = 0;
+
+      if (!order?.lines) {
+        return undefined;
+      }
+      order.lines.forEach(line => {
+        if (
+          line?.variant?.stocks?.find(
+            stock => stock.warehouse.id === warehouse.id
+          )
+        ) {
+          linesAvailable += 1;
+        }
+      });
+
+      return {
+        warehouse,
+        linesAvailable
+      };
+    });
+
+    const defaultWarehouse = warehousesAvailability?.reduce((prev, curr) =>
+      curr.linesAvailable > prev.linesAvailable ? curr : prev
+    ).warehouse;
+    setFulfillmentWarehouse(defaultWarehouse);
   }, [warehousesData, warehousesLoading]);
 
   const {

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -186,6 +186,7 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
         )}
         shippingMethods={data?.order?.shippingMethods || []}
         userPermissions={user?.userPermissions || []}
+        selectedWarehouse={fulfillmentWarehouse}
         onOrderCancel={() => openModal("cancel")}
         onOrderFulfill={() => navigate(orderFulfillUrl(id))}
         onFulfillmentApprove={fulfillmentId =>
@@ -232,6 +233,7 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
           })
         }
         onInvoiceSend={id => openModal("invoice-send", { id })}
+        onWarehouseChange={() => openModal("change-warehouse")}
         onSubmit={handleSubmit}
       />
       <OrderCannotCancelOrderDialog

--- a/src/storybook/stories/orders/OrderDetailsPage.tsx
+++ b/src/storybook/stories/orders/OrderDetailsPage.tsx
@@ -21,6 +21,7 @@ const order = orderFixture(placeholderImage);
 
 const props: Omit<OrderDetailsPageProps, "classes"> = {
   disabled: false,
+  selectedWarehouse: undefined,
   onBack: () => undefined,
   onBillingAddressEdit: undefined,
   onFulfillmentApprove: () => undefined,
@@ -40,6 +41,7 @@ const props: Omit<OrderDetailsPageProps, "classes"> = {
   onProductClick: undefined,
   onProfileView: () => undefined,
   onShippingAddressEdit: undefined,
+  onWarehouseChange: undefined,
   onSubmit: () => undefined,
   order,
   shop: shopFixture,


### PR DESCRIPTION
I want to merge this change because it changes the UI of order card headers & adds button for warehouse selection in Unfulfilled Products Card.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.1

### Screenshots

default:
![image](https://user-images.githubusercontent.com/41952692/154525869-03f7a6be-f2fe-447a-9c04-8a47208fca9e.png)

hover state:
![image](https://user-images.githubusercontent.com/41952692/154525118-5330ab04-96fb-4138-a2b4-434e36463dda.png)

other circles:
![image](https://user-images.githubusercontent.com/41952692/154525717-45959832-2a49-4e2d-8509-06e02887a99a.png)

dark mode:
![image](https://user-images.githubusercontent.com/41952692/154526047-025c1b0e-1853-4824-9752-5ba3f23be691.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
