### PR TITLE
Fetch only published products in draft order

### DIFF
--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -12986,11 +12986,11 @@ export type SearchGiftCardTagsQueryHookResult = ReturnType<typeof useSearchGiftC
 export type SearchGiftCardTagsLazyQueryHookResult = ReturnType<typeof useSearchGiftCardTagsLazyQuery>;
 export type SearchGiftCardTagsQueryResult = Apollo.QueryResult<Types.SearchGiftCardTagsQuery, Types.SearchGiftCardTagsQueryVariables>;
 export const SearchOrderVariantDocument = gql`
-    query SearchOrderVariant($channel: String!, $first: Int!, $query: String!, $after: String, $address: AddressInput) {
+    query SearchOrderVariant($channel: String!, $first: Int!, $query: String!, $after: String, $address: AddressInput, $isPublished: Boolean, $stockAvailability: StockAvailability) {
   search: products(
     first: $first
     after: $after
-    filter: {search: $query}
+    filter: {search: $query, isPublished: $isPublished, stockAvailability: $stockAvailability}
     channel: $channel
   ) {
     edges {
@@ -13059,6 +13059,8 @@ export const SearchOrderVariantDocument = gql`
  *      query: // value for 'query'
  *      after: // value for 'after'
  *      address: // value for 'address'
+ *      isPublished: // value for 'isPublished'
+ *      stockAvailability: // value for 'stockAvailability'
  *   },
  * });
  */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -6868,6 +6868,8 @@ export type SearchOrderVariantQueryVariables = Exact<{
   query: Scalars['String'];
   after?: InputMaybe<Scalars['String']>;
   address?: InputMaybe<AddressInput>;
+  isPublished?: InputMaybe<Scalars['Boolean']>;
+  stockAvailability?: InputMaybe<StockAvailability>;
 }>;
 
 

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -4,6 +4,7 @@ import {
   OrderDetailsQuery,
   OrderDraftUpdateMutation,
   OrderDraftUpdateMutationVariables,
+  StockAvailability,
   useCustomerAddressesQuery
 } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -95,7 +96,9 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     variables: {
       ...DEFAULT_INITIAL_SEARCH_DATA,
       channel: order.channel.slug,
-      address: getVariantSearchAddress(order)
+      address: getVariantSearchAddress(order),
+      isPublished: true,
+      stockAvailability: StockAvailability.IN_STOCK
     }
   });
 

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -115,7 +115,10 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
     search: variantSearch,
     result: variantSearchOpts
   } = useOrderVariantSearch({
-    variables: { ...DEFAULT_INITIAL_SEARCH_DATA, channel: order.channel.slug }
+    variables: {
+      ...DEFAULT_INITIAL_SEARCH_DATA,
+      channel: order.channel.slug
+    }
   });
   const warehouses = useWarehouseListQuery({
     displayLoader: true,

--- a/src/searches/useOrderVariantSearch.ts
+++ b/src/searches/useOrderVariantSearch.ts
@@ -13,11 +13,17 @@ export const searchOrderVariant = gql`
     $query: String!
     $after: String
     $address: AddressInput
+    $isPublished: Boolean
+    $stockAvailability: StockAvailability
   ) {
     search: products(
       first: $first
       after: $after
-      filter: { search: $query }
+      filter: {
+        search: $query
+        isPublished: $isPublished
+        stockAvailability: $stockAvailability
+      }
       channel: $channel
     ) {
       edges {


### PR DESCRIPTION
I want to merge this change because it filters the products user can add to draft order. Only available (in stock) and published products will be visible in the list.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
