### PR TITLE
Prevent navigation from variant page if form is dirty

### DIFF
--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -11,6 +11,7 @@ export interface ExitFormDialogData {
   setEnableExitDialog: (value: boolean) => void;
   shouldBlockNavigation: () => boolean;
   setIsSubmitting: (value: boolean) => void;
+  submit: () => SubmitPromise;
 }
 
 export type SubmitFn = (dataOrEvent?: any) => SubmitPromise<any[]>;
@@ -35,7 +36,8 @@ export const ExitFormDialogContext = React.createContext<ExitFormDialogData>({
   setEnableExitDialog: () => undefined,
   setExitDialogSubmitRef: () => undefined,
   shouldBlockNavigation: () => false,
-  setIsSubmitting: () => undefined
+  setIsSubmitting: () => undefined,
+  submit: () => Promise.resolve([])
 });
 
 const defaultValues = {
@@ -49,7 +51,7 @@ const defaultValues = {
   formsData: {}
 };
 
-const ExitFormDialogProvider = ({ children }) => {
+export function useExitFormDialogProvider() {
   const history = useHistory();
   const { history: routerHistory } = useRouter();
 
@@ -207,7 +209,6 @@ const ExitFormDialogProvider = ({ children }) => {
     const errors = await Promise.all(
       getDirtyFormsSubmitFn().map(submitFn => submitFn())
     );
-
     const isError = errors.flat().some(errors => errors);
 
     setIsSubmitting(false);
@@ -237,8 +238,27 @@ const ExitFormDialogProvider = ({ children }) => {
     shouldBlockNavigation,
     setEnableExitDialog,
     setExitDialogSubmitRef: setSubmitRef,
-    setIsSubmitting
+    setIsSubmitting,
+    submit: handleSubmit
   };
+
+  return {
+    providerData,
+    showDialog,
+    handleSubmit,
+    handleLeave,
+    handleClose
+  };
+}
+
+const ExitFormDialogProvider = ({ children }) => {
+  const {
+    handleClose,
+    handleLeave,
+    handleSubmit,
+    providerData,
+    showDialog
+  } = useExitFormDialogProvider();
 
   return (
     <ExitFormDialogContext.Provider value={providerData}>

--- a/src/components/Form/useExitFormDialog.test.tsx
+++ b/src/components/Form/useExitFormDialog.test.tsx
@@ -1,0 +1,153 @@
+import useForm, { SubmitPromise } from "@saleor/hooks/useForm";
+import { act, renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { useHistory } from "react-router";
+import { MemoryRouter } from "react-router-dom";
+
+import {
+  ExitFormDialogContext,
+  useExitFormDialogProvider
+} from "./ExitFormDialogProvider";
+import { useExitFormDialog } from "./useExitFormDialog";
+
+jest.mock("../../hooks/useNotifier", () => undefined);
+
+const MockExitFormDialogProvider = ({ children }) => {
+  const { providerData } = useExitFormDialogProvider();
+  return (
+    <ExitFormDialogContext.Provider value={providerData}>
+      {children}
+    </ExitFormDialogContext.Provider>
+  );
+};
+
+const initialPath = "/";
+const targetPath = "/path";
+
+const setup = (submitFn: () => SubmitPromise, confirmLeave = true) =>
+  renderHook(
+    () => {
+      const form = useForm({ field: "" }, submitFn, { confirmLeave });
+      const exit = useExitFormDialog();
+      const history = useHistory();
+
+      return {
+        form,
+        exit,
+        history
+      };
+    },
+    {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <MockExitFormDialogProvider>{children}</MockExitFormDialogProvider>
+        </MemoryRouter>
+      )
+    }
+  );
+
+describe("useExitFormDialog", () => {
+  it("blocks navigation after leaving dirty form", async () => {
+    // Given
+    const submitFn = jest.fn(() => Promise.resolve([]));
+    const { result } = setup(submitFn);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" }
+      });
+    });
+    act(() => {
+      result.current.history.push(targetPath);
+    });
+
+    // Then
+    expect(result.current.exit.shouldBlockNavigation()).toBe(true);
+    expect(result.current.history.location.pathname).toBe(initialPath);
+  });
+
+  it("allows navigation after leaving dirty form if no confirmation is needed", async () => {
+    // Given
+    const submitFn = jest.fn(() => Promise.resolve([]));
+    const { result } = setup(submitFn, false);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" }
+      });
+    });
+    act(() => {
+      result.current.history.push(targetPath);
+    });
+
+    // Then
+    expect(result.current.exit.shouldBlockNavigation()).toBe(false);
+    expect(result.current.history.location.pathname).toBe(targetPath);
+  });
+
+  it("blocks navigation if an error occured", async () => {
+    // Given
+    const submitFn = jest.fn(() =>
+      Promise.resolve([{ field: "field", code: "code" }])
+    );
+    const { result } = setup(submitFn);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" }
+      });
+      result.current.history.push(targetPath);
+    });
+    await act(() => result.current.exit.submit());
+
+    // Then
+    expect(result.current.history.location.pathname).toBe(initialPath);
+  });
+
+  it("allows navigation if an error occured, but confirmation is not needed", async () => {
+    // Given
+    const submitFn = jest.fn(() =>
+      Promise.resolve([{ field: "field", code: "code" }])
+    );
+    const { result } = setup(submitFn, false);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" }
+      });
+      result.current.history.push(targetPath);
+    });
+    await act(() => result.current.exit.submit());
+
+    // Then
+    expect(result.current.history.location.pathname).toBe(targetPath);
+  });
+
+  it("blocks navigation if an error occured and user tries to leave anyway", async () => {
+    // Given
+    const submitFn = jest.fn(() =>
+      Promise.resolve([{ field: "field", code: "code" }])
+    );
+    const { result } = setup(submitFn);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" }
+      });
+      result.current.history.push(targetPath);
+    });
+    await act(() => result.current.exit.submit());
+    act(() => {
+      result.current.history.push(targetPath);
+    });
+
+    // Then
+    expect(result.current.exit.shouldBlockNavigation()).toBe(true);
+    expect(result.current.history.location.pathname).toBe(initialPath);
+  });
+});

--- a/src/components/Form/useExitFormDialog.ts
+++ b/src/components/Form/useExitFormDialog.ts
@@ -8,10 +8,7 @@ import {
 } from "./ExitFormDialogProvider";
 
 export interface UseExitFormDialogResult
-  extends Pick<
-      ExitFormDialogData,
-      "setEnableExitDialog" | "shouldBlockNavigation" | "setIsSubmitting"
-    >,
+  extends Omit<ExitFormDialogData, "setIsDirty" | "setExitDialogSubmitRef">,
     WithFormId {
   setIsDirty: (isDirty: boolean) => void;
   setExitDialogSubmitRef: (submitFn: SubmitFn) => void;

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -190,6 +190,8 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
         })
       );
     }
+
+    return [];
   };
 
   const variant = data?.productVariant;
@@ -385,6 +387,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
         onSubmit={async data => {
           const errors = await handleSubmit(data);
           const channelErrors = await handleSubmitChannels(data, variant);
+
           return [...errors, ...channelErrors];
         }}
         onWarehouseConfigure={() => navigate(warehouseAddPath)}


### PR DESCRIPTION
I want to merge this change because it:
- adds basic tests for exiting form
- fixes bug causing navigation to stop working after editing variant attribute 

**PR intended to be tested with API branch:** main

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
