### PR TITLE
Trim queries with whitespace

### DIFF
--- a/src/products/views/ProductList/useSortRedirects.ts
+++ b/src/products/views/ProductList/useSortRedirects.ts
@@ -14,6 +14,7 @@ export function useSortRedirects(
 ) {
   const navigate = useNavigator();
 
+  const hasQuery = !!params.query.trim();
   useEffect(() => {
     const sortWithQuery = ProductListUrlSortField.rank;
     const sortWithoutQuery =
@@ -23,8 +24,8 @@ export function useSortRedirects(
     navigate(
       productListUrl({
         ...params,
-        asc: params.query ? false : params.asc,
-        sort: params.query ? sortWithQuery : sortWithoutQuery
+        asc: hasQuery ? false : params.asc,
+        sort: hasQuery ? sortWithQuery : sortWithoutQuery
       })
     );
   }, [params.query]);

--- a/src/products/views/ProductList/useSortRedirects.ts
+++ b/src/products/views/ProductList/useSortRedirects.ts
@@ -14,7 +14,8 @@ export function useSortRedirects(
 ) {
   const navigate = useNavigator();
 
-  const hasQuery = !!params.query.trim();
+  const hasQuery = !!params.query?.trim();
+
   useEffect(() => {
     const sortWithQuery = ProductListUrlSortField.rank;
     const sortWithoutQuery =

--- a/src/utils/handlers/filterHandlers.ts
+++ b/src/utils/handlers/filterHandlers.ts
@@ -62,7 +62,7 @@ function createFilterHandlers<
         after: undefined,
         before: undefined,
         activeTab: undefined,
-        query
+        query: query?.trim()
       })
     );
   };


### PR DESCRIPTION
I want to merge this change because dashboard sends queries with `search` field consisting only of whitespace. It should be trimmed.

Also, sorting by rank in product list is disabled when search is empty.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
