### PR TITLE
Pass appId to iframe src

### DIFF
--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -9,6 +9,7 @@ import { useAppActions } from "./useAppActions";
 interface Props {
   src: string;
   appToken: string;
+  appId: string;
   onLoad?(): void;
   onError?(): void;
 }
@@ -18,6 +19,7 @@ const getOrigin = (url: string) => new URL(url).origin;
 export const AppFrame: React.FC<Props> = ({
   src,
   appToken,
+  appId,
   onLoad,
   onError
 }) => {
@@ -50,7 +52,7 @@ export const AppFrame: React.FC<Props> = ({
   return (
     <iframe
       ref={frameRef}
-      src={urlJoin(src, `?domain=${shop.domain.host}`)}
+      src={urlJoin(src, `?domain=${shop.domain.host}&id=${appId}`)}
       onError={onError}
       onLoad={handleLoad}
       className={classes.iframe}

--- a/src/apps/components/AppPage/AppPage.tsx
+++ b/src/apps/components/AppPage/AppPage.tsx
@@ -99,7 +99,12 @@ export const AppPage: React.FC<AppPageProps> = ({
       <CardSpacer />
       <div className={classes.iframeContainer}>
         {url && (
-          <AppFrame src={url} appToken={data.accessToken} onError={onError} />
+          <AppFrame
+            src={url}
+            appToken={data.accessToken}
+            onError={onError}
+            appId={data.id}
+          />
         )}
       </div>
       <CardSpacer />

--- a/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
+++ b/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
@@ -35,7 +35,11 @@ export const ExternalAppProvider: React.FC = ({ children }) => {
       {children}
       <AppDialog open={open} onClose={handleClose} title={appData?.label}>
         {open && appData && (
-          <AppFrame src={appData.src} appToken={appData.appToken} />
+          <AppFrame
+            src={appData.src}
+            appToken={appData.appToken}
+            appId={appData.id}
+          />
         )}
       </AppDialog>
     </ExternalAppContext.Provider>


### PR DESCRIPTION
I want to merge this change because:
* It passes appId to iframe src (it's used by https://github.com/saleor/app-bridge/pull/4)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
