### PR TITLE
Indicate menu focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,9 +4828,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.1.tgz",
-      "integrity": "sha512-2sGPfMLszKb2Zejd9/hs5MNLhvcIW+bQj+6CTnq8+BbKNt/zqg6t1YQrucb72otUUTJMC6VIjnvtMITmpsgLsQ==",
+      "version": "github:saleor/macaw-ui#1f78f97748c00a64ca46973c32eacc4d9a1ac2ac",
+      "from": "github:saleor/macaw-ui#SALEOR-5840-button-states",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "0.3.1",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#SALEOR-5840-button-states",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/components/CardMenu/CardMenu.tsx
+++ b/src/components/CardMenu/CardMenu.tsx
@@ -131,6 +131,7 @@ const CardMenu: React.FC<CardMenuProps> = props => {
         ref={anchorRef}
         onClick={handleToggle}
         variant={outlined ? "primary" : "secondary"}
+        state={open ? "active" : "default"}
       >
         <MoreIcon />
       </IconButton>
@@ -163,6 +164,7 @@ const CardMenu: React.FC<CardMenuProps> = props => {
                       disabled={menuItem.loading || menuItem.disabled}
                       onClick={() => handleMenuClick(menuItemIndex)}
                       key={menuItem.label}
+                      button
                     >
                       <div
                         className={classNames(className, {


### PR DESCRIPTION
I want to merge this change because it changes how buttons opening dropdowns behave - they stay pressed as long as menu is open.

**PR intended to be tested with API branch:** main

### Screenshots
<img width="320" alt="Zrzut ekranu 2022-03-14 o 13 54 41" src="https://user-images.githubusercontent.com/6833443/158350155-5429183d-55d1-4e35-afda-919373d15ba8.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
