### PR TITLE
Fix empty rich text editor not loading

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 import * as fixtures from "./fixtures.json";
 import { RichTextEditorProps } from "./RichTextEditor";
+import RichTextEditorContent from "./RichTextEditorContent";
 
 export const data: OutputData = fixtures.richTextEditor;
 
@@ -25,4 +26,5 @@ storiesOf("Generics / Rich text editor", module)
   .addDecorator(Decorator)
   .add("default", () => <RichTextEditor {...props} />)
   .add("disabled", () => <RichTextEditor {...props} disabled={true} />)
-  .add("error", () => <RichTextEditor {...props} error={true} />);
+  .add("error", () => <RichTextEditor {...props} error={true} />)
+  .add("static", () => <RichTextEditorContent {...props} />);

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -33,12 +33,11 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   const editor = React.useRef<EditorJS>();
   const editorContainer = React.useRef<HTMLDivElement>();
   const togglePromiseQueue = React.useRef(PromiseQueue()); // used to await subsequent toggle invocations
-  const initialMount = React.useRef(true);
 
   React.useEffect(
     () => {
       if (data !== undefined && !editor.current) {
-        const editorjs = new EditorJS({
+        editor.current = new EditorJS({
           data,
           holder: editorContainer.current,
           logLevel: "ERROR" as LogLevels,
@@ -51,13 +50,10 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
             // const undo = new Undo({ editor });
             // undo.initialize(data);
 
-            editor.current = editorjs;
-
             if (onReady) {
               onReady();
             }
           },
-          readOnly: disabled,
           tools
         });
       }
@@ -96,11 +92,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       }
     };
 
-    if (!initialMount.current) {
-      toggle();
-    } else {
-      initialMount.current = false;
-    }
+    toggle();
   }, [disabled]);
 
   return (

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { RichTextEditorContentProps, tools } from "./RichTextEditorContent";
 import useStyles from "./styles";
+import { clean } from "./utils";
 
 export type RichTextEditorChange = (data: OutputData) => void;
 export interface RichTextEditorProps extends RichTextEditorContentProps {
@@ -59,9 +60,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
       }
 
       return () => {
-        if (editor.current) {
-          editor.current.destroy();
-        }
+        clean(editor.current);
         editor.current = null;
       };
     },

--- a/src/components/RichTextEditor/RichTextEditorContent.tsx
+++ b/src/components/RichTextEditor/RichTextEditorContent.tsx
@@ -15,6 +15,7 @@ import createGenericInlineTool from "editorjs-inline-tool";
 import React from "react";
 
 import useStyles from "./styles";
+import { clean } from "./utils";
 
 export interface RichTextEditorContentProps {
   className?: string;
@@ -85,9 +86,7 @@ const RichTextEditorContent: React.FC<RichTextEditorContentProps> = ({
       }
 
       return () => {
-        if (editor.current) {
-          editor.current.destroy();
-        }
+        clean(editor.current);
         editor.current = null;
       };
     },

--- a/src/components/RichTextEditor/RichTextEditorContent.tsx
+++ b/src/components/RichTextEditor/RichTextEditorContent.tsx
@@ -97,7 +97,7 @@ const RichTextEditorContent: React.FC<RichTextEditorContentProps> = ({
 
   return (
     <div
-      className={classNames(classes.editor, className)}
+      className={classNames(classes.editor, classes.rootStatic, className)}
       ref={editorContainer}
     />
   );

--- a/src/components/RichTextEditor/styles.ts
+++ b/src/components/RichTextEditor/styles.ts
@@ -108,6 +108,9 @@ const useStyles = makeStyles(
       },
       rootError: {
         borderColor: theme.palette.error.main
+      },
+      rootStatic: {
+        fontSize: theme.typography.body1.fontSize
       }
     };
   },

--- a/src/components/RichTextEditor/styles.ts
+++ b/src/components/RichTextEditor/styles.ts
@@ -102,7 +102,9 @@ const useStyles = makeStyles(
         boxShadow: `inset 0px 0px 0 2px ${theme.palette.primary.main}`
       },
       rootDisabled: {
-        ...theme.overrides.MuiOutlinedInput.root["&$disabled"]["& fieldset"]
+        ...theme.overrides.MuiOutlinedInput.root["&$disabled"]["& fieldset"],
+        background: theme.palette.background.default,
+        color: theme.palette.saleor.main[4]
       },
       rootError: {
         borderColor: theme.palette.error.main

--- a/src/components/RichTextEditor/utils.ts
+++ b/src/components/RichTextEditor/utils.ts
@@ -1,0 +1,9 @@
+import EditorJS from "@editorjs/editorjs";
+
+export async function clean(editor: EditorJS) {
+  if (editor) {
+    // Prevents race conditions
+    await editor.isReady;
+    editor.destroy();
+  }
+}

--- a/src/utils/richText/useRichText.ts
+++ b/src/utils/richText/useRichText.ts
@@ -3,6 +3,10 @@ import { RichTextEditorChange } from "@saleor/components/RichTextEditor";
 import isEqual from "lodash/isEqual";
 import { MutableRefObject, useEffect, useRef, useState } from "react";
 
+const emptyContent: OutputData = {
+  blocks: []
+};
+
 function useRichText(opts: {
   initial: string | null;
   triggerChange: () => void;
@@ -12,7 +16,7 @@ function useRichText(opts: {
 
   useEffect(() => {
     if (opts.initial === null) {
-      data.current = { blocks: [] };
+      data.current = emptyContent;
       setLoaded(true);
       return;
     }


### PR DESCRIPTION
I want to merge this change because it fixes bug that caused editor to not initialize when `data` is empty.

**PR intended to be tested with API branch:** main

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
