### PR TITLE
Fix sidebar items not showing up with partial permissions

### DIFF
--- a/src/apps/useExtensions.ts
+++ b/src/apps/useExtensions.ts
@@ -1,3 +1,4 @@
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import {
   AppExtensionMountEnum,
   ExtensionListQuery,
@@ -64,6 +65,10 @@ export const useExtensions = <T extends AppExtensionMountEnum>(
   mountList: T[]
 ): Record<T, Extension[]> => {
   const { openApp } = useExternalApp();
+  const permissions = useUserPermissions();
+  const extensionsPermissions = permissions?.find(
+    perm => perm.code === PermissionEnum.MANAGE_APPS
+  );
 
   const { data } = useExtensionListQuery({
     fetchPolicy: "cache-first",
@@ -71,7 +76,8 @@ export const useExtensions = <T extends AppExtensionMountEnum>(
       filter: {
         mount: mountList
       }
-    }
+    },
+    skip: !extensionsPermissions
   });
 
   const extensions = filterAndMapToTarget(

--- a/src/components/AppLayout/menuStructure.ts
+++ b/src/components/AppLayout/menuStructure.ts
@@ -248,7 +248,10 @@ function useMenuStructure(
     const userPermissions = (user?.userPermissions || []).map(
       permission => permission.code
     );
-    return (menuItem.permissions || []).every(permission =>
+    if (!menuItem?.permissions) {
+      return true;
+    }
+    return menuItem.permissions.some(permission =>
       userPermissions.includes(permission)
     );
   };
@@ -259,12 +262,10 @@ function useMenuStructure(
   return [
     menuItems.reduce(
       (resultItems: FilterableMenuItem[], menuItem: FilterableMenuItem) => {
-        const { children } = menuItem;
-
         if (!isMenuItemPermitted(menuItem)) {
           return resultItems;
         }
-
+        const { children } = menuItem;
         const filteredChildren = children
           ? getFilteredMenuItems(children)
           : undefined;

--- a/src/components/Navigator/useQuickSearch.ts
+++ b/src/components/Navigator/useQuickSearch.ts
@@ -37,7 +37,7 @@ function useQuickSearch(
       ...DEFAULT_INITIAL_SEARCH_DATA,
       first: 5
     },
-    skip: true
+    skip: !query
   });
   const [{ data: catalog }, searchCatalog] = useSearchCatalog(5);
   const [createOrder] = useOrderDraftCreateMutation({

--- a/src/components/Navigator/useQuickSearch.ts
+++ b/src/components/Navigator/useQuickSearch.ts
@@ -36,7 +36,8 @@ function useQuickSearch(
     variables: {
       ...DEFAULT_INITIAL_SEARCH_DATA,
       first: 5
-    }
+    },
+    skip: true
   });
   const [{ data: catalog }, searchCatalog] = useSearchCatalog(5);
   const [createOrder] = useOrderDraftCreateMutation({


### PR DESCRIPTION
I want to merge this change because it fixes a bug with sidebar items not showing up when we have only some of the permissions, e.g. configuration didn't show up unless we had all permissions.

Also this PR disables two queries on dashboard startup which gave error on user with few permissions:

- `SearchCustomers` which was invoked by Navigator - it's not required on startup so it's skipped when query is an empty string
-  `ExtensionList` which was invoked by Sidebar - now it is executed only when user has `MANAGE_APPS` permission, because backend requires it anyway.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
