### PR TITLE
Fix: zh-CN

### DIFF
--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -43,7 +43,7 @@ export enum Locale {
   TR = "tr",
   UK = "uk",
   VI = "vi",
-  ZH_HANS = "zh-Hans",
+  ZH_CN = "zh-CN",
   ZH_HANT = "zh-Hant"
 }
 
@@ -94,7 +94,7 @@ export const localeNames: Record<Locale, string> = {
   [Locale.TR]: "Türkçe",
   [Locale.UK]: "Українська",
   [Locale.VI]: "Tiếng Việt",
-  [Locale.ZH_HANS]: "简体中文",
+  [Locale.ZH_CN]: "简体中文",
   [Locale.ZH_HANT]: "繁體中文"
 };
 


### PR DESCRIPTION
简体中文 should be `zh-CN`

### Screenshots
![image](https://user-images.githubusercontent.com/53158137/161554975-eab6ab2c-efcc-4168-9648-a455e06d0498.png)

