### PR TITLE
Fix variant page crashing when multiple product images

### DIFF
--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -28,6 +28,7 @@ import { Backlink, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { FetchMoreProps, RelayToFlat, ReorderAction } from "@saleor/types";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
+import clone from "lodash/clone";
 
 import ProductShipping from "../ProductShipping/ProductShipping";
 import ProductStocks, { ProductStockInput } from "../ProductStocks";
@@ -165,9 +166,11 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
   ] = React.useState(false);
 
   const variantMedia = variant?.media?.map(image => image.id);
-  const productMedia = variant?.product?.media?.sort((prev, next) =>
+  const unsortedProductMedia = clone(variant?.product?.media)
+  const productMedia = unsortedProductMedia?.sort((prev, next) =>
     prev.sortOrder > next.sortOrder ? 1 : -1
   );
+
   const media = productMedia
     ?.filter(image => variantMedia.indexOf(image.id) !== -1)
     .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));


### PR DESCRIPTION
I want to merge this change because it fixes an issue where dashboard crashes on navigating to variant page if the product has more than 1 image.

Fixes issues - #1962 

**PR intended to be tested with API branch:** 3.1.8

### Pull Request Checklist

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

API_URI=https://master.staging.saleor.cloud/graphql/
