### PR TITLE
Set descending order when ordering by rank

### DIFF
--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -62,7 +62,7 @@ import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandl
 import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import { mapEdgesToItems, mapNodeToChoice } from "@saleor/utils/maps";
 import { getSortUrlVariables } from "@saleor/utils/sort";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import ProductListPage from "../../components/ProductListPage";
@@ -76,7 +76,8 @@ import {
   getFilterVariables,
   saveFilterTab
 } from "./filters";
-import { canBeSorted, DEFAULT_SORT_KEY, getSortQueryVariables } from "./sort";
+import { getSortQueryVariables } from "./sort";
+import { useSortRedirects } from "./useSortRedirects";
 import { getAvailableProductKinds, getProductKindOpts } from "./utils";
 
 interface ProductListProps {
@@ -176,6 +177,8 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     channel => channel.slug === params.channel
   );
 
+  useSortRedirects(params, !!selectedChannel);
+
   const [openModal, closeModal] = createDialogActionHandlers<
     ProductListUrlDialog,
     ProductListUrlQueryParams
@@ -222,32 +225,6 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     navigate,
     params
   });
-
-  useEffect(() => {
-    const sortWithQuery = ProductListUrlSortField.rank;
-    const sortWithoutQuery =
-      params.sort === ProductListUrlSortField.rank
-        ? DEFAULT_SORT_KEY
-        : params.sort;
-    navigate(
-      productListUrl({
-        ...params,
-        asc: params.query ? undefined : params.asc,
-        sort: params.query ? sortWithQuery : sortWithoutQuery
-      })
-    );
-  }, [params.query]);
-
-  useEffect(() => {
-    if (!canBeSorted(params.sort, !!selectedChannel)) {
-      navigate(
-        productListUrl({
-          ...params,
-          sort: DEFAULT_SORT_KEY
-        })
-      );
-    }
-  }, [params]);
 
   const handleTabChange = (tab: number) => {
     reset();

--- a/src/products/views/ProductList/useSortRedirects.ts
+++ b/src/products/views/ProductList/useSortRedirects.ts
@@ -1,0 +1,42 @@
+import useNavigator from "@saleor/hooks/useNavigator";
+import {
+  productListUrl,
+  ProductListUrlQueryParams,
+  ProductListUrlSortField
+} from "@saleor/products/urls";
+import { useEffect } from "react";
+
+import { canBeSorted, DEFAULT_SORT_KEY } from "./sort";
+
+export function useSortRedirects(
+  params: ProductListUrlQueryParams,
+  isChannelSelected: boolean
+) {
+  const navigate = useNavigator();
+
+  useEffect(() => {
+    const sortWithQuery = ProductListUrlSortField.rank;
+    const sortWithoutQuery =
+      params.sort === ProductListUrlSortField.rank
+        ? DEFAULT_SORT_KEY
+        : params.sort;
+    navigate(
+      productListUrl({
+        ...params,
+        asc: params.query ? false : params.asc,
+        sort: params.query ? sortWithQuery : sortWithoutQuery
+      })
+    );
+  }, [params.query]);
+
+  useEffect(() => {
+    if (!canBeSorted(params.sort, isChannelSelected)) {
+      navigate(
+        productListUrl({
+          ...params,
+          sort: DEFAULT_SORT_KEY
+        })
+      );
+    }
+  }, [params]);
+}


### PR DESCRIPTION
I want to merge this change because it fixes search that was ordering from worst to best match instead the other way.

**PR intended to be tested with API branch:** main

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
