### PR TITLE
Handle case when attribute value is empty on initial render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.1.0-dev",
+  "version": "3.4.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/categories/components/CategoryDetailsForm/CategoryDetailsForm.tsx
+++ b/src/categories/components/CategoryDetailsForm/CategoryDetailsForm.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, TextField } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RichTextEditor from "@saleor/components/RichTextEditor";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { ProductErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -58,7 +59,7 @@ export const CategoryDetailsForm: React.FC<CategoryDetailsFormProps> = ({
           />
         </div>
         <FormSpacer />
-        {isReadyForMount && (
+        {isReadyForMount ? (
           <RichTextEditor
             defaultValue={defaultValue}
             editorRef={editorRef}
@@ -66,6 +67,14 @@ export const CategoryDetailsForm: React.FC<CategoryDetailsFormProps> = ({
             disabled={disabled}
             error={!!formErrors.description}
             helperText={getProductErrorMessage(formErrors.description, intl)}
+            label={intl.formatMessage({
+              id: "8HRy+U",
+              defaultMessage: "Category Description"
+            })}
+            name="description"
+          />
+        ) : (
+          <RichTextEditorLoading
             label={intl.formatMessage({
               id: "8HRy+U",
               defaultMessage: "Category Description"

--- a/src/categories/components/CategoryUpdatePage/form.tsx
+++ b/src/categories/components/CategoryUpdatePage/form.tsx
@@ -78,6 +78,7 @@ function useCategoryUpdateForm(
 
   const richText = useRichText({
     initial: category?.description,
+    loading: !category,
     triggerChange
   });
 

--- a/src/collections/components/CollectionDetails/CollectionDetails.tsx
+++ b/src/collections/components/CollectionDetails/CollectionDetails.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, TextField } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RichTextEditor from "@saleor/components/RichTextEditor";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { CollectionErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -56,7 +57,7 @@ const CollectionDetails: React.FC<CollectionDetailsProps> = ({
           fullWidth
         />
         <FormSpacer />
-        {isReadyForMount && (
+        {isReadyForMount ? (
           <RichTextEditor
             defaultValue={defaultValue}
             editorRef={editorRef}
@@ -66,6 +67,11 @@ const CollectionDetails: React.FC<CollectionDetailsProps> = ({
             label={intl.formatMessage(commonMessages.description)}
             name="description"
             disabled={disabled}
+          />
+        ) : (
+          <RichTextEditorLoading
+            label={intl.formatMessage(commonMessages.description)}
+            name="description"
           />
         )}
       </CardContent>

--- a/src/collections/components/CollectionDetailsPage/form.tsx
+++ b/src/collections/components/CollectionDetailsPage/form.tsx
@@ -96,6 +96,7 @@ function useCollectionUpdateForm(
 
   const richText = useRichText({
     initial: collection?.description,
+    loading: !collection,
     triggerChange
   });
 

--- a/src/components/RichTextEditor/RichTextEditorLoading.tsx
+++ b/src/components/RichTextEditor/RichTextEditorLoading.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import RichTextEditor, { RichTextEditorProps } from "./RichTextEditor";
+
+interface RichTextEditorLoadingProps
+  extends Omit<
+    RichTextEditorProps,
+    | "disabled"
+    | "editorRef"
+    | "onChange"
+    | "defaultValue"
+    | "error"
+    | "helperText"
+  > {
+  helperText?: RichTextEditorProps["helperText"];
+}
+
+export const RichTextEditorLoading = (props: RichTextEditorLoadingProps) => (
+  <RichTextEditor
+    {...props}
+    disabled={true}
+    readOnly={true}
+    error={null}
+    helperText={props.helperText ?? ""}
+    defaultValue={{ blocks: [] }}
+    editorRef={{ current: null }}
+  />
+);

--- a/src/pages/components/PageDetailsPage/form.tsx
+++ b/src/pages/components/PageDetailsPage/form.tsx
@@ -163,6 +163,7 @@ function usePageForm(
 
   const richText = useRichText({
     initial: pageExists ? page?.content : null,
+    loading: pageExists ? !page : false,
     triggerChange
   });
 

--- a/src/pages/components/PageInfo/PageInfo.tsx
+++ b/src/pages/components/PageInfo/PageInfo.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, TextField } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RichTextEditor from "@saleor/components/RichTextEditor";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { PageErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -64,7 +65,7 @@ const PageInfo: React.FC<PageInfoProps> = props => {
           onChange={onChange}
         />
         <FormSpacer />
-        {isReadyForMount && (
+        {isReadyForMount ? (
           <RichTextEditor
             defaultValue={defaultValue}
             editorRef={editorRef}
@@ -72,6 +73,15 @@ const PageInfo: React.FC<PageInfoProps> = props => {
             disabled={disabled}
             error={!!formErrors.content}
             helperText={getPageErrorMessage(formErrors.content, intl)}
+            label={intl.formatMessage({
+              id: "gMwpNC",
+              defaultMessage: "Content",
+              description: "page content"
+            })}
+            name={"content" as keyof PageData}
+          />
+        ) : (
+          <RichTextEditorLoading
             label={intl.formatMessage({
               id: "gMwpNC",
               defaultMessage: "Content",

--- a/src/products/components/ProductDetailsForm/ProductDetailsForm.tsx
+++ b/src/products/components/ProductDetailsForm/ProductDetailsForm.tsx
@@ -5,6 +5,7 @@ import FormSpacer from "@saleor/components/FormSpacer";
 import Grid from "@saleor/components/Grid";
 import Hr from "@saleor/components/Hr";
 import RichTextEditor from "@saleor/components/RichTextEditor";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { ProductErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -60,7 +61,7 @@ export const ProductDetailsForm: React.FC<ProductDetailsFormProps> = ({
           onChange={onChange}
         />
         <FormSpacer />
-        {isReadyForMount && (
+        {isReadyForMount ? (
           <RichTextEditor
             editorRef={editorRef}
             defaultValue={defaultValue}
@@ -68,6 +69,11 @@ export const ProductDetailsForm: React.FC<ProductDetailsFormProps> = ({
             disabled={disabled}
             error={!!formErrors.description}
             helperText={getProductErrorMessage(formErrors.description, intl)}
+            label={intl.formatMessage(commonMessages.description)}
+            name="description"
+          />
+        ) : (
+          <RichTextEditorLoading
             label={intl.formatMessage(commonMessages.description)}
             name="description"
           />

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -281,6 +281,7 @@ function useProductUpdateForm(
   const stocks = useFormset(getStockInputFromProduct(product));
   const richText = useRichText({
     initial: product?.description,
+    loading: !product,
     triggerChange
   });
 

--- a/src/shipping/components/ShippingRateInfo/ShippingRateInfo.tsx
+++ b/src/shipping/components/ShippingRateInfo/ShippingRateInfo.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, TextField } from "@material-ui/core";
 import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import RichTextEditor from "@saleor/components/RichTextEditor";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { ShippingErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -100,7 +101,7 @@ const ShippingRateInfo: React.FC<ShippingRateInfoProps> = props => {
           onChange={onChange}
         />
         <CardSpacer />
-        {isReadyForMount && (
+        {isReadyForMount ? (
           <RichTextEditor
             defaultValue={defaultValue}
             editorRef={editorRef}
@@ -108,6 +109,11 @@ const ShippingRateInfo: React.FC<ShippingRateInfoProps> = props => {
             disabled={disabled}
             error={!!formErrors.description}
             helperText={getShippingErrorMessage(formErrors.description, intl)}
+            label={intl.formatMessage(messages.description)}
+            name="description"
+          />
+        ) : (
+          <RichTextEditorLoading
             label={intl.formatMessage(messages.description)}
             name="description"
           />

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
@@ -130,6 +130,7 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
 
   const richText = useRichText({
     initial: rate?.description,
+    loading: !rate,
     triggerChange
   });
 

--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -3,6 +3,7 @@ import { Typography } from "@material-ui/core";
 import { useExitFormDialog } from "@saleor/components/Form/useExitFormDialog";
 import RichTextEditor from "@saleor/components/RichTextEditor";
 import RichTextEditorContent from "@saleor/components/RichTextEditor/RichTextEditorContent";
+import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import useRichText from "@saleor/utils/richText/useRichText";
@@ -51,7 +52,7 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
 
   return edit ? (
     <form onSubmit={submit}>
-      {isReadyForMount && (
+      {isReadyForMount ? (
         <RichTextEditor
           defaultValue={defaultValue}
           editorRef={editorRef}
@@ -59,6 +60,15 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
           disabled={disabled}
           error={undefined}
           helperText={undefined}
+          label={intl.formatMessage({
+            id: "/vCXIP",
+            defaultMessage: "Translation"
+          })}
+          name="translation"
+          data-test-id="translation-field"
+        />
+      ) : (
+        <RichTextEditorLoading
           label={intl.formatMessage({
             id: "/vCXIP",
             defaultMessage: "Translation"

--- a/src/utils/richText/useMultipleRichText.ts
+++ b/src/utils/richText/useMultipleRichText.ts
@@ -41,6 +41,11 @@ export const useMultipleRichText = <TKey extends string>({
 
   const getDefaultValue = useCallback(
     (id: TKey) => {
+      if (initial[id] === undefined) {
+        setShouldMountById(id, true);
+        return "";
+      }
+
       try {
         const result = JSON.parse(initial[id]);
         setShouldMountById(id, true);

--- a/src/utils/richText/useRichText.test.ts
+++ b/src/utils/richText/useRichText.test.ts
@@ -23,13 +23,15 @@ describe("useRichText", () => {
   it("properly informs RichTextEditor when data is ready to mount", () => {
     // eslint-disable-next-line prefer-const
     let initial: string | undefined;
+    let loading = true;
     const { result, rerender } = renderHook(() =>
-      useRichText({ initial, triggerChange })
+      useRichText({ initial, loading, triggerChange })
     );
 
     expect(result.current.isReadyForMount).toBe(false);
 
     initial = JSON.stringify(fixtures.short); // for JSON.parse()
+    loading = false;
     rerender();
 
     expect(result.current.defaultValue).toStrictEqual(fixtures.short);
@@ -39,13 +41,15 @@ describe("useRichText", () => {
   it("returns undefined when JSON cannot be parsed", () => {
     // eslint-disable-next-line prefer-const
     let initial: string | undefined;
+    let loading = true;
     const { result, rerender } = renderHook(() =>
-      useRichText({ initial, triggerChange })
+      useRichText({ initial, loading, triggerChange })
     );
 
     expect(result.current.isReadyForMount).toBe(false);
 
     initial = "this-isnt-valid-json";
+    loading = false;
     rerender();
 
     expect(result.current.defaultValue).toBe(undefined);

--- a/src/utils/richText/useRichText.ts
+++ b/src/utils/richText/useRichText.ts
@@ -4,10 +4,15 @@ import { useMemo, useRef, useState } from "react";
 
 interface UseRichTextOptions {
   initial: string | null;
+  loading?: boolean;
   triggerChange: () => void;
 }
 
-export function useRichText({ initial, triggerChange }: UseRichTextOptions) {
+export function useRichText({
+  initial,
+  loading,
+  triggerChange
+}: UseRichTextOptions) {
   const editorRef = useRef<EditorCore>(null);
   const [isReadyForMount, setIsReadyForMount] = useState(false);
 
@@ -24,6 +29,10 @@ export function useRichText({ initial, triggerChange }: UseRichTextOptions) {
   };
 
   const defaultValue = useMemo<OutputData | undefined>(() => {
+    if (loading) {
+      return;
+    }
+
     if (initial === undefined) {
       setIsReadyForMount(true);
       return "";

--- a/src/utils/richText/useRichText.ts
+++ b/src/utils/richText/useRichText.ts
@@ -24,6 +24,11 @@ export function useRichText({ initial, triggerChange }: UseRichTextOptions) {
   };
 
   const defaultValue = useMemo<OutputData | undefined>(() => {
+    if (initial === undefined) {
+      setIsReadyForMount(true);
+      return "";
+    }
+
     try {
       const result = JSON.parse(initial);
       setIsReadyForMount(true);


### PR DESCRIPTION
I want to merge this change because it fixes issues with useRichText and useMultpleRichText that didn't receive any data (ex. product create)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
