### PR TITLE
Fix @saleor/macaw-ui dependency version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,8 +4828,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:saleor/macaw-ui#1f78f97748c00a64ca46973c32eacc4d9a1ac2ac",
-      "from": "github:saleor/macaw-ui#SALEOR-5840-button-states",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.3.tgz",
+      "integrity": "sha512-b2dLlOAXDe2OSmYeZSFKwiRMrJc+YkGhvvQCHQXHHP89TZbGZlWP0F13ycCI3OJSfYbCWZlQGM+alMiE31HOuA==",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:saleor/macaw-ui#SALEOR-5840-button-states",
+    "@saleor/macaw-ui": "0.3.3",
     "@saleor/sdk": "^0.4.2",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",


### PR DESCRIPTION
I want to merge this change because `SALEOR-5840-button-states` was a branch, that was removed 21 hours ago (see: https://github.com/saleor/macaw-ui/pull/124)
