### PR TITLE
Fix undefined thumbnail url in variant details

### DIFF
--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -242,7 +242,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                     <ProductVariantNavigation
                       current={variant?.id}
                       defaultVariantId={defaultVariantId}
-                      fallbackThumbnail={variant?.product.thumbnail.url}
+                      fallbackThumbnail={variant?.product?.thumbnail?.url}
                       variants={variant?.product.variants}
                       onAdd={onAdd}
                       onRowClick={(variantId: string) => {

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -242,7 +242,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                     <ProductVariantNavigation
                       current={variant?.id}
                       defaultVariantId={defaultVariantId}
-                      fallbackThumbnail={variant?.product?.thumbnail?.url}
+                      fallbackThumbnail={variant?.product?.thumbnail.url}
                       variants={variant?.product.variants}
                       onAdd={onAdd}
                       onRowClick={(variantId: string) => {


### PR DESCRIPTION
I want to merge this change because it fixes a bug with undefined fallback url in variant details

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
