### PR TITLE
Fix event spread in PriceField

### DIFF
--- a/src/components/PriceField/PriceField.tsx
+++ b/src/components/PriceField/PriceField.tsx
@@ -1,5 +1,6 @@
 import { InputAdornment, TextField, TextFieldProps } from "@material-ui/core";
 import { InputProps } from "@material-ui/core/Input";
+import { FormChange } from "@saleor/hooks/useForm";
 import { makeStyles } from "@saleor/macaw-ui";
 import React, { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -70,21 +71,27 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
     [currencySymbol]
   );
 
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
-    const splitCharacter = findPriceSeparator(e.target.value);
-    const [integerPart, decimalPart] = e.target.value.split(splitCharacter);
+  const handleChange: FormChange = e => {
+    let value = e.target.value;
+    const splitCharacter = findPriceSeparator(value);
+    const [integerPart, decimalPart] = value.split(splitCharacter);
 
     if (maxDecimalLength === 0 && decimalPart) {
       // this shouldn't happen - decimal character should be ignored
-      e.target.value = integerPart;
+      value = integerPart;
     }
 
     if (decimalPart?.length > maxDecimalLength) {
       const shortenedDecimalPart = decimalPart.slice(0, maxDecimalLength);
-      e.target.value = `${integerPart}${splitCharacter}${shortenedDecimalPart}`;
+      value = `${integerPart}${splitCharacter}${shortenedDecimalPart}`;
     }
 
-    onChange(e);
+    onChange({
+      target: {
+        name: e.target.name,
+        value
+      }
+    });
   };
 
   const handleKeyPress: TextFieldProps["onKeyDown"] = e => {

--- a/src/components/PriceField/PriceField.tsx
+++ b/src/components/PriceField/PriceField.tsx
@@ -71,21 +71,20 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
   );
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = e => {
-    let newValue = e.target.value;
-    const splitCharacter = findPriceSeparator(newValue);
+    const splitCharacter = findPriceSeparator(e.target.value);
     const [integerPart, decimalPart] = e.target.value.split(splitCharacter);
 
     if (maxDecimalLength === 0 && decimalPart) {
       // this shouldn't happen - decimal character should be ignored
-      newValue = integerPart;
+      e.target.value = integerPart;
     }
 
     if (decimalPart?.length > maxDecimalLength) {
       const shortenedDecimalPart = decimalPart.slice(0, maxDecimalLength);
-      newValue = `${integerPart}${splitCharacter}${shortenedDecimalPart}`;
+      e.target.value = `${integerPart}${splitCharacter}${shortenedDecimalPart}`;
     }
 
-    onChange({ ...e, target: { ...e.target, value: newValue } });
+    onChange(e);
   };
 
   const handleKeyPress: TextFieldProps["onKeyDown"] = e => {


### PR DESCRIPTION
I want to merge this change because it fixes an issue introduced in #1954 that caused to create incorrect `e.target` due to object spread instead of modyfing the `e.target.value`

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
