### PR TITLE
Fix saving rich text attribute

### DIFF
--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -220,7 +220,15 @@ export const prepareAttributesInput = ({
       attrInput.push(booleanInput);
       return attrInput;
     }
-    // for cases other than rich text and boolean
+    if (inputType === AttributeInputTypeEnum.RICH_TEXT) {
+      attrInput.push({
+        id: attr.id,
+        richText: attr.value[0]
+      });
+      return attrInput;
+    }
+
+    // for cases other than rich text, boolean and file
     // we can skip attribute
     if (!attr.value[0]) {
       return attrInput;


### PR DESCRIPTION
I want to merge this change because it fixes a bug introduced in #1968 - rich text attribute case was accidentally deleted from parser function, which resulted in fallback to default case - which is not designed to handle rich text.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
