### PR TITLE
Navigate to order draft list after canceling order draft

### DIFF
--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -2,6 +2,8 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import {
   OrderDetailsQuery,
+  OrderDraftCancelMutation,
+  OrderDraftCancelMutationVariables,
   OrderDraftUpdateMutation,
   OrderDraftUpdateMutationVariables,
   StockAvailability,
@@ -56,7 +58,10 @@ interface OrderDraftDetailsProps {
     OrderDraftUpdateMutation,
     OrderDraftUpdateMutationVariables
   >;
-  orderDraftCancel: any;
+  orderDraftCancel: PartialMutationProviderOutput<
+    OrderDraftCancelMutation,
+    OrderDraftCancelMutationVariables
+  >;
   orderDraftFinalize: any;
   openModal: (action: OrderUrlDialog, newParams?: OrderUrlQueryParams) => void;
   closeModal: any;
@@ -166,6 +171,14 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
       input: data
     });
 
+  const handleOrderDraftCancel = async () => {
+    const errors = await extractMutationErrors(orderDraftCancel.mutate({ id }));
+    if (!errors.length) {
+      navigate(orderDraftListUrl());
+    }
+    return errors;
+  };
+
   return (
     <>
       <WindowTitle
@@ -225,7 +238,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
         confirmButtonState={orderDraftCancel.opts.status}
         errors={orderDraftCancel.opts.data?.draftOrderDelete.errors || []}
         onClose={closeModal}
-        onConfirm={() => orderDraftCancel.mutate({ id })}
+        onConfirm={handleOrderDraftCancel}
         open={params.action === "cancel"}
         orderNumber={getStringOrPlaceholder(order?.number)}
       />


### PR DESCRIPTION
I want to merge this change because it fixes an error when canceling order draft. Successful cancelation didn't result in navigation to order draft list, displaying 404 error instead.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
