### PR TITLE
Fix shifted text in create variants dialog

### DIFF
--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -77,7 +77,6 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
               </Typography>
               <FormSpacer />
               <RadioGroupField
-                alignTop
                 choices={options.map(option => ({
                   label: (
                     <div

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -10,22 +10,12 @@ import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RadioGroupField from "@saleor/components/RadioGroupField";
 import { buttonMessages } from "@saleor/intl";
-import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { messages } from "./messages";
+import { useStyles } from "./styles";
 import { ProductVariantCreateOptionEnum } from "./types";
-
-const useStyles = makeStyles(
-  theme => ({
-    option: {
-      marginBottom: theme.spacing(2),
-      width: 400
-    }
-  }),
-  { name: "ProductVariantCreateDialog" }
-);
 
 interface ProductVariantCreateDialogForm {
   option: ProductVariantCreateOptionEnum;
@@ -71,7 +61,7 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
             <DialogTitle>
               <FormattedMessage {...messages.title} />
             </DialogTitle>
-            <DialogContent>
+            <DialogContent className={classes.dialogContent}>
               <Typography variant="body2">
                 <FormattedMessage {...messages.description} />
               </Typography>

--- a/src/products/components/ProductVariantCreateDialog/styles.ts
+++ b/src/products/components/ProductVariantCreateDialog/styles.ts
@@ -1,0 +1,14 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    option: {
+      marginBottom: theme.spacing(2),
+      width: 400
+    },
+    dialogContent: {
+      padding: 0
+    }
+  }),
+  { name: "ProductVariantCreateDialog" }
+);


### PR DESCRIPTION
I want to merge this change because it fixes a problem with shifted text in `ProductVariantCreateDialog`.

I avoided making changes to `RadioGroupField` which is used in 18 different places.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.1

### Screenshots
Before:
<img width="501" alt="Create Variants" src="https://user-images.githubusercontent.com/41952692/159940284-1b0e804d-e6d7-40c5-b24c-28a8570f003e.png">

After:
<img width="503" alt="Create Variants" src="https://user-images.githubusercontent.com/41952692/159940455-d124fb66-bde9-45f8-b434-64833175af63.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
