### PR TITLE
Add permission-based restrictions in Customer views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4358,8 +4358,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:saleor/macaw-ui#e85d8a5082e058c8165c662d4f535e3cd917d2c4",
-      "from": "github:saleor/macaw-ui",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.1.tgz",
+      "integrity": "sha512-2sGPfMLszKb2Zejd9/hs5MNLhvcIW+bQj+6CTnq8+BbKNt/zqg6t1YQrucb72otUUTJMC6VIjnvtMITmpsgLsQ==",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4358,9 +4358,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.1.tgz",
-      "integrity": "sha512-2sGPfMLszKb2Zejd9/hs5MNLhvcIW+bQj+6CTnq8+BbKNt/zqg6t1YQrucb72otUUTJMC6VIjnvtMITmpsgLsQ==",
+      "version": "github:saleor/macaw-ui#e85d8a5082e058c8165c662d4f535e3cd917d2c4",
+      "from": "github:saleor/macaw-ui",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:saleor/macaw-ui",
+    "@saleor/macaw-ui": "0.3.1",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "^0.3.1",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/auth/hooks/useUserPermissions.ts
+++ b/src/auth/hooks/useUserPermissions.ts
@@ -1,0 +1,3 @@
+import { useUser } from "..";
+
+export const useUserPermissions = () => useUser().user?.userPermissions;

--- a/src/components/ChannelsAvailabilityCard/ChannelsAvailabilityCardWrapper.tsx
+++ b/src/components/ChannelsAvailabilityCard/ChannelsAvailabilityCardWrapper.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent, Typography } from "@material-ui/core";
-import { useUser } from "@saleor/auth";
 import CardTitle from "@saleor/components/CardTitle";
 import Hr from "@saleor/components/Hr";
 import RequirePermissions from "@saleor/components/RequirePermissions";
@@ -28,7 +27,6 @@ export const ChannelsAvailabilityWrapper: React.FC<ChannelsAvailabilityWrapperPr
   } = props;
   const intl = useIntl();
   const classes = useStyles({});
-  const { user } = useUser();
   const channelsAvailabilityText = intl.formatMessage(
     {
       defaultMessage:
@@ -51,10 +49,7 @@ export const ChannelsAvailabilityWrapper: React.FC<ChannelsAvailabilityWrapperPr
             description: "section header"
           })}
           toolbar={
-            <RequirePermissions
-              userPermissions={user?.userPermissions || []}
-              requiredPermissions={managePermissions}
-            >
+            <RequirePermissions requiredPermissions={managePermissions}>
               <Button
                 onClick={openModal}
                 data-test-id="channels-availability-manage-button"

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -1,4 +1,5 @@
 import { FetchMoreProps, SearchPageProps } from "@saleor/types";
+import { PermissionEnum } from "@saleor/types/globalTypes";
 import { MessageDescriptor } from "react-intl";
 
 import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
@@ -34,6 +35,7 @@ export interface IFilterElement<T extends string = string>
   multipleFields?: IFilterElement[];
   id?: string;
   dependencies?: string[];
+  permissions?: PermissionEnum[];
 }
 
 export interface FilterBaseFieldProps<T extends string = string> {

--- a/src/components/RequirePermissions.tsx
+++ b/src/components/RequirePermissions.tsx
@@ -1,3 +1,4 @@
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import { User_userPermissions } from "@saleor/fragments/types/User";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import React from "react";
@@ -16,15 +17,19 @@ export function hasPermissions(
 export interface RequirePermissionsProps {
   children: React.ReactNode | React.ReactNodeArray;
   requiredPermissions: PermissionEnum[];
-  userPermissions: User_userPermissions[];
 }
 
 const RequirePermissions: React.FC<RequirePermissionsProps> = ({
   children,
-  requiredPermissions,
-  userPermissions
-}) =>
-  hasPermissions(userPermissions, requiredPermissions) ? <>{children}</> : null;
+  requiredPermissions
+}) => {
+  const userPermissions = useUserPermissions();
+
+  return userPermissions &&
+    hasPermissions(userPermissions, requiredPermissions) ? (
+    <>{children}</>
+  ) : null;
+};
 
 RequirePermissions.displayName = "RequirePermissions";
 export default RequirePermissions;

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import { CardSpacer } from "@saleor/components/CardSpacer";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
@@ -5,6 +6,7 @@ import Grid from "@saleor/components/Grid";
 import Metadata from "@saleor/components/Metadata/Metadata";
 import { MetadataFormData } from "@saleor/components/Metadata/types";
 import PageHeader from "@saleor/components/PageHeader";
+import RequirePermissions from "@saleor/components/RequirePermissions";
 import Savebar from "@saleor/components/Savebar";
 import { UpdateCustomer_customerUpdate_errors } from "@saleor/customers/types/UpdateCustomer";
 import { AccountErrorFragment } from "@saleor/fragments/types/AccountErrorFragment";
@@ -13,6 +15,7 @@ import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { Backlink } from "@saleor/macaw-ui";
+import { PermissionEnum } from "@saleor/types/globalTypes";
 import { mapEdgesToItems, mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
@@ -62,6 +65,7 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
   onDelete
 }: CustomerDetailsPageProps) => {
   const intl = useIntl();
+  const userPermissions = useUserPermissions();
 
   const initialForm: CustomerDetailsPageFormData = {
     email: customer?.email || "",
@@ -105,12 +109,17 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
                   onChange={change}
                 />
                 <CardSpacer />
-                <CustomerOrders
-                  orders={mapEdgesToItems(customer?.orders)}
-                  onViewAllOrdersClick={onViewAllOrdersClick}
-                  onRowClick={onRowClick}
-                />
-                <CardSpacer />
+                <RequirePermissions
+                  userPermissions={userPermissions}
+                  requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
+                >
+                  <CustomerOrders
+                    orders={mapEdgesToItems(customer?.orders)}
+                    onViewAllOrdersClick={onViewAllOrdersClick}
+                    onRowClick={onRowClick}
+                  />
+                  <CardSpacer />
+                </RequirePermissions>
                 <Metadata data={data} onChange={changeMetadata} />
               </div>
               <div>
@@ -122,7 +131,12 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
                 <CardSpacer />
                 <CustomerStats customer={customer} />
                 <CardSpacer />
-                <CustomerGiftCardsCard />
+                <RequirePermissions
+                  userPermissions={userPermissions}
+                  requiredPermissions={[PermissionEnum.MANAGE_GIFT_CARD]}
+                >
+                  <CustomerGiftCardsCard />
+                </RequirePermissions>
               </div>
             </Grid>
             <Savebar

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -1,4 +1,3 @@
-import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import { CardSpacer } from "@saleor/components/CardSpacer";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
@@ -65,7 +64,6 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
   onDelete
 }: CustomerDetailsPageProps) => {
   const intl = useIntl();
-  const userPermissions = useUserPermissions();
 
   const initialForm: CustomerDetailsPageFormData = {
     email: customer?.email || "",
@@ -110,7 +108,6 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
                 />
                 <CardSpacer />
                 <RequirePermissions
-                  userPermissions={userPermissions}
                   requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
                 >
                   <CustomerOrders
@@ -132,7 +129,6 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
                 <CustomerStats customer={customer} />
                 <CardSpacer />
                 <RequirePermissions
-                  userPermissions={userPermissions}
                   requiredPermissions={[PermissionEnum.MANAGE_GIFT_CARD]}
                 >
                   <CustomerGiftCardsCard />

--- a/src/customers/components/CustomerList/CustomerList.tsx
+++ b/src/customers/components/CustomerList/CustomerList.tsx
@@ -11,7 +11,7 @@ import TableHead from "@saleor/components/TableHead";
 import TablePagination from "@saleor/components/TablePagination";
 import { CustomerListUrlSortField } from "@saleor/customers/urls";
 import { makeStyles } from "@saleor/macaw-ui";
-import { getUserName, maybe, renderCollection } from "@saleor/misc";
+import { getUserName, renderCollection } from "@saleor/misc";
 import { ListActions, ListProps, SortPage } from "@saleor/types";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import { getArrowDirection } from "@saleor/utils/sort";
@@ -72,6 +72,7 @@ const CustomerList: React.FC<CustomerListProps> = props => {
   } = props;
 
   const userPermissions = useUserPermissions();
+
   const classes = useStyles(props);
 
   return (
@@ -112,7 +113,6 @@ const CustomerList: React.FC<CustomerListProps> = props => {
           <FormattedMessage defaultMessage="Customer Email" />
         </TableCellHeader>
         <RequirePermissions
-          userPermissions={userPermissions}
           requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
         >
           <TableCellHeader
@@ -170,10 +170,9 @@ const CustomerList: React.FC<CustomerListProps> = props => {
                   {getUserName(customer)}
                 </TableCell>
                 <TableCell className={classes.colEmail}>
-                  {maybe<React.ReactNode>(() => customer.email, <Skeleton />)}
+                  {customer?.email ?? <Skeleton />}
                 </TableCell>
                 <RequirePermissions
-                  userPermissions={userPermissions}
                   requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
                 >
                   <TableCell className={classes.colOrders}>

--- a/src/customers/components/CustomerList/CustomerList.tsx
+++ b/src/customers/components/CustomerList/CustomerList.tsx
@@ -1,5 +1,4 @@
 import { TableBody, TableCell, TableFooter, TableRow } from "@material-ui/core";
-import { useUser } from "@saleor/auth";
 import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import Checkbox from "@saleor/components/Checkbox";
 import RequirePermissions, {
@@ -73,7 +72,6 @@ const CustomerList: React.FC<CustomerListProps> = props => {
   } = props;
 
   const userPermissions = useUserPermissions();
-
   const classes = useStyles(props);
 
   return (

--- a/src/customers/components/CustomerList/CustomerList.tsx
+++ b/src/customers/components/CustomerList/CustomerList.tsx
@@ -177,10 +177,7 @@ const CustomerList: React.FC<CustomerListProps> = props => {
                   requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
                 >
                   <TableCell className={classes.colOrders}>
-                    {maybe<React.ReactNode>(
-                      () => customer.orders.totalCount,
-                      <Skeleton />
-                    )}
+                    {customer?.orders?.totalCount ?? <Skeleton />}
                   </TableCell>
                 </RequirePermissions>
               </TableRow>

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@material-ui/core";
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import Container from "@saleor/components/Container";
 import FilterBar from "@saleor/components/FilterBar";
 import PageHeader from "@saleor/components/PageHeader";
@@ -48,7 +49,8 @@ const CustomerListPage: React.FC<CustomerListPageProps> = ({
 }) => {
   const intl = useIntl();
 
-  const structure = createFilterStructure(intl, filterOpts);
+  const userPermissions = useUserPermissions();
+  const structure = createFilterStructure(intl, filterOpts, userPermissions);
 
   return (
     <Container>

--- a/src/customers/components/CustomerListPage/filters.ts
+++ b/src/customers/components/CustomerListPage/filters.ts
@@ -1,5 +1,8 @@
 import { IFilter } from "@saleor/components/Filter";
+import { hasPermissions } from "@saleor/components/RequirePermissions";
+import { User_userPermissions } from "@saleor/fragments/types/User";
 import { FilterOpts, MinMax } from "@saleor/types";
+import { PermissionEnum } from "@saleor/types/globalTypes";
 import {
   createDateField,
   createNumberField
@@ -28,7 +31,8 @@ const messages = defineMessages({
 
 export function createFilterStructure(
   intl: IntlShape,
-  opts: CustomerListFilterOpts
+  opts: CustomerListFilterOpts,
+  userPermissions: User_userPermissions[]
 ): IFilter<CustomerFilterKeys> {
   return [
     {
@@ -45,7 +49,8 @@ export function createFilterStructure(
         intl.formatMessage(messages.numberOfOrders),
         opts.numberOfOrders.value
       ),
-      active: opts.numberOfOrders.active
+      active: opts.numberOfOrders.active,
+      permissions: [PermissionEnum.MANAGE_ORDERS]
     }
-  ];
+  ].filter(filter => hasPermissions(userPermissions, filter.permissions ?? []));
 }

--- a/src/customers/components/CustomerStats/CustomerStats.tsx
+++ b/src/customers/components/CustomerStats/CustomerStats.tsx
@@ -1,13 +1,15 @@
 import { Card, CardContent, Typography } from "@material-ui/core";
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import CardTitle from "@saleor/components/CardTitle";
 import { DateTime } from "@saleor/components/Date";
 import { Hr } from "@saleor/components/Hr";
+import RequirePermissions from "@saleor/components/RequirePermissions";
 import Skeleton from "@saleor/components/Skeleton";
 import { makeStyles } from "@saleor/macaw-ui";
+import { PermissionEnum } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { maybe } from "../../../misc";
 import { CustomerDetails_user } from "../../types/CustomerDetails";
 
 const useStyles = makeStyles(
@@ -29,6 +31,7 @@ export interface CustomerStatsProps {
 const CustomerStats: React.FC<CustomerStatsProps> = props => {
   const { customer } = props;
   const classes = useStyles(props);
+  const userPermissions = useUserPermissions();
 
   const intl = useIntl();
 
@@ -44,26 +47,28 @@ const CustomerStats: React.FC<CustomerStatsProps> = props => {
         <Typography className={classes.label} variant="caption">
           <FormattedMessage defaultMessage="Last login" />
         </Typography>
-        {maybe(
-          () => (
-            <Typography variant="h6" className={classes.value}>
-              {customer.lastLogin === null ? (
-                "-"
-              ) : (
-                <DateTime date={customer.lastLogin} />
-              )}
-            </Typography>
-          ),
+        {customer ? (
+          <Typography variant="h6" className={classes.value}>
+            {customer.lastLogin === null ? (
+              "-"
+            ) : (
+              <DateTime date={customer.lastLogin} />
+            )}
+          </Typography>
+        ) : (
           <Skeleton />
         )}
       </CardContent>
-      <Hr />
-      <CardContent>
-        <Typography className={classes.label} variant="caption">
-          <FormattedMessage defaultMessage="Last order" />
-        </Typography>
-        {maybe(
-          () => (
+      <RequirePermissions
+        userPermissions={userPermissions}
+        requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
+      >
+        <Hr />
+        <CardContent>
+          <Typography className={classes.label} variant="caption">
+            <FormattedMessage defaultMessage="Last order" />
+          </Typography>
+          {customer && customer.lastPlacedOrder ? (
             <Typography variant="h6" className={classes.value}>
               {customer.lastPlacedOrder.edges.length === 0 ? (
                 "-"
@@ -73,10 +78,11 @@ const CustomerStats: React.FC<CustomerStatsProps> = props => {
                 />
               )}
             </Typography>
-          ),
-          <Skeleton />
-        )}
-      </CardContent>
+          ) : (
+            <Skeleton />
+          )}
+        </CardContent>
+      </RequirePermissions>
     </Card>
   );
 };

--- a/src/customers/components/CustomerStats/CustomerStats.tsx
+++ b/src/customers/components/CustomerStats/CustomerStats.tsx
@@ -1,5 +1,4 @@
 import { Card, CardContent, Typography } from "@material-ui/core";
-import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import CardTitle from "@saleor/components/CardTitle";
 import { DateTime } from "@saleor/components/Date";
 import { Hr } from "@saleor/components/Hr";
@@ -31,7 +30,6 @@ export interface CustomerStatsProps {
 const CustomerStats: React.FC<CustomerStatsProps> = props => {
   const { customer } = props;
   const classes = useStyles(props);
-  const userPermissions = useUserPermissions();
 
   const intl = useIntl();
 
@@ -59,10 +57,7 @@ const CustomerStats: React.FC<CustomerStatsProps> = props => {
           <Skeleton />
         )}
       </CardContent>
-      <RequirePermissions
-        userPermissions={userPermissions}
-        requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
-      >
+      <RequirePermissions requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}>
         <Hr />
         <CardContent>
           <Typography className={classes.label} variant="caption">

--- a/src/customers/queries.ts
+++ b/src/customers/queries.ts
@@ -27,6 +27,7 @@ const customerList = gql`
     $last: Int
     $filter: CustomerFilterInput
     $sort: UserSortingInput
+    $PERMISSION_MANAGE_ORDERS: Boolean!
   ) {
     customers(
       after: $after
@@ -39,7 +40,7 @@ const customerList = gql`
       edges {
         node {
           ...CustomerFragment
-          orders {
+          orders @include(if: $PERMISSION_MANAGE_ORDERS) {
             totalCount
           }
         }
@@ -60,10 +61,10 @@ export const useCustomerListQuery = makeQuery<
 
 const customerDetails = gql`
   ${customerDetailsFragment}
-  query CustomerDetails($id: ID!) {
+  query CustomerDetails($id: ID!, $PERMISSION_MANAGE_ORDERS: Boolean!) {
     user(id: $id) {
       ...CustomerDetailsFragment
-      orders(last: 5) {
+      orders(last: 5) @include(if: $PERMISSION_MANAGE_ORDERS) {
         edges {
           node {
             id
@@ -79,7 +80,7 @@ const customerDetails = gql`
           }
         }
       }
-      lastPlacedOrder: orders(last: 1) {
+      lastPlacedOrder: orders(last: 1) @include(if: $PERMISSION_MANAGE_ORDERS) {
         edges {
           node {
             id

--- a/src/customers/types/CustomerDetails.ts
+++ b/src/customers/types/CustomerDetails.ts
@@ -135,4 +135,5 @@ export interface CustomerDetails {
 
 export interface CustomerDetailsVariables {
   id: string;
+  PERMISSION_MANAGE_ORDERS: boolean;
 }

--- a/src/customers/types/ListCustomers.ts
+++ b/src/customers/types/ListCustomers.ts
@@ -53,4 +53,5 @@ export interface ListCustomersVariables {
   last?: number | null;
   filter?: CustomerFilterInput | null;
   sort?: UserSortingInput | null;
+  PERMISSION_MANAGE_ORDERS: boolean;
 }

--- a/src/customers/views/CustomerList/filters.test.ts
+++ b/src/customers/views/CustomerList/filters.test.ts
@@ -1,6 +1,7 @@
 import { createFilterStructure } from "@saleor/customers/components/CustomerListPage";
 import { CustomerListUrlFilters } from "@saleor/customers/urls";
 import { date } from "@saleor/fixtures";
+import { PermissionEnum } from "@saleor/types/globalTypes";
 import { getFilterQueryParams } from "@saleor/utils/filters";
 import { stringifyQs } from "@saleor/utils/urls";
 import { getExistingKeys, setFilterOptsStatus } from "@test/filters";
@@ -31,22 +32,37 @@ describe("Filtering query params", () => {
 describe("Filtering URL params", () => {
   const intl = createIntl(config);
 
-  const filters = createFilterStructure(intl, {
-    joined: {
-      active: false,
-      value: {
-        max: date.to,
-        min: date.from
+  const filters = createFilterStructure(
+    intl,
+    {
+      joined: {
+        active: false,
+        value: {
+          max: date.to,
+          min: date.from
+        }
+      },
+      numberOfOrders: {
+        active: false,
+        value: {
+          max: "5",
+          min: "1"
+        }
       }
     },
-    numberOfOrders: {
-      active: false,
-      value: {
-        max: "5",
-        min: "1"
+    [
+      {
+        code: PermissionEnum.MANAGE_USERS,
+        name: "Manage customers.",
+        __typename: "UserPermission"
+      },
+      {
+        code: PermissionEnum.MANAGE_ORDERS,
+        name: "Manage orders..",
+        __typename: "UserPermission"
       }
-    }
-  });
+    ]
+  );
 
   it("should be empty if no active filters", () => {
     const filterQueryParams = getFilterQueryParams(

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -10,7 +10,6 @@ import RequirePermissions from "@saleor/components/RequirePermissions";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import { makeStyles } from "@saleor/macaw-ui";
-import { UserPermissionProps } from "@saleor/types";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import React from "react";
 import { useIntl } from "react-intl";
@@ -33,7 +32,7 @@ const useStyles = makeStyles(
   { name: "HomeNotificationTable" }
 );
 
-interface HomeNotificationTableProps extends UserPermissionProps {
+interface HomeNotificationTableProps {
   ordersToCapture: number;
   ordersToFulfill: number;
   productsOutOfStock: number;
@@ -53,7 +52,6 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
     ordersToCapture,
     ordersToFulfill,
     productsOutOfStock,
-    userPermissions,
     noChannel
   } = props;
 
@@ -67,7 +65,6 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
         <TableBody className={classes.tableRow}>
           {noChannel && (
             <RequirePermissions
-              userPermissions={userPermissions}
               requiredPermissions={[PermissionEnum.MANAGE_CHANNELS]}
             >
               <TableRow hover={true} onClick={onCreateNewChannelClick}>
@@ -83,7 +80,6 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
             </RequirePermissions>
           )}
           <RequirePermissions
-            userPermissions={userPermissions}
             requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
           >
             <TableRow hover={true} onClick={onOrdersToFulfillClick}>
@@ -128,7 +124,6 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
             </TableRow>
           </RequirePermissions>
           <RequirePermissions
-            userPermissions={userPermissions}
             requiredPermissions={[PermissionEnum.MANAGE_PRODUCTS]}
           >
             <TableRow hover={true} onClick={onProductsOutOfStockClick}>

--- a/src/home/components/HomePage/HomePage.tsx
+++ b/src/home/components/HomePage/HomePage.tsx
@@ -5,7 +5,6 @@ import Money from "@saleor/components/Money";
 import RequirePermissions from "@saleor/components/RequirePermissions";
 import Skeleton from "@saleor/components/Skeleton";
 import { makeStyles } from "@saleor/macaw-ui";
-import { UserPermissionProps } from "@saleor/types";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import React from "react";
 
@@ -44,7 +43,7 @@ const useStyles = makeStyles(
   { name: "HomePage" }
 );
 
-export interface HomePageProps extends UserPermissionProps {
+export interface HomePageProps {
   activities: Home_activities_edges_node[];
   orders: number | null;
   ordersToCapture: number | null;
@@ -76,7 +75,6 @@ const HomePage: React.FC<HomePageProps> = props => {
     ordersToCapture = 0,
     ordersToFulfill = 0,
     productsOutOfStock = 0,
-    userPermissions = [],
     noChannel
   } = props;
 
@@ -89,7 +87,6 @@ const HomePage: React.FC<HomePageProps> = props => {
       <Grid>
         <div>
           <RequirePermissions
-            userPermissions={userPermissions}
             requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
           >
             <div className={classes.cardContainer}>
@@ -141,13 +138,11 @@ const HomePage: React.FC<HomePageProps> = props => {
             ordersToCapture={ordersToCapture}
             ordersToFulfill={ordersToFulfill}
             productsOutOfStock={productsOutOfStock}
-            userPermissions={userPermissions}
             noChannel={noChannel}
           />
           <CardSpacer />
           {topProducts && (
             <RequirePermissions
-              userPermissions={userPermissions}
               requiredPermissions={[
                 PermissionEnum.MANAGE_ORDERS,
                 PermissionEnum.MANAGE_PRODUCTS
@@ -165,7 +160,6 @@ const HomePage: React.FC<HomePageProps> = props => {
         {activities && (
           <div>
             <RequirePermissions
-              userPermissions={userPermissions}
               requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
             >
               <HomeActivityCard

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -65,7 +65,6 @@ const HomeSection = () => {
       ordersToFulfill={data?.ordersToFulfill?.totalCount}
       productsOutOfStock={data?.productsOutOfStock.totalCount}
       userName={getUserName(user, true)}
-      userPermissions={user?.userPermissions}
       noChannel={noChannel}
     />
   );

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -12,7 +12,7 @@ import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
 import { Button, makeStyles } from "@saleor/macaw-ui";
 import { SearchCustomers_search_edges_node } from "@saleor/searches/types/SearchCustomers";
-import { FetchMoreProps, UserPermissionProps } from "@saleor/types";
+import { FetchMoreProps } from "@saleor/types";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import React from "react";
@@ -55,9 +55,7 @@ export interface CustomerEditData {
   prevUserEmail?: string;
 }
 
-export interface OrderCustomerProps
-  extends Partial<FetchMoreProps>,
-    UserPermissionProps {
+export interface OrderCustomerProps extends Partial<FetchMoreProps> {
   order: OrderDetails_order;
   users?: SearchCustomers_search_edges_node[];
   loading?: boolean;
@@ -79,7 +77,6 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
     loading,
     order,
     users,
-    userPermissions,
     onCustomerEdit,
     onBillingAddressEdit,
     onFetchMore: onFetchMoreUsers,
@@ -131,7 +128,6 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
         toolbar={
           !!canEditCustomer && (
             <RequirePermissions
-              userPermissions={userPermissions}
               requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
             >
               <Button
@@ -209,7 +205,6 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
               {user.email}
             </Typography>
             <RequirePermissions
-              userPermissions={userPermissions}
               requiredPermissions={[PermissionEnum.MANAGE_USERS]}
             >
               <div>

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -15,7 +15,6 @@ import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { Backlink } from "@saleor/macaw-ui";
 import { makeStyles } from "@saleor/macaw-ui";
 import OrderChannelSectionCard from "@saleor/orders/components/OrderChannelSectionCard";
-import { UserPermissionProps } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
@@ -55,7 +54,7 @@ const useStyles = makeStyles(
   }
 );
 
-export interface OrderDetailsPageProps extends UserPermissionProps {
+export interface OrderDetailsPageProps {
   order: OrderDetails_order;
   shop: OrderDetails_shop;
   shippingMethods?: Array<{
@@ -114,7 +113,6 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     order,
     shop,
     saveButtonBarState,
-    userPermissions,
     onBack,
     onBillingAddressEdit,
     onFulfillmentApprove,
@@ -299,7 +297,6 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
                   canEditAddresses={canEditAddresses}
                   canEditCustomer={false}
                   order={order}
-                  userPermissions={userPermissions}
                   onBillingAddressEdit={onBillingAddressEdit}
                   onShippingAddressEdit={onShippingAddressEdit}
                   onProfileView={onProfileView}

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -14,7 +14,7 @@ import { Backlink } from "@saleor/macaw-ui";
 import { makeStyles } from "@saleor/macaw-ui";
 import DraftOrderChannelSectionCard from "@saleor/orders/components/DraftOrderChannelSectionCard";
 import { SearchCustomers_search_edges_node } from "@saleor/searches/types/SearchCustomers";
-import { FetchMoreProps, UserPermissionProps } from "@saleor/types";
+import { FetchMoreProps } from "@saleor/types";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -37,9 +37,7 @@ const useStyles = makeStyles(
   { name: "OrderDraftPage" }
 );
 
-export interface OrderDraftPageProps
-  extends FetchMoreProps,
-    UserPermissionProps {
+export interface OrderDraftPageProps extends FetchMoreProps {
   disabled: boolean;
   order: OrderDetails_order;
   users: SearchCustomers_search_edges_node[];
@@ -85,8 +83,7 @@ const OrderDraftPage: React.FC<OrderDraftPageProps> = props => {
     onProfileView,
     order,
     users,
-    usersLoading,
-    userPermissions
+    usersLoading
   } = props;
   const classes = useStyles(props);
 
@@ -147,7 +144,6 @@ const OrderDraftPage: React.FC<OrderDraftPageProps> = props => {
             loading={usersLoading}
             order={order}
             users={users}
-            userPermissions={userPermissions}
             onBillingAddressEdit={onBillingAddressEdit}
             onCustomerEdit={onCustomerEdit}
             onFetchMore={onFetchMore}

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -1,4 +1,3 @@
-import { useUser } from "@saleor/auth";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { useCustomerAddressesQuery } from "@saleor/customers/queries";
@@ -84,7 +83,6 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
 }) => {
   const order = data.order;
   const navigate = useNavigator();
-  const { user } = useUser();
 
   const {
     loadMore,
@@ -214,7 +212,6 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
             }
             saveButtonBarState="default"
             onProfileView={() => navigate(customerUrl(order.user.id))}
-            userPermissions={user?.userPermissions || []}
           />
         </OrderLineDiscountProvider>
       </OrderDiscountProvider>

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -1,4 +1,3 @@
-import { useUser } from "@saleor/auth";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import { useCustomerAddressesQuery } from "@saleor/customers/queries";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -95,7 +94,6 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
   const order = data?.order;
   const shop = data?.shop;
   const navigate = useNavigator();
-  const { user } = useUser();
 
   const warehouses = useWarehouseList({
     displayLoader: true,
@@ -168,7 +166,6 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
           ]
         )}
         shippingMethods={data?.order?.shippingMethods || []}
-        userPermissions={user?.userPermissions || []}
         onOrderCancel={() => openModal("cancel")}
         onOrderFulfill={() => navigate(orderFulfillUrl(id))}
         onFulfillmentApprove={fulfillmentId =>

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -1,4 +1,3 @@
-import { useUser } from "@saleor/auth";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { useCustomerAddressesQuery } from "@saleor/customers/queries";
@@ -109,7 +108,6 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
   const order = data.order;
   const shop = data.shop;
   const navigate = useNavigator();
-  const { user } = useUser();
 
   const {
     loadMore,
@@ -201,7 +199,6 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
               ]
             )}
             shippingMethods={data?.order?.shippingMethods || []}
-            userPermissions={user?.userPermissions || []}
             onOrderCancel={() => openModal("cancel")}
             onOrderFulfill={() => navigate(orderFulfillUrl(id))}
             onFulfillmentApprove={fulfillmentId =>

--- a/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
+++ b/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
@@ -28,7 +28,6 @@ export interface ShippingZonesListPageProps
 const ShippingZonesListPage: React.FC<ShippingZonesListPageProps> = ({
   defaultWeightUnit,
   disabled,
-  userPermissions,
   onBack,
   onSubmit,
   ...listProps
@@ -52,7 +51,6 @@ const ShippingZonesListPage: React.FC<ShippingZonesListPageProps> = ({
         </div>
         <div>
           <RequirePermissions
-            userPermissions={userPermissions}
             requiredPermissions={[PermissionEnum.MANAGE_SETTINGS]}
           >
             <ShippingWeightUnitForm

--- a/src/storybook/stories/components/ActionDialog.tsx
+++ b/src/storybook/stories/components/ActionDialog.tsx
@@ -3,12 +3,12 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import Decorator from "../../Decorator";
-import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
+import { MockedUserProvider } from "../customers/MockedUserProvider";
 
 const ActionDialog = props => (
-  <ComponentWithMockContext>
+  <MockedUserProvider>
     <ActionDialogComponent {...props} />
-  </ComponentWithMockContext>
+  </MockedUserProvider>
 );
 
 storiesOf("Generics / ActionDialog", module)

--- a/src/storybook/stories/components/ActionDialog.tsx
+++ b/src/storybook/stories/components/ActionDialog.tsx
@@ -1,8 +1,15 @@
-import ActionDialog from "@saleor/components/ActionDialog";
+import ActionDialogComponent from "@saleor/components/ActionDialog";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import Decorator from "../../Decorator";
+import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
+
+const ActionDialog = props => (
+  <ComponentWithMockContext>
+    <ActionDialogComponent {...props} />
+  </ComponentWithMockContext>
+);
 
 storiesOf("Generics / ActionDialog", module)
   .addDecorator(Decorator)

--- a/src/storybook/stories/customers/ComponentWithMockContext.tsx
+++ b/src/storybook/stories/customers/ComponentWithMockContext.tsx
@@ -1,8 +1,11 @@
 import { UserContext } from "@saleor/auth";
 import { adminUserPermissions } from "@saleor/fixtures";
+import { User_userPermissions } from "@saleor/fragments/types/User";
 import * as React from "react";
 
-export const ComponentWithMockContext: React.FC = ({ children }) => (
+export const ComponentWithMockContext: React.FC<{
+  customPermissions?: User_userPermissions[];
+}> = ({ customPermissions, children }) => (
   <UserContext.Provider
     value={{
       login: undefined,
@@ -17,7 +20,7 @@ export const ComponentWithMockContext: React.FC = ({ children }) => (
         firstName: "user",
         lastName: "user",
         isStaff: true,
-        userPermissions: adminUserPermissions,
+        userPermissions: customPermissions ?? adminUserPermissions,
         avatar: null,
         __typename: "User"
       }

--- a/src/storybook/stories/customers/ComponentWithMockContext.tsx
+++ b/src/storybook/stories/customers/ComponentWithMockContext.tsx
@@ -1,0 +1,28 @@
+import { UserContext } from "@saleor/auth";
+import { adminUserPermissions } from "@saleor/fixtures";
+import * as React from "react";
+
+export const ComponentWithMockContext: React.FC = ({ children }) => (
+  <UserContext.Provider
+    value={{
+      login: undefined,
+      loginByExternalPlugin: undefined,
+      logout: undefined,
+      requestLoginByExternalPlugin: undefined,
+      authenticating: false,
+      authenticated: false,
+      user: {
+        id: "0",
+        email: "email@email.me",
+        firstName: "user",
+        lastName: "user",
+        isStaff: true,
+        userPermissions: adminUserPermissions,
+        avatar: null,
+        __typename: "User"
+      }
+    }}
+  >
+    {children}
+  </UserContext.Provider>
+);

--- a/src/storybook/stories/customers/CustomerDetailsPage.tsx
+++ b/src/storybook/stories/customers/CustomerDetailsPage.tsx
@@ -7,7 +7,7 @@ import CustomerDetailsPageComponent, {
 } from "../../../customers/components/CustomerDetailsPage";
 import { customer } from "../../../customers/fixtures";
 import Decorator from "../../Decorator";
-import { ComponentWithMockContext } from "./ComponentWithMockContext";
+import { MockedUserProvider } from "./MockedUserProvider";
 
 const props: Omit<CustomerDetailsPageProps, "classes"> = {
   customer,
@@ -30,9 +30,9 @@ interface CustomerDetailsPageErrors {
 }
 
 const CustomerDetailsPage = props => (
-  <ComponentWithMockContext>
+  <MockedUserProvider>
     <CustomerDetailsPageComponent {...props} />
-  </ComponentWithMockContext>
+  </MockedUserProvider>
 );
 
 storiesOf("Views / Customers / Customer details", module)

--- a/src/storybook/stories/customers/CustomerDetailsPage.tsx
+++ b/src/storybook/stories/customers/CustomerDetailsPage.tsx
@@ -2,11 +2,12 @@ import { AccountErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
-import CustomerDetailsPage, {
+import CustomerDetailsPageComponent, {
   CustomerDetailsPageProps
 } from "../../../customers/components/CustomerDetailsPage";
 import { customer } from "../../../customers/fixtures";
 import Decorator from "../../Decorator";
+import { ComponentWithMockContext } from "./ComponentWithMockContext";
 
 const props: Omit<CustomerDetailsPageProps, "classes"> = {
   customer,
@@ -27,6 +28,12 @@ interface CustomerDetailsPageErrors {
   lastName: string;
   note: string;
 }
+
+const CustomerDetailsPage = props => (
+  <ComponentWithMockContext>
+    <CustomerDetailsPageComponent {...props} />
+  </ComponentWithMockContext>
+);
 
 storiesOf("Views / Customers / Customer details", module)
   .addDecorator(Decorator)

--- a/src/storybook/stories/customers/CustomerListPage.tsx
+++ b/src/storybook/stories/customers/CustomerListPage.tsx
@@ -2,7 +2,7 @@ import { CustomerListUrlSortField } from "@saleor/customers/urls";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
-import CustomerListPage, {
+import CustomerListPageComponent, {
   CustomerListPageProps
 } from "../../../customers/components/CustomerListPage";
 import { customerList } from "../../../customers/fixtures";
@@ -15,6 +15,7 @@ import {
   tabPageProps
 } from "../../../fixtures";
 import Decorator from "../../Decorator";
+import { ComponentWithMockContext } from "./ComponentWithMockContext";
 
 const props: CustomerListPageProps = {
   ...filterPageProps,
@@ -45,6 +46,12 @@ const props: CustomerListPageProps = {
     sort: CustomerListUrlSortField.name
   }
 };
+
+const CustomerListPage = props => (
+  <ComponentWithMockContext>
+    <CustomerListPageComponent {...props} />
+  </ComponentWithMockContext>
+);
 
 storiesOf("Views / Customers / Customer list", module)
   .addDecorator(Decorator)

--- a/src/storybook/stories/customers/CustomerListPage.tsx
+++ b/src/storybook/stories/customers/CustomerListPage.tsx
@@ -15,7 +15,7 @@ import {
   tabPageProps
 } from "../../../fixtures";
 import Decorator from "../../Decorator";
-import { ComponentWithMockContext } from "./ComponentWithMockContext";
+import { MockedUserProvider } from "./MockedUserProvider";
 
 const props: CustomerListPageProps = {
   ...filterPageProps,
@@ -48,9 +48,9 @@ const props: CustomerListPageProps = {
 };
 
 const CustomerListPage = props => (
-  <ComponentWithMockContext>
+  <MockedUserProvider>
     <CustomerListPageComponent {...props} />
-  </ComponentWithMockContext>
+  </MockedUserProvider>
 );
 
 storiesOf("Views / Customers / Customer list", module)

--- a/src/storybook/stories/customers/MockedUserProvider.tsx
+++ b/src/storybook/stories/customers/MockedUserProvider.tsx
@@ -3,7 +3,7 @@ import { adminUserPermissions } from "@saleor/fixtures";
 import { User_userPermissions } from "@saleor/fragments/types/User";
 import * as React from "react";
 
-export const ComponentWithMockContext: React.FC<{
+export const MockedUserProvider: React.FC<{
   customPermissions?: User_userPermissions[];
 }> = ({ customPermissions, children }) => (
   <UserContext.Provider

--- a/src/storybook/stories/home/HomePage.tsx
+++ b/src/storybook/stories/home/HomePage.tsx
@@ -10,7 +10,7 @@ import HomePageComponent, {
 } from "../../../home/components/HomePage";
 import { shop as shopFixture } from "../../../home/fixtures";
 import Decorator from "../../Decorator";
-import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
+import { MockedUserProvider } from "../customers/MockedUserProvider";
 
 const shop = shopFixture(placeholderImage);
 
@@ -35,9 +35,9 @@ const HomePage = props => {
   const customPermissions = props?.customPermissions;
 
   return (
-    <ComponentWithMockContext customPermissions={customPermissions}>
+    <MockedUserProvider customPermissions={customPermissions}>
       <HomePageComponent {...props} />
-    </ComponentWithMockContext>
+    </MockedUserProvider>
   );
 };
 

--- a/src/storybook/stories/home/HomePage.tsx
+++ b/src/storybook/stories/home/HomePage.tsx
@@ -5,9 +5,12 @@ import { mapEdgesToItems } from "@saleor/utils/maps";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
-import HomePage, { HomePageProps } from "../../../home/components/HomePage";
+import HomePageComponent, {
+  HomePageProps
+} from "../../../home/components/HomePage";
 import { shop as shopFixture } from "../../../home/fixtures";
 import Decorator from "../../Decorator";
+import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
 
 const shop = shopFixture(placeholderImage);
 
@@ -25,8 +28,17 @@ const homePageProps: Omit<HomePageProps, "classes"> = {
   productsOutOfStock: shop.productsOutOfStock.totalCount,
   sales: shop.salesToday.gross,
   topProducts: mapEdgesToItems(shop.productTopToday),
-  userName: "admin@example.com",
-  userPermissions: adminUserPermissions
+  userName: "admin@example.com"
+};
+
+const HomePage = props => {
+  const customPermissions = props?.customPermissions;
+
+  return (
+    <ComponentWithMockContext customPermissions={customPermissions}>
+      <HomePageComponent {...props} />
+    </ComponentWithMockContext>
+  );
 };
 
 storiesOf("Views / HomePage", module)
@@ -49,12 +61,12 @@ storiesOf("Views / HomePage", module)
     <HomePage {...homePageProps} topProducts={[]} activities={[]} />
   ))
   .add("no permissions", () => (
-    <HomePage {...homePageProps} userPermissions={[]} />
+    <HomePage {...homePageProps} customPermissions={[]} />
   ))
   .add("product permissions", () => (
     <HomePage
       {...homePageProps}
-      userPermissions={adminUserPermissions.filter(
+      customPermissions={adminUserPermissions.filter(
         perm => perm.code === PermissionEnum.MANAGE_PRODUCTS
       )}
     />
@@ -62,7 +74,7 @@ storiesOf("Views / HomePage", module)
   .add("order permissions", () => (
     <HomePage
       {...homePageProps}
-      userPermissions={adminUserPermissions.filter(
+      customPermissions={adminUserPermissions.filter(
         perm => perm.code === PermissionEnum.MANAGE_ORDERS
       )}
     />

--- a/src/storybook/stories/orders/OrderCustomer.tsx
+++ b/src/storybook/stories/orders/OrderCustomer.tsx
@@ -6,7 +6,7 @@ import OrderCustomerComponent, {
 } from "../../../orders/components/OrderCustomer";
 import { clients, order as orderFixture } from "../../../orders/fixtures";
 import Decorator from "../../Decorator";
-import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
+import { MockedUserProvider } from "../customers/MockedUserProvider";
 
 const order = orderFixture("");
 
@@ -26,9 +26,9 @@ const OrderCustomer = props => {
   const customPermissions = props?.customPermissions;
 
   return (
-    <ComponentWithMockContext customPermissions={customPermissions}>
+    <MockedUserProvider customPermissions={customPermissions}>
       <OrderCustomerComponent {...props} />
-    </ComponentWithMockContext>
+    </MockedUserProvider>
   );
 };
 

--- a/src/storybook/stories/orders/OrderCustomer.tsx
+++ b/src/storybook/stories/orders/OrderCustomer.tsx
@@ -1,12 +1,12 @@
-import { adminUserPermissions } from "@saleor/fixtures";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
-import OrderCustomer, {
+import OrderCustomerComponent, {
   OrderCustomerProps
 } from "../../../orders/components/OrderCustomer";
 import { clients, order as orderFixture } from "../../../orders/fixtures";
 import Decorator from "../../Decorator";
+import { ComponentWithMockContext } from "../customers/ComponentWithMockContext";
 
 const order = orderFixture("");
 
@@ -19,8 +19,17 @@ const props: Omit<OrderCustomerProps, "classes"> = {
   onProfileView: () => undefined,
   onShippingAddressEdit: undefined,
   order,
-  userPermissions: adminUserPermissions,
   users: clients
+};
+
+const OrderCustomer = props => {
+  const customPermissions = props?.customPermissions;
+
+  return (
+    <ComponentWithMockContext customPermissions={customPermissions}>
+      <OrderCustomerComponent {...props} />
+    </ComponentWithMockContext>
+  );
 };
 
 storiesOf("Orders / OrderCustomer", module)
@@ -40,5 +49,5 @@ storiesOf("Orders / OrderCustomer", module)
     <OrderCustomer {...props} canEditAddresses={true} canEditCustomer={true} />
   ))
   .add("no user permissions", () => (
-    <OrderCustomer {...props} userPermissions={[]} />
+    <OrderCustomer {...props} customPermissions={[]} />
   ));

--- a/src/storybook/stories/orders/OrderDetailsPage.tsx
+++ b/src/storybook/stories/orders/OrderDetailsPage.tsx
@@ -1,5 +1,4 @@
 import placeholderImage from "@assets/images/placeholder60x60.png";
-import { adminUserPermissions } from "@saleor/fixtures";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -43,8 +42,7 @@ const props: Omit<OrderDetailsPageProps, "classes"> = {
   onSubmit: () => undefined,
   order,
   shop: shopFixture,
-  saveButtonBarState: "default",
-  userPermissions: adminUserPermissions
+  saveButtonBarState: "default"
 };
 
 storiesOf("Views / Orders / Order details", module)

--- a/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
@@ -1,13 +1,14 @@
 import placeholderImage from "@assets/images/placeholder60x60.png";
-import { adminUserPermissions, fetchMoreProps } from "@saleor/fixtures";
+import { fetchMoreProps } from "@saleor/fixtures";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
-import OrderDraftPage, {
+import OrderDraftPageComponent, {
   OrderDraftPageProps
 } from "../../../../orders/components/OrderDraftPage";
 import { clients, draftOrder } from "../../../../orders/fixtures";
 import Decorator from "../../../Decorator";
+import { ComponentWithMockContext } from "../../customers/ComponentWithMockContext";
 import { getDiscountsProvidersWrapper } from "./utils";
 
 const order = draftOrder(placeholderImage);
@@ -31,12 +32,21 @@ const props: Omit<OrderDraftPageProps, "classes"> = {
   onShippingMethodEdit: undefined,
   order,
   saveButtonBarState: "default",
-  userPermissions: adminUserPermissions,
   users: clients,
   usersLoading: false
 };
 
 const DiscountsDecorator = getDiscountsProvidersWrapper(order);
+
+const OrderDraftPage = props => {
+  const customPermissions = props?.customPermissions;
+
+  return (
+    <ComponentWithMockContext customPermissions={customPermissions}>
+      <OrderDraftPageComponent {...props} />
+    </ComponentWithMockContext>
+  );
+};
 
 storiesOf("Views / Orders / Order draft", module)
   .addDecorator(Decorator)
@@ -49,5 +59,5 @@ storiesOf("Views / Orders / Order draft", module)
     <OrderDraftPage {...props} order={{ ...order, lines: [] }} />
   ))
   .add("no user permissions", () => (
-    <OrderDraftPage {...props} userPermissions={[]} />
+    <OrderDraftPage {...props} customPermissions={[]} />
   ));

--- a/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
@@ -8,7 +8,7 @@ import OrderDraftPageComponent, {
 } from "../../../../orders/components/OrderDraftPage";
 import { clients, draftOrder } from "../../../../orders/fixtures";
 import Decorator from "../../../Decorator";
-import { ComponentWithMockContext } from "../../customers/ComponentWithMockContext";
+import { MockedUserProvider } from "../../customers/MockedUserProvider";
 import { getDiscountsProvidersWrapper } from "./utils";
 
 const order = draftOrder(placeholderImage);
@@ -42,9 +42,9 @@ const OrderDraftPage = props => {
   const customPermissions = props?.customPermissions;
 
   return (
-    <ComponentWithMockContext customPermissions={customPermissions}>
+    <MockedUserProvider customPermissions={customPermissions}>
       <OrderDraftPageComponent {...props} />
-    </ComponentWithMockContext>
+    </MockedUserProvider>
   );
 };
 


### PR DESCRIPTION
I want to merge this change because it:

- Restricts Order queries in Customer queries based on permissions
- Hides Order section in customer view if user doesn't have permissions
- Hides Gift card card in customer view if user doesn't have permissions
- Hides filtering based on orders if user doesn't have permissions
- Hides order count column in customer list if user doesn't have permissions
- Adds mock user context to Customer stories
- Changes stories to pass custom permissions to mock context

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->
https://github.com/saleor/saleor/pull/9128

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-5784-fix-leaking-order-data-for-unauthorized-user-3-1.api.saleor.rocks/graphql/
