### PR TITLE
Fix typo: "infotmation" → "information"

### DIFF
--- a/locale/ar.json
+++ b/locale/ar.json
@@ -2274,7 +2274,7 @@
     "string": "ملاحظة"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/az.json
+++ b/locale/az.json
@@ -2274,7 +2274,7 @@
     "string": "Qeyd"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/bg.json
+++ b/locale/bg.json
@@ -2274,7 +2274,7 @@
     "string": "Бележка"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/bn.json
+++ b/locale/bn.json
@@ -2274,7 +2274,7 @@
     "string": "Note"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/ca.json
+++ b/locale/ca.json
@@ -2274,7 +2274,7 @@
     "string": "Nota"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/cs.json
+++ b/locale/cs.json
@@ -2274,7 +2274,7 @@
     "string": "Poznámka"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/da.json
+++ b/locale/da.json
@@ -2274,7 +2274,7 @@
     "string": "Note"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/de.json
+++ b/locale/de.json
@@ -2274,7 +2274,7 @@
     "string": "Notiz"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2728,7 +2728,7 @@
     "string": "Note"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/el.json
+++ b/locale/el.json
@@ -2274,7 +2274,7 @@
     "string": "Σημείωση"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/es_CO.json
+++ b/locale/es_CO.json
@@ -2274,7 +2274,7 @@
     "string": "nota"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/et.json
+++ b/locale/et.json
@@ -2274,7 +2274,7 @@
     "string": "Märkus"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/fa.json
+++ b/locale/fa.json
@@ -2274,7 +2274,7 @@
     "string": "یادداشت"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/hi.json
+++ b/locale/hi.json
@@ -2274,7 +2274,7 @@
     "string": "टिप्पणी"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/hu.json
+++ b/locale/hu.json
@@ -2274,7 +2274,7 @@
     "string": "Megjegyzés"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/hy.json
+++ b/locale/hy.json
@@ -2274,7 +2274,7 @@
     "string": "Նշում"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/id.json
+++ b/locale/id.json
@@ -2274,7 +2274,7 @@
     "string": "Catatan"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/is.json
+++ b/locale/is.json
@@ -2274,7 +2274,7 @@
     "string": "Athugasemd"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -2274,7 +2274,7 @@
     "string": "備考"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -2274,7 +2274,7 @@
     "string": "노트"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/mn.json
+++ b/locale/mn.json
@@ -2274,7 +2274,7 @@
     "string": "Тэмдэглэл"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -2274,7 +2274,7 @@
     "string": "Aantekening"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -2274,7 +2274,7 @@
     "string": "Nota"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/pt_BR.json
+++ b/locale/pt_BR.json
@@ -2274,7 +2274,7 @@
     "string": "Nota"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/ro.json
+++ b/locale/ro.json
@@ -2274,7 +2274,7 @@
     "string": "Notă"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/sk.json
+++ b/locale/sk.json
@@ -2274,7 +2274,7 @@
     "string": "Poznámka"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/sl.json
+++ b/locale/sl.json
@@ -2274,7 +2274,7 @@
     "string": "Opomba"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/sq.json
+++ b/locale/sq.json
@@ -2274,7 +2274,7 @@
     "string": "Shenime"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -2274,7 +2274,7 @@
     "string": "Notering"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/th.json
+++ b/locale/th.json
@@ -2274,7 +2274,7 @@
     "string": "Note"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -2274,7 +2274,7 @@
     "string": "Not"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/zh-Hans.json
+++ b/locale/zh-Hans.json
@@ -2274,7 +2274,7 @@
     "string": "备注"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/locale/zh-Hant.json
+++ b/locale/zh-Hant.json
@@ -2274,7 +2274,7 @@
     "string": "Note"
   },
   "src_dot_customers_dot_components_dot_CustomerCreateNote_dot_932844352": {
-    "string": "Enter any extra infotmation regarding this customer."
+    "string": "Enter any extra information regarding this customer."
   },
   "src_dot_customers_dot_components_dot_CustomerCreatePage_dot_4025686004": {
     "context": "page header",

--- a/src/customers/components/CustomerCreateNote/CustomerCreateNote.tsx
+++ b/src/customers/components/CustomerCreateNote/CustomerCreateNote.tsx
@@ -36,7 +36,7 @@ const CustomerCreateNote: React.FC<CustomerCreateNoteProps> = ({
       />
       <CardContent>
         <Typography>
-          <FormattedMessage defaultMessage="Enter any extra infotmation regarding this customer." />
+          <FormattedMessage defaultMessage="Enter any extra information regarding this customer." />
         </Typography>
         <FormSpacer />
         <TextField


### PR DESCRIPTION
There is a typo I noticed when creating a new customer:
![image](https://user-images.githubusercontent.com/525780/155983759-b0b7634b-1057-4687-85f7-40ae45e5ea3c.png)

**PR intended to be tested with API branch:** latest HEAD

### Screenshots

See above

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
