### PR TITLE
Fix invisible edit button in media tiles hover state

### DIFF
--- a/src/components/MediaTile/MediaTile.tsx
+++ b/src/components/MediaTile/MediaTile.tsx
@@ -1,6 +1,5 @@
 import { CircularProgress } from "@material-ui/core";
-import EditIcon from "@material-ui/icons/Edit";
-import { DeleteIcon, IconButton, makeStyles } from "@saleor/macaw-ui";
+import { DeleteIcon, EditIcon, makeStyles } from "@saleor/macaw-ui";
 import classNames from "classnames";
 import React from "react";
 
@@ -28,7 +27,8 @@ const useStyles = makeStyles(
       width: 148
     },
     mediaOverlay: {
-      background: "rgba(0, 0, 0, 0.6)",
+      background: theme.palette.background.default,
+      opacity: 0.8,
       cursor: "move",
       display: "none",
       height: 148,
@@ -47,6 +47,18 @@ const useStyles = makeStyles(
     mediaOverlayToolbar: {
       display: "flex",
       justifyContent: "flex-end"
+    },
+    controlButton: {
+      color: theme.palette.saleor.main[1],
+      cursor: "pointer",
+      margin: theme.spacing(2),
+
+      "&:hover": {
+        color: theme.palette.saleor.active[1]
+      },
+      "&:first-child": {
+        marginRight: 0
+      }
     }
   }),
   { name: "MediaTile" }
@@ -84,14 +96,14 @@ const MediaTile: React.FC<MediaTileProps> = props => {
         ) : (
           <div className={classes.mediaOverlayToolbar}>
             {onEdit && (
-              <IconButton variant="secondary" color="primary" onClick={onEdit}>
+              <div className={classes.controlButton} onClick={onEdit}>
                 <EditIcon />
-              </IconButton>
+              </div>
             )}
             {onDelete && (
-              <IconButton color="primary" onClick={onDelete}>
+              <div className={classes.controlButton} onClick={onDelete}>
                 <DeleteIcon />
-              </IconButton>
+              </div>
             )}
           </div>
         )}

--- a/src/components/MediaTile/MediaTile.tsx
+++ b/src/components/MediaTile/MediaTile.tsx
@@ -50,8 +50,11 @@ const useStyles = makeStyles(
     },
     controlButton: {
       color: theme.palette.saleor.main[1],
+      backgroundColor: "transparent",
+      border: "none",
       cursor: "pointer",
       margin: theme.spacing(2),
+      padding: 0,
 
       "&:hover": {
         color: theme.palette.saleor.active[1]
@@ -96,14 +99,14 @@ const MediaTile: React.FC<MediaTileProps> = props => {
         ) : (
           <div className={classes.mediaOverlayToolbar}>
             {onEdit && (
-              <div className={classes.controlButton} onClick={onEdit}>
+              <button className={classes.controlButton} onClick={onEdit}>
                 <EditIcon />
-              </div>
+              </button>
             )}
             {onDelete && (
-              <div className={classes.controlButton} onClick={onDelete}>
+              <button className={classes.controlButton} onClick={onDelete}>
                 <DeleteIcon />
-              </div>
+              </button>
             )}
           </div>
         )}


### PR DESCRIPTION
I want to merge this change because it fixes a problem with invisible edit button in media tiles.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** 3.1
### Screenshots

Before:
![image](https://user-images.githubusercontent.com/41952692/157751688-8ccb8661-4a92-4a2c-94dd-a96009ee780d.png)

After:
![image](https://user-images.githubusercontent.com/41952692/157751518-713d08be-74ff-4850-8a1d-ac6cd1bcf16d.png)
![image](https://user-images.githubusercontent.com/41952692/157751116-f7d88a2f-475a-4e94-9263-49e43cadccb0.png)
![image](https://user-images.githubusercontent.com/41952692/157751255-1c7ea5ce-c438-457b-a9fe-18c5262be4fc.png)
![image](https://user-images.githubusercontent.com/41952692/157751433-ff1aca69-166b-4202-a5ef-507ab9297792.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
