### PR TITLE
Fix styling for long warehouse names

### DIFF
--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -94,6 +94,7 @@ interface OrderCardTitleProps {
   orderNumber?: string;
   warehouseName?: string;
   withStatus?: boolean;
+  className?: string;
 }
 
 const selectStatus = (status: CardTitleStatus) => {
@@ -124,7 +125,8 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
   orderNumber = "",
   warehouseName,
   withStatus = false,
-  toolbar
+  toolbar,
+  className
 }) => {
   const intl = useIntl();
   const classes = useStyles({});
@@ -151,6 +153,7 @@ const OrderCardTitle: React.FC<OrderCardTitleProps> = ({
   return (
     <DefaultCardTitle
       toolbar={toolbar}
+      className={className}
       title={
         <div className={classes.title}>
           {withStatus && (

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -152,39 +152,39 @@ export const OrderChangeWarehouseDialog: React.FC<OrderChangeWarehouseDialogProp
               const someLinesUnavailable = unavailableLines?.length > 0;
               return (
                 <TableRow key={warehouse.id}>
-                  <TableCell className={classes.warehouseCell}>
-                    <div>
-                      <FormControlLabel
-                        value={warehouse.id}
-                        control={<Radio color="primary" />}
-                        label={
-                          <div className={classes.radioLabelContainer}>
+                  <TableCell>
+                    <FormControlLabel
+                      value={warehouse.id}
+                      control={<Radio color="primary" />}
+                      label={
+                        <div className={classes.radioLabelContainer}>
+                          <span className={classes.warehouseName}>
                             {warehouse.name}
-                            {someLinesUnavailable && (
-                              <Typography className={classes.supportText}>
-                                {unavailableLines.length === 1
-                                  ? intl.formatMessage(
-                                      messages.productUnavailable,
-                                      {
-                                        productName:
-                                          unavailableLines[0].productName
-                                      }
-                                    )
-                                  : intl.formatMessage(
-                                      messages.multipleProductsUnavailable,
-                                      { productCount: unavailableLines.length }
-                                    )}
-                              </Typography>
-                            )}
-                          </div>
-                        }
-                      />
-                      {currentWarehouse?.id === warehouse?.id && (
-                        <Typography className={classes.helpText}>
-                          {intl.formatMessage(messages.currentSelection)}
-                        </Typography>
-                      )}
-                    </div>
+                          </span>
+                          {someLinesUnavailable && (
+                            <Typography className={classes.supportText}>
+                              {unavailableLines.length === 1
+                                ? intl.formatMessage(
+                                    messages.productUnavailable,
+                                    {
+                                      productName:
+                                        unavailableLines[0].productName
+                                    }
+                                  )
+                                : intl.formatMessage(
+                                    messages.multipleProductsUnavailable,
+                                    { productCount: unavailableLines.length }
+                                  )}
+                            </Typography>
+                          )}
+                        </div>
+                      }
+                    />
+                    {currentWarehouse?.id === warehouse?.id && (
+                      <Typography className={classes.helpText}>
+                        {intl.formatMessage(messages.currentSelection)}
+                      </Typography>
+                    )}
                   </TableCell>
                 </TableRow>
               );

--- a/src/orders/components/OrderChangeWarehouseDialog/styles.ts
+++ b/src/orders/components/OrderChangeWarehouseDialog/styles.ts
@@ -5,10 +5,6 @@ export const useStyles = makeStyles(
     container: {
       paddingTop: 0
     },
-    radioLabelContainer: {
-      display: "flex",
-      flexDirection: "column"
-    },
     searchBox: {
       marginTop: theme.spacing(2),
       marginBottom: theme.spacing(2)
@@ -25,9 +21,6 @@ export const useStyles = makeStyles(
       fontSize: "12px",
       lineHeight: "160%"
     },
-    warehouseCell: {
-      paddingLeft: 0
-    },
     helpText: {
       display: "inline",
       fontSize: "12px",
@@ -38,6 +31,15 @@ export const useStyles = makeStyles(
       fontSize: "14px",
       lineHeight: "160%",
       color: theme.palette.saleor.main[3]
+    },
+    radioLabelContainer: {
+      display: "flex",
+      flexDirection: "column"
+    },
+    warehouseName: {
+      maxWidth: "350px",
+      overflow: "hidden",
+      textOverflow: "ellipsis"
     }
   }),
   { name: "OrderChangeWarehouseDialog" }

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -41,6 +41,25 @@ const useStyles = makeStyles(
       "&:hover": {
         backgroundColor: theme.palette.saleor.active[5],
         color: theme.palette.saleor.active[1]
+      },
+      "& > div": {
+        minWidth: 0,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis"
+      }
+    },
+    cardTitle: {
+      justifyContent: "space-between",
+      "& > div": {
+        "&:first-child": {
+          flex: 0,
+          whiteSpace: "nowrap"
+        },
+        "&:last-child": {
+          flex: "0 1 auto",
+          minWidth: 0
+        }
       }
     }
   }),
@@ -78,9 +97,10 @@ const OrderUnfulfilledProductsCard: React.FC<OrderUnfulfilledProductsCardProps> 
           lines={lines}
           withStatus
           status="unfulfilled"
+          className={classes.cardTitle}
           toolbar={
             <div className={classes.toolbar} onClick={onWarehouseChange}>
-              {selectedWarehouse?.name ?? <Skeleton />}
+              <div>{selectedWarehouse?.name ?? <Skeleton />}</div>
               <ChevronIcon />
             </div>
           }

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -58,7 +58,8 @@ const useStyles = makeStyles(
         },
         "&:last-child": {
           flex: "0 1 auto",
-          minWidth: 0
+          minWidth: 0,
+          marginLeft: theme.spacing(1)
         }
       }
     }


### PR DESCRIPTION
I want to merge this change because it fixes styling in Change Warehouse Dialog & Order Details for very long warehouse names.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
<img width="602" alt="Change warehouse" src="https://user-images.githubusercontent.com/41952692/165345102-9394576e-c729-45e7-834f-6a40b595a0a5.png">

<img width="841" alt="Quantity" src="https://user-images.githubusercontent.com/41952692/165345113-3b4548d6-0406-4423-9759-8dbde22a12a7.png">


After:
<img width="600" alt="Change warehouse" src="https://user-images.githubusercontent.com/41952692/165345122-97d4c4a4-3024-4bda-9da9-8364a8974850.png">

<img width="840" alt="Unfulfilled (1)" src="https://user-images.githubusercontent.com/41952692/165345134-99dc9088-5979-4697-b594-837bec0a82c7.png">




### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
