### PR TITLE
Stop sending IDs for empty attribute values

### DIFF
--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -195,20 +195,6 @@ function getFileInput(
   };
 }
 
-function getReferenceInput(attribute: AttributeInput) {
-  return {
-    id: attribute.id,
-    references: attribute.value
-  };
-}
-
-function getRichTextInput(attribute: AttributeInput) {
-  return {
-    id: attribute.id,
-    richText: attribute.value[0]
-  };
-}
-
 function getBooleanInput(attribute: AttributeInput) {
   return {
     id: attribute.id,
@@ -216,57 +202,58 @@ function getBooleanInput(attribute: AttributeInput) {
   };
 }
 
-function getDateInput(attribute: AttributeInput) {
-  return {
-    id: attribute.id,
-    date: attribute.value[0]
-  };
-}
-
-function getDateTimeInput(attribute: AttributeInput) {
-  return {
-    id: attribute.id,
-    dateTime: attribute.value[0]
-  };
-}
-
-function getDefaultInput(attribute: AttributeInput) {
-  return {
-    id: attribute.id,
-    values: ["", undefined, null].includes(attribute.value[0])
-      ? []
-      : attribute.value
-  };
-}
-
 export const prepareAttributesInput = ({
   attributes,
   updatedFileAttributes
 }: AttributesArgs): AttributeValueInput[] =>
-  attributes.map(attribute => {
-    switch (attribute.data.inputType) {
-      case AttributeInputTypeEnum.FILE:
-        return getFileInput(attribute, updatedFileAttributes);
-
-      case AttributeInputTypeEnum.REFERENCE:
-        return getReferenceInput(attribute);
-
-      case AttributeInputTypeEnum.RICH_TEXT:
-        return getRichTextInput(attribute);
-
-      case AttributeInputTypeEnum.BOOLEAN:
-        return getBooleanInput(attribute);
-
-      case AttributeInputTypeEnum.DATE:
-        return getDateInput(attribute);
-
-      case AttributeInputTypeEnum.DATE_TIME:
-        return getDateTimeInput(attribute);
-
-      default:
-        return getDefaultInput(attribute);
+  attributes.reduce((attrInput, attr) => {
+    const inputType = attr.data.inputType;
+    if (inputType === AttributeInputTypeEnum.FILE) {
+      const fileInput = getFileInput(attr, updatedFileAttributes);
+      if (fileInput.file) {
+        attrInput.push(fileInput);
+      }
+      return attrInput;
     }
-  });
+    if (inputType === AttributeInputTypeEnum.BOOLEAN) {
+      const booleanInput = getBooleanInput(attr);
+      attrInput.push(booleanInput);
+      return attrInput;
+    }
+    // for cases other than rich text and boolean
+    // we can skip attribute
+    if (!attr.value[0]) {
+      return attrInput;
+    }
+    if (inputType === AttributeInputTypeEnum.REFERENCE) {
+      attrInput.push({
+        id: attr.id,
+        references: attr.value
+      });
+      return attrInput;
+    }
+    if (inputType === AttributeInputTypeEnum.DATE) {
+      attrInput.push({
+        id: attr.id,
+        date: attr.value[0]
+      });
+      return attrInput;
+    }
+    if (inputType === AttributeInputTypeEnum.DATE_TIME) {
+      attrInput.push({
+        id: attr.id,
+        dateTime: attr.value[0]
+      });
+      return attrInput;
+    }
+
+    attrInput.push({
+      id: attr.id,
+      values: attr.value
+    });
+
+    return attrInput;
+  }, []);
 
 export const handleUploadMultipleFiles = async (
   attributesWithNewFileValue: FormsetData<null, File>,


### PR DESCRIPTION
I want to merge this change because dashboard is sending empty attribute values in variables like this:
```
"attributes": [
  {
    "id": "'QXR0cmlidXRlOjI2NTA='"
  }
],
```
We should skip these.
This change should be tested in:

- page create/update
- product create/update
- variant create/update

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.1

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
