### PR TITLE
Ignore more than 2 decimal numbers in price input

### DIFF
--- a/src/components/PriceField/PriceField.tsx
+++ b/src/components/PriceField/PriceField.tsx
@@ -1,4 +1,4 @@
-import { InputAdornment, TextField } from "@material-ui/core";
+import { InputAdornment, TextField, TextFieldProps } from "@material-ui/core";
 import { InputProps } from "@material-ui/core/Input";
 import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
@@ -43,6 +43,8 @@ interface PriceFieldProps {
   onChange(event: any);
 }
 
+const MAX_DECIMAL_LENGTH = 2;
+
 export const PriceField: React.FC<PriceFieldProps> = props => {
   const {
     className,
@@ -61,6 +63,17 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
 
   const classes = useStyles(props);
   const minValue = 0;
+
+  const handleChange: TextFieldProps["onChange"] = e => {
+    const [, decimalPart] = e.target.value.split(".");
+
+    if (decimalPart?.length > MAX_DECIMAL_LENGTH) {
+      return;
+    }
+
+    onChange(e);
+  };
+
   return (
     <TextField
       className={className}
@@ -88,6 +101,7 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
         ),
         inputProps: {
           min: 0,
+          step: "0.01",
           ...InputProps?.inputProps
         },
         type: "number"
@@ -100,7 +114,7 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
       name={name}
       disabled={disabled}
       required={required}
-      onChange={onChange}
+      onChange={handleChange}
     />
   );
 };


### PR DESCRIPTION
I want to merge this change because it fixes an issue where user could insert prices that would have more than 2 numbers after the decimal point, which would cause error when trying to save any form containing such prices.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:

https://user-images.githubusercontent.com/4144459/160163445-8194c9fb-d31f-4b86-9d1b-73da8c80f346.mp4

After:

https://user-images.githubusercontent.com/4144459/160163458-1ff7dedb-e2c0-4d3c-9a28-3674ffe05744.mp4



<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
