### PR TITLE
Change cost price placeholder

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6839,9 +6839,9 @@
     "context": "tabel column header",
     "string": "Selling Price"
   },
-  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_2051669917": {
+  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_2644882304": {
     "context": "tabel column header",
-    "string": "Cost Price"
+    "string": "Cost"
   },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_3211447524": {
     "context": "info text",

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -149,7 +149,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
               </TableCell>
               <TableCell className={classes.colType}>
                 <FormattedMessage
-                  defaultMessage="Cost Price"
+                  defaultMessage="Cost"
                   description="tabel column header"
                 />
               </TableCell>
@@ -206,7 +206,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                           className={classes.input}
                           error={!!costPriceError}
                           label={intl.formatMessage({
-                            defaultMessage: "Cost Price",
+                            defaultMessage: "Cost",
                             description: "tabel column header"
                           })}
                           name={`${listing.id}-channel-costPrice`}


### PR DESCRIPTION
I want to merge this change because it changes "cost price" label in inputs to "cost" which takes up less space and looks better.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
