### PR TITLE
Update voucher creation text for "Only once per order"

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -928,10 +928,6 @@
     "context": "e-mail or full name",
     "string": "Customer"
   },
-  "5c2JVF": {
-    "context": "voucher application, switch button",
-    "string": "Only once per order"
-  },
   "5dLpx0": {
     "context": "references attribute type",
     "string": "References"
@@ -4637,6 +4633,10 @@
   "Y3pCRX": {
     "context": "attribute can be searched in storefront",
     "string": "Use as filter"
+  },
+  "Y3zr/B": {
+    "context": "voucher application, switch button",
+    "string": "Apply only to a single cheapest eligible product"
   },
   "Y4cy0i": {
     "context": "dialog header",

--- a/src/discounts/components/VoucherValue/VoucherValue.tsx
+++ b/src/discounts/components/VoucherValue/VoucherValue.tsx
@@ -194,8 +194,8 @@ const VoucherValue: React.FC<VoucherValueProps> = props => {
           label={
             <>
               <FormattedMessage
-                id="5c2JVF"
-                defaultMessage="Only once per order"
+                id="Y3zr/B"
+                defaultMessage="Apply only to a single cheapest eligible product"
                 description="voucher application, switch button"
               />
               <Typography variant="caption">


### PR DESCRIPTION
I want to merge this change because it makes it more clear what the "Only once per order" option mean in Voucher creation/update

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
![image (8)](https://user-images.githubusercontent.com/4144459/169548783-125f8b03-6ba9-4e81-ab72-1635c34e0822.png)

After:

<img width="875" alt="CleanShot 2022-05-20 at 16 19 32@2x" src="https://user-images.githubusercontent.com/4144459/169548495-655a2def-848d-40bc-9c6c-bc78d89cb622.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
