### PR TITLE
Add rel=noopener to links that take users to external sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27156,7 +27156,7 @@
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -19,12 +19,28 @@ interface ExternalLinkProps extends React.HTMLProps<HTMLAnchorElement> {
 }
 
 const ExternalLink: React.FC<ExternalLinkProps> = props => {
-  const { className, children, href, typographyProps, ...rest } = props;
+  const {
+    className,
+    children,
+    href,
+    typographyProps,
+    target,
+    rel,
+    ...rest
+  } = props;
 
   const classes = useStyles(props);
 
+  const opensNewTab = target === "_blank";
+
   return (
-    <a href={href} className={classes.link} {...rest}>
+    <a
+      href={href}
+      className={classes.link}
+      target={target}
+      rel={rel ?? opensNewTab ? "noopener noreferer" : ""}
+      {...rest}
+    >
       <Typography className={className} color="primary" {...typographyProps}>
         {children}
       </Typography>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -50,10 +50,14 @@ const Link: React.FC<LinkProps> = props => {
     onClick,
     disabled,
     href,
+    target,
+    rel,
     ...linkProps
   } = props;
 
   const classes = useStyles(props);
+
+  const opensNewTab = target === "_blank";
 
   const commonLinkProps = {
     className: classNames(className, {
@@ -71,6 +75,8 @@ const Link: React.FC<LinkProps> = props => {
       event.preventDefault();
       onClick(event);
     },
+    target,
+    rel: rel ?? (opensNewTab && isExternalURL) ? "noopener noreferer" : "",
     ...linkProps,
   };
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -76,7 +76,8 @@ const Link: React.FC<LinkProps> = props => {
       onClick(event);
     },
     target,
-    rel: rel ?? (opensNewTab && isExternalURL) ? "noopener noreferer" : "",
+    rel:
+      rel ?? (opensNewTab && isExternalURL(href)) ? "noopener noreferer" : "",
     ...linkProps,
   };
 

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -232,6 +232,7 @@ export const OrderNormalDetails: React.FC<OrderNormalDetailsProps> = ({
           window.open(
             order.invoices.find(invoice => invoice.id === id)?.url,
             "_blank",
+            "rel=noopener",
           )
         }
         onInvoiceGenerate={() =>

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -241,6 +241,7 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
               window.open(
                 order.invoices.find(invoice => invoice.id === id)?.url,
                 "_blank",
+                "rel=noopener",
               )
             }
             onInvoiceGenerate={() =>


### PR DESCRIPTION
I want to merge this change because links in older browsers that have `target=_blank` [expose `window.opener`](https://mathiasbynens.github.io/rel-noopener/) to 3rd party websites, which is a security issue.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
7. [ ] productType
8. [ ] shipping
9. [ ] customer
10. [ ] permissions
11. [ ] menuNavigation
12. [ ] pages
13. [ ] sales
14. [ ] vouchers
15. [ ] homePage
16. [ ] login
17. [ ] orders
18. [ ] products
19. [ ] app
20. [ ] plugins
21. [ ] translations
22. [ ] navigation

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
CONTAINERS=1