### PR TITLE
Fix menu items permissions logic

### DIFF
--- a/src/components/AppLayout/menuStructure.ts
+++ b/src/components/AppLayout/menuStructure.ts
@@ -244,11 +244,14 @@ function useMenuStructure(
     }
   ];
 
-  const isMenuItemPermitted = (menuItem: FilterableMenuItem) =>
-    !menuItem.permissions ||
-    (user?.userPermissions || []).some(permission =>
-      menuItem.permissions.includes(permission.code)
+  const isMenuItemPermitted = (menuItem: FilterableMenuItem) => {
+    const userPermissions = (user?.userPermissions || []).map(
+      permission => permission.code
     );
+    return (menuItem.permissions || []).every(permission =>
+      userPermissions.includes(permission)
+    );
+  };
 
   const getFilteredMenuItems = (menuItems: FilterableMenuItem[]) =>
     menuItems.filter(isMenuItemPermitted);


### PR DESCRIPTION
I want to merge this change because our permissions logic for menu items was broken (e.g. hiding item, that don't require any permissions at all, as `[]` is truthy).