### PR TITLE
Remove redundant confirmLeave on tracking number dialog

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2231,11 +2231,11 @@
   },
   "src_dot_components_dot_Form_dot_cancelButton": {
     "context": "ExitFormPrompt cancel button",
-    "string": "leave without saving"
+    "string": "Leave without saving"
   },
   "src_dot_components_dot_Form_dot_confirmButton": {
     "context": "ExitFormPrompt confirm button",
-    "string": "save & continue"
+    "string": "Save & continue"
   },
   "src_dot_components_dot_Form_dot_description": {
     "context": "ExitFormPrompt description",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2237,9 +2237,17 @@
     "context": "ExitFormPrompt confirm button",
     "string": "Save changes"
   },
+  "src_dot_components_dot_Form_dot_continueEditingButton": {
+    "context": "ExitFormPrompt continue editing button",
+    "string": "Continue editing"
+  },
   "src_dot_components_dot_Form_dot_title": {
     "context": "ExitFormPrompt title",
     "string": "Would you like to save changes?"
+  },
+  "src_dot_components_dot_Form_dot_unableToSaveTitle": {
+    "context": "ExitFormPrompt title",
+    "string": "You have unsaved changes"
   },
   "src_dot_components_dot_ImageUpload_dot_1731007575": {
     "context": "image upload",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2231,19 +2231,15 @@
   },
   "src_dot_components_dot_Form_dot_cancelButton": {
     "context": "ExitFormPrompt cancel button",
-    "string": "Leave without saving"
+    "string": "Discard changes"
   },
   "src_dot_components_dot_Form_dot_confirmButton": {
     "context": "ExitFormPrompt confirm button",
-    "string": "Save & continue"
-  },
-  "src_dot_components_dot_Form_dot_description": {
-    "context": "ExitFormPrompt description",
-    "string": "You have unsaved changes on this view. What would you like to do with them?"
+    "string": "Save changes"
   },
   "src_dot_components_dot_Form_dot_title": {
     "context": "ExitFormPrompt title",
-    "string": "Are you sure you want to leave?"
+    "string": "Would you like to save changes?"
   },
   "src_dot_components_dot_ImageUpload_dot_1731007575": {
     "context": "image upload",

--- a/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
+++ b/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
@@ -12,6 +12,7 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAppErrorMessage from "@saleor/utils/errors/app";
 import React from "react";
@@ -56,8 +57,13 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
   const permissionsError = getAppErrorMessage(formErrors.permissions, intl);
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ data, change, hasChanged, submit }) => (
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ data, change, hasChanged, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}
@@ -96,7 +102,7 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
             />
           </Grid>
           <Savebar
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
+++ b/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
@@ -12,7 +12,6 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAppErrorMessage from "@saleor/utils/errors/app";
 import React from "react";
@@ -61,7 +60,7 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ data, change, submit, saveDisabled }) => (
         <Container>

--- a/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
+++ b/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
@@ -63,7 +63,7 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
       onSubmit={onSubmit}
       isDisabled={opts => basicFormDisableConditions(opts, disabled)}
     >
-      {({ data, change, hasChanged, submit, saveDisabled }) => (
+      {({ data, change, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}

--- a/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
+++ b/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
@@ -62,7 +62,7 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, change, submit, saveDisabled }) => (
+      {({ data, change, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}
@@ -101,7 +101,7 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
             />
           </Grid>
           <Savebar
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -18,7 +18,6 @@ import {
   Button,
   ConfirmButtonTransitionState
 } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAppErrorMessage from "@saleor/utils/errors/app";
 import WebhooksList from "@saleor/webhooks/components/WebhooksList";
@@ -106,7 +105,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ data, change, submit, saveDisabled }) => (
         <Container>

--- a/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -108,7 +108,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
       onSubmit={onSubmit}
       isDisabled={opts => basicFormDisableConditions(opts, disabled)}
     >
-      {({ data, change, hasChanged, submit, saveDisabled }) => (
+      {({ data, change, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}

--- a/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   ConfirmButtonTransitionState
 } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAppErrorMessage from "@saleor/utils/errors/app";
 import WebhooksList from "@saleor/webhooks/components/WebhooksList";
@@ -101,8 +102,13 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ data, change, hasChanged, submit }) => (
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ data, change, hasChanged, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}
@@ -182,7 +188,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
             </div>
           </Grid>
           <Savebar
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -107,7 +107,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, change, submit, saveDisabled }) => (
+      {({ data, change, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.apps)}
@@ -187,7 +187,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
             </div>
           </Grid>
           <Savebar
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -166,7 +166,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
         change,
         set,
         data,
-        saveDisabled,
+        isSaveDisabled,
         submit,
         errors,
         setError,
@@ -244,7 +244,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
                 </div>
               </Grid>
               <Savebar
-                disabled={saveDisabled}
+                disabled={isSaveDisabled}
                 state={saveButtonBarState}
                 onCancel={onBack}
                 onSubmit={submit}

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -20,7 +20,7 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { maybe } from "@saleor/misc";
+import { basicFormDisableConditions, maybe } from "@saleor/misc";
 import { ListSettings, ReorderAction } from "@saleor/types";
 import { mapEdgesToItems, mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -156,12 +156,17 @@ const AttributePage: React.FC<AttributePageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={handleSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
       {({
         change,
         set,
         data,
-        hasChanged,
+        saveDisabled,
         submit,
         errors,
         setError,
@@ -239,7 +244,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
                 </div>
               </Grid>
               <Savebar
-                disabled={disabled || !hasChanged}
+                disabled={saveDisabled}
                 state={saveButtonBarState}
                 onCancel={onBack}
                 onSubmit={submit}

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -20,7 +20,7 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions, maybe } from "@saleor/misc";
+import { maybe } from "@saleor/misc";
 import { ListSettings, ReorderAction } from "@saleor/types";
 import { mapEdgesToItems, mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -160,7 +160,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={handleSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({
         change,

--- a/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
+++ b/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
@@ -32,7 +32,7 @@ export const CategoryCreatePage: React.FC<CategoryCreatePageProps> = ({
 
   return (
     <CategoryCreateForm onSubmit={onSubmit} disabled={disabled}>
-      {({ data, change, handlers, submit, saveDisabled }) => (
+      {({ data, change, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.categories)}
@@ -74,7 +74,7 @@ export const CategoryCreatePage: React.FC<CategoryCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
             />
           </div>
         </Container>

--- a/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
+++ b/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
@@ -31,8 +31,8 @@ export const CategoryCreatePage: React.FC<CategoryCreatePageProps> = ({
   const intl = useIntl();
 
   return (
-    <CategoryCreateForm onSubmit={onSubmit}>
-      {({ data, change, handlers, submit, hasChanged }) => (
+    <CategoryCreateForm onSubmit={onSubmit} disabled={disabled}>
+      {({ data, change, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.categories)}
@@ -74,7 +74,7 @@ export const CategoryCreatePage: React.FC<CategoryCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
             />
           </div>
         </Container>

--- a/src/categories/components/CategoryCreatePage/form.tsx
+++ b/src/categories/components/CategoryCreatePage/form.tsx
@@ -47,7 +47,7 @@ const initialData: CategoryCreateFormData = {
 
 function useCategoryCreateForm(
   onSubmit: (data: CategoryCreateData) => Promise<any[]>,
-  disabled?: boolean
+  disabled: boolean
 ): UseCategoryCreateFormResult {
   const {
     handleChange,

--- a/src/categories/components/CategoryCreatePage/form.tsx
+++ b/src/categories/components/CategoryCreatePage/form.tsx
@@ -33,6 +33,7 @@ export interface UseCategoryCreateFormResult
 export interface CategoryCreateFormProps {
   children: (props: UseCategoryCreateFormResult) => React.ReactNode;
   onSubmit: (data: CategoryCreateData) => Promise<any[]>;
+  disabled: boolean;
 }
 
 const initialData: CategoryCreateFormData = {
@@ -45,7 +46,8 @@ const initialData: CategoryCreateFormData = {
 };
 
 function useCategoryCreateForm(
-  onSubmit: (data: CategoryCreateData) => Promise<any[]>
+  onSubmit: (data: CategoryCreateData) => Promise<any[]>,
+  disabled?: boolean
 ): UseCategoryCreateFormResult {
   const {
     handleChange,
@@ -53,7 +55,8 @@ function useCategoryCreateForm(
     hasChanged,
     triggerChange,
     setChanged,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(initialData, undefined, { confirmLeave: true });
 
   const handleFormSubmit = useHandleFormSubmit({
@@ -87,6 +90,9 @@ function useCategoryCreateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const saveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data: getData(),
@@ -95,15 +101,17 @@ function useCategoryCreateForm(
       changeMetadata
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
 const CategoryCreateForm: React.FC<CategoryCreateFormProps> = ({
   children,
-  onSubmit
+  onSubmit,
+  disabled
 }) => {
-  const props = useCategoryCreateForm(onSubmit);
+  const props = useCategoryCreateForm(onSubmit, disabled);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/categories/components/CategoryCreatePage/form.tsx
+++ b/src/categories/components/CategoryCreatePage/form.tsx
@@ -90,8 +90,8 @@ function useCategoryCreateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = disabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -102,7 +102,7 @@ function useCategoryCreateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -97,7 +97,7 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, change, handlers, submit, saveDisabled }) => (
+      {({ data, change, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.categories)}
@@ -221,7 +221,7 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
             onDelete={onDelete}
             onSubmit={submit}
             state={saveButtonBarState}
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
           />
         </Container>
       )}

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -92,8 +92,12 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
   const intl = useIntl();
 
   return (
-    <CategoryUpdateForm category={category} onSubmit={onSubmit}>
-      {({ data, change, handlers, submit, hasChanged }) => (
+    <CategoryUpdateForm
+      category={category}
+      onSubmit={onSubmit}
+      disabled={disabled}
+    >
+      {({ data, change, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.categories)}
@@ -217,7 +221,7 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
             onDelete={onDelete}
             onSubmit={submit}
             state={saveButtonBarState}
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
           />
         </Container>
       )}

--- a/src/categories/components/CategoryUpdatePage/form.tsx
+++ b/src/categories/components/CategoryUpdatePage/form.tsx
@@ -38,6 +38,7 @@ export interface CategoryUpdateFormProps {
   children: (props: UseCategoryUpdateFormResult) => React.ReactNode;
   category: CategoryDetailsFragment;
   onSubmit: (data: CategoryUpdateData) => Promise<any[]>;
+  disabled: boolean;
 }
 
 const getInitialData = (category?: CategoryDetailsFragment) => ({
@@ -52,7 +53,8 @@ const getInitialData = (category?: CategoryDetailsFragment) => ({
 
 function useCategoryUpdateForm(
   category: CategoryDetailsFragment,
-  onSubmit: (data: CategoryUpdateData) => Promise<any[]>
+  onSubmit: (data: CategoryUpdateData) => Promise<any[]>,
+  disabled: boolean
 ): UseCategoryUpdateFormResult {
   const {
     handleChange,
@@ -60,7 +62,8 @@ function useCategoryUpdateForm(
     triggerChange,
     hasChanged,
     setChanged,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(getInitialData(category), undefined, { confirmLeave: true });
 
   const handleFormSubmit = useHandleFormSubmit({
@@ -101,6 +104,9 @@ function useCategoryUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const saveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data: getData(),
@@ -109,16 +115,18 @@ function useCategoryUpdateForm(
       changeMetadata
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
 const CategoryUpdateForm: React.FC<CategoryUpdateFormProps> = ({
   children,
   category,
-  onSubmit
+  onSubmit,
+  disabled
 }) => {
-  const props = useCategoryUpdateForm(category, onSubmit);
+  const props = useCategoryUpdateForm(category, onSubmit, disabled);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/categories/components/CategoryUpdatePage/form.tsx
+++ b/src/categories/components/CategoryUpdatePage/form.tsx
@@ -104,8 +104,8 @@ function useCategoryUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = disabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -116,7 +116,7 @@ function useCategoryUpdateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -1,6 +1,6 @@
 import ShippingZonesCard from "@saleor/channels/components/ShippingZonesCard/ShippingZonesCard";
 import CardSpacer from "@saleor/components/CardSpacer";
-import Form from "@saleor/components/Form";
+import Form, { FormDataWithOpts } from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import Savebar from "@saleor/components/Savebar";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
@@ -94,9 +94,25 @@ const ChannelDetailsPage = function<TErrors>({
         !shippingZonesToDisplay.some(({ id }) => id === searchedZoneId)
     );
 
+  const isDisabled = (data: FormDataWithOpts<FormData>) => {
+    const formDisabled =
+      !data.name ||
+      !data.slug ||
+      !data.currencyCode ||
+      !data.defaultCountry ||
+      !(data.name.trim().length > 0);
+
+    return disabled || formDisabled || !data.hasChanged;
+  };
+
   return (
-    <Form confirmLeave onSubmit={onSubmit} initial={initialData}>
-      {({ change, data, hasChanged, submit, set }) => {
+    <Form
+      confirmLeave
+      onSubmit={onSubmit}
+      initial={initialData}
+      isDisabled={isDisabled}
+    >
+      {({ change, data, submit, set, isSaveDisabled }) => {
         const handleCurrencyCodeSelect = createSingleAutocompleteSelectHandler(
           change,
           setSelectedCurrencyCode,
@@ -147,13 +163,6 @@ const ChannelDetailsPage = function<TErrors>({
           );
         };
 
-        const formDisabled =
-          !data.name ||
-          !data.slug ||
-          !data.currencyCode ||
-          !data.defaultCountry ||
-          !(data.name.trim().length > 0);
-
         return (
           <>
             <Grid>
@@ -197,7 +206,7 @@ const ChannelDetailsPage = function<TErrors>({
               onSubmit={submit}
               onDelete={onDelete}
               state={saveButtonBarState}
-              disabled={disabled || formDisabled || !onSubmit || !hasChanged}
+              disabled={isSaveDisabled}
             />
           </>
         );

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -94,7 +94,7 @@ const ChannelDetailsPage = function<TErrors>({
         !shippingZonesToDisplay.some(({ id }) => id === searchedZoneId)
     );
 
-  const isDisabled = (data: FormDataWithOpts<FormData>) => {
+  const checkIfSaveIsDisabled = (data: FormDataWithOpts<FormData>) => {
     const formDisabled =
       !data.name ||
       !data.slug ||
@@ -110,7 +110,7 @@ const ChannelDetailsPage = function<TErrors>({
       confirmLeave
       onSubmit={onSubmit}
       initial={initialData}
-      isDisabled={isDisabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
     >
       {({ change, data, submit, set, isSaveDisabled }) => {
         const handleCurrencyCodeSelect = createSingleAutocompleteSelectHandler(

--- a/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -54,8 +54,9 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
       onSubmit={onSubmit}
       currentChannels={currentChannels}
       setChannels={onChannelsChange}
+      disabled={disabled}
     >
-      {({ change, data, handlers, hasChanged, submit }) => (
+      {({ change, data, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.collections)}
@@ -156,7 +157,7 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
           </Grid>
           <Savebar
             state={saveButtonBarState}
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
             onCancel={onBack}
             onSubmit={submit}
           />

--- a/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -56,7 +56,7 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
       setChannels={onChannelsChange}
       disabled={disabled}
     >
-      {({ change, data, handlers, submit, saveDisabled }) => (
+      {({ change, data, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.collections)}
@@ -157,7 +157,7 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
           </Grid>
           <Savebar
             state={saveButtonBarState}
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             onCancel={onBack}
             onSubmit={submit}
           />

--- a/src/collections/components/CollectionCreatePage/form.tsx
+++ b/src/collections/components/CollectionCreatePage/form.tsx
@@ -49,6 +49,7 @@ export interface CollectionCreateFormProps {
   setChannels: (data: ChannelCollectionData[]) => void;
   children: (props: UseCollectionCreateFormResult) => React.ReactNode;
   onSubmit: (data: CollectionCreateData) => SubmitPromise;
+  disabled: boolean;
 }
 
 const getInitialData = (
@@ -71,7 +72,8 @@ const getInitialData = (
 function useCollectionCreateForm(
   currentChannels: ChannelCollectionData[],
   setChannels: (data: ChannelCollectionData[]) => void,
-  onSubmit: (data: CollectionCreateData) => SubmitPromise
+  onSubmit: (data: CollectionCreateData) => SubmitPromise,
+  disabled: boolean
 ): UseCollectionCreateFormResult {
   const {
     handleChange,
@@ -79,7 +81,8 @@ function useCollectionCreateForm(
     triggerChange,
     setChanged,
     hasChanged,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(getInitialData(currentChannels), undefined, {
     confirmLeave: true,
     formId: COLLECTION_CREATE_FORM_ID
@@ -122,6 +125,9 @@ function useCollectionCreateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const saveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data: getData(),
@@ -131,7 +137,8 @@ function useCollectionCreateForm(
       changeMetadata
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -139,9 +146,15 @@ const CollectionCreateForm: React.FC<CollectionCreateFormProps> = ({
   currentChannels,
   setChannels,
   children,
-  onSubmit
+  onSubmit,
+  disabled
 }) => {
-  const props = useCollectionCreateForm(currentChannels, setChannels, onSubmit);
+  const props = useCollectionCreateForm(
+    currentChannels,
+    setChannels,
+    onSubmit,
+    disabled
+  );
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/collections/components/CollectionCreatePage/form.tsx
+++ b/src/collections/components/CollectionCreatePage/form.tsx
@@ -125,8 +125,8 @@ function useCollectionCreateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = disabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -138,7 +138,7 @@ function useCollectionCreateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -76,7 +76,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
       disabled={disabled}
       hasChannelChanged={hasChannelChanged}
     >
-      {({ change, data, handlers, submit, saveDisabled }) => (
+      {({ change, data, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.collections)}
@@ -152,7 +152,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
           </Grid>
           <Savebar
             state={saveButtonBarState}
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             onCancel={onBack}
             onDelete={onCollectionRemove}
             onSubmit={submit}

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -73,8 +73,10 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
       currentChannels={currentChannels}
       setChannels={onChannelsChange}
       onSubmit={onSubmit}
+      disabled={disabled}
+      hasChannelChanged={hasChannelChanged}
     >
-      {({ change, data, handlers, hasChanged, submit }) => (
+      {({ change, data, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.collections)}
@@ -150,7 +152,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
           </Grid>
           <Savebar
             state={saveButtonBarState}
-            disabled={disabled || (!hasChanged && !hasChannelChanged)}
+            disabled={saveDisabled}
             onCancel={onBack}
             onDelete={onCollectionRemove}
             onSubmit={submit}

--- a/src/collections/components/CollectionDetailsPage/form.tsx
+++ b/src/collections/components/CollectionDetailsPage/form.tsx
@@ -48,6 +48,8 @@ export interface CollectionUpdateFormProps {
   currentChannels: ChannelCollectionData[];
   setChannels: (data: ChannelCollectionData[]) => void;
   onSubmit: (data: CollectionUpdateData) => Promise<any[]>;
+  disabled: boolean;
+  hasChannelChanged: boolean;
 }
 
 const getInitialData = (
@@ -68,7 +70,9 @@ function useCollectionUpdateForm(
   collection: CollectionDetailsFragment,
   currentChannels: ChannelCollectionData[],
   setChannels: (data: ChannelCollectionData[]) => void,
-  onSubmit: (data: CollectionUpdateData) => Promise<any[]>
+  onSubmit: (data: CollectionUpdateData) => Promise<any[]>,
+  disabled: boolean,
+  hasChannelChanged: boolean
 ): UseCollectionUpdateFormResult {
   const {
     handleChange,
@@ -76,7 +80,8 @@ function useCollectionUpdateForm(
     triggerChange,
     setChanged,
     hasChanged,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(getInitialData(collection, currentChannels), undefined, {
     confirmLeave: true,
     formId: COLLECTION_DETAILS_FORM_ID
@@ -126,6 +131,9 @@ function useCollectionUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const saveDisabled = disabled || (!hasChanged && !hasChannelChanged);
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data: getData(),
@@ -135,7 +143,8 @@ function useCollectionUpdateForm(
       changeMetadata
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -144,13 +153,17 @@ const CollectionUpdateForm: React.FC<CollectionUpdateFormProps> = ({
   currentChannels,
   setChannels,
   children,
-  onSubmit
+  onSubmit,
+  disabled,
+  hasChannelChanged
 }) => {
   const props = useCollectionUpdateForm(
     collection,
     currentChannels,
     setChannels,
-    onSubmit
+    onSubmit,
+    disabled,
+    hasChannelChanged
   );
 
   return <form onSubmit={props.submit}>{children(props)}</form>;

--- a/src/collections/components/CollectionDetailsPage/form.tsx
+++ b/src/collections/components/CollectionDetailsPage/form.tsx
@@ -131,8 +131,8 @@ function useCollectionUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = disabled || (!hasChanged && !hasChannelChanged);
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || (!hasChanged && !hasChannelChanged);
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -144,7 +144,7 @@ function useCollectionUpdateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/components/DateTimeField.tsx
+++ b/src/components/DateTimeField.tsx
@@ -6,8 +6,8 @@ import {
   ProductErrorWithAttributesFragment
 } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
-import { DateTime, joinDateTime, splitDateTime } from "@saleor/misc";
-import React, { useEffect, useState } from "react";
+import { joinDateTime, splitDateTime } from "@saleor/misc";
+import React from "react";
 import { useIntl } from "react-intl";
 
 type DateTimeFieldProps = Omit<TextFieldProps, "label" | "error"> & {
@@ -21,14 +21,11 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
   error,
   name,
   onChange,
-  value: initialValue
+  value
 }) => {
   const intl = useIntl();
-  const [value, setValue] = useState<DateTime>(
-    initialValue ? splitDateTime(initialValue) : { date: "", time: "" }
-  );
 
-  useEffect(() => onChange(joinDateTime(value.date, value.time)), [value]);
+  const parsedValue = value ? splitDateTime(value) : { date: "", time: "" };
 
   return (
     <>
@@ -41,10 +38,11 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
         name={`${name}:date`}
         onChange={event => {
           const date = event.target.value;
-          setValue(value => ({ ...value, date }));
+
+          onChange(joinDateTime(date, parsedValue.time));
         }}
         type="date"
-        value={value.date}
+        value={parsedValue.date}
         InputLabelProps={{ shrink: true }}
       />
       <TextField
@@ -56,10 +54,11 @@ export const DateTimeField: React.FC<DateTimeFieldProps> = ({
         name={`${name}:time`}
         onChange={event => {
           const time = event.target.value;
-          setValue(value => ({ ...value, time }));
+
+          onChange(joinDateTime(parsedValue.date, time));
         }}
         type="time"
-        value={value.time}
+        value={parsedValue.time}
         InputLabelProps={{ shrink: true }}
       />
     </>

--- a/src/components/Form/ExitFormDialog.tsx
+++ b/src/components/Form/ExitFormDialog.tsx
@@ -34,20 +34,26 @@ interface ExitFormDialogProps {
   onClose: () => void;
   onLeave: () => void;
   isOpen: boolean;
+  isSubmitDisabled: boolean;
 }
 
 const ExitFormDialog: React.FC<ExitFormDialogProps> = ({
   onSubmit,
   onLeave,
   onClose,
-  isOpen
+  isOpen,
+  isSubmitDisabled
 }) => {
   const classes = useStyles();
   const intl = useIntl();
 
   return (
     <Dialog className={classes.container} open={isOpen} onClose={onClose}>
-      <CardTitle title={intl.formatMessage(messages.title)} />
+      <CardTitle
+        title={intl.formatMessage(
+          isSubmitDisabled ? messages.unableToSaveTitle : messages.title
+        )}
+      />
       <DialogContent className={classes.dialogContent}>
         <div className={classes.buttonsContainer}>
           <Button onClick={onLeave}>
@@ -57,10 +63,14 @@ const ExitFormDialog: React.FC<ExitFormDialogProps> = ({
           <Button
             variant="contained"
             color="primary"
-            onClick={onSubmit}
+            onClick={isSubmitDisabled ? onClose : onSubmit}
             data-test-id="save-and-continue"
           >
-            {intl.formatMessage(messages.confirmButton)}
+            {intl.formatMessage(
+              isSubmitDisabled
+                ? messages.continueEditingButton
+                : messages.confirmButton
+            )}
           </Button>
         </div>
       </DialogContent>

--- a/src/components/Form/ExitFormDialog.tsx
+++ b/src/components/Form/ExitFormDialog.tsx
@@ -41,8 +41,8 @@ const ExitFormDialog: React.FC<ExitFormDialogProps> = ({
   const intl = useIntl();
 
   return (
-    <Dialog className={classes.container} open={isOpen}>
-      <CardTitle title={intl.formatMessage(messages.title)} onClose={onClose} />
+    <Dialog className={classes.container} open={isOpen} onClose={onClose}>
+      <CardTitle title={intl.formatMessage(messages.title)} />
       <DialogContent>
         <FormattedMessage {...messages.description} />
         <CardSpacer />

--- a/src/components/Form/ExitFormDialog.tsx
+++ b/src/components/Form/ExitFormDialog.tsx
@@ -1,9 +1,8 @@
 import { Button, Dialog, DialogContent, makeStyles } from "@material-ui/core";
 import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
-import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { exitFormPromptMessages as messages } from "./messages";
 
@@ -19,6 +18,12 @@ const useStyles = makeStyles(
     buttonsContainer: {
       display: "flex",
       justifyContent: "flex-end"
+    },
+    dialogContent: {
+      "@media (min-width: 800px)": {
+        minWidth: 500
+      },
+      paddingTop: 0
     }
   }),
   { name: "ExitFormPrompt" }
@@ -43,10 +48,7 @@ const ExitFormDialog: React.FC<ExitFormDialogProps> = ({
   return (
     <Dialog className={classes.container} open={isOpen} onClose={onClose}>
       <CardTitle title={intl.formatMessage(messages.title)} />
-      <DialogContent>
-        <FormattedMessage {...messages.description} />
-        <CardSpacer />
-        <CardSpacer />
+      <DialogContent className={classes.dialogContent}>
         <div className={classes.buttonsContainer}>
           <Button onClick={onLeave}>
             {intl.formatMessage(messages.cancelButton)}

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -258,7 +258,9 @@ export function useExitFormDialogProvider() {
     showDialog,
     handleSubmit,
     handleLeave,
-    handleClose
+    handleClose,
+    shouldBlockNav,
+    isSubmitDisabled
   };
 }
 
@@ -268,13 +270,15 @@ const ExitFormDialogProvider = ({ children }) => {
     handleLeave,
     handleSubmit,
     providerData,
-    showDialog
+    showDialog,
+    shouldBlockNav,
+    isSubmitDisabled
   } = useExitFormDialogProvider();
 
   useBeforeUnload(e => {
     // If form is dirty and user does a refresh,
     // the browser will ask about unsaved changes
-    if (shouldBlockNavigation() && !isInDevelopment) {
+    if (shouldBlockNav() && !isInDevelopment) {
       e.preventDefault();
       e.returnValue = "";
     }

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -211,9 +211,10 @@ export function useExitFormDialogProvider() {
     const errors = await Promise.all(
       getDirtyFormsSubmitFn().map(submitFn => submitFn())
     );
-    const isError = errors.flat().some(errors => errors);
 
     setIsSubmitting(false);
+
+    const isError = errors.flat().some(errors => errors);
 
     if (!isError) {
       continueNavigation();

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -14,6 +14,7 @@ export interface ExitFormDialogData {
   shouldBlockNavigation: () => boolean;
   setIsSubmitting: (value: boolean) => void;
   submit: () => SubmitPromise;
+  setIsSubmitDisabled: (value: boolean) => void;
 }
 
 export type SubmitFn = (dataOrEvent?: any) => SubmitPromise<any[]>;
@@ -39,7 +40,8 @@ export const ExitFormDialogContext = React.createContext<ExitFormDialogData>({
   setExitDialogSubmitRef: () => undefined,
   shouldBlockNavigation: () => false,
   setIsSubmitting: () => undefined,
-  submit: () => Promise.resolve([])
+  submit: () => Promise.resolve([]),
+  setIsSubmitDisabled: () => undefined
 });
 
 const defaultValues = {
@@ -58,6 +60,11 @@ export function useExitFormDialogProvider() {
   const { history: routerHistory } = useRouter();
 
   const [showDialog, setShowDialog] = useState(defaultValues.showDialog);
+  const isSubmitDisabled = useRef<boolean>(false);
+
+  const setIsSubmitDisabled = (status: boolean) => {
+    isSubmitDisabled.current = status;
+  };
 
   const isSubmitting = useRef(defaultValues.isSubmitting);
   const formsData = useRef<FormsData>({});
@@ -242,7 +249,8 @@ export function useExitFormDialogProvider() {
     setEnableExitDialog,
     setExitDialogSubmitRef: setSubmitRef,
     setIsSubmitting,
-    submit: handleSubmit
+    submit: handleSubmit,
+    setIsSubmitDisabled
   };
 
   return {
@@ -266,7 +274,7 @@ const ExitFormDialogProvider = ({ children }) => {
   useBeforeUnload(e => {
     // If form is dirty and user does a refresh,
     // the browser will ask about unsaved changes
-    if (shouldBlockNav() && !isInDevelopment) {
+    if (shouldBlockNavigation() && !isInDevelopment) {
       e.preventDefault();
       e.returnValue = "";
     }
@@ -279,6 +287,7 @@ const ExitFormDialogProvider = ({ children }) => {
         onSubmit={handleSubmit}
         onLeave={handleLeave}
         onClose={handleClose}
+        isSubmitDisabled={isSubmitDisabled.current}
       />
       {children}
     </ExitFormDialogContext.Provider>

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -4,6 +4,7 @@ import { useHistory } from "react-router";
 import useRouter from "use-react-router";
 
 import ExitFormDialog from "./ExitFormDialog";
+import useBeforeUnload from "./useBeforeUnload";
 
 export interface ExitFormDialogData {
   setIsDirty: (id: symbol, isDirty: boolean) => void;
@@ -259,6 +260,15 @@ const ExitFormDialogProvider = ({ children }) => {
     providerData,
     showDialog
   } = useExitFormDialogProvider();
+
+  useBeforeUnload(e => {
+    // If form is dirty and user does a refresh,
+    // the browser will ask about unsaved changes
+    if (shouldBlockNav()) {
+      e.preventDefault();
+      e.returnValue = "";
+    }
+  });
 
   return (
     <ExitFormDialogContext.Provider value={providerData}>

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -1,4 +1,5 @@
 import { SubmitPromise } from "@saleor/hooks/useForm";
+import { isInDevelopment } from "@saleor/misc";
 import React, { useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router";
 import useRouter from "use-react-router";
@@ -264,7 +265,7 @@ const ExitFormDialogProvider = ({ children }) => {
   useBeforeUnload(e => {
     // If form is dirty and user does a refresh,
     // the browser will ask about unsaved changes
-    if (shouldBlockNav()) {
+    if (shouldBlockNav() && !isInDevelopment) {
       e.preventDefault();
       e.returnValue = "";
     }

--- a/src/components/Form/ExitFormDialogProvider.tsx
+++ b/src/components/Form/ExitFormDialogProvider.tsx
@@ -60,7 +60,7 @@ export function useExitFormDialogProvider() {
   const { history: routerHistory } = useRouter();
 
   const [showDialog, setShowDialog] = useState(defaultValues.showDialog);
-  const isSubmitDisabled = useRef<boolean>(false);
+  const isSubmitDisabled = useRef(false);
 
   const setIsSubmitDisabled = (status: boolean) => {
     isSubmitDisabled.current = status;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -3,11 +3,10 @@ import React from "react";
 
 import { FormId } from "./ExitFormDialogProvider";
 
-export interface FormDataWithOpts extends FormData {
-  hasChanged: boolean;
-}
+export type FormDataWithOpts<TData> = TData &
+  Pick<UseFormResult<TData>, "hasChanged">;
 
-export type IsDisabledFnType = (data: FormDataWithOpts) => boolean;
+export type IsDisabledFnType<T> = (data: FormDataWithOpts<T>) => boolean;
 
 export interface FormProps<TData, TErrors>
   extends Omit<React.HTMLProps<HTMLFormElement>, "onSubmit"> {
@@ -17,7 +16,7 @@ export interface FormProps<TData, TErrors>
   resetOnSubmit?: boolean;
   onSubmit?: (data: TData) => SubmitPromise<TErrors[]> | void;
   formId?: FormId;
-  isDisabled?: IsDisabledFnType;
+  isDisabled?: IsDisabledFnType<TData>;
 }
 
 function Form<TData, Terrors>({
@@ -28,12 +27,14 @@ function Form<TData, Terrors>({
   confirmLeave = false,
   formId,
   isDisabled,
+  disabled,
   ...rest
 }: FormProps<TData, Terrors>) {
   const renderProps = useForm(initial, onSubmit, {
     confirmLeave,
     formId,
-    isDisabled
+    isDisabled,
+    disabled
   });
 
   function handleSubmit(event?: React.FormEvent<any>, cb?: () => void) {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -3,6 +3,12 @@ import React from "react";
 
 import { FormId } from "./ExitFormDialogProvider";
 
+export interface FormDataWithOpts extends FormData {
+  hasChanged: boolean;
+}
+
+export type IsDisabledFnType = (data: FormDataWithOpts) => boolean;
+
 export interface FormProps<TData, TErrors>
   extends Omit<React.HTMLProps<HTMLFormElement>, "onSubmit"> {
   children: (props: UseFormResult<TData>) => React.ReactNode;
@@ -11,6 +17,7 @@ export interface FormProps<TData, TErrors>
   resetOnSubmit?: boolean;
   onSubmit?: (data: TData) => SubmitPromise<TErrors[]> | void;
   formId?: FormId;
+  isDisabled?: IsDisabledFnType;
 }
 
 function Form<TData, Terrors>({
@@ -20,9 +27,14 @@ function Form<TData, Terrors>({
   onSubmit,
   confirmLeave = false,
   formId,
+  isDisabled,
   ...rest
 }: FormProps<TData, Terrors>) {
-  const renderProps = useForm(initial, onSubmit, { confirmLeave, formId });
+  const renderProps = useForm(initial, onSubmit, {
+    confirmLeave,
+    formId,
+    isDisabled
+  });
 
   function handleSubmit(event?: React.FormEvent<any>, cb?: () => void) {
     const { reset, submit } = renderProps;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -6,7 +6,9 @@ import { FormId } from "./ExitFormDialogProvider";
 export type FormDataWithOpts<TData> = TData &
   Pick<UseFormResult<TData>, "hasChanged">;
 
-export type IsDisabledFnType<T> = (data: FormDataWithOpts<T>) => boolean;
+export type CheckIfSaveIsDisabledFnType<T> = (
+  data: FormDataWithOpts<T>
+) => boolean;
 
 export interface FormProps<TData, TErrors>
   extends Omit<React.HTMLProps<HTMLFormElement>, "onSubmit"> {
@@ -16,7 +18,7 @@ export interface FormProps<TData, TErrors>
   resetOnSubmit?: boolean;
   onSubmit?: (data: TData) => SubmitPromise<TErrors[]> | void;
   formId?: FormId;
-  isDisabled?: IsDisabledFnType<TData>;
+  checkIfSaveIsDisabled?: CheckIfSaveIsDisabledFnType<TData>;
 }
 
 function Form<TData, Terrors>({
@@ -26,14 +28,14 @@ function Form<TData, Terrors>({
   onSubmit,
   confirmLeave = false,
   formId,
-  isDisabled,
+  checkIfSaveIsDisabled,
   disabled,
   ...rest
 }: FormProps<TData, Terrors>) {
   const renderProps = useForm(initial, onSubmit, {
     confirmLeave,
     formId,
-    isDisabled,
+    checkIfSaveIsDisabled,
     disabled
   });
 

--- a/src/components/Form/messages.ts
+++ b/src/components/Form/messages.ts
@@ -5,6 +5,10 @@ export const exitFormPromptMessages = defineMessages({
     defaultMessage: "Would you like to save changes?",
     description: "ExitFormPrompt title"
   },
+  unableToSaveTitle: {
+    defaultMessage: "You have unsaved changes",
+    description: "ExitFormPrompt title"
+  },
   cancelButton: {
     defaultMessage: "Discard changes",
     description: "ExitFormPrompt cancel button"
@@ -12,5 +16,9 @@ export const exitFormPromptMessages = defineMessages({
   confirmButton: {
     defaultMessage: "Save changes",
     description: "ExitFormPrompt confirm button"
+  },
+  continueEditingButton: {
+    defaultMessage: "Continue editing",
+    description: "ExitFormPrompt continue editing button"
   }
 });

--- a/src/components/Form/messages.ts
+++ b/src/components/Form/messages.ts
@@ -11,11 +11,11 @@ export const exitFormPromptMessages = defineMessages({
     description: "ExitFormPrompt description"
   },
   cancelButton: {
-    defaultMessage: "leave without saving",
+    defaultMessage: "Leave without saving",
     description: "ExitFormPrompt cancel button"
   },
   confirmButton: {
-    defaultMessage: "save & continue",
+    defaultMessage: "Save & continue",
     description: "ExitFormPrompt confirm button"
   }
 });

--- a/src/components/Form/messages.ts
+++ b/src/components/Form/messages.ts
@@ -2,20 +2,15 @@ import { defineMessages } from "react-intl";
 
 export const exitFormPromptMessages = defineMessages({
   title: {
-    defaultMessage: "Are you sure you want to leave?",
+    defaultMessage: "Would you like to save changes?",
     description: "ExitFormPrompt title"
   },
-  description: {
-    defaultMessage:
-      "You have unsaved changes on this view. What would you like to do with them?",
-    description: "ExitFormPrompt description"
-  },
   cancelButton: {
-    defaultMessage: "Leave without saving",
+    defaultMessage: "Discard changes",
     description: "ExitFormPrompt cancel button"
   },
   confirmButton: {
-    defaultMessage: "Save & continue",
+    defaultMessage: "Save changes",
     description: "ExitFormPrompt confirm button"
   }
 });

--- a/src/components/Form/useBeforeUnload.ts
+++ b/src/components/Form/useBeforeUnload.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from "react";
+
+const useBeforeUnload = fn => {
+  const cb = useRef(fn);
+
+  useEffect(() => {
+    cb.current = fn;
+  }, [fn]);
+
+  useEffect(() => {
+    const onBeforeUnload = (...args) => cb.current?.(...args);
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+};
+
+export default useBeforeUnload;

--- a/src/components/Form/useExitFormDialog.ts
+++ b/src/components/Form/useExitFormDialog.ts
@@ -14,6 +14,7 @@ export interface UseExitFormDialogResult
       | "shouldBlockNavigation"
       | "setIsSubmitting"
       | "setIsSubmitDisabled"
+      | "submit"
     >,
     WithFormId {
   setIsDirty: (isDirty: boolean) => void;

--- a/src/components/Form/useExitFormDialog.ts
+++ b/src/components/Form/useExitFormDialog.ts
@@ -8,7 +8,13 @@ import {
 } from "./ExitFormDialogProvider";
 
 export interface UseExitFormDialogResult
-  extends Omit<ExitFormDialogData, "setIsDirty" | "setExitDialogSubmitRef">,
+  extends Pick<
+      ExitFormDialogData,
+      | "setEnableExitDialog"
+      | "shouldBlockNavigation"
+      | "setIsSubmitting"
+      | "setIsSubmitDisabled"
+    >,
     WithFormId {
   setIsDirty: (isDirty: boolean) => void;
   setExitDialogSubmitRef: (submitFn: SubmitFn) => void;

--- a/src/components/Form/useExitFormDialog.ts
+++ b/src/components/Form/useExitFormDialog.ts
@@ -1,4 +1,4 @@
-import { useContext, useRef } from "react";
+import React, { useContext, useRef } from "react";
 
 import {
   ExitFormDialogContext,
@@ -22,19 +22,29 @@ export interface UseExitFormDialogResult
 
 export interface UseExitFormDialogProps {
   formId: symbol;
+  isDisabled?: boolean;
 }
 
 export const useExitFormDialog = (
-  { formId }: UseExitFormDialogProps = { formId: undefined }
+  { formId, isDisabled }: UseExitFormDialogProps = { formId: undefined }
 ): UseExitFormDialogResult => {
   const id = useRef(formId || Symbol()).current;
 
-  const { setIsDirty, setExitDialogSubmitRef, ...rest } = useContext(
-    ExitFormDialogContext
-  );
+  const exitDialogProps = useContext(ExitFormDialogContext);
+  const {
+    setIsDirty,
+    setIsSubmitDisabled,
+    setExitDialogSubmitRef
+  } = exitDialogProps;
+
+  React.useEffect(() => {
+    if (isDisabled !== undefined) {
+      setIsSubmitDisabled(isDisabled);
+    }
+  }, [isDisabled]);
 
   return {
-    ...rest,
+    ...exitDialogProps,
     formId: id,
     setIsDirty: (value: boolean) => setIsDirty(id, value),
     setExitDialogSubmitRef: (submitFn: SubmitFn) =>

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -141,7 +141,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
       onSubmit={handleSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => {
+      {({ change, data, isSaveDisabled, submit }) => {
         const handleCountrySelect = createSingleAutocompleteSelectHandler(
           change,
           setCountryDisplayName,
@@ -187,7 +187,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBar}
               onSubmit={submit}
               onCancel={onBack}

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -13,10 +13,7 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import {
-  basicFormDisableConditions,
-  extractMutationErrors
-} from "@saleor/misc";
+import { extractMutationErrors } from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
@@ -142,7 +139,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={handleSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => {
         const handleCountrySelect = createSingleAutocompleteSelectHandler(

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -13,7 +13,10 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { extractMutationErrors } from "@saleor/misc";
+import {
+  basicFormDisableConditions,
+  extractMutationErrors
+} from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
@@ -135,8 +138,13 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
-      {({ change, data, hasChanged, submit }) => {
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={handleSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => {
         const handleCountrySelect = createSingleAutocompleteSelectHandler(
           change,
           setCountryDisplayName,
@@ -182,7 +190,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBar}
               onSubmit={submit}
               onCancel={onBack}

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -21,7 +21,7 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { getUserName } from "../../../misc";
+import { basicFormDisableConditions, getUserName } from "../../../misc";
 import CustomerAddresses from "../CustomerAddresses";
 import CustomerDetails from "../CustomerDetails";
 import CustomerInfo from "../CustomerInfo";
@@ -80,8 +80,13 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
   } = useMetadataChangeTrigger();
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit }) => {
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -136,7 +141,7 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBar}
               onSubmit={submit}
               onCancel={onBack}

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -86,7 +86,7 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => {
+      {({ change, data, isSaveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -141,7 +141,7 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBar}
               onSubmit={submit}
               onCancel={onBack}

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -21,7 +21,7 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { basicFormDisableConditions, getUserName } from "../../../misc";
+import { getUserName } from "../../../misc";
 import CustomerAddresses from "../CustomerAddresses";
 import CustomerDetails from "../CustomerDetails";
 import CustomerInfo from "../CustomerInfo";
@@ -84,7 +84,7 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);

--- a/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
+++ b/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
@@ -81,7 +81,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
     privateMetadata: []
   };
 
-  const isFormDisabled = (data: FormDataWithOpts<FormData>) =>
+  const checkIfSaveIsDisabled = (data: FormDataWithOpts<FormData>) =>
     data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
     disabled ||
     !data.hasChanged;
@@ -92,7 +92,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
       initial={initialForm}
       onSubmit={onSubmit}
       formId={SALE_CREATE_FORM_ID}
-      isDisabled={isFormDisabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
     >
       {({ change, data, submit, triggerChange, isSaveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(

--- a/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
+++ b/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
@@ -2,7 +2,7 @@ import { validateSalePrice } from "@saleor/channels/utils";
 import CardSpacer from "@saleor/components/CardSpacer";
 import ChannelsAvailabilityCard from "@saleor/components/ChannelsAvailabilityCard";
 import Container from "@saleor/components/Container";
-import Form from "@saleor/components/Form";
+import Form, { FormDataWithOpts } from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import Metadata, { MetadataFormData } from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
@@ -81,22 +81,25 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
     privateMetadata: []
   };
 
+  const isFormDisabled = (data: FormData & FormDataWithOpts) =>
+    data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
+    disabled ||
+    !data.hasChanged;
+
   return (
     <Form
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
       formId={SALE_CREATE_FORM_ID}
+      isDisabled={isFormDisabled}
     >
-      {({ change, data, hasChanged, submit, triggerChange }) => {
+      {({ change, data, submit, triggerChange, saveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(
           data.channelListings,
           onChannelsChange,
           triggerChange,
           data.type
-        );
-        const formDisabled = data.channelListings?.some(channel =>
-          validateSalePrice(data, channel)
         );
         const changeMetadata = makeMetadataChangeHandler(change);
 
@@ -152,7 +155,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={disabled || formDisabled || !hasChanged}
+              disabled={saveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
+++ b/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
@@ -81,7 +81,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
     privateMetadata: []
   };
 
-  const isFormDisabled = (data: FormData & FormDataWithOpts) =>
+  const isFormDisabled = (data: FormDataWithOpts<FormData>) =>
     data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
     disabled ||
     !data.hasChanged;
@@ -94,7 +94,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
       formId={SALE_CREATE_FORM_ID}
       isDisabled={isFormDisabled}
     >
-      {({ change, data, submit, triggerChange, saveDisabled }) => {
+      {({ change, data, submit, triggerChange, isSaveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(
           data.channelListings,
           onChannelsChange,
@@ -155,7 +155,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -2,7 +2,7 @@ import { ChannelSaleData, validateSalePrice } from "@saleor/channels/utils";
 import CardSpacer from "@saleor/components/CardSpacer";
 import ChannelsAvailabilityCard from "@saleor/components/ChannelsAvailabilityCard";
 import Container from "@saleor/components/Container";
-import Form from "@saleor/components/Form";
+import Form, { FormDataWithOpts } from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import Metadata, { MetadataFormData } from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
@@ -156,22 +156,26 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
     metadata: sale?.metadata.map(mapMetadataItemToInput),
     privateMetadata: sale?.privateMetadata.map(mapMetadataItemToInput)
   };
+
+  const isFormDisabled = (data: SaleDetailsPageFormData & FormDataWithOpts) =>
+    data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
+    disabled ||
+    (!data.hasChanged && !hasChannelChanged);
+
   return (
     <Form
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
       formId={SALE_UPDATE_FORM_ID}
+      isDisabled={isFormDisabled}
     >
-      {({ change, data, hasChanged, submit, triggerChange }) => {
+      {({ change, data, submit, triggerChange, saveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(
           data.channelListings,
           onChannelsChange,
           triggerChange,
           data.type
-        );
-        const formDisabled = data.channelListings?.some(channel =>
-          validateSalePrice(data, channel)
         );
         const changeMetadata = makeMetadataChangeHandler(change);
 
@@ -370,9 +374,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={
-                disabled || formDisabled || (!hasChanged && !hasChannelChanged)
-              }
+              disabled={saveDisabled}
               onCancel={onBack}
               onDelete={onRemove}
               onSubmit={submit}

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -157,7 +157,9 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
     privateMetadata: sale?.privateMetadata.map(mapMetadataItemToInput)
   };
 
-  const isFormDisabled = (data: FormDataWithOpts<SaleDetailsPageFormData>) =>
+  const checkIfSaveIsDisabled = (
+    data: FormDataWithOpts<SaleDetailsPageFormData>
+  ) =>
     data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
     disabled ||
     (!data.hasChanged && !hasChannelChanged);
@@ -168,7 +170,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
       initial={initialForm}
       onSubmit={onSubmit}
       formId={SALE_UPDATE_FORM_ID}
-      isDisabled={isFormDisabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
     >
       {({ change, data, submit, triggerChange, isSaveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -157,7 +157,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
     privateMetadata: sale?.privateMetadata.map(mapMetadataItemToInput)
   };
 
-  const isFormDisabled = (data: SaleDetailsPageFormData & FormDataWithOpts) =>
+  const isFormDisabled = (data: FormDataWithOpts<SaleDetailsPageFormData>) =>
     data.channelListings?.some(channel => validateSalePrice(data, channel)) ||
     disabled ||
     (!data.hasChanged && !hasChannelChanged);
@@ -170,7 +170,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
       formId={SALE_UPDATE_FORM_ID}
       isDisabled={isFormDisabled}
     >
-      {({ change, data, submit, triggerChange, saveDisabled }) => {
+      {({ change, data, submit, triggerChange, isSaveDisabled }) => {
         const handleChannelChange = createSaleChannelsChangeHandler(
           data.channelListings,
           onChannelsChange,
@@ -374,7 +374,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onDelete={onRemove}
               onSubmit={submit}

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -91,7 +91,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     privateMetadata: []
   };
 
-  const isFormDisabled = (data: FormData & FormDataWithOpts) =>
+  const isFormDisabled = (data: FormDataWithOpts<FormData>) =>
     (data.discountType.toString() !== "SHIPPING" &&
       data.channelListings?.some(
         channel =>
@@ -110,7 +110,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
       formId={VOUCHER_CREATE_FORM_ID}
       isDisabled={isFormDisabled}
     >
-      {({ change, data, submit, triggerChange, set, saveDisabled }) => {
+      {({ change, data, submit, triggerChange, set, isSaveDisabled }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(
           change
         );
@@ -203,7 +203,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -91,7 +91,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     privateMetadata: []
   };
 
-  const isFormDisabled = (data: FormDataWithOpts<FormData>) =>
+  const checkIfSaveIsDisabled = (data: FormDataWithOpts<FormData>) =>
     (data.discountType.toString() !== "SHIPPING" &&
       data.channelListings?.some(
         channel =>
@@ -108,7 +108,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
       initial={initialForm}
       onSubmit={onSubmit}
       formId={VOUCHER_CREATE_FORM_ID}
-      isDisabled={isFormDisabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
     >
       {({ change, data, submit, triggerChange, set, isSaveDisabled }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -2,7 +2,7 @@ import { ChannelVoucherData } from "@saleor/channels/utils";
 import CardSpacer from "@saleor/components/CardSpacer";
 import ChannelsAvailabilityCard from "@saleor/components/ChannelsAvailabilityCard";
 import Container from "@saleor/components/Container";
-import Form from "@saleor/components/Form";
+import Form, { FormDataWithOpts } from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import Metadata from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
@@ -91,14 +91,26 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     privateMetadata: []
   };
 
+  const isFormDisabled = (data: FormData & FormDataWithOpts) =>
+    (data.discountType.toString() !== "SHIPPING" &&
+      data.channelListings?.some(
+        channel =>
+          validatePrice(channel.discountValue) ||
+          (data.requirementsPicker === RequirementsPicker.ORDER &&
+            validatePrice(channel.minSpent))
+      )) ||
+    disabled ||
+    (!data.hasChanged && hasChannelChanged);
+
   return (
     <Form
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
       formId={VOUCHER_CREATE_FORM_ID}
+      isDisabled={isFormDisabled}
     >
-      {({ change, data, hasChanged, submit, triggerChange, set }) => {
+      {({ change, data, submit, triggerChange, set, saveDisabled }) => {
         const handleDiscountTypeChange = createDiscountTypeChangeHandler(
           change
         );
@@ -107,14 +119,6 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
           onChannelsChange,
           triggerChange
         );
-        const formDisabled =
-          data.discountType.toString() !== "SHIPPING" &&
-          data.channelListings?.some(
-            channel =>
-              validatePrice(channel.discountValue) ||
-              (data.requirementsPicker === RequirementsPicker.ORDER &&
-                validatePrice(channel.minSpent))
-          );
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -199,9 +203,7 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
               <Metadata data={data} onChange={changeMetadata} />
             </Grid>
             <Savebar
-              disabled={
-                disabled || formDisabled || (!hasChanged && !hasChannelChanged)
-              }
+              disabled={saveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -53,7 +53,7 @@ export interface CommonUseFormResult<TData> {
   change: FormChange;
   hasChanged: boolean;
   submit: (dataOrEvent?: any) => SubmitPromise<any[]>;
-  saveDisabled?: boolean;
+  isSaveDisabled?: boolean;
 }
 
 export interface CommonUseFormResultWithHandlers<TData, THandlers>
@@ -101,7 +101,7 @@ function useForm<T extends FormData, TErrors>(
 
   const basicFormDisableConditions = () => !hasChanged || disabled;
 
-  const saveDisabled = () => {
+  const isSaveDisabled = () => {
     if (isDisabled) {
       return isDisabled({
         ...data,
@@ -122,7 +122,10 @@ function useForm<T extends FormData, TErrors>(
     setEnableExitDialog,
     setIsSubmitDisabled,
     formId
-  } = useExitFormDialog({ formId: propsFormId, isDisabled: saveDisabled() });
+  } = useExitFormDialog({
+    formId: propsFormId,
+    isDisabled: isSaveDisabled()
+  });
 
   const handleFormSubmit = useHandleFormSubmit({
     formId,
@@ -241,7 +244,7 @@ function useForm<T extends FormData, TErrors>(
     triggerChange: handleSetChanged,
     setChanged: handleSetChanged,
     setIsSubmitDisabled,
-    saveDisabled: saveDisabled()
+    isSaveDisabled: isSaveDisabled()
   };
 }
 

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { IsDisabledFnType } from "@saleor/components/Form";
+import { CheckIfSaveIsDisabledFnType } from "@saleor/components/Form";
 import { FormId } from "@saleor/components/Form/ExitFormDialogProvider";
 import {
   useExitFormDialog,
@@ -29,7 +29,7 @@ export type FormErrors<T> = {
 export interface UseFormOpts<T> {
   confirmLeave: boolean;
   formId?: FormId;
-  isDisabled?: IsDisabledFnType<T>;
+  checkIfSaveIsDisabled?: CheckIfSaveIsDisabledFnType<T>;
   disabled?: boolean;
 }
 
@@ -91,7 +91,12 @@ function useForm<T extends FormData, TErrors>(
   onSubmit?: (data: T) => SubmitPromise<TErrors[]> | void,
   opts: UseFormOpts<T> = { confirmLeave: false, formId: undefined }
 ): UseFormResult<T> {
-  const { confirmLeave, formId: propsFormId, isDisabled, disabled } = opts;
+  const {
+    confirmLeave,
+    formId: propsFormId,
+    checkIfSaveIsDisabled,
+    disabled
+  } = opts;
   const [hasChanged, setChanged] = useState(false);
   const [errors, setErrors] = useState<FormErrors<T>>({});
   const [data, setData] = useStateFromProps(initialData, {
@@ -102,8 +107,8 @@ function useForm<T extends FormData, TErrors>(
   const basicFormDisableConditions = () => !hasChanged || disabled;
 
   const isSaveDisabled = () => {
-    if (isDisabled) {
-      return isDisabled({
+    if (checkIfSaveIsDisabled) {
+      return checkIfSaveIsDisabled({
         ...data,
         hasChanged
       });

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -42,6 +42,7 @@ export interface UseFormResult<TData>
   errors: FormErrors<TData>;
   setError: (name: keyof TData, error: string | React.ReactNode) => void;
   clearErrors: (name?: keyof TData | Array<keyof TData>) => void;
+  setIsSubmitDisabled: (value: boolean) => void;
 }
 
 export interface CommonUseFormResult<TData> {
@@ -49,6 +50,7 @@ export interface CommonUseFormResult<TData> {
   change: FormChange;
   hasChanged: boolean;
   submit: (dataOrEvent?: any) => SubmitPromise<any[]>;
+  setIsSubmitDisabled?: (value: boolean) => void;
 }
 
 export interface CommonUseFormResultWithHandlers<TData, THandlers>
@@ -98,6 +100,7 @@ function useForm<T extends FormData, TErrors>(
     setIsDirty: setIsFormDirtyInExitDialog,
     setExitDialogSubmitRef,
     setEnableExitDialog,
+    setIsSubmitDisabled,
     formId
   } = useExitFormDialog({ formId: propsFormId });
 
@@ -216,7 +219,8 @@ function useForm<T extends FormData, TErrors>(
     toggleValue,
     handleChange,
     triggerChange: handleSetChanged,
-    setChanged: handleSetChanged
+    setChanged: handleSetChanged,
+    setIsSubmitDisabled
   };
 }
 

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,3 +1,4 @@
+import { IsDisabledFnType } from "@saleor/components/Form";
 import { FormId } from "@saleor/components/Form/ExitFormDialogProvider";
 import {
   useExitFormDialog,
@@ -28,6 +29,7 @@ export type FormErrors<T> = {
 export interface UseFormOpts {
   confirmLeave: boolean;
   formId?: FormId;
+  isDisabled?: IsDisabledFnType;
 }
 
 export interface UseFormResult<TData>
@@ -88,7 +90,7 @@ function useForm<T extends FormData, TErrors>(
   onSubmit?: (data: T) => SubmitPromise<TErrors[]> | void,
   opts: UseFormOpts = { confirmLeave: false, formId: undefined }
 ): UseFormResult<T> {
-  const { confirmLeave, formId: propsFormId } = opts;
+  const { confirmLeave, formId: propsFormId, isDisabled } = opts;
   const [hasChanged, setChanged] = useState(false);
   const [errors, setErrors] = useState<FormErrors<T>>({});
   const [data, setData] = useStateFromProps(initialData, {
@@ -96,13 +98,20 @@ function useForm<T extends FormData, TErrors>(
     onRefresh: newData => handleRefresh(data, newData, handleSetChanged)
   });
 
+  const saveDisabled =
+    isDisabled &&
+    isDisabled({
+      ...data,
+      hasChanged
+    });
+
   const {
     setIsDirty: setIsFormDirtyInExitDialog,
     setExitDialogSubmitRef,
     setEnableExitDialog,
     setIsSubmitDisabled,
     formId
-  } = useExitFormDialog({ formId: propsFormId });
+  } = useExitFormDialog({ formId: propsFormId, isDisabled: saveDisabled });
 
   const handleFormSubmit = useHandleFormSubmit({
     formId,
@@ -220,7 +229,8 @@ function useForm<T extends FormData, TErrors>(
     handleChange,
     triggerChange: handleSetChanged,
     setChanged: handleSetChanged,
-    setIsSubmitDisabled
+    setIsSubmitDisabled,
+    saveDisabled
   };
 }
 

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -50,7 +50,7 @@ export interface CommonUseFormResult<TData> {
   change: FormChange;
   hasChanged: boolean;
   submit: (dataOrEvent?: any) => SubmitPromise<any[]>;
-  setIsSubmitDisabled?: (value: boolean) => void;
+  saveDisabled?: boolean;
 }
 
 export interface CommonUseFormResultWithHandlers<TData, THandlers>

--- a/src/hooks/useHandleFormSubmit.ts
+++ b/src/hooks/useHandleFormSubmit.ts
@@ -35,13 +35,13 @@ function useHandleFormSubmit<TData, TErrors>({
 
     const errors = await result;
 
+    setIsSubmitting(false);
+
     if (errors?.length === 0) {
       setChanged(false);
 
       return [];
     }
-
-    setIsSubmitting(false);
 
     return errors;
   }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -11,7 +11,6 @@ import uniqBy from "lodash/uniqBy";
 import moment from "moment-timezone";
 import { IntlShape } from "react-intl";
 
-import { FormDataWithOpts } from "./components/Form";
 import { MultiAutocompleteChoiceType } from "./components/MultiAutocompleteSelectField";
 import { AddressType, AddressTypeInput } from "./customers/types";
 import { AddressFragment } from "./graphql";

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -11,6 +11,7 @@ import uniqBy from "lodash/uniqBy";
 import moment from "moment-timezone";
 import { IntlShape } from "react-intl";
 
+import { FormDataWithOpts } from "./components/Form";
 import { MultiAutocompleteChoiceType } from "./components/MultiAutocompleteSelectField";
 import { AddressType, AddressTypeInput } from "./customers/types";
 import { AddressFragment } from "./graphql";
@@ -525,3 +526,8 @@ export const combinedMultiAutocompleteChoices = (
 
 export const isInDevelopment =
   !process.env.NODE_ENV || process.env.NODE_ENV === "development";
+
+export const basicFormDisableConditions = (
+  opts: FormDataWithOpts,
+  disabled: boolean
+) => !opts.hasChanged || disabled;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -526,8 +526,3 @@ export const combinedMultiAutocompleteChoices = (
 
 export const isInDevelopment =
   !process.env.NODE_ENV || process.env.NODE_ENV === "development";
-
-export const basicFormDisableConditions = (
-  opts: FormDataWithOpts,
-  disabled: boolean
-) => !opts.hasChanged || disabled;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -522,3 +522,6 @@ export const combinedMultiAutocompleteChoices = (
   selected: MultiAutocompleteChoiceType[],
   choices: MultiAutocompleteChoiceType[]
 ) => uniqBy([...selected, ...choices], "value");
+
+export const isInDevelopment =
+  !process.env.NODE_ENV || process.env.NODE_ENV === "development";

--- a/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
+++ b/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
@@ -52,7 +52,7 @@ const OrderFulfillmentTrackingDialog: React.FC<OrderFulfillmentTrackingDialogPro
 
   return (
     <Dialog onClose={onClose} open={open} fullWidth maxWidth="xs">
-      <Form confirmLeave initial={initialData} onSubmit={onConfirm}>
+      <Form initial={initialData} onSubmit={onConfirm}>
         {({ change, data, submit }) => (
           <>
             <DialogTitle>

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -69,7 +69,7 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, handlers, change, submit, saveDisabled }) => {
+      {({ data, handlers, change, submit, isSaveDisabled }) => {
         const isProductRefund = data.type === OrderRefundType.PRODUCTS;
 
         return (
@@ -157,7 +157,7 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
                   }
                   data={data}
                   order={order}
-                  disabled={saveDisabled}
+                  disabled={isSaveDisabled}
                   errors={errors}
                   onChange={change}
                   onRefund={submit}

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -67,8 +67,9 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
       order={order}
       defaultType={defaultType}
       onSubmit={onSubmit}
+      disabled={disabled}
     >
-      {({ data, handlers, change, submit }) => {
+      {({ data, handlers, change, submit, saveDisabled }) => {
         const isProductRefund = data.type === OrderRefundType.PRODUCTS;
 
         return (
@@ -156,7 +157,7 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
                   }
                   data={data}
                   order={order}
-                  disabled={disabled}
+                  disabled={saveDisabled}
                   errors={errors}
                   onChange={change}
                   onRefund={submit}

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -57,6 +57,7 @@ interface OrderRefundFormProps {
   order: OrderRefundDataQuery["order"];
   defaultType: OrderRefundType;
   onSubmit: (data: OrderRefundSubmitData) => SubmitPromise;
+  disabled: boolean;
 }
 
 function getOrderRefundPageFormData(
@@ -73,7 +74,8 @@ function getOrderRefundPageFormData(
 function useOrderRefundForm(
   order: OrderRefundDataQuery["order"],
   defaultType: OrderRefundType,
-  onSubmit: (data: OrderRefundSubmitData) => SubmitPromise
+  onSubmit: (data: OrderRefundSubmitData) => SubmitPromise,
+  disabled: boolean
 ): UseOrderRefundFormResult {
   const {
     handleChange,
@@ -81,12 +83,15 @@ function useOrderRefundForm(
     hasChanged,
     triggerChange,
     data: formData,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(getOrderRefundPageFormData(defaultType), undefined, {
     confirmLeave: true
   });
 
-  const { setExitDialogSubmitRef } = useExitFormDialog();
+  const { setExitDialogSubmitRef } = useExitFormDialog({
+    formId
+  });
 
   const refundedProductQuantities = useFormset<null, string>(
     order?.lines
@@ -188,7 +193,8 @@ function useOrderRefundForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const disabled = !order;
+  const saveDisabled = disabled || !order;
+  setIsSubmitDisabled(saveDisabled);
 
   return {
     change: handleChange,
@@ -201,7 +207,8 @@ function useOrderRefundForm(
       setMaximalRefundedProductQuantities: handleMaximalRefundedProductQuantitiesSet
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -209,9 +216,10 @@ const OrderRefundForm: React.FC<OrderRefundFormProps> = ({
   children,
   order,
   defaultType,
-  onSubmit
+  onSubmit,
+  disabled
 }) => {
-  const props = useOrderRefundForm(order, defaultType, onSubmit);
+  const props = useOrderRefundForm(order, defaultType, onSubmit, disabled);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -193,8 +193,8 @@ function useOrderRefundForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = disabled || !order;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !order;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -208,7 +208,7 @@ function useOrderRefundForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -45,110 +45,97 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
   const intl = useIntl();
   return (
     <OrderRefundForm order={order} onSubmit={onSubmit}>
-      {({ data, handlers, change, submit }) => {
-        const {
-          fulfilledItemsQuantities,
-          waitingItemsQuantities,
-          unfulfilledItemsQuantities
-        } = data;
-
-        const hasAnyItemsSelected =
-          fulfilledItemsQuantities.some(({ value }) => !!value) ||
-          waitingItemsQuantities.some(({ value }) => !!value) ||
-          unfulfilledItemsQuantities.some(({ value }) => !!value);
-
-        return (
-          <Container>
-            <Backlink onClick={onBack}>
-              {intl.formatMessage(messages.appTitle, {
-                orderNumber: order?.number
-              })}
-            </Backlink>
-            <PageHeader
-              title={intl.formatMessage(messages.pageTitle, {
-                orderNumber: order?.number
-              })}
-            />
-            <Grid>
-              <div>
-                {!!data.unfulfilledItemsQuantities.length && (
-                  <>
+      {({ data, handlers, change, submit, saveDisabled }) => (
+        <Container>
+          <Backlink onClick={onBack}>
+            {intl.formatMessage(messages.appTitle, {
+              orderNumber: order?.number
+            })}
+          </Backlink>
+          <PageHeader
+            title={intl.formatMessage(messages.pageTitle, {
+              orderNumber: order?.number
+            })}
+          />
+          <Grid>
+            <div>
+              {!!data.unfulfilledItemsQuantities.length && (
+                <>
+                  <ItemsCard
+                    errors={errors}
+                    order={order}
+                    lines={getUnfulfilledLines(order)}
+                    itemsQuantities={data.unfulfilledItemsQuantities}
+                    itemsSelections={data.itemsToBeReplaced}
+                    onChangeQuantity={handlers.changeUnfulfiledItemsQuantity}
+                    onSetMaxQuantity={
+                      handlers.handleSetMaximalUnfulfiledItemsQuantities
+                    }
+                    onChangeSelected={handlers.changeItemsToBeReplaced}
+                  />
+                  <CardSpacer />
+                </>
+              )}
+              {renderCollection(
+                getWaitingFulfillments(order),
+                ({ id, lines }) => (
+                  <React.Fragment key={id}>
                     <ItemsCard
                       errors={errors}
                       order={order}
-                      lines={getUnfulfilledLines(order)}
-                      itemsQuantities={data.unfulfilledItemsQuantities}
+                      fulfilmentId={id}
+                      lines={getParsedLines(lines)}
+                      itemsQuantities={data.waitingItemsQuantities}
                       itemsSelections={data.itemsToBeReplaced}
-                      onChangeQuantity={handlers.changeUnfulfiledItemsQuantity}
-                      onSetMaxQuantity={
-                        handlers.handleSetMaximalUnfulfiledItemsQuantities
-                      }
+                      onChangeQuantity={handlers.changeWaitingItemsQuantity}
+                      onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
+                        id
+                      )}
                       onChangeSelected={handlers.changeItemsToBeReplaced}
                     />
                     <CardSpacer />
-                  </>
-                )}
-                {renderCollection(
-                  getWaitingFulfillments(order),
-                  ({ id, lines }) => (
-                    <React.Fragment key={id}>
-                      <ItemsCard
-                        errors={errors}
-                        order={order}
-                        fulfilmentId={id}
-                        lines={getParsedLines(lines)}
-                        itemsQuantities={data.waitingItemsQuantities}
-                        itemsSelections={data.itemsToBeReplaced}
-                        onChangeQuantity={handlers.changeWaitingItemsQuantity}
-                        onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
-                          id
-                        )}
-                        onChangeSelected={handlers.changeItemsToBeReplaced}
-                      />
-                      <CardSpacer />
-                    </React.Fragment>
-                  )
-                )}
-                {renderCollection(
-                  getFulfilledFulfillemnts(order),
-                  ({ id, lines }) => (
-                    <React.Fragment key={id}>
-                      <ItemsCard
-                        errors={errors}
-                        order={order}
-                        fulfilmentId={id}
-                        lines={getParsedLines(lines)}
-                        itemsQuantities={data.fulfilledItemsQuantities}
-                        itemsSelections={data.itemsToBeReplaced}
-                        onChangeQuantity={handlers.changeFulfiledItemsQuantity}
-                        onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
-                          id
-                        )}
-                        onChangeSelected={handlers.changeItemsToBeReplaced}
-                      />
-                      <CardSpacer />
-                    </React.Fragment>
-                  )
-                )}
-              </div>
-              <div>
-                <OrderAmount
-                  allowNoRefund
-                  isReturn
-                  amountData={getReturnProductsAmountValues(order, data)}
-                  data={data}
-                  order={order}
-                  disableSubmitButton={!hasAnyItemsSelected}
-                  disabled={loading}
-                  errors={errors}
-                  onChange={change}
-                  onRefund={submit}
-                />
-              </div>
-            </Grid>
-          </Container>
-        );
-      }}
+                  </React.Fragment>
+                )
+              )}
+              {renderCollection(
+                getFulfilledFulfillemnts(order),
+                ({ id, lines }) => (
+                  <React.Fragment key={id}>
+                    <ItemsCard
+                      errors={errors}
+                      order={order}
+                      fulfilmentId={id}
+                      lines={getParsedLines(lines)}
+                      itemsQuantities={data.fulfilledItemsQuantities}
+                      itemsSelections={data.itemsToBeReplaced}
+                      onChangeQuantity={handlers.changeFulfiledItemsQuantity}
+                      onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
+                        id
+                      )}
+                      onChangeSelected={handlers.changeItemsToBeReplaced}
+                    />
+                    <CardSpacer />
+                  </React.Fragment>
+                )
+              )}
+            </div>
+            <div>
+              <OrderAmount
+                allowNoRefund
+                isReturn
+                amountData={getReturnProductsAmountValues(order, data)}
+                data={data}
+                order={order}
+                disableSubmitButton={saveDisabled}
+                disabled={loading}
+                errors={errors}
+                onChange={change}
+                onRefund={submit}
+              />
+            </div>
+          </Grid>
+        </Container>
+      )}
     </OrderRefundForm>
   );
 };

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -45,7 +45,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
   const intl = useIntl();
   return (
     <OrderRefundForm order={order} onSubmit={onSubmit}>
-      {({ data, handlers, change, submit, saveDisabled }) => (
+      {({ data, handlers, change, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(messages.appTitle, {
@@ -126,7 +126,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                 amountData={getReturnProductsAmountValues(order, data)}
                 data={data}
                 order={order}
-                disableSubmitButton={saveDisabled}
+                disableSubmitButton={isSaveDisabled}
                 disabled={loading}
                 errors={errors}
                 onChange={change}

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -85,12 +85,15 @@ function useOrderReturnForm(
     hasChanged,
     data: formData,
     triggerChange,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = useForm(getOrderRefundPageFormData(), undefined, {
     confirmLeave: true
   });
 
-  const { setExitDialogSubmitRef } = useExitFormDialog();
+  const { setExitDialogSubmitRef } = useExitFormDialog({
+    formId
+  });
 
   const unfulfiledItemsQuantites = useFormset<LineItemData, number>(
     getOrderUnfulfilledLines(order).map(getParsedLineData({ initialValue: 0 }))
@@ -241,6 +244,14 @@ function useOrderReturnForm(
     };
   }
 
+  const hasAnyItemsSelected =
+    fulfiledItemsQuatities.data.some(({ value }) => !!value) ||
+    waitingItemsQuantities.data.some(({ value }) => !!value) ||
+    unfulfiledItemsQuantites.data.some(({ value }) => !!value);
+
+  const saveDisabled = !hasAnyItemsSelected;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data,
@@ -259,7 +270,8 @@ function useOrderReturnForm(
       handleSetMaximalUnfulfiledItemsQuantities
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -249,8 +249,8 @@ function useOrderReturnForm(
     waitingItemsQuantities.data.some(({ value }) => !!value) ||
     unfulfiledItemsQuantites.data.some(({ value }) => !!value);
 
-  const saveDisabled = !hasAnyItemsSelected;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = !hasAnyItemsSelected;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -271,7 +271,7 @@ function useOrderReturnForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
+++ b/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
@@ -43,8 +43,9 @@ const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
       orderSettings={orderSettings}
       shop={shop}
       onSubmit={onSubmit}
+      disabled={disabled}
     >
-      {({ data, submit, hasChanged, change }) => (
+      {({ data, submit, change, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.orders)}
@@ -73,7 +74,7 @@ const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
           <Savebar
             onCancel={onBack}
             onSubmit={submit}
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
             state={saveButtonBarState}
           />
         </Container>

--- a/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
+++ b/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
@@ -45,7 +45,7 @@ const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, submit, change, saveDisabled }) => (
+      {({ data, submit, change, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.orders)}
@@ -74,7 +74,7 @@ const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
           <Savebar
             onCancel={onBack}
             onSubmit={submit}
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             state={saveButtonBarState}
           />
         </Container>

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -2,7 +2,10 @@ import {
   OrderSettingsFragment,
   ShopOrderSettingsFragment
 } from "@saleor/graphql";
-import useForm, { FormChange, SubmitPromise } from "@saleor/hooks/useForm";
+import useForm, {
+  CommonUseFormResult,
+  SubmitPromise
+} from "@saleor/hooks/useForm";
 import useHandleFormSubmit from "@saleor/hooks/useHandleFormSubmit";
 import React from "react";
 
@@ -13,18 +16,15 @@ export interface OrderSettingsFormData {
   automaticallyFulfillNonShippableGiftCard: boolean;
 }
 
-export interface UseOrderSettingsFormResult {
-  change: FormChange;
-  data: OrderSettingsFormData;
-  hasChanged: boolean;
-  submit: () => SubmitPromise<any[]>;
-}
-
+export type UseOrderSettingsFormResult = CommonUseFormResult<
+  OrderSettingsFormData
+>;
 export interface OrderSettingsFormProps {
   children: (props: UseOrderSettingsFormResult) => React.ReactNode;
   orderSettings: OrderSettingsFragment;
   shop: ShopOrderSettingsFragment;
   onSubmit: (data: OrderSettingsFormData) => SubmitPromise;
+  disabled: boolean;
 }
 
 function getOrderSeettingsFormData(
@@ -44,15 +44,19 @@ function getOrderSeettingsFormData(
 function useOrderSettingsForm(
   orderSettings: OrderSettingsFragment,
   shop: ShopOrderSettingsFragment,
-  onSubmit: (data: OrderSettingsFormData) => SubmitPromise
+  onSubmit: (data: OrderSettingsFormData) => SubmitPromise,
+  disabled: boolean
 ): UseOrderSettingsFormResult {
-  const { data, handleChange, formId, hasChanged, setChanged } = useForm(
-    getOrderSeettingsFormData(orderSettings, shop),
-    undefined,
-    {
-      confirmLeave: true
-    }
-  );
+  const {
+    data,
+    handleChange,
+    formId,
+    hasChanged,
+    setChanged,
+    setIsSubmitDisabled
+  } = useForm(getOrderSeettingsFormData(orderSettings, shop), undefined, {
+    confirmLeave: true
+  });
 
   const handleFormSubmit = useHandleFormSubmit({
     formId,
@@ -61,12 +65,15 @@ function useOrderSettingsForm(
   });
 
   const submit = () => handleFormSubmit(data);
+  const saveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
 
   return {
     change: handleChange,
     data,
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -74,9 +81,10 @@ const OrderSettingsForm: React.FC<OrderSettingsFormProps> = ({
   children,
   orderSettings,
   shop,
-  onSubmit
+  onSubmit,
+  disabled
 }) => {
-  const props = useOrderSettingsForm(orderSettings, shop, onSubmit);
+  const props = useOrderSettingsForm(orderSettings, shop, onSubmit, disabled);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -65,15 +65,15 @@ function useOrderSettingsForm(
   });
 
   const submit = () => handleFormSubmit(data);
-  const saveDisabled = disabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
     data,
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
+++ b/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
@@ -64,7 +64,7 @@ const PageTypeCreatePage: React.FC<PageTypeCreatePageProps> = props => {
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ change, data, submit, saveDisabled }) => {
+      {({ change, data, submit, isSaveDisabled }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -108,7 +108,7 @@ const PageTypeCreatePage: React.FC<PageTypeCreatePageProps> = props => {
             <Savebar
               onCancel={onBack}
               onSubmit={submit}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
+++ b/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
@@ -13,6 +13,7 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -58,8 +59,13 @@ const PageTypeCreatePage: React.FC<PageTypeCreatePageProps> = props => {
   } = useMetadataChangeTrigger();
 
   return (
-    <Form confirmLeave initial={formInitialData} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit }) => {
+    <Form
+      confirmLeave
+      initial={formInitialData}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, submit, saveDisabled }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -103,7 +109,7 @@ const PageTypeCreatePage: React.FC<PageTypeCreatePageProps> = props => {
             <Savebar
               onCancel={onBack}
               onSubmit={submit}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
+++ b/src/pageTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
@@ -13,7 +13,6 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -63,7 +62,7 @@ const PageTypeCreatePage: React.FC<PageTypeCreatePageProps> = props => {
       confirmLeave
       initial={formInitialData}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, submit, saveDisabled }) => {
         const changeMetadata = makeMetadataChangeHandler(change);

--- a/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -19,7 +19,6 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import { ListActions, ReorderEvent } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -115,7 +114,7 @@ const PageTypeDetailsPage: React.FC<PageTypeDetailsPageProps> = props => {
       confirmLeave
       initial={formInitialData}
       onSubmit={handleSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);

--- a/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -19,6 +19,7 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import { ListActions, ReorderEvent } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -110,8 +111,13 @@ const PageTypeDetailsPage: React.FC<PageTypeDetailsPageProps> = props => {
   };
 
   return (
-    <Form confirmLeave initial={formInitialData} onSubmit={handleSubmit}>
-      {({ change, data, hasChanged, submit }) => {
+    <Form
+      confirmLeave
+      initial={formInitialData}
+      onSubmit={handleSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -174,7 +180,7 @@ const PageTypeDetailsPage: React.FC<PageTypeDetailsPageProps> = props => {
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/pageTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -116,7 +116,7 @@ const PageTypeDetailsPage: React.FC<PageTypeDetailsPageProps> = props => {
       onSubmit={handleSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => {
+      {({ change, data, isSaveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -179,7 +179,7 @@ const PageTypeDetailsPage: React.FC<PageTypeDetailsPageProps> = props => {
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -137,7 +137,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
       onSubmit={onSubmit}
       disabled={loading}
     >
-      {({ change, data, handlers, submit, saveDisabled }) => (
+      {({ change, data, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.pages)}
@@ -243,7 +243,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
             </div>
           </Grid>
           <Savebar
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onDelete={page === null ? undefined : onRemove}

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -135,8 +135,9 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
       fetchMoreReferenceProducts={fetchMoreReferenceProducts}
       assignReferencesAttributeId={assignReferencesAttributeId}
       onSubmit={onSubmit}
+      disabled={loading}
     >
-      {({ change, data, valid, handlers, hasChanged, submit }) => (
+      {({ change, data, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.pages)}
@@ -242,7 +243,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
             </div>
           </Grid>
           <Savebar
-            disabled={loading || !hasChanged || !valid}
+            disabled={saveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onDelete={page === null ? undefined : onRemove}

--- a/src/pages/components/PageDetailsPage/form.tsx
+++ b/src/pages/components/PageDetailsPage/form.tsx
@@ -240,8 +240,8 @@ function usePageForm(
 
   const valid = pageExists || !!opts.selectedPageType;
 
-  const saveDisabled = disabled || !hasChanged || !valid;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || !hasChanged || !valid;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -261,7 +261,7 @@ function usePageForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/pages/components/PageDetailsPage/form.tsx
+++ b/src/pages/components/PageDetailsPage/form.tsx
@@ -97,6 +97,7 @@ export interface PageFormProps extends UsePageFormOpts {
   children: (props: UsePageUpdateFormResult) => React.ReactNode;
   page: PageDetailsFragment;
   onSubmit: (data: PageData) => SubmitPromise;
+  disabled: boolean;
 }
 
 const getInitialFormData = (page?: PageDetailsFragment): PageFormData => ({
@@ -114,6 +115,7 @@ const getInitialFormData = (page?: PageDetailsFragment): PageFormData => ({
 function usePageForm(
   page: PageDetailsFragment,
   onSubmit: (data: PageData) => SubmitPromise,
+  disabled: boolean,
   opts: UsePageFormOpts
 ): UsePageUpdateFormResult {
   const pageExists = page !== null;
@@ -138,7 +140,7 @@ function usePageForm(
     confirmLeave: true
   });
 
-  const { setExitDialogSubmitRef } = useExitFormDialog({
+  const { setExitDialogSubmitRef, setIsSubmitDisabled } = useExitFormDialog({
     formId
   });
 
@@ -238,6 +240,9 @@ function usePageForm(
 
   const valid = pageExists || !!opts.selectedPageType;
 
+  const saveDisabled = disabled || !hasChanged || !valid;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data: getData(),
@@ -255,7 +260,8 @@ function usePageForm(
       selectPageType: handlePageTypeSelect
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -263,9 +269,10 @@ const PageForm: React.FC<PageFormProps> = ({
   children,
   page,
   onSubmit,
+  disabled,
   ...rest
 }) => {
-  const props = usePageForm(page, onSubmit, rest);
+  const props = usePageForm(page, onSubmit, disabled, rest);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
+++ b/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
@@ -7,6 +7,7 @@ import { PermissionEnum, PermissionGroupErrorFragment } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getPermissionGroupErrorMessage from "@saleor/utils/errors/permissionGroups";
 import React from "react";
@@ -55,8 +56,13 @@ const PermissionGroupCreatePage: React.FC<PermissionGroupCreatePageProps> = ({
   );
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ data, change, submit, hasChanged }) => (
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ data, change, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.permissionGroups)}
@@ -95,7 +101,7 @@ const PermissionGroupCreatePage: React.FC<PermissionGroupCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
             />
           </div>
         </Container>

--- a/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
+++ b/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
@@ -61,7 +61,7 @@ const PermissionGroupCreatePage: React.FC<PermissionGroupCreatePageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data, change, submit, saveDisabled }) => (
+      {({ data, change, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>
             {intl.formatMessage(sectionNames.permissionGroups)}
@@ -100,7 +100,7 @@ const PermissionGroupCreatePage: React.FC<PermissionGroupCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
             />
           </div>
         </Container>

--- a/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
+++ b/src/permissionGroups/components/PermissionGroupCreatePage/PermissionGroupCreatePage.tsx
@@ -7,7 +7,6 @@ import { PermissionEnum, PermissionGroupErrorFragment } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import { getFormErrors } from "@saleor/utils/errors";
 import getPermissionGroupErrorMessage from "@saleor/utils/errors/permissionGroups";
 import React from "react";
@@ -60,7 +59,7 @@ const PermissionGroupCreatePage: React.FC<PermissionGroupCreatePageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ data, change, submit, saveDisabled }) => (
         <Container>

--- a/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
+++ b/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
@@ -13,10 +13,7 @@ import {
 import { ChangeEvent, SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import {
-  basicFormDisableConditions,
-  getStringOrPlaceholder
-} from "@saleor/misc";
+import { getStringOrPlaceholder } from "@saleor/misc";
 import { isSecretField } from "@saleor/plugins/utils";
 import React from "react";
 import { useIntl } from "react-intl";
@@ -78,7 +75,7 @@ const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
       initial={initialFormData()}
       onSubmit={onSubmit}
       key={selectedChannelId}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ data, submit, set, saveDisabled }) => {
         const onChange = (event: ChangeEvent) => {

--- a/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
+++ b/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
@@ -13,7 +13,10 @@ import {
 import { ChangeEvent, SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { getStringOrPlaceholder } from "@saleor/misc";
+import {
+  basicFormDisableConditions,
+  getStringOrPlaceholder
+} from "@saleor/misc";
 import { isSecretField } from "@saleor/plugins/utils";
 import React from "react";
 import { useIntl } from "react-intl";
@@ -75,8 +78,9 @@ const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
       initial={initialFormData()}
       onSubmit={onSubmit}
       key={selectedChannelId}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
     >
-      {({ data, hasChanged, submit, set }) => {
+      {({ data, submit, set, saveDisabled }) => {
         const onChange = (event: ChangeEvent) => {
           const { name, value } = event.target;
           const newData = {
@@ -159,7 +163,7 @@ const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
               onCancel={onBack}
               onSubmit={submit}

--- a/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
+++ b/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
@@ -77,7 +77,7 @@ const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
       key={selectedChannelId}
       disabled={disabled}
     >
-      {({ data, submit, set, saveDisabled }) => {
+      {({ data, submit, set, isSaveDisabled }) => {
         const onChange = (event: ChangeEvent) => {
           const { name, value } = event.target;
           const newData = {
@@ -160,7 +160,7 @@ const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
               onCancel={onBack}
               onSubmit={submit}

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -97,7 +97,7 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => {
+      {({ change, data, isSaveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         const changeKind = makeProductTypeKindChangeHandler(
@@ -150,7 +150,7 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
             <Savebar
               onCancel={onBack}
               onSubmit={submit}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -14,7 +14,6 @@ import { ChangeEvent, FormChange, SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import { makeProductTypeKindChangeHandler } from "@saleor/productTypes/handlers";
 import { UserError } from "@saleor/types";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -96,7 +95,7 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
       confirmLeave
       initial={initialData}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -14,6 +14,7 @@ import { ChangeEvent, FormChange, SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import { makeProductTypeKindChangeHandler } from "@saleor/productTypes/handlers";
 import { UserError } from "@saleor/types";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -91,8 +92,13 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialData} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit }) => {
+    <Form
+      confirmLeave
+      initial={initialData}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         const changeKind = makeProductTypeKindChangeHandler(
@@ -145,7 +151,7 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
             <Savebar
               onCancel={onBack}
               onSubmit={submit}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -17,7 +17,7 @@ import { ChangeEvent, FormChange, SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { maybe } from "@saleor/misc";
+import { basicFormDisableConditions, maybe } from "@saleor/misc";
 import { ListActions, ReorderEvent, UserError } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -156,8 +156,13 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
   };
 
   return (
-    <Form initial={formInitialData} onSubmit={handleSubmit} confirmLeave>
-      {({ change, data, hasChanged, submit, setChanged }) => {
+    <Form
+      initial={formInitialData}
+      onSubmit={handleSubmit}
+      confirmLeave
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit, setChanged }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -256,7 +261,7 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -162,7 +162,7 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
       confirmLeave
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit, setChanged }) => {
+      {({ change, data, isSaveDisabled, submit, setChanged }) => {
         const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
@@ -261,7 +261,7 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
             />
           </Container>

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -17,7 +17,7 @@ import { ChangeEvent, FormChange, SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions, maybe } from "@saleor/misc";
+import { maybe } from "@saleor/misc";
 import { ListActions, ReorderEvent, UserError } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -160,7 +160,7 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
       initial={formInitialData}
       onSubmit={handleSubmit}
       confirmLeave
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit, setChanged }) => {
         const changeMetadata = makeMetadataChangeHandler(change);

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -204,7 +204,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
       assignReferencesAttributeId={assignReferencesAttributeId}
       loading={loading}
     >
-      {({ change, data, formErrors, handlers, submit, saveDisabled }) => {
+      {({ change, data, formErrors, handlers, submit, isSaveDisabled }) => {
         // Comparing explicitly to false because `hasVariants` can be undefined
         const isSimpleProduct = data.productType?.hasVariants === false;
 
@@ -360,7 +360,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
             />
             {canOpenAssignReferencesAttributeDialog && (
               <AssignAttributeValueDialog

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -202,16 +202,9 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
       fetchReferenceProducts={fetchReferenceProducts}
       fetchMoreReferenceProducts={fetchMoreReferenceProducts}
       assignReferencesAttributeId={assignReferencesAttributeId}
+      loading={loading}
     >
-      {({
-        change,
-        data,
-        formErrors,
-        disabled: formDisabled,
-        handlers,
-        hasChanged,
-        submit
-      }) => {
+      {({ change, data, formErrors, handlers, submit, saveDisabled }) => {
         // Comparing explicitly to false because `hasVariants` can be undefined
         const isSimpleProduct = data.productType?.hasVariants === false;
 
@@ -367,7 +360,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={loading || !onSubmit || formDisabled || !hasChanged}
+              disabled={saveDisabled}
             />
             {canOpenAssignReferencesAttributeDialog && (
               <AssignAttributeValueDialog

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -391,8 +391,8 @@ function useProductCreateForm(
 
   const isSaveEnabled = !shouldEnableSave();
 
-  const saveDisabled = loading || !onSubmit || isSaveEnabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = loading || !onSubmit || isSaveEnabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -422,7 +422,7 @@ function useProductCreateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -163,11 +163,13 @@ export interface ProductCreateFormProps extends UseProductCreateFormOpts {
   children: (props: UseProductCreateFormResult) => React.ReactNode;
   initial?: Partial<ProductCreateFormData>;
   onSubmit: (data: ProductCreateData) => SubmitPromise;
+  loading: boolean;
 }
 
 function useProductCreateForm(
   initial: Partial<ProductCreateFormData>,
   onSubmit: (data: ProductCreateData) => SubmitPromise,
+  loading: boolean,
   opts: UseProductCreateFormOpts
 ): UseProductCreateFormResult {
   const intl = useIntl();
@@ -229,10 +231,6 @@ function useProductCreateForm(
   const [description, changeDescription] = useRichText({
     initial: null,
     triggerChange
-  });
-
-  const { setExitDialogSubmitRef } = useExitFormDialog({
-    formId: PRODUCT_CREATE_FORM_ID
   });
 
   const {
@@ -357,6 +355,10 @@ function useProductCreateForm(
 
   const submit = () => handleFormSubmit(data);
 
+  const { setExitDialogSubmitRef, setIsSubmitDisabled } = useExitFormDialog({
+    formId: PRODUCT_CREATE_FORM_ID
+  });
+
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
   const shouldEnableSave = () => {
@@ -387,12 +389,15 @@ function useProductCreateForm(
     return true;
   };
 
-  const disabled = !shouldEnableSave();
+  const isSaveEnabled = !shouldEnableSave();
+
+  const saveDisabled = loading || !onSubmit || isSaveEnabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
 
   return {
     change: handleChange,
     data,
-    disabled,
+    disabled: isSaveEnabled,
     formErrors: form.errors,
     handlers: {
       addStock: handleStockAdd,
@@ -416,7 +421,8 @@ function useProductCreateForm(
       selectTaxRate: handleTaxTypeSelect
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -424,9 +430,10 @@ const ProductCreateForm: React.FC<ProductCreateFormProps> = ({
   children,
   initial,
   onSubmit,
+  loading,
   ...rest
 }) => {
-  const props = useProductCreateForm(initial || {}, onSubmit, rest);
+  const props = useProductCreateForm(initial || {}, onSubmit, loading, rest);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -287,7 +287,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
       disabled={disabled}
       hasChannelChanged={hasChannelChanged}
     >
-      {({ change, data, formErrors, handlers, submit, saveDisabled }) => (
+      {({ change, data, formErrors, handlers, submit, isSaveDisabled }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -502,7 +502,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               onDelete={onDelete}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
             />
             {canOpenAssignReferencesAttributeDialog && (
               <AssignAttributeValueDialog

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -284,16 +284,10 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
       fetchReferenceProducts={fetchReferenceProducts}
       fetchMoreReferenceProducts={fetchMoreReferenceProducts}
       assignReferencesAttributeId={assignReferencesAttributeId}
+      disabled={disabled}
+      hasChannelChanged={hasChannelChanged}
     >
-      {({
-        change,
-        data,
-        formErrors,
-        disabled: formDisabled,
-        handlers,
-        hasChanged,
-        submit
-      }) => (
+      {({ change, data, formErrors, handlers, submit, saveDisabled }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -508,9 +502,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               onDelete={onDelete}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={
-                disabled || formDisabled || (!hasChanged && !hasChannelChanged)
-              }
+              disabled={saveDisabled}
             />
             {canOpenAssignReferencesAttributeDialog && (
               <AssignAttributeValueDialog

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -157,7 +157,6 @@ export interface UseProductUpdateFormResult
     ProductUpdateData,
     ProductUpdateHandlers
   > {
-  disabled: boolean;
   formErrors: FormErrors<ProductUpdateSubmitData>;
 }
 
@@ -193,6 +192,8 @@ export interface ProductUpdateFormProps extends UseProductUpdateFormOpts {
   children: (props: UseProductUpdateFormResult) => React.ReactNode;
   product: ProductFragment;
   onSubmit: (data: ProductUpdateSubmitData) => SubmitPromise;
+  disabled: boolean;
+  hasChannelChanged: boolean;
 }
 
 const getStocksData = (
@@ -222,6 +223,8 @@ const getStocksData = (
 function useProductUpdateForm(
   product: ProductFragment,
   onSubmit: (data: ProductUpdateSubmitData) => SubmitPromise,
+  disabled: boolean,
+  hasChannelChanged: boolean,
   opts: UseProductUpdateFormOpts
 ): UseProductUpdateFormResult {
   const intl = useIntl();
@@ -244,7 +247,8 @@ function useProductUpdateForm(
     toggleValue,
     data: formData,
     setChanged,
-    hasChanged
+    hasChanged,
+    setIsSubmitDisabled
   } = form;
 
   const attributes = useFormset(getAttributeInputFromProduct(product));
@@ -435,12 +439,15 @@ function useProductUpdateForm(
     return true;
   };
 
-  const disabled = !shouldEnableSave();
+  const isSaveEnabled = !shouldEnableSave();
+
+  const saveDisabled =
+    disabled || isSaveEnabled || (!hasChanged && !hasChannelChanged);
+  setIsSubmitDisabled(saveDisabled);
 
   return {
     change: handleChange,
     data,
-    disabled,
     formErrors: form.errors,
     handlers: {
       addStock: handleStockAdd,
@@ -464,7 +471,8 @@ function useProductUpdateForm(
       selectTaxRate: handleTaxTypeSelect
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -472,9 +480,17 @@ const ProductUpdateForm: React.FC<ProductUpdateFormProps> = ({
   children,
   product,
   onSubmit,
+  disabled,
+  hasChannelChanged,
   ...rest
 }) => {
-  const props = useProductUpdateForm(product, onSubmit, rest);
+  const props = useProductUpdateForm(
+    product,
+    onSubmit,
+    disabled,
+    hasChannelChanged,
+    rest
+  );
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -441,9 +441,9 @@ function useProductUpdateForm(
 
   const isSaveEnabled = !shouldEnableSave();
 
-  const saveDisabled =
+  const isSaveDisabled =
     disabled || isSaveEnabled || (!hasChanged && !hasChannelChanged);
-  setIsSubmitDisabled(saveDisabled);
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -472,7 +472,7 @@ function useProductUpdateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -149,15 +149,9 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
       fetchReferenceProducts={fetchReferenceProducts}
       fetchMoreReferenceProducts={fetchMoreReferenceProducts}
       assignReferencesAttributeId={assignReferencesAttributeId}
+      disabled={disabled}
     >
-      {({
-        change,
-        data,
-        formErrors,
-        disabled: formDisabled,
-        handlers,
-        submit
-      }) => (
+      {({ change, data, formErrors, handlers, submit, saveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>{product?.name}</Backlink>
           <PageHeader title={header} />
@@ -258,7 +252,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
             </div>
           </Grid>
           <Savebar
-            disabled={disabled || formDisabled || !onSubmit}
+            disabled={saveDisabled}
             labels={{
               confirm: intl.formatMessage(messages.saveVariant),
               delete: intl.formatMessage(messages.deleteVariant)

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -151,7 +151,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
       assignReferencesAttributeId={assignReferencesAttributeId}
       disabled={disabled}
     >
-      {({ change, data, formErrors, handlers, submit, saveDisabled }) => (
+      {({ change, data, formErrors, handlers, submit, isSaveDisabled }) => (
         <Container>
           <Backlink onClick={onBack}>{product?.name}</Backlink>
           <PageHeader title={header} />
@@ -252,7 +252,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
             </div>
           </Grid>
           <Savebar
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             labels={{
               confirm: intl.formatMessage(messages.saveVariant),
               delete: intl.formatMessage(messages.deleteVariant)

--- a/src/products/components/ProductVariantCreatePage/form.tsx
+++ b/src/products/components/ProductVariantCreatePage/form.tsx
@@ -235,8 +235,8 @@ function useProductVariantCreateForm(
     data.hasPreorderEndDate &&
     !!form.errors.preorderEndDateTime;
 
-  const saveDisabled = disabled || formDisabled || !onSubmit;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = disabled || formDisabled || !onSubmit;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -259,7 +259,7 @@ function useProductVariantCreateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/products/components/ProductVariantCreatePage/form.tsx
+++ b/src/products/components/ProductVariantCreatePage/form.tsx
@@ -94,6 +94,7 @@ export interface ProductVariantCreateFormProps
   children: (props: UseProductVariantCreateFormResult) => React.ReactNode;
   product: ProductVariantCreateDataQuery["product"];
   onSubmit: (data: ProductVariantCreateData) => void;
+  disabled: boolean;
 }
 
 const initial: ProductVariantCreateFormData = {
@@ -113,6 +114,7 @@ const initial: ProductVariantCreateFormData = {
 function useProductVariantCreateForm(
   product: ProductVariantCreateDataQuery["product"],
   onSubmit: (data: ProductVariantCreateData) => void,
+  disabled: boolean,
   opts: UseProductVariantCreateFormOpts
 ): UseProductVariantCreateFormResult {
   const intl = useIntl();
@@ -126,7 +128,8 @@ function useProductVariantCreateForm(
     handleChange,
     hasChanged,
     data: formData,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = form;
 
   const attributes = useFormset(attributeInput);
@@ -227,13 +230,18 @@ function useProductVariantCreateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const formDisabled =
+    data.isPreorder &&
+    data.hasPreorderEndDate &&
+    !!form.errors.preorderEndDateTime;
+
+  const saveDisabled = disabled || formDisabled || !onSubmit;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data,
-    disabled:
-      data.isPreorder &&
-      data.hasPreorderEndDate &&
-      !!form.errors.preorderEndDateTime,
+    disabled,
     formErrors: form.errors,
     handlers: {
       addStock: handleStockAdd,
@@ -250,7 +258,8 @@ function useProductVariantCreateForm(
       selectAttributeReference: handleAttributeReferenceChange
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -258,9 +267,10 @@ const ProductVariantCreateForm: React.FC<ProductVariantCreateFormProps> = ({
   children,
   product,
   onSubmit,
+  disabled,
   ...rest
 }) => {
-  const props = useProductVariantCreateForm(product, onSubmit, rest);
+  const props = useProductVariantCreateForm(product, onSubmit, disabled, rest);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -220,7 +220,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
           assignReferencesAttributeId={assignReferencesAttributeId}
           loading={loading}
         >
-          {({ change, data, formErrors, saveDisabled, handlers, submit }) => {
+          {({ change, data, formErrors, isSaveDisabled, handlers, submit }) => {
             const nonSelectionAttributes = data.attributes.filter(
               byAttributeScope(VariantAttributeScope.NOT_VARIANT_SELECTION)
             );
@@ -366,7 +366,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   </div>
                 </Grid>
                 <Savebar
-                  disabled={saveDisabled}
+                  disabled={isSaveDisabled}
                   state={saveButtonBarState}
                   onCancel={onBack}
                   onDelete={onDelete}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -218,16 +218,9 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
           fetchReferenceProducts={fetchReferenceProducts}
           fetchMoreReferenceProducts={fetchMoreReferenceProducts}
           assignReferencesAttributeId={assignReferencesAttributeId}
+          loading={loading}
         >
-          {({
-            change,
-            data,
-            formErrors,
-            disabled: formDisabled,
-            handlers,
-            hasChanged,
-            submit
-          }) => {
+          {({ change, data, formErrors, saveDisabled, handlers, submit }) => {
             const nonSelectionAttributes = data.attributes.filter(
               byAttributeScope(VariantAttributeScope.NOT_VARIANT_SELECTION)
             );
@@ -373,7 +366,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   </div>
                 </Grid>
                 <Savebar
-                  disabled={loading || formDisabled || !hasChanged}
+                  disabled={saveDisabled}
                   state={saveButtonBarState}
                   onCancel={onBack}
                   onDelete={onDelete}

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -335,8 +335,8 @@ function useProductVariantUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
-  const saveDisabled = loading || disabled || !hasChanged;
-  setIsSubmitDisabled(saveDisabled);
+  const isSaveDisabled = loading || disabled || !hasChanged;
+  setIsSubmitDisabled(isSaveDisabled);
 
   return {
     change: handleChange,
@@ -360,7 +360,7 @@ function useProductVariantUpdateForm(
     },
     hasChanged,
     submit,
-    saveDisabled
+    isSaveDisabled
   };
 }
 

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -130,12 +130,14 @@ export interface ProductVariantUpdateFormProps
   extends UseProductVariantUpdateFormOpts {
   children: (props: UseProductVariantUpdateFormResult) => React.ReactNode;
   variant: ProductVariantFragment;
+  loading: boolean;
   onSubmit: (data: ProductVariantUpdateSubmitData) => SubmitPromise;
 }
 
 function useProductVariantUpdateForm(
   variant: ProductVariantFragment,
   onSubmit: (data: ProductVariantUpdateSubmitData) => SubmitPromise,
+  loading: boolean,
   opts: UseProductVariantUpdateFormOpts
 ): UseProductVariantUpdateFormResult {
   const intl = useIntl();
@@ -180,7 +182,8 @@ function useProductVariantUpdateForm(
     data: formData,
     setChanged,
     hasChanged,
-    formId
+    formId,
+    setIsSubmitDisabled
   } = form;
 
   const { setExitDialogSubmitRef } = useExitFormDialog({
@@ -332,6 +335,9 @@ function useProductVariantUpdateForm(
 
   useEffect(() => setExitDialogSubmitRef(submit), [submit]);
 
+  const saveDisabled = loading || disabled || !hasChanged;
+  setIsSubmitDisabled(saveDisabled);
+
   return {
     change: handleChange,
     data,
@@ -353,7 +359,8 @@ function useProductVariantUpdateForm(
       selectAttributeReference: handleAttributeReferenceChange
     },
     hasChanged,
-    submit
+    submit,
+    saveDisabled
   };
 }
 
@@ -361,9 +368,10 @@ const ProductVariantUpdateForm: React.FC<ProductVariantUpdateFormProps> = ({
   children,
   variant,
   onSubmit,
+  loading,
   ...rest
 }) => {
-  const props = useProductVariantUpdateForm(variant, onSubmit, rest);
+  const props = useProductVariantUpdateForm(variant, onSubmit, loading, rest);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -7,7 +7,6 @@ import {
   handleUploadMultipleFiles,
   prepareAttributesInput
 } from "@saleor/attributes/utils/handlers";
-import { getAllErrorMessages } from "@saleor/auth";
 import { ChannelData } from "@saleor/channels/utils";
 import {
   AttributeErrorFragment,

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -124,12 +124,6 @@ export function createHandler(
 
     const result = await productCreate(productVariables);
 
-    // When 400 is thrown Apollo for some reason adds ApolloError in result.errors
-    // This code is required to prevent navigation in exit form
-    if (result.errors && (result.errors as any)?.networkError) {
-      errors = [...errors, ...getAllErrorMessages(result.errors as any)];
-    }
-
     let hasErrors = errors.length > 0;
 
     const hasVariants = productType?.hasVariants;

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -7,6 +7,7 @@ import {
   handleUploadMultipleFiles,
   prepareAttributesInput
 } from "@saleor/attributes/utils/handlers";
+import { getAllErrorMessages } from "@saleor/auth";
 import { ChannelData } from "@saleor/channels/utils";
 import {
   AttributeErrorFragment,
@@ -122,10 +123,17 @@ export function createHandler(
     };
 
     const result = await productCreate(productVariables);
+
+    // When 400 is thrown Apollo for some reason adds ApolloError in result.errors
+    // This code is required to prevent navigation in exit form
+    if (result.errors && (result.errors as any)?.networkError) {
+      errors = [...errors, ...getAllErrorMessages(result.errors as any)];
+    }
+
     let hasErrors = errors.length > 0;
 
-    const hasVariants = productType.hasVariants;
-    const productId = result.data.productCreate.product?.id;
+    const hasVariants = productType?.hasVariants;
+    const productId = result?.data?.productCreate?.product?.id;
 
     if (!productId) {
       return { errors };

--- a/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
+++ b/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
@@ -72,7 +72,7 @@ const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => (
+      {({ change, data, isSaveDisabled, submit }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -110,7 +110,7 @@ const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
+++ b/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
@@ -9,7 +9,6 @@ import { CountryFragment, ShippingErrorFragment } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -71,7 +70,7 @@ const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => (
         <>

--- a/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
+++ b/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
@@ -9,6 +9,7 @@ import { CountryFragment, ShippingErrorFragment } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -66,8 +67,13 @@ const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit }) => (
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -105,7 +111,7 @@ const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               onCancel={onBack}
               onSubmit={submit}
               state={saveButtonBarState}

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -130,7 +130,7 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
       confirmLeave
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit, toggleValue }) => {
+      {({ change, data, isSaveDisabled, submit, toggleValue }) => {
         const handleWarehouseChange = createMultiAutocompleteSelectHandler(
           toggleValue,
           setWarehouseDisplayValues,
@@ -220,7 +220,7 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -24,10 +24,7 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import React from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
-import {
-  basicFormDisableConditions,
-  getStringOrPlaceholder
-} from "../../../misc";
+import { getStringOrPlaceholder } from "../../../misc";
 import { ChannelProps, FetchMoreProps, SearchProps } from "../../../types";
 import { ShippingZoneUpdateFormData } from "../../components/ShippingZoneDetailsPage/types";
 import ShippingZoneInfo from "../ShippingZoneInfo";
@@ -131,7 +128,7 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
       initial={initialForm}
       onSubmit={onSubmit}
       confirmLeave
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit, toggleValue }) => {
         const handleWarehouseChange = createMultiAutocompleteSelectHandler(

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -24,7 +24,10 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import React from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
-import { getStringOrPlaceholder } from "../../../misc";
+import {
+  basicFormDisableConditions,
+  getStringOrPlaceholder
+} from "../../../misc";
 import { ChannelProps, FetchMoreProps, SearchProps } from "../../../types";
 import { ShippingZoneUpdateFormData } from "../../components/ShippingZoneDetailsPage/types";
 import ShippingZoneInfo from "../ShippingZoneInfo";
@@ -124,8 +127,13 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
   } = useMetadataChangeTrigger();
 
   return (
-    <Form initial={initialForm} onSubmit={onSubmit} confirmLeave>
-      {({ change, data, hasChanged, submit, toggleValue }) => {
+    <Form
+      initial={initialForm}
+      onSubmit={onSubmit}
+      confirmLeave
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit, toggleValue }) => {
         const handleWarehouseChange = createMultiAutocompleteSelectHandler(
           toggleValue,
           setWarehouseDisplayValues,
@@ -215,7 +223,7 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -136,7 +136,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
       confirmLeave
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => {
+      {({ change, data, isSaveDisabled, submit }) => {
         const countryChoices = mapCountriesToChoices(shop?.countries || []);
         const handleCountryChange = createSingleAutocompleteSelectHandler(
           change,
@@ -202,7 +202,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
             </Grid>
             <Savebar
               state={saveButtonBarState}
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onSubmit={submit}
             />

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -16,7 +16,6 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
-import { basicFormDisableConditions } from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
@@ -135,7 +134,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
         return submitFunc(data);
       }}
       confirmLeave
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => {
         const countryChoices = mapCountriesToChoices(shop?.countries || []);

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -16,6 +16,7 @@ import {
   ConfirmButtonTransitionState,
   makeStyles
 } from "@saleor/macaw-ui";
+import { basicFormDisableConditions } from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
@@ -134,8 +135,9 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
         return submitFunc(data);
       }}
       confirmLeave
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
     >
-      {({ change, data, hasChanged, submit }) => {
+      {({ change, data, saveDisabled, submit }) => {
         const countryChoices = mapCountriesToChoices(shop?.countries || []);
         const handleCountryChange = createSingleAutocompleteSelectHandler(
           change,
@@ -201,7 +203,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
             </Grid>
             <Savebar
               state={saveButtonBarState}
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               onCancel={onBack}
               onSubmit={submit}
             />

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -107,7 +107,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ data: formData, change, saveDisabled, submit, toggleValue }) => {
+      {({ data: formData, change, isSaveDisabled, submit, toggleValue }) => {
         const permissionGroupsChange = createMultiAutocompleteSelectHandler(
           toggleValue,
           setPermissionGroupsDisplayValues,
@@ -192,7 +192,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               state={saveButtonBarState}
               onCancel={onBack}
               onSubmit={submit}

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -18,7 +18,7 @@ import useLocale from "@saleor/hooks/useLocale";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { basicFormDisableConditions, getUserName } from "@saleor/misc";
+import { getUserName } from "@saleor/misc";
 import UserStatus from "@saleor/staff/components/UserStatus";
 import { FetchMoreProps, RelayToFlat, SearchPageProps } from "@saleor/types";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
@@ -105,7 +105,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ data: formData, change, saveDisabled, submit, toggleValue }) => {
         const permissionGroupsChange = createMultiAutocompleteSelectHandler(

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -18,7 +18,7 @@ import useLocale from "@saleor/hooks/useLocale";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { getUserName } from "@saleor/misc";
+import { basicFormDisableConditions, getUserName } from "@saleor/misc";
 import UserStatus from "@saleor/staff/components/UserStatus";
 import { FetchMoreProps, RelayToFlat, SearchPageProps } from "@saleor/types";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
@@ -101,8 +101,13 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ data: formData, change, hasChanged, submit, toggleValue }) => {
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ data: formData, change, saveDisabled, submit, toggleValue }) => {
         const permissionGroupsChange = createMultiAutocompleteSelectHandler(
           toggleValue,
           setPermissionGroupsDisplayValues,
@@ -187,7 +192,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               state={saveButtonBarState}
               onCancel={onBack}
               onSubmit={submit}

--- a/src/taxes/components/CountryListPage/CountryListPage.tsx
+++ b/src/taxes/components/CountryListPage/CountryListPage.tsx
@@ -10,7 +10,7 @@ import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { basicFormDisableConditions, maybe } from "../../../misc";
+import { maybe } from "../../../misc";
 import CountryList from "../CountryList";
 import TaxConfiguration from "../TaxConfiguration";
 
@@ -50,7 +50,7 @@ const CountryListPage: React.FC<CountryListPageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={onSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit }) => (
         <>

--- a/src/taxes/components/CountryListPage/CountryListPage.tsx
+++ b/src/taxes/components/CountryListPage/CountryListPage.tsx
@@ -52,7 +52,7 @@ const CountryListPage: React.FC<CountryListPageProps> = ({
       onSubmit={onSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit }) => (
+      {({ change, data, isSaveDisabled, submit }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -82,7 +82,7 @@ const CountryListPage: React.FC<CountryListPageProps> = ({
             </Grid>
           </Container>
           <Savebar
-            disabled={saveDisabled}
+            disabled={isSaveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/taxes/components/CountryListPage/CountryListPage.tsx
+++ b/src/taxes/components/CountryListPage/CountryListPage.tsx
@@ -10,7 +10,7 @@ import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { maybe } from "../../../misc";
+import { basicFormDisableConditions, maybe } from "../../../misc";
 import CountryList from "../CountryList";
 import TaxConfiguration from "../TaxConfiguration";
 
@@ -46,8 +46,13 @@ const CountryListPage: React.FC<CountryListPageProps> = ({
     showGross: maybe(() => shop.displayGrossPrices, false)
   };
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={onSubmit}>
-      {({ change, data, hasChanged, submit }) => (
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={onSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit }) => (
         <>
           <Container>
             <Backlink onClick={onBack}>
@@ -77,7 +82,7 @@ const CountryListPage: React.FC<CountryListPageProps> = ({
             </Grid>
           </Container>
           <Savebar
-            disabled={disabled || !hasChanged}
+            disabled={saveDisabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onSubmit={submit}

--- a/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
+++ b/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
@@ -90,7 +90,7 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
       onSubmit={handleSubmit}
       disabled={disabled}
     >
-      {({ change, data, saveDisabled, submit, set }) => {
+      {({ change, data, isSaveDisabled, submit, set }) => {
         const countryChoices = mapCountriesToChoices(countries);
         const handleCountryChange = createSingleAutocompleteSelectHandler(
           change,
@@ -139,7 +139,7 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={saveDisabled}
+              disabled={isSaveDisabled}
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}

--- a/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
+++ b/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
@@ -18,11 +18,7 @@ import { SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import {
-  basicFormDisableConditions,
-  findValueInEnum,
-  maybe
-} from "@saleor/misc";
+import { findValueInEnum, maybe } from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices, mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
@@ -92,7 +88,7 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
       confirmLeave
       initial={initialForm}
       onSubmit={handleSubmit}
-      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+      disabled={disabled}
     >
       {({ change, data, saveDisabled, submit, set }) => {
         const countryChoices = mapCountriesToChoices(countries);

--- a/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
+++ b/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
@@ -18,7 +18,11 @@ import { SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { findValueInEnum, maybe } from "@saleor/misc";
+import {
+  basicFormDisableConditions,
+  findValueInEnum,
+  maybe
+} from "@saleor/misc";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { mapCountriesToChoices, mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
@@ -84,8 +88,13 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
   };
 
   return (
-    <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
-      {({ change, data, hasChanged, submit, set }) => {
+    <Form
+      confirmLeave
+      initial={initialForm}
+      onSubmit={handleSubmit}
+      isDisabled={opts => basicFormDisableConditions(opts, disabled)}
+    >
+      {({ change, data, saveDisabled, submit, set }) => {
         const countryChoices = mapCountriesToChoices(countries);
         const handleCountryChange = createSingleAutocompleteSelectHandler(
           change,
@@ -134,7 +143,7 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
               </div>
             </Grid>
             <Savebar
-              disabled={disabled || !hasChanged}
+              disabled={saveDisabled}
               onCancel={onBack}
               onDelete={onDelete}
               onSubmit={submit}


### PR DESCRIPTION
I want to merge this change because it removed `confirmLeave` on tracking dialog. It prevents exit dialog to appear when tracking number has been edited

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
