### PR TITLE
Fix variant create null thumbnail

### DIFF
--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -235,7 +235,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                     <ProductVariantNavigation
                       current={variant?.id}
                       defaultVariantId={defaultVariantId}
-                      fallbackThumbnail={variant?.product?.thumbnail.url}
+                      fallbackThumbnail={variant?.product?.thumbnail?.url}
                       variants={variant?.product.variants}
                       onAdd={onAdd}
                       onRowClick={(variantId: string) => {

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -389,9 +389,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
 
   const handleBack = () => navigate(productListUrl());
 
-  if (product === null) {
-    return <NotFoundPage onBack={handleBack} />;
-  }
   const handleVariantAdd = () => navigate(productVariantAddUrl(id));
   const handleVariantsAdd = () => navigate(productVariantCreatorUrl(id));
 
@@ -519,6 +516,10 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     loading: !!searchAttributeValuesOpts.loading,
     onFetchMore: loadMoreAttributeValues
   };
+
+  if (product === null) {
+    return <NotFoundPage onBack={handleBack} />;
+  }
 
   return (
     <>

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -197,10 +197,6 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
   const variant = data?.productVariant;
   const channels = createVariantChannels(variant);
 
-  if (variant === null) {
-    return <NotFoundPage onBack={handleBack} />;
-  }
-
   const [
     deactivatePreorder,
     deactivatePreoderOpts
@@ -359,6 +355,10 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
 
   const attributeValues =
     mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+
+  if (variant === null) {
+    return <NotFoundPage onBack={handleBack} />;
+  }
 
   return (
     <>


### PR DESCRIPTION
I want to merge this change because it fixes a bug which hasn't really been fixed in #1934 because `thumbnail` field indeed can be null.

Also in this PR early return statement are moved in files `ProductUpdate` and `ProductVariant` because for non-existent products this results in too few hooks rendered.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
