### PR TITLE
Handle case when rich text editor hook gets malformed data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.1.0-dev",
+  "version": "3.4.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24397,9 +24397,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "mochawesome-merge": "^4.2.1",
     "mochawesome-report-generator": "^6.0.1",
     "mock-apollo-client": "^0.4.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.6.2",
     "react-test-renderer": "^16.12.0",
     "regenerator-runtime": "^0.11.1",
     "register-service-worker": "^1.7.2",

--- a/src/components/RichTextEditor/ParsingError.tsx
+++ b/src/components/RichTextEditor/ParsingError.tsx
@@ -1,0 +1,60 @@
+import type EditorJS from "@editorjs/editorjs";
+import { Notification, ThemeProvider } from "@saleor/macaw-ui";
+import themeOverrides from "@saleor/themeOverrides";
+import React from "react";
+import ReactDOM from "react-dom";
+
+interface ParsingErrorProps {
+  api: EditorJS;
+}
+
+// TODO: Update design to look better
+export const ParsingErrorComponent = ({ api }: ParsingErrorProps) => (
+  <Notification
+    type="error"
+    title="It looks like your data is malformed! You can either delete this message and
+    type new content, or check in console what happened"
+    onClose={() => api.blocks.delete()}
+  />
+);
+
+const Wrapper: React.FC<{}> = ({ children }) => (
+  <ThemeProvider overrides={themeOverrides}>{children}</ThemeProvider>
+);
+
+export class ParsingError {
+  api = null;
+  el = null;
+  constructor({ api }) {
+    this.api = api;
+  }
+
+  findId() {
+    const randomNumber = Math.ceil(Math.random() * 100);
+    const id = `parsing-error-${randomNumber}`;
+    if (document.getElementById(id)) {
+      return this.findId();
+    }
+    return id;
+  }
+
+  render() {
+    this.el = document.createElement("div");
+    this.el.setAttribute("id", this.findId());
+    ReactDOM.render(
+      <Wrapper>
+        <ParsingErrorComponent api={this.api} />
+      </Wrapper>,
+      this.el
+    );
+    return this.el;
+  }
+
+  removed() {
+    ReactDOM.unmountComponentAtNode(this.el);
+  }
+
+  save() {
+    return {};
+  }
+}

--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -29,4 +29,10 @@ storiesOf("Generics / Rich text editor", module)
   .add("error", () => <RichTextEditor {...props} error={true} />)
   .add("static", () => (
     <RichTextEditorContent {...props} value={defaultValue} />
+  ))
+  .add("parsing error", () => (
+    <RichTextEditor
+      {...props}
+      defaultValue={fixtures.parsingError as OutputData}
+    />
   ));

--- a/src/components/RichTextEditor/consts.tsx
+++ b/src/components/RichTextEditor/consts.tsx
@@ -7,6 +7,8 @@ import Quote from "@editorjs/quote";
 import strikethroughIcon from "@saleor/icons/StrikethroughIcon";
 import createGenericInlineTool from "editorjs-inline-tool";
 
+import { ParsingError } from "./ParsingError";
+
 const inlineToolbar = ["link", "bold", "italic", "strikethrough"];
 
 export const tools: Record<string, ToolConstructable | ToolSettings> = {
@@ -38,5 +40,8 @@ export const tools: Record<string, ToolConstructable | ToolSettings> = {
     shortcut: "CMD+S",
     tagName: "s",
     toolboxIcon: strikethroughIcon
-  })
+  }),
+  parsingError: {
+    class: ParsingError
+  }
 };

--- a/src/components/RichTextEditor/fixtures.json
+++ b/src/components/RichTextEditor/fixtures.json
@@ -1,4 +1,10 @@
 {
+  "parsingError": {
+    "time": 1603898483525,
+    "blocks": [
+      {"type": "parsingError", "data": ""}
+    ]
+  },
   "richTextEditor": {
     "time": 1603898483525,
     "blocks": [

--- a/src/utils/richText/useMultipleRichText.ts
+++ b/src/utils/richText/useMultipleRichText.ts
@@ -41,12 +41,21 @@ export const useMultipleRichText = <TKey extends string>({
 
   const getDefaultValue = useCallback(
     (id: TKey) => {
+      if (initial[id] === undefined) {
+        setShouldMountById(id, true);
+        return "";
+      }
+
       try {
         const result = JSON.parse(initial[id]);
         setShouldMountById(id, true);
         return result;
       } catch (e) {
-        return undefined;
+        console.error(e);
+        setShouldMountById(id, true);
+        return {
+          blocks: [{ type: "parsingError" }]
+        };
       }
     },
     [initial]

--- a/src/utils/richText/useRichText.ts
+++ b/src/utils/richText/useRichText.ts
@@ -24,12 +24,21 @@ export function useRichText({ initial, triggerChange }: UseRichTextOptions) {
   };
 
   const defaultValue = useMemo<OutputData | undefined>(() => {
+    if (initial === undefined) {
+      setIsReadyForMount(true);
+      return "";
+    }
+
     try {
       const result = JSON.parse(initial);
       setIsReadyForMount(true);
       return result;
     } catch (e) {
-      return undefined;
+      console.error(e);
+      setIsReadyForMount(true);
+      return {
+        blocks: [{ type: "parsingError" }]
+      };
     }
   }, [initial]);
 


### PR DESCRIPTION
I want to merge this change because it adds handling for a situation when `useRichText` or `useMultipleRichText` receive malformed JSON data and adds support into RichTextEditor for new block `parsingError`.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/

