### PR TITLE
Fix translation link color

### DIFF
--- a/src/translations/components/TranslationFields/TranslationFields.tsx
+++ b/src/translations/components/TranslationFields/TranslationFields.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(
     },
     content: {
       "& a": {
-        color: theme.palette.secondary.light
+        color: theme.palette.textHighlighted.active
       },
       "& blockquote": {
         borderLeft: `2px solid ${theme.palette.divider}`,


### PR DESCRIPTION
I want to merge this change because it fixes the translation colour link

Before:
![image](https://user-images.githubusercontent.com/13994677/154944452-50cacc88-5cf4-4731-8da4-f59fabc99b53.png)
![image](https://user-images.githubusercontent.com/13994677/154944473-3310e759-8940-4a49-a8ad-cd671c155bdc.png)


After:
![image](https://user-images.githubusercontent.com/13994677/154944378-0eb0dd50-2cb9-4e80-9943-e49d2bd6d57a.png)


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
