### PR TITLE
Add stacking context to App wrapper

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -83,6 +83,7 @@ const useStyles = makeStyles(
       }
     },
     root: {
+      isolation: "isolate",
       [theme.breakpoints.up("md")]: {
         display: "flex"
       },


### PR DESCRIPTION
I want to merge this change because it wraps the app with `isolation: isolate` to create new CSS stacking context. This makes every component that uses React Portal (ex. Popper) to be above the components inside the app. Thanks to this we don't have to worry about z-index values used inside dashboard colliding with external libraries.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
