### PR TITLE
Change shipping edit dialog

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4321,10 +4321,6 @@
     "context": "search modal billing title",
     "string": "Billing address"
   },
-  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerAddress": {
-    "context": "address type",
-    "string": "Use one of customer addresses"
-  },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerChangeBillingDescription": {
     "context": "dialog content",
     "string": "Select one of customer addresses or add a new address:"
@@ -4337,9 +4333,9 @@
     "context": "dialog header",
     "string": "Change address for order"
   },
-  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_newAddress": {
-    "context": "address type",
-    "string": "Add new address"
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerHasNoAddresses": {
+    "context": "info when customer doesn't have any addresses",
+    "string": "Customer has no saved addresses"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_noAddressBillingDescription": {
     "context": "dialog content",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4367,19 +4367,19 @@
   },
   "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_changeAddress": {
     "context": "option label",
-    "string": "Change address"
+    "string": "Change"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_description": {
     "context": "dialog description",
-    "string": "You have changed customer assigned to this order. What would you like to do with the shipping address?"
+    "string": "A new customer has been assigned for this order, but the address remained of a previous customer."
   },
   "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_keepAddress": {
     "context": "option label",
-    "string": "Keep address"
+    "string": "Keep"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_title": {
     "context": "dialog header",
-    "string": "Changed Customer"
+    "string": "Would you like to change address?"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerNote_dot_1505053535": {
     "string": "No notes from customer"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,9 +4828,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.3.3.tgz",
-      "integrity": "sha512-b2dLlOAXDe2OSmYeZSFKwiRMrJc+YkGhvvQCHQXHHP89TZbGZlWP0F13ycCI3OJSfYbCWZlQGM+alMiE31HOuA==",
+      "version": "github:saleor/macaw-ui#f2c497c8d9344466e6c380f60ba9496a67c2a15b",
+      "from": "github:saleor/macaw-ui#f2c497c",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,8 +4828,8 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:saleor/macaw-ui#f2c497c8d9344466e6c380f60ba9496a67c2a15b",
-      "from": "github:saleor/macaw-ui#f2c497c",
+      "version": "github:saleor/macaw-ui#ea9c45ba026e16947af5a1975be144361fd1a5c7",
+      "from": "github:saleor/macaw-ui#ea9c45b",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:saleor/macaw-ui#f2c497c",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#ea9c45b",
     "@saleor/sdk": "^0.4.4",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "^0.3.3",
+    "@saleor/macaw-ui": "github:saleor/macaw-ui#f2c497c",
     "@saleor/sdk": "^0.4.4",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/customers/components/CustomerAddressChoiceCard/styles.ts
+++ b/src/customers/components/CustomerAddressChoiceCard/styles.ts
@@ -9,8 +9,7 @@ export const useStyles = makeStyles(
       borderWidth: "2px"
     },
     cardSelected: {
-      borderColor: theme.palette.primary.main,
-      cursor: "pointer"
+      borderColor: theme.palette.primary.main
     },
     cardContent: {
       display: "flex",

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -9896,8 +9896,15 @@ export type PageBulkRemoveMutationHookResult = ReturnType<typeof usePageBulkRemo
 export type PageBulkRemoveMutationResult = Apollo.MutationResult<Types.PageBulkRemoveMutation>;
 export type PageBulkRemoveMutationOptions = Apollo.BaseMutationOptions<Types.PageBulkRemoveMutation, Types.PageBulkRemoveMutationVariables>;
 export const PageListDocument = gql`
-    query PageList($first: Int, $after: String, $last: Int, $before: String, $sort: PageSortingInput) {
-  pages(before: $before, after: $after, first: $first, last: $last, sortBy: $sort) {
+    query PageList($first: Int, $after: String, $last: Int, $before: String, $sort: PageSortingInput, $filter: PageFilterInput) {
+  pages(
+    before: $before
+    after: $after
+    first: $first
+    last: $last
+    sortBy: $sort
+    filter: $filter
+  ) {
     edges {
       node {
         ...Page
@@ -9930,6 +9937,7 @@ export const PageListDocument = gql`
  *      last: // value for 'last'
  *      before: // value for 'before'
  *      sort: // value for 'sort'
+ *      filter: // value for 'filter'
  *   },
  * });
  */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -6309,6 +6309,7 @@ export type PageListQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']>;
   before?: InputMaybe<Scalars['String']>;
   sort?: InputMaybe<PageSortingInput>;
+  filter?: InputMaybe<PageFilterInput>;
 }>;
 
 

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -178,7 +178,7 @@ export const transformOrderStatus = (
   };
 };
 
-export const transformAddressToForm = (data?: AddressType) => ({
+export const getAddressFormData = (data?: AddressType) => ({
   city: data?.city || "",
   cityArea: data?.cityArea || "",
   companyName: data?.companyName || "",

--- a/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
+++ b/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
@@ -26,14 +26,14 @@ interface OrderAddressFieldsProps {
   errors: OrderErrorFragment[];
 }
 
-const getVariant = (action: string) => {
+const getVariant = (action: string): AddressEditDialogVariant => {
   switch (action) {
     case "edit-customer-address":
-      return AddressEditDialogVariant.CHANGE_CUSTOMER_ADDRESS;
+      return "CHANGE_CUSTOMER_ADDRESS";
     case "edit-shipping-address":
-      return AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS;
+      return "CHANGE_SHIPPING_ADDRESS";
     case "edit-billing-address":
-      return AddressEditDialogVariant.CHANGE_BILLING_ADDRESS;
+      return "CHANGE_BILLING_ADDRESS";
     default:
       return undefined;
   }
@@ -64,9 +64,11 @@ const OrderAddressFields: React.FC<OrderAddressFieldsProps> = ({
     onConfirm
   };
 
+  const isAddressEditDialogVariantSelected = !!getVariant(action);
+
   return (
     <OrderCustomerAddressesEditDialog
-      open={!!getVariant(action)}
+      open={isAddressEditDialogVariantSelected}
       variant={getVariant(action)}
       {...addressFieldCommonProps}
     />

--- a/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
+++ b/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
@@ -1,12 +1,10 @@
 import {
-  AddressFragment,
   CustomerAddressesQuery,
   OrderDetailsQuery,
   OrderErrorFragment
 } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import { transformAddressToForm } from "@saleor/misc";
 import React from "react";
 
 import OrderCustomerAddressesEditDialog, {
@@ -19,7 +17,6 @@ import {
 
 interface OrderAddressFieldsProps {
   action: string;
-  isDraft: boolean;
   customerAddressesLoading: boolean;
   customer: CustomerAddressesQuery["user"];
   countries: OrderDetailsQuery["shop"]["countries"];
@@ -27,22 +24,30 @@ interface OrderAddressFieldsProps {
   onConfirm: (data: OrderCustomerAddressesEditDialogOutput) => SubmitPromise;
   confirmButtonState: ConfirmButtonTransitionState;
   errors: OrderErrorFragment[];
-  orderShippingAddress: AddressFragment;
-  orderBillingAddress: AddressFragment;
 }
+
+const getVariant = (action: string) => {
+  switch (action) {
+    case "edit-customer-address":
+      return AddressEditDialogVariant.CHANGE_CUSTOMER_ADDRESS;
+    case "edit-shipping-address":
+      return AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS;
+    case "edit-billing-address":
+      return AddressEditDialogVariant.CHANGE_BILLING_ADDRESS;
+    default:
+      return undefined;
+  }
+};
 
 const OrderAddressFields: React.FC<OrderAddressFieldsProps> = ({
   action,
-  isDraft,
   customerAddressesLoading,
   customer,
   countries,
   onClose,
   onConfirm,
   confirmButtonState,
-  errors,
-  orderShippingAddress,
-  orderBillingAddress
+  errors
 }) => {
   const addressFieldCommonProps: Omit<
     OrderCustomerAddressesEditDialogProps,
@@ -52,8 +57,6 @@ const OrderAddressFields: React.FC<OrderAddressFieldsProps> = ({
     confirmButtonState,
     countries,
     errors,
-    orderShippingAddress: transformAddressToForm(orderShippingAddress),
-    orderBillingAddress: transformAddressToForm(orderBillingAddress),
     customerAddresses: customer?.addresses,
     defaultShippingAddress: customer?.defaultShippingAddress,
     defaultBillingAddress: customer?.defaultBillingAddress,
@@ -62,26 +65,11 @@ const OrderAddressFields: React.FC<OrderAddressFieldsProps> = ({
   };
 
   return (
-    <>
-      {isDraft && (
-        <OrderCustomerAddressesEditDialog
-          open={action === "edit-customer-addresses"}
-          variant={AddressEditDialogVariant.CHANGE_CUSTOMER}
-          {...addressFieldCommonProps}
-        />
-      )}
-
-      <OrderCustomerAddressesEditDialog
-        open={action === "edit-shipping-address"}
-        variant={AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS}
-        {...addressFieldCommonProps}
-      />
-      <OrderCustomerAddressesEditDialog
-        open={action === "edit-billing-address"}
-        variant={AddressEditDialogVariant.CHANGE_BILLING_ADDRESS}
-        {...addressFieldCommonProps}
-      />
-    </>
+    <OrderCustomerAddressesEditDialog
+      open={!!getVariant(action)}
+      variant={getVariant(action)}
+      {...addressFieldCommonProps}
+    />
   );
 };
 

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -1,4 +1,5 @@
-import { Divider } from "@material-ui/core";
+import { CircularProgress, Divider } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
 import AddressEdit from "@saleor/components/AddressEdit";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
@@ -10,7 +11,7 @@ import {
 } from "@saleor/graphql";
 import { FormChange } from "@saleor/hooks/useForm";
 import { SwitchSelector, SwitchSelectorButton } from "@saleor/macaw-ui";
-import React, { useEffect } from "react";
+import React from "react";
 
 import { getById } from "../OrderReturnPage/utils";
 import { AddressInputOptionEnum } from "./form";
@@ -33,7 +34,20 @@ export interface OrderCustomerAddressEditProps {
   onChangeCustomerAddress: (customerAddress: AddressFragment) => void;
 }
 
+const useStyles = makeStyles(
+  () => ({
+    loading: {
+      alignItems: "center",
+      display: "flex",
+      minHeight: 200,
+      justifyContent: "center"
+    }
+  }),
+  { name: "OrderCustomerAddressEdit" }
+);
+
 const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props => {
+  const classes = useStyles();
   const {
     loading,
     customerAddresses,
@@ -70,7 +84,7 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
     setTemporarySelectedAddress
   ] = React.useState(initialAddress);
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (temporarySelectedAddress) {
       onChangeCustomerAddress(temporarySelectedAddress);
     }
@@ -93,32 +107,40 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
           </SwitchSelectorButton>
         ))}
       </SwitchSelector>
+
       <FormSpacer />
       <Divider />
       <FormSpacer />
 
-      {addressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS && (
+      {loading ? (
+        <div className={classes.loading}>
+          <CircularProgress size={128} />
+        </div>
+      ) : (
         <>
-          <OrderCustomerAddressesSearch
-            customerAddresses={customerAddresses}
-            selectedCustomerAddressId={selectedCustomerAddressId}
-            loading={loading}
-            temporarilySelectedAddress={temporarySelectedAddress}
-            setTemporaryAddress={setTemporarySelectedAddress}
-          />
-          <FormSpacer />
-        </>
-      )}
+          {addressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS && (
+            <>
+              <OrderCustomerAddressesSearch
+                customerAddresses={customerAddresses}
+                selectedCustomerAddressId={selectedCustomerAddressId}
+                temporarilySelectedAddress={temporarySelectedAddress}
+                setTemporaryAddress={setTemporarySelectedAddress}
+              />
+              <FormSpacer />
+            </>
+          )}
 
-      {addressInputOption === AddressInputOptionEnum.NEW_ADDRESS && (
-        <AddressEdit
-          countries={countryChoices}
-          countryDisplayValue={formAddressCountryDisplayName}
-          data={formAddress}
-          errors={formErrors}
-          onChange={onChangeFormAddress}
-          onCountryChange={onChangeFormAddressCountry}
-        />
+          {addressInputOption === AddressInputOptionEnum.NEW_ADDRESS && (
+            <AddressEdit
+              countries={countryChoices}
+              countryDisplayValue={formAddressCountryDisplayName}
+              data={formAddress}
+              errors={formErrors}
+              onChange={onChangeFormAddress}
+              onCountryChange={onChangeFormAddressCountry}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -9,7 +9,7 @@ import {
   OrderErrorFragment
 } from "@saleor/graphql";
 import { FormChange } from "@saleor/hooks/useForm";
-import { SwitchSelector } from "@saleor/macaw-ui";
+import { SwitchSelector, SwitchSelectorButton } from "@saleor/macaw-ui";
 import React, { useEffect } from "react";
 
 import { getById } from "../OrderReturnPage/utils";
@@ -78,15 +78,21 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
 
   return (
     <>
-      <SwitchSelector
-        options={switchOptions}
-        activeTab={addressInputOption}
-        setActiveTab={value =>
-          onChangeAddressInputOption({
-            target: { name: addressInputName, value }
-          })
-        }
-      />
+      <SwitchSelector>
+        {switchOptions.map(({ label, value }) => (
+          <SwitchSelectorButton
+            value={value}
+            onClick={() =>
+              onChangeAddressInputOption({
+                target: { name: addressInputName, value }
+              })
+            }
+            activeTab={addressInputOption}
+          >
+            {label}
+          </SwitchSelectorButton>
+        ))}
+      </SwitchSelector>
       <FormSpacer />
       <Divider />
       <FormSpacer />

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -6,7 +6,6 @@ import { countries, order as orderFixture } from "../../fixtures";
 import OrderCustomerAddressesEditDialog, {
   OrderCustomerAddressesEditDialogProps
 } from ".";
-import { AddressEditDialogVariant } from "./types";
 
 const order = orderFixture("");
 
@@ -23,6 +22,16 @@ const props: OrderCustomerAddressesEditDialogProps = {
 
 storiesOf("Orders / Changing address in order", module)
   .addDecorator(Decorator)
+  .add("address change when customer is changed", () => (
+    <OrderCustomerAddressesEditDialog
+      {...props}
+      variant="CHANGE_CUSTOMER_ADDRESS"
+      customerAddresses={[
+        order.shippingAddress,
+        { ...order.billingAddress, id: "asdfghjfuunie" }
+      ]}
+    />
+  ))
   .add("shipping address change", () => (
     <OrderCustomerAddressesEditDialog
       {...props}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -12,7 +12,7 @@ const order = orderFixture("");
 
 const props: OrderCustomerAddressesEditDialogProps = {
   confirmButtonState: "default",
-  variant: AddressEditDialogVariant.CHANGE_CUSTOMER,
+  variant: "CHANGE_SHIPPING_ADDRESS",
   loading: false,
   onClose: () => undefined,
   onConfirm: () => undefined,
@@ -23,19 +23,9 @@ const props: OrderCustomerAddressesEditDialogProps = {
 
 storiesOf("Orders / Changing address in order", module)
   .addDecorator(Decorator)
-  .add("address change when customer is changed", () => (
-    <OrderCustomerAddressesEditDialog
-      {...props}
-      customerAddresses={[
-        order.shippingAddress,
-        { ...order.billingAddress, id: "asdfghjfuunie" }
-      ]}
-    />
-  ))
   .add("shipping address change", () => (
     <OrderCustomerAddressesEditDialog
       {...props}
-      variant={AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS}
       customerAddresses={[
         order.shippingAddress,
         { ...order.billingAddress, id: "asdfghjfuunie" }
@@ -45,7 +35,7 @@ storiesOf("Orders / Changing address in order", module)
   .add("billing address change", () => (
     <OrderCustomerAddressesEditDialog
       {...props}
-      variant={AddressEditDialogVariant.CHANGE_BILLING_ADDRESS}
+      variant="CHANGE_BILLING_ADDRESS"
       customerAddresses={[
         order.shippingAddress,
         { ...order.billingAddress, id: "asdfghjfuunie" }

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -80,8 +80,9 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   const classes = useStyles(props);
   const intl = useIntl();
 
-  const hasCustomerChanged =
-    variant === AddressEditDialogVariant.CHANGE_CUSTOMER_ADDRESS;
+  const hasCustomerChanged = variant === "CHANGE_CUSTOMER_ADDRESS";
+  const isShippingAddressEdited =
+    variant === "CHANGE_SHIPPING_ADDRESS" || hasCustomerChanged;
 
   const {
     errors: shippingValidationErrors,
@@ -118,29 +119,24 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
         ? getCustomerAddress(data.customerBillingAddress.id)
         : handleNewBillingAddressSubmit(data.billingAddress);
 
-    if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
+    if (isShippingAddressEdited) {
       return {
         shippingAddress,
         ...(data.cloneAddress && { billingAddress: shippingAddress })
       };
     }
-    if (variant === AddressEditDialogVariant.CHANGE_BILLING_ADDRESS) {
-      return {
-        ...(data.cloneAddress && { shippingAddress: billingAddress }),
-        billingAddress
-      };
-    }
+
     return {
-      shippingAddress,
-      billingAddress: data.cloneAddress ? shippingAddress : billingAddress
+      ...(data.cloneAddress && { shippingAddress: billingAddress }),
+      billingAddress
     };
   };
 
   const getDialogTitle = (): MessageDescriptor => {
-    if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
+    if (variant === "CHANGE_SHIPPING_ADDRESS") {
       return dialogMessages.shippingChangeTitle;
     }
-    if (variant === AddressEditDialogVariant.CHANGE_BILLING_ADDRESS) {
+    if (variant === "CHANGE_BILLING_ADDRESS") {
       return dialogMessages.billingChangeTitle;
     }
     return dialogMessages.customerChangeTitle;
@@ -176,11 +172,14 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     customerAddresses
   };
 
-  const getVariant = (action: AddressEditDialogVariant) => {
+  const getVariant = (
+    action: AddressEditDialogVariant
+  ): "shipping" | "billing" => {
     switch (action) {
-      case AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS:
+      case "CHANGE_CUSTOMER_ADDRESS":
+      case "CHANGE_SHIPPING_ADDRESS":
         return "shipping";
-      case AddressEditDialogVariant.CHANGE_BILLING_ADDRESS:
+      case "CHANGE_BILLING_ADDRESS":
         return "billing";
     }
   };
@@ -188,9 +187,6 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   const exitModal = () => {
     onClose();
   };
-
-  const isShippingEdit =
-    variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS;
 
   return (
     <Dialog onClose={exitModal} open={open} fullWidth>
@@ -227,12 +223,12 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                   {...addressEditProps}
                   customerAddresses={customerAddresses}
                   selectedCustomerAddressId={
-                    isShippingEdit
+                    isShippingAddressEdited
                       ? data.customerShippingAddress?.id
                       : data.customerBillingAddress?.id
                   }
                   onChangeCustomerAddress={customerAddress =>
-                    isShippingEdit
+                    isShippingAddressEdited
                       ? handlers.changeCustomerAddress(
                           customerAddress,
                           "customerShippingAddress"
@@ -263,7 +259,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                     />
                   }
                   label={intl.formatMessage(
-                    isShippingEdit
+                    isShippingAddressEdited
                       ? dialogMessages.billingSameAsShipping
                       : dialogMessages.shippingSameAsBilling
                   )}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -2,15 +2,11 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  Divider,
-  FormControlLabel,
-  Typography
+  FormControlLabel
 } from "@material-ui/core";
-import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import Checkbox from "@saleor/components/Checkbox";
 import ConfirmButton from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
-import { AddressTypeInput } from "@saleor/customers/types";
 import {
   AddressFragment,
   AddressInput,
@@ -23,8 +19,15 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
-import { ConfirmButtonTransitionState, DialogHeader } from "@saleor/macaw-ui";
-import { transformAddressToAddressInput } from "@saleor/misc";
+import {
+  Button,
+  ConfirmButtonTransitionState,
+  DialogHeader
+} from "@saleor/macaw-ui";
+import {
+  getAddressFormData,
+  transformAddressToAddressInput
+} from "@saleor/misc";
 import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, MessageDescriptor, useIntl } from "react-intl";
@@ -36,12 +39,10 @@ import OrderCustomerAddressesEditForm, {
 } from "./form";
 import { dialogMessages } from "./messages";
 import OrderCustomerAddressEdit from "./OrderCustomerAddressEdit";
-import OrderCustomerAddressesSearch from "./OrderCustomerAddressesSearch";
 import { useStyles } from "./styles";
 import {
   AddressEditDialogVariant,
-  OrderCustomerAddressesEditDialogOutput,
-  OrderCustomerSearchAddressState
+  OrderCustomerAddressesEditDialogOutput
 } from "./types";
 import { getAddressEditProps, validateDefaultAddress } from "./utils";
 
@@ -51,8 +52,6 @@ export interface OrderCustomerAddressesEditDialogProps {
   loading: boolean;
   confirmButtonState: ConfirmButtonTransitionState;
   errors: OrderErrorFragment[];
-  orderShippingAddress?: AddressTypeInput;
-  orderBillingAddress?: AddressTypeInput;
   countries?: CountryWithCodeFragment[];
   customerAddresses?: AddressFragment[];
   defaultShippingAddress?: Node;
@@ -62,11 +61,6 @@ export interface OrderCustomerAddressesEditDialogProps {
     data: Partial<OrderCustomerAddressesEditDialogOutput>
   ): SubmitPromise<any[]>;
 }
-
-const defaultSearchState: OrderCustomerSearchAddressState = {
-  open: false,
-  type: undefined
-};
 
 const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialogProps> = props => {
   const {
@@ -80,50 +74,28 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     defaultShippingAddress,
     defaultBillingAddress,
     onClose,
-    onConfirm,
-    orderShippingAddress,
-    orderBillingAddress
+    onConfirm
   } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
 
   const hasCustomerChanged =
-    variant === AddressEditDialogVariant.CHANGE_CUSTOMER;
+    variant === AddressEditDialogVariant.CHANGE_CUSTOMER_ADDRESS;
 
   const {
     errors: shippingValidationErrors,
-    submit: handleShippingSubmit
+    submit: handleNewShippingAddressSubmit
   } = useAddressValidation(address => address, AddressTypeEnum.SHIPPING);
   const {
     errors: billingValidationErrors,
-    submit: handleBillingSubmit
+    submit: handleNewBillingAddressSubmit
   } = useAddressValidation(address => address, AddressTypeEnum.BILLING);
 
   const dialogErrors = useModalDialogErrors(
     [...errors, ...shippingValidationErrors, ...billingValidationErrors],
     open
   );
-
-  const continueToSearchAddressesState = (
-    data: OrderCustomerAddressesEditFormData
-  ): boolean => {
-    if (hasCustomerChanged || addressSearchState.open) {
-      return false;
-    }
-    if (!customerAddresses.length) {
-      return false;
-    }
-    if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
-      return (
-        data.shippingAddressInputOption ===
-        AddressInputOptionEnum.CUSTOMER_ADDRESS
-      );
-    }
-    return (
-      data.billingAddressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS
-    );
-  };
 
   const getCustomerAddress = (
     selectedCustomerAddressID: string
@@ -138,13 +110,13 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
       data.shippingAddressInputOption ===
         AddressInputOptionEnum.CUSTOMER_ADDRESS
         ? getCustomerAddress(data.customerShippingAddress.id)
-        : handleShippingSubmit(data.shippingAddress);
+        : handleNewShippingAddressSubmit(data.shippingAddress);
 
     const billingAddress =
       customerAddresses.length > 0 &&
       data.billingAddressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS
         ? getCustomerAddress(data.customerBillingAddress.id)
-        : handleBillingSubmit(data.billingAddress);
+        : handleNewBillingAddressSubmit(data.billingAddress);
 
     if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
       return {
@@ -165,14 +137,6 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   };
 
   const getDialogTitle = (): MessageDescriptor => {
-    if (addressSearchState.open) {
-      if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
-        return dialogMessages.shippingTitle;
-      }
-      if (variant === AddressEditDialogVariant.CHANGE_BILLING_ADDRESS) {
-        return dialogMessages.billingTitle;
-      }
-    }
     if (variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS) {
       return dialogMessages.shippingChangeTitle;
     }
@@ -181,34 +145,11 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     }
     return dialogMessages.customerChangeTitle;
   };
-  const getDialogDescription = (): MessageDescriptor => {
-    if (customerAddresses.length === 0) {
-      return dialogMessages.noAddressDescription;
-    }
-    if (variant === AddressEditDialogVariant.CHANGE_CUSTOMER) {
-      return dialogMessages.customerChangeDescription;
-    }
-    return dialogMessages.addressChangeDescription;
-  };
 
-  const handleContinue = (data: OrderCustomerAddressesEditFormData) => {
-    if (continueToSearchAddressesState(data)) {
-      setAddressSearchState({
-        open: true,
-        type:
-          variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS
-            ? AddressTypeEnum.SHIPPING
-            : AddressTypeEnum.BILLING
-      });
-      return;
-    }
-    handleSubmit(data);
-  };
   const handleSubmit = async (data: OrderCustomerAddressesEditFormData) => {
     const addressesInput = handleAddressesSubmit(data);
     if (addressesInput) {
       await onConfirm(addressesInput as OrderCustomerAddressesEditDialogOutput);
-      setAddressSearchState(defaultSearchState);
     }
 
     return Promise.resolve([
@@ -218,10 +159,6 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   };
 
   const countryChoices = mapCountriesToChoices(countries);
-
-  const [addressSearchState, setAddressSearchState] = React.useState<
-    OrderCustomerSearchAddressState
-  >(defaultSearchState);
 
   const validatedDefaultShippingAddress = validateDefaultAddress(
     defaultShippingAddress,
@@ -239,10 +176,21 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     customerAddresses
   };
 
+  const getVariant = (action: AddressEditDialogVariant) => {
+    switch (action) {
+      case AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS:
+        return "shipping";
+      case AddressEditDialogVariant.CHANGE_BILLING_ADDRESS:
+        return "billing";
+    }
+  };
+
   const exitModal = () => {
     onClose();
-    setAddressSearchState(defaultSearchState);
   };
+
+  const isShippingEdit =
+    variant === AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS;
 
   return (
     <Dialog onClose={exitModal} open={open} fullWidth>
@@ -252,207 +200,95 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
       <OrderCustomerAddressesEditForm
         countryChoices={countryChoices}
         countries={countries}
+        hasAddresses={!!customerAddresses.length}
         defaultShippingAddress={validatedDefaultShippingAddress}
         defaultBillingAddress={validatedDefaultBillingAddress}
         defaultCloneAddress={hasCustomerChanged}
         initial={{
-          shippingAddress: orderShippingAddress,
-          billingAddress: orderBillingAddress
+          shippingAddress: getAddressFormData(),
+          billingAddress: getAddressFormData()
         }}
-        onSubmit={handleContinue}
+        onSubmit={handleSubmit}
       >
         {({ change, data, handlers }) => {
-          const shippingAddressEditProps = getAddressEditProps(
-            "shipping",
+          const addressEditProps = getAddressEditProps(
+            getVariant(variant),
             data,
             handlers,
             change,
             dialogErrors,
-            setAddressSearchState,
             addressEditCommonProps
           );
-          const billingAddressEditProps = getAddressEditProps(
-            "billing",
-            data,
-            handlers,
-            change,
-            dialogErrors,
-            setAddressSearchState,
-            addressEditCommonProps
-          );
+
           return (
             <>
-              {addressSearchState.open ? (
-                <OrderCustomerAddressesSearch
-                  openFromCustomerChange={hasCustomerChanged}
-                  type={addressSearchState?.type}
-                  cloneAddress={data.cloneAddress}
-                  formChange={change}
-                  transitionState={confirmButtonState}
+              <DialogContent className={classes.dialogContent}>
+                <OrderCustomerAddressEdit
+                  {...addressEditProps}
                   customerAddresses={customerAddresses}
                   selectedCustomerAddressId={
-                    addressSearchState.type === AddressTypeEnum.SHIPPING
+                    isShippingEdit
                       ? data.customerShippingAddress?.id
                       : data.customerBillingAddress?.id
                   }
-                  onChangeCustomerShippingAddress={customerAddress =>
-                    handlers.changeCustomerAddress(
-                      customerAddress,
-                      "customerShippingAddress"
-                    )
+                  onChangeCustomerAddress={customerAddress =>
+                    isShippingEdit
+                      ? handlers.changeCustomerAddress(
+                          customerAddress,
+                          "customerShippingAddress"
+                        )
+                      : handlers.changeCustomerAddress(
+                          customerAddress,
+                          "customerBillingAddress"
+                        )
                   }
-                  onChangeCustomerBillingAddress={customerAddress =>
-                    handlers.changeCustomerAddress(
-                      customerAddress,
-                      "customerBillingAddress"
-                    )
-                  }
-                  exitSearch={() => setAddressSearchState(defaultSearchState)}
                 />
-              ) : (
-                <>
-                  <DialogContent className={classes.dialogContent}>
-                    <Typography>
-                      <FormattedMessage {...getDialogDescription()} />
-                    </Typography>
-                    <VerticalSpacer />
-                    {hasCustomerChanged && (
-                      <>
-                        <OrderCustomerAddressEdit
-                          {...shippingAddressEditProps}
-                        />
-                        <FormSpacer />
-                        <Divider />
-                        <FormSpacer />
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              checked={data.cloneAddress}
-                              name="billingSameAsShipping"
-                              onChange={() =>
-                                change({
-                                  target: {
-                                    name: "cloneAddress",
-                                    value: !data.cloneAddress
-                                  }
-                                })
-                              }
-                              data-test-id="billing-same-as-shipping"
-                            />
+                <FormSpacer />
+              </DialogContent>
+              <DialogActions>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={data.cloneAddress}
+                      name="addressesAreTheSame"
+                      onChange={() =>
+                        change({
+                          target: {
+                            name: "cloneAddress",
+                            value: !data.cloneAddress
                           }
-                          label={intl.formatMessage(
-                            dialogMessages.billingSameAsShipping
-                          )}
-                        />
-                        {!data.cloneAddress && (
-                          <>
-                            <FormSpacer />
-                            <Typography>
-                              {customerAddresses.length > 0 ? (
-                                <FormattedMessage
-                                  {...dialogMessages.customerChangeBillingDescription}
-                                />
-                              ) : (
-                                <FormattedMessage
-                                  {...dialogMessages.noAddressBillingDescription}
-                                />
-                              )}
-                            </Typography>
-                            <FormSpacer />
-                            <OrderCustomerAddressEdit
-                              {...billingAddressEditProps}
-                            />
-                          </>
-                        )}
-                      </>
-                    )}
-                    {variant ===
-                      AddressEditDialogVariant.CHANGE_SHIPPING_ADDRESS && (
-                      <>
-                        <OrderCustomerAddressEdit
-                          {...shippingAddressEditProps}
-                        />
-                        {data.shippingAddressInputOption ===
-                          AddressInputOptionEnum.NEW_ADDRESS && (
-                          <>
-                            <FormSpacer />
-                            <Divider />
-                            <FormControlLabel
-                              control={
-                                <Checkbox
-                                  checked={data.cloneAddress}
-                                  name="billingSameAsShipping"
-                                  onChange={() =>
-                                    change({
-                                      target: {
-                                        name: "cloneAddress",
-                                        value: !data.cloneAddress
-                                      }
-                                    })
-                                  }
-                                  data-test-id="billing-same-as-shipping"
-                                />
-                              }
-                              label={intl.formatMessage(
-                                dialogMessages.billingSameAsShipping
-                              )}
-                            />
-                          </>
-                        )}
-                      </>
-                    )}
-                    {variant ===
-                      AddressEditDialogVariant.CHANGE_BILLING_ADDRESS && (
-                      <>
-                        <OrderCustomerAddressEdit
-                          {...billingAddressEditProps}
-                        />
-                        {data.shippingAddressInputOption ===
-                          AddressInputOptionEnum.NEW_ADDRESS && (
-                          <>
-                            <FormSpacer />
-                            <Divider />
-                            <FormControlLabel
-                              control={
-                                <Checkbox
-                                  checked={data.cloneAddress}
-                                  name="shippingSameAsBilling"
-                                  onChange={() =>
-                                    change({
-                                      target: {
-                                        name: "cloneAddress",
-                                        value: !data.cloneAddress
-                                      }
-                                    })
-                                  }
-                                  data-test-id="billing-same-as-shipping"
-                                />
-                              }
-                              label={intl.formatMessage(
-                                dialogMessages.shippingSameAsBilling
-                              )}
-                            />
-                          </>
-                        )}
-                      </>
-                    )}
-                  </DialogContent>
-                  <DialogActions>
-                    <ConfirmButton
-                      transitionState={confirmButtonState}
-                      variant="primary"
-                      type="submit"
-                      data-test-id="submit"
-                    >
-                      <FormattedMessage
-                        {...(continueToSearchAddressesState(data)
-                          ? buttonMessages.continue
-                          : buttonMessages.save)}
-                      />
-                    </ConfirmButton>
-                  </DialogActions>
-                </>
-              )}
+                        })
+                      }
+                      data-test-id="addresses-are-the-same"
+                    />
+                  }
+                  label={intl.formatMessage(
+                    isShippingEdit
+                      ? dialogMessages.billingSameAsShipping
+                      : dialogMessages.shippingSameAsBilling
+                  )}
+                />
+                <Button
+                  variant="secondary"
+                  onClick={() => exitModal()}
+                  // One mui style has to be overwritten
+                  // Inline styling has higher specificity
+                  style={{
+                    marginLeft: "auto"
+                  }}
+                  data-test-id="cancel"
+                >
+                  <FormattedMessage {...buttonMessages.cancel} />
+                </Button>
+                <ConfirmButton
+                  transitionState={confirmButtonState}
+                  variant="primary"
+                  type="submit"
+                  data-test-id="submit"
+                >
+                  <FormattedMessage {...buttonMessages.save} />
+                </ConfirmButton>
+              </DialogActions>
             </>
           );
         }}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
@@ -1,6 +1,5 @@
 import { InputAdornment, TextField, Typography } from "@material-ui/core";
 import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
-import Skeleton from "@saleor/components/Skeleton";
 import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
 import { AddressFragment } from "@saleor/graphql";
 import { SearchIcon } from "@saleor/macaw-ui";
@@ -15,7 +14,6 @@ import { parseQuery, stringifyAddress } from "./utils";
 export interface OrderCustomerAddressesSearchProps {
   selectedCustomerAddressId: string;
   customerAddresses: AddressFragment[];
-  loading?: boolean;
   temporarilySelectedAddress?: AddressFragment;
   setTemporaryAddress: (address: AddressFragment) => void;
 }
@@ -23,7 +21,6 @@ export interface OrderCustomerAddressesSearchProps {
 const OrderCustomerAddressesSearch: React.FC<OrderCustomerAddressesSearchProps> = props => {
   const {
     customerAddresses,
-    loading,
     temporarilySelectedAddress,
     setTemporaryAddress
   } = props;
@@ -66,9 +63,7 @@ const OrderCustomerAddressesSearch: React.FC<OrderCustomerAddressesSearchProps> 
           [classes.scrollableWrapper]: filteredCustomerAddresses.length > 0
         })}
       >
-        {loading ? (
-          <Skeleton />
-        ) : filteredCustomerAddresses.length === 0 ? (
+        {filteredCustomerAddresses.length === 0 ? (
           <Typography>
             {intl.formatMessage(
               customerAddresses.length

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
@@ -1,80 +1,37 @@
-import {
-  Checkbox,
-  DialogActions,
-  DialogContent,
-  FormControlLabel,
-  InputAdornment,
-  TextField
-} from "@material-ui/core";
+import { InputAdornment, TextField, Typography } from "@material-ui/core";
 import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
-import { ConfirmButton } from "@saleor/components/ConfirmButton";
+import Skeleton from "@saleor/components/Skeleton";
 import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
-import { AddressFragment, AddressTypeEnum } from "@saleor/graphql";
-import { FormChange } from "@saleor/hooks/useForm";
-import { buttonMessages } from "@saleor/intl";
-import {
-  Button,
-  ConfirmButtonTransitionState,
-  SearchIcon
-} from "@saleor/macaw-ui";
+import { AddressFragment } from "@saleor/graphql";
+import { SearchIcon } from "@saleor/macaw-ui";
+import classNames from "classnames";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
-import { getById } from "../OrderReturnPage/utils";
 import { dialogMessages as messages } from "./messages";
 import { useStyles } from "./styles";
 import { parseQuery, stringifyAddress } from "./utils";
 
 export interface OrderCustomerAddressesSearchProps {
-  type: AddressTypeEnum;
-  cloneAddress: boolean;
-  formChange: FormChange;
-  openFromCustomerChange: boolean;
-  transitionState: ConfirmButtonTransitionState;
   selectedCustomerAddressId: string;
   customerAddresses: AddressFragment[];
-  onChangeCustomerShippingAddress: (customerAddress: AddressFragment) => void;
-  onChangeCustomerBillingAddress: (customerAddress: AddressFragment) => void;
-  exitSearch();
+  loading?: boolean;
+  temporarilySelectedAddress?: AddressFragment;
+  setTemporaryAddress: (address: AddressFragment) => void;
 }
 
 const OrderCustomerAddressesSearch: React.FC<OrderCustomerAddressesSearchProps> = props => {
   const {
-    type,
-    cloneAddress,
-    formChange,
-    transitionState,
-    openFromCustomerChange,
-    selectedCustomerAddressId,
     customerAddresses,
-    onChangeCustomerShippingAddress,
-    onChangeCustomerBillingAddress,
-    exitSearch
+    loading,
+    temporarilySelectedAddress,
+    setTemporaryAddress
   } = props;
 
-  const intl = useIntl();
   const classes = useStyles(props);
-
-  const initialAddress = customerAddresses.find(
-    getById(selectedCustomerAddressId)
-  );
+  const intl = useIntl();
 
   const [query, setQuery] = React.useState("");
-  const [
-    temporarySelectedAddress,
-    setTemporarySelectedAddress
-  ] = React.useState(initialAddress);
-
-  const handleSelect = () => {
-    if (type === AddressTypeEnum.SHIPPING) {
-      onChangeCustomerShippingAddress(temporarySelectedAddress);
-    } else {
-      onChangeCustomerBillingAddress(temporarySelectedAddress);
-    }
-    if (openFromCustomerChange) {
-      exitSearch();
-    }
-  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
@@ -88,76 +45,52 @@ const OrderCustomerAddressesSearch: React.FC<OrderCustomerAddressesSearchProps> 
 
   return (
     <>
-      <DialogContent className={classes.dialogContent}>
-        {intl.formatMessage(messages.searchInfo)}
-        <VerticalSpacer spacing={2} />
-        <TextField
-          value={query}
-          variant="outlined"
-          onChange={handleChange}
-          placeholder={"Search addresses"}
-          fullWidth
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon />
-              </InputAdornment>
-            )
-          }}
-          inputProps={{ className: classes.searchInput }}
-        />
-        <VerticalSpacer spacing={2} />
-        <div className={classes.scrollableWrapper}>
-          {filteredCustomerAddresses.length === 0
-            ? intl.formatMessage(messages.noResultsFound)
-            : filteredCustomerAddresses?.map(address => (
-                <React.Fragment key={address.id}>
-                  <CustomerAddressChoiceCard
-                    selected={address.id === temporarySelectedAddress.id}
-                    onSelect={() => setTemporarySelectedAddress(address)}
-                    address={address}
-                  />
-                  <VerticalSpacer spacing={2} />
-                </React.Fragment>
-              ))}
-        </div>
-        {!openFromCustomerChange && filteredCustomerAddresses.length !== 0 && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={cloneAddress}
-                name="cloneAddress"
-                onChange={() =>
-                  formChange({
-                    target: {
-                      name: "cloneAddress",
-                      value: !cloneAddress
-                    }
-                  })
-                }
-              />
-            }
-            label={intl.formatMessage(
-              type === AddressTypeEnum.SHIPPING
-                ? messages.billingSameAsShipping
-                : messages.shippingSameAsBilling
+      <TextField
+        value={query}
+        variant="outlined"
+        onChange={handleChange}
+        placeholder={"Search addresses"}
+        fullWidth
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          )
+        }}
+        inputProps={{ className: classes.searchInput }}
+      />
+      <VerticalSpacer spacing={2} />
+      <div
+        className={classNames(classes.wrapper, {
+          [classes.scrollableWrapper]: filteredCustomerAddresses.length > 0
+        })}
+      >
+        {loading ? (
+          <Skeleton />
+        ) : filteredCustomerAddresses.length === 0 ? (
+          <Typography>
+            {intl.formatMessage(
+              customerAddresses.length
+                ? messages.noResultsFound
+                : messages.customerHasNoAddresses
             )}
-          />
+          </Typography>
+        ) : (
+          filteredCustomerAddresses?.map(address => (
+            <React.Fragment key={address.id}>
+              <CustomerAddressChoiceCard
+                selected={address.id === temporarilySelectedAddress?.id}
+                onSelect={() => setTemporaryAddress(address)}
+                address={address}
+              />
+              {filteredCustomerAddresses.length > 1 && (
+                <VerticalSpacer spacing={2} />
+              )}
+            </React.Fragment>
+          ))
         )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={exitSearch} variant="secondary">
-          <FormattedMessage {...buttonMessages.cancel} />
-        </Button>
-        <ConfirmButton
-          variant="primary"
-          transitionState={transitionState}
-          type={openFromCustomerChange ? undefined : "submit"}
-          onClick={handleSelect}
-        >
-          <FormattedMessage {...buttonMessages.select} />
-        </ConfirmButton>
-      </DialogActions>
+      </div>
     </>
   );
 };

--- a/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
@@ -63,6 +63,7 @@ interface UseOrderCustomerAddressesEditFormOpts {
   defaultShippingAddress: Node;
   defaultBillingAddress: Node;
   defaultCloneAddress: boolean;
+  hasAddresses: boolean;
 }
 
 export interface OrderCustomerAddressesEditFormProps
@@ -86,8 +87,12 @@ function useOrderCustomerAddressesEditForm(
   };
   const defaultInitialFormData: OrderCustomerAddressesEditFormData = {
     cloneAddress: opts.defaultCloneAddress,
-    shippingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
-    billingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
+    shippingAddressInputOption: opts.hasAddresses
+      ? AddressInputOptionEnum.CUSTOMER_ADDRESS
+      : AddressInputOptionEnum.NEW_ADDRESS,
+    billingAddressInputOption: opts.hasAddresses
+      ? AddressInputOptionEnum.CUSTOMER_ADDRESS
+      : AddressInputOptionEnum.NEW_ADDRESS,
     customerShippingAddress: opts.defaultShippingAddress,
     customerBillingAddress: opts.defaultBillingAddress,
     shippingAddress: emptyAddress,
@@ -138,13 +143,15 @@ function useOrderCustomerAddressesEditForm(
   const handleCustomerAddressChange = (
     customerAddress: AddressFragment,
     addressType: "customerShippingAddress" | "customerBillingAddress"
-  ) =>
+  ) => {
     change({
       target: {
         name: addressType,
         value: customerAddress
       }
     });
+  };
+
   const handleShippingCountrySelect = createSingleAutocompleteSelectHandler(
     event =>
       change({

--- a/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
@@ -58,16 +58,9 @@ export const dialogMessages = defineMessages({
   noResultsFound: {
     defaultMessage: "No results found",
     description: "info when addresses search is unsuccessful"
-  }
-});
-
-export const addressEditMessages = defineMessages({
-  customerAddress: {
-    defaultMessage: "Use one of customer addresses",
-    description: "address type"
   },
-  newAddress: {
-    defaultMessage: "Add new address",
-    description: "address type"
+  customerHasNoAddresses: {
+    defaultMessage: "Customer has no saved addresses",
+    description: "info when customer doesn't have any addresses"
   }
 });

--- a/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
@@ -2,15 +2,20 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
   theme => ({
+    root: {
+      padding: 0
+    },
     dialogContent: {
       maxHeight: `calc(100vh - 250px)`,
-      overflowY: "scroll",
       overflowX: "hidden",
-      padding: "24px",
+      padding: "0 24px",
       margin: 0
     },
-    scrollableWrapper: {
+    wrapper: {
       maxHeight: 400,
+      minHeight: theme.spacing(3)
+    },
+    scrollableWrapper: {
       overflowY: "scroll"
     },
     container: {
@@ -22,6 +27,9 @@ export const useStyles = makeStyles(
     searchInput: {
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(2)
+    },
+    exitButton: {
+      marginLeft: "auto"
     }
   }),
   { name: "OrderCustomerAddressesEditDialog" }

--- a/src/orders/components/OrderCustomerAddressesEditDialog/types.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/types.ts
@@ -4,9 +4,8 @@ export interface OrderCustomerAddressesEditDialogOutput {
   shippingAddress: AddressInput;
   billingAddress: AddressInput;
 }
-export enum AddressEditDialogVariant {
-  CHANGE_CUSTOMER,
-  CHANGE_CUSTOMER_ADDRESS,
-  CHANGE_SHIPPING_ADDRESS,
-  CHANGE_BILLING_ADDRESS
-}
+
+export type AddressEditDialogVariant =
+  | "CHANGE_CUSTOMER_ADDRESS"
+  | "CHANGE_SHIPPING_ADDRESS"
+  | "CHANGE_BILLING_ADDRESS";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/types.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/types.ts
@@ -1,15 +1,12 @@
-import { AddressInput, AddressTypeEnum } from "@saleor/graphql";
+import { AddressInput } from "@saleor/graphql";
 
-export interface OrderCustomerSearchAddressState {
-  open: boolean;
-  type: AddressTypeEnum;
-}
 export interface OrderCustomerAddressesEditDialogOutput {
   shippingAddress: AddressInput;
   billingAddress: AddressInput;
 }
 export enum AddressEditDialogVariant {
   CHANGE_CUSTOMER,
+  CHANGE_CUSTOMER_ADDRESS,
   CHANGE_SHIPPING_ADDRESS,
   CHANGE_BILLING_ADDRESS
 }

--- a/src/orders/components/OrderCustomerAddressesEditDialog/utils.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/utils.ts
@@ -15,7 +15,6 @@ import {
   OrderCustomerAddressesEditHandlers
 } from "./form";
 import { OrderCustomerAddressEditProps } from "./OrderCustomerAddressEdit";
-import { OrderCustomerSearchAddressState } from "./types";
 
 interface AddressEditCommonProps {
   showCard: boolean;
@@ -54,11 +53,8 @@ export const getAddressEditProps = (
   handlers: OrderCustomerAddressesEditHandlers,
   change: FormChange,
   dialogErrors: Array<OrderErrorFragment | AccountErrorFragment>,
-  setAddressSearchState: React.Dispatch<
-    React.SetStateAction<OrderCustomerSearchAddressState>
-  >,
   addressEditCommonProps: AddressEditCommonProps
-): OrderCustomerAddressEditProps => {
+): Omit<OrderCustomerAddressEditProps, "onChangeCustomerAddress"> => {
   if (variant === "shipping") {
     return {
       ...addressEditCommonProps,
@@ -66,11 +62,6 @@ export const getAddressEditProps = (
       formErrors: dialogErrors.filter(
         error => error.addressType === AddressTypeEnum.SHIPPING
       ),
-      onEdit: () =>
-        setAddressSearchState({
-          open: true,
-          type: AddressTypeEnum.SHIPPING
-        }),
       onChangeAddressInputOption: change,
       addressInputOption: data.shippingAddressInputOption,
       selectedCustomerAddressId: data.customerShippingAddress?.id,
@@ -87,11 +78,6 @@ export const getAddressEditProps = (
     formErrors: dialogErrors.filter(
       error => error.addressType === AddressTypeEnum.BILLING
     ),
-    onEdit: () =>
-      setAddressSearchState({
-        open: true,
-        type: AddressTypeEnum.BILLING
-      }),
     onChangeAddressInputOption: change,
     addressInputOption: data.billingAddressInputOption,
     selectedCustomerAddressId: data.customerBillingAddress?.id,

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.stories.tsx
@@ -8,7 +8,7 @@ import OrderCustomerChangeDialog, {
 
 const props: OrderCustomerChangeDialogProps = {
   onClose: () => undefined,
-  onConfirm: () => undefined,
+  onChoiceClick: () => undefined,
   open: true
 };
 
@@ -18,7 +18,7 @@ storiesOf("Orders / OrderCustomerChangeDialog", module)
     <OrderCustomerChangeDialog
       {...props}
       onClose={() => undefined}
-      onConfirm={() => undefined}
+      onChoiceClick={() => undefined}
       open={true}
     />
   ));

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
@@ -32,7 +32,7 @@ const OrderCustomerChangeDialog: React.FC<OrderCustomerChangeDialogProps> = prop
         <FormattedMessage {...messages.title} />
       </DialogTitle>
       <DialogContent className={classes.overflow}>
-        <Typography>
+        <Typography variant="subtitle1">
           <FormattedMessage {...messages.description} />
         </Typography>
         <FormSpacer />

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
@@ -1,79 +1,59 @@
 import {
+  Button,
   Dialog,
-  DialogActions,
   DialogContent,
   DialogTitle,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
   Typography
 } from "@material-ui/core";
-import ConfirmButton from "@saleor/components/ConfirmButton";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import FormSpacer from "@saleor/components/FormSpacer";
-import { buttonMessages } from "@saleor/intl";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import OrderCustomerChangeForm, {
-  CustomerChangeActionEnum,
-  OrderCustomerChangeData
-} from "./form";
+import { CustomerChangeActionEnum } from "./form";
 import messages from "./messages";
 import { useStyles } from "./styles";
 
 export interface OrderCustomerChangeDialogProps {
   open: boolean;
-  onConfirm: (data: OrderCustomerChangeData) => void;
+  onChoiceClick: (choice: CustomerChangeActionEnum) => void;
   onClose();
 }
 
 const OrderCustomerChangeDialog: React.FC<OrderCustomerChangeDialogProps> = props => {
-  const { open, onClose, onConfirm } = props;
+  const { open, onClose, onChoiceClick } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
 
   return (
     <Dialog onClose={onClose} open={open}>
-      <OrderCustomerChangeForm onSubmit={onConfirm}>
-        {({ change, data }) => (
-          <>
-            <DialogTitle>
-              <FormattedMessage {...messages.title} />
-            </DialogTitle>
-            <DialogContent className={classes.overflow}>
-              <Typography>
-                <FormattedMessage {...messages.description} />
-              </Typography>
-              <FormSpacer />
-              <RadioGroup
-                className={classes.container}
-                value={data.changeActionOption}
-                name="changeActionOption"
-                onChange={event => change(event)}
-              >
-                <FormControlLabel
-                  value={CustomerChangeActionEnum.KEEP_ADDRESS}
-                  control={<Radio color="primary" />}
-                  label={intl.formatMessage(messages.keepAddress)}
-                  className={classes.optionLabel}
-                />
-                <FormControlLabel
-                  value={CustomerChangeActionEnum.CHANGE_ADDRESS}
-                  control={<Radio color="primary" />}
-                  label={intl.formatMessage(messages.changeAddress)}
-                  className={classes.optionLabel}
-                />
-              </RadioGroup>
-            </DialogContent>
-            <DialogActions>
-              <ConfirmButton transitionState="default" type="submit">
-                <FormattedMessage {...buttonMessages.continue} />
-              </ConfirmButton>
-            </DialogActions>
-          </>
-        )}
-      </OrderCustomerChangeForm>
+      <DialogTitle>
+        <FormattedMessage {...messages.title} />
+      </DialogTitle>
+      <DialogContent className={classes.overflow}>
+        <Typography>
+          <FormattedMessage {...messages.description} />
+        </Typography>
+        <FormSpacer />
+        <div className={classes.buttonsContainer}>
+          <Button
+            onClick={() => onChoiceClick(CustomerChangeActionEnum.KEEP_ADDRESS)}
+          >
+            {intl.formatMessage(messages.keepAddress)}
+          </Button>
+          <HorizontalSpacer />
+          <Button
+            onClick={() =>
+              onChoiceClick(CustomerChangeActionEnum.CHANGE_ADDRESS)
+            }
+            color="primary"
+            variant="contained"
+          >
+            {intl.formatMessage(messages.changeAddress)}
+          </Button>
+        </div>
+      </DialogContent>
     </Dialog>
   );
 };

--- a/src/orders/components/OrderCustomerChangeDialog/messages.ts
+++ b/src/orders/components/OrderCustomerChangeDialog/messages.ts
@@ -2,20 +2,20 @@ import { defineMessages } from "react-intl";
 
 const messages = defineMessages({
   title: {
-    defaultMessage: "Changed Customer",
+    defaultMessage: "Would you like to change address?",
     description: "dialog header"
   },
   description: {
     defaultMessage:
-      "You have changed customer assigned to this order. What would you like to do with the shipping address?",
+      "A new customer has been assigned for this order, but the address remained of a previous customer.",
     description: "dialog description"
   },
   keepAddress: {
-    defaultMessage: "Keep address",
+    defaultMessage: "Keep",
     description: "option label"
   },
   changeAddress: {
-    defaultMessage: "Change address",
+    defaultMessage: "Change",
     description: "option label"
   }
 });

--- a/src/orders/components/OrderCustomerChangeDialog/styles.ts
+++ b/src/orders/components/OrderCustomerChangeDialog/styles.ts
@@ -10,6 +10,10 @@ export const useStyles = makeStyles(
     },
     overflow: {
       overflowY: "visible"
+    },
+    buttonsContainer: {
+      display: "flex",
+      justifyContent: "flex-end"
     }
   },
   { name: "OrderCustomerChangeDialog" }

--- a/src/orders/components/OrderCustomerChangeDialog/styles.ts
+++ b/src/orders/components/OrderCustomerChangeDialog/styles.ts
@@ -9,7 +9,8 @@ export const useStyles = makeStyles(
       display: "block"
     },
     overflow: {
-      overflowY: "visible"
+      overflowY: "visible",
+      paddingTop: 0
     },
     buttonsContainer: {
       display: "flex",

--- a/src/orders/components/OrderPayment/OrderPayment.tsx
+++ b/src/orders/components/OrderPayment/OrderPayment.tsx
@@ -41,6 +41,11 @@ const useStyles = makeStyles(
     },
     titleContainer: {
       display: "flex"
+    },
+    buttonContainer: {
+      "& button:not(:first-child)": {
+        marginLeft: theme.spacing(1)
+      }
     }
   }),
   { name: "OrderPayment" }
@@ -109,7 +114,7 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
               </div>
               {maybe(() => order.status) !== OrderStatus.CANCELED &&
                 (canCapture || canRefund || canVoid || canMarkAsPaid) && (
-                  <div>
+                  <div className={classes.buttonContainer}>
                     {canCapture && (
                       <Button variant="tertiary" onClick={onCapture}>
                         <FormattedMessage {...paymentButtonMessages.capture} />

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -107,7 +107,7 @@ export type OrderUrlDialog =
   | "cancel-fulfillment"
   | "capture"
   | "customer-change"
-  | "edit-customer-addresses"
+  | "edit-customer-address"
   | "edit-billing-address"
   | "edit-fulfillment"
   | "edit-shipping"

--- a/src/orders/views/OrderDetails/OrderDetails.tsx
+++ b/src/orders/views/OrderDetails/OrderDetails.tsx
@@ -190,6 +190,7 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                   updatePrivateMetadataOpts={updatePrivateMetadataOpts}
                   openModal={openModal}
                   closeModal={closeModal}
+                  loading={loading}
                 />
               )}
               {isOrderDraft && (
@@ -237,6 +238,7 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                   updatePrivateMetadataOpts={updatePrivateMetadataOpts}
                   openModal={openModal}
                   closeModal={closeModal}
+                  loading={loading}
                 />
               )}
             </>

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -59,7 +59,11 @@ interface OrderDraftDetailsProps {
 }
 
 export const isAnyAddressEditModalOpen = (uri: string | undefined): boolean =>
-  ["edit-shipping-address", "edit-billing-address"].includes(uri);
+  [
+    "edit-shipping-address",
+    "edit-billing-address",
+    "edit-customer-address"
+  ].includes(uri);
 
 export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
   id,
@@ -107,7 +111,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     variables: {
       id: order?.user?.id
     },
-    skip: !order?.user?.id
+    skip: !order?.user?.id || !isAnyAddressEditModalOpen(params.action)
   });
 
   const intl = useIntl();

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -9,10 +9,7 @@ import {
 import useNavigator from "@saleor/hooks/useNavigator";
 import { CustomerEditData } from "@saleor/orders/components/OrderCustomer";
 import { OrderCustomerAddressesEditDialogOutput } from "@saleor/orders/components/OrderCustomerAddressesEditDialog/types";
-import {
-  CustomerChangeActionEnum,
-  OrderCustomerChangeData
-} from "@saleor/orders/components/OrderCustomerChangeDialog/form";
+import { CustomerChangeActionEnum } from "@saleor/orders/components/OrderCustomerChangeDialog/form";
 import OrderCustomerChangeDialog from "@saleor/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog";
 import { getVariantSearchAddress } from "@saleor/orders/utils/data";
 import { OrderDiscountProvider } from "@saleor/products/components/OrderDiscountProviders/OrderDiscountProvider";
@@ -62,11 +59,7 @@ interface OrderDraftDetailsProps {
 }
 
 export const isAnyAddressEditModalOpen = (uri: string | undefined): boolean =>
-  [
-    "edit-customer-addresses",
-    "edit-shipping-address",
-    "edit-billing-address"
-  ].includes(uri);
+  ["edit-shipping-address", "edit-billing-address"].includes(uri);
 
 export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
   id,
@@ -114,7 +107,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     variables: {
       id: order?.user?.id
     },
-    skip: !order?.user?.id || !isAnyAddressEditModalOpen(params.action)
+    skip: !order?.user?.id
   });
 
   const intl = useIntl();
@@ -143,13 +136,13 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
       return;
     }
 
-    const modalUri = prevUser ? "customer-change" : "edit-customer-addresses";
+    const modalUri = prevUser ? "customer-change" : "edit-customer-address";
     openModal(modalUri);
   };
 
-  const handleCustomerChangeAction = (data: OrderCustomerChangeData) => {
-    if (data.changeActionOption === CustomerChangeActionEnum.CHANGE_ADDRESS) {
-      openModal("edit-customer-addresses");
+  const handleCustomerChangeAction = (choice: CustomerChangeActionEnum) => {
+    if (choice === CustomerChangeActionEnum.CHANGE_ADDRESS) {
+      openModal("edit-customer-address");
     } else {
       closeModal();
     }
@@ -270,14 +263,11 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
       <OrderCustomerChangeDialog
         open={params.action === "customer-change"}
         onClose={closeModal}
-        onConfirm={handleCustomerChangeAction}
+        onChoiceClick={handleCustomerChangeAction}
       />
       <OrderAddressFields
         action={params?.action}
-        orderShippingAddress={order?.shippingAddress}
-        orderBillingAddress={order?.billingAddress}
-        customerAddressesLoading={customerAddressesLoading}
-        isDraft
+        customerAddressesLoading={customerAddressesLoading || loading}
         countries={data?.shop?.countries}
         customer={customerAddresses?.user}
         onClose={closeModal}

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -69,6 +69,7 @@ interface OrderNormalDetailsProps {
   updatePrivateMetadataOpts: any;
   openModal: any;
   closeModal: any;
+  loading?: boolean;
 }
 
 export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
@@ -90,7 +91,8 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
   updateMetadataOpts,
   updatePrivateMetadataOpts,
   openModal,
-  closeModal
+  closeModal,
+  loading
 }) => {
   const order = data?.order;
   const shop = data?.shop;
@@ -335,7 +337,7 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
       />
       <OrderAddressFields
         action={params?.action}
-        customerAddressesLoading={customerAddressesLoading}
+        customerAddressesLoading={customerAddressesLoading || loading}
         countries={data?.shop?.countries}
         customer={customerAddresses?.user}
         onClose={closeModal}

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -335,10 +335,7 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
       />
       <OrderAddressFields
         action={params?.action}
-        orderShippingAddress={order?.shippingAddress}
-        orderBillingAddress={order?.billingAddress}
         customerAddressesLoading={customerAddressesLoading}
-        isDraft={false}
         countries={data?.shop?.countries}
         customer={customerAddresses?.user}
         onClose={closeModal}

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -412,9 +412,6 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
       <OrderAddressFields
         action={params?.action}
         customerAddressesLoading={customerAddressesLoading}
-        orderShippingAddress={order?.shippingAddress}
-        orderBillingAddress={order?.billingAddress}
-        isDraft={false}
         countries={data?.shop?.countries}
         customer={customerAddresses?.user}
         onClose={closeModal}

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -79,6 +79,7 @@ interface OrderUnconfirmedDetailsProps {
   updatePrivateMetadataOpts: any;
   openModal: any;
   closeModal: any;
+  loading?: boolean;
 }
 
 export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = ({
@@ -104,7 +105,8 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
   updateMetadataOpts,
   updatePrivateMetadataOpts,
   openModal,
-  closeModal
+  closeModal,
+  loading
 }) => {
   const order = data.order;
   const shop = data.shop;
@@ -411,7 +413,7 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
       />
       <OrderAddressFields
         action={params?.action}
-        customerAddressesLoading={customerAddressesLoading}
+        customerAddressesLoading={customerAddressesLoading || loading}
         countries={data?.shop?.countries}
         customer={customerAddresses?.user}
         onClose={closeModal}

--- a/src/storybook/stories/components/AddressEdit.tsx
+++ b/src/storybook/stories/components/AddressEdit.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { customer } from "../../../customers/fixtures";
-import { transformAddressToForm } from "../../../misc";
+import { getAddressFormData } from "../../../misc";
 import { countries } from "../../../orders/fixtures";
 import Decorator from "../../Decorator";
 
@@ -21,7 +21,7 @@ storiesOf("Generics / AddressEdit", module)
       <CardContent>
         <AddressEdit
           errors={[]}
-          data={transformAddressToForm(customer.defaultBillingAddress)}
+          data={getAddressFormData(customer.defaultBillingAddress)}
           countries={mapCountriesToChoices(countries)}
           countryDisplayValue={customer.defaultBillingAddress.country.country}
           onChange={undefined}


### PR DESCRIPTION
I want to merge this change because it:
- Changes the order address edit flow
- Makes address edit to be only done in one dialog window as opposed to multiple different ones
- Implements new UI component - Select Switch

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

![image](https://user-images.githubusercontent.com/13994677/159651829-6bec9f8d-8aba-43cd-b5c2-674617b21ffd.png)
![image](https://user-images.githubusercontent.com/13994677/159651908-6a1ef238-6d24-497f-becb-2df48291ff58.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
