### PR TITLE
Fix mutations without onCompleted

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -17,34 +17,28 @@ export const displayDemoMessage = (
   });
 };
 
-const getAllErrorMessages = (error: ApolloError) => {
-  const errorMessages = [];
-
-  if (error.graphQLErrors.length) {
-    error.graphQLErrors.forEach(err => {
-      errorMessages.push(err.message);
-    });
-  }
-
+const getNetworkErrors = (error: ApolloError): string[] => {
   const networkErrors = error.networkError as ServerErrorWithName;
 
-  if (error.networkError) {
+  if (networkErrors) {
     // Apparently network errors can be an object or an array
     if (Array.isArray(networkErrors.result)) {
       networkErrors.result.forEach(result => {
         if (result.errors) {
-          result.errors.forEach(({ message }) => {
-            errorMessages.push(message);
-          });
+          return result.errors.map(({ message }) => message);
         }
       });
-    } else {
-      errorMessages.push(networkErrors.result.errors.message);
     }
+    return networkErrors.result.errors.message;
   }
 
-  return errorMessages;
+  return [];
 };
+
+const getAllErrorMessages = (error: ApolloError) => [
+  ...(error.graphQLErrors?.map(err => err.message) || []),
+  ...getNetworkErrors(error)
+];
 
 export const showAllErrors = ({
   notify,

--- a/src/hooks/makeMutation.ts
+++ b/src/hooks/makeMutation.ts
@@ -53,7 +53,9 @@ export function useMutation<TData, TVariables>(
         notify
       });
 
-      onCompleted(data);
+      if (onCompleted) {
+        onCompleted(data);
+      }
     },
     onError: (err: ApolloError) => {
       if (err.graphQLErrors) {


### PR DESCRIPTION
I want to merge this change because it fixes bug causing mutations without `onCompleted` prop to throw error.

**PR intended to be tested with API branch:** main

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
