### PR TITLE
Replace defaultMessage "Country" and "Country Area"

### DIFF
--- a/src/components/AddressEdit/AddressEdit.tsx
+++ b/src/components/AddressEdit/AddressEdit.tsx
@@ -239,7 +239,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             helperText={getErrorMessage(formErrors.country, intl)}
             label={intl.formatMessage({
               id: "vONi+O",
-              defaultMessage: "Country"
+              defaultMessage: "Country / Region"
             })}
             name="country"
             onChange={onCountryChange}
@@ -254,7 +254,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             helperText={getErrorMessage(formErrors.countryArea, intl)}
             label={intl.formatMessage({
               id: "AuwpCm",
-              defaultMessage: "Country area"
+              defaultMessage: "State / Province"
             })}
             name="countryArea"
             onChange={onChange}

--- a/src/components/CompanyAddressInput/CompanyAddressForm.tsx
+++ b/src/components/CompanyAddressInput/CompanyAddressForm.tsx
@@ -176,7 +176,7 @@ const CompanyAddressForm: React.FC<CompanyAddressFormProps> = props => {
           helperText={getErrorMessage(formErrors.country, intl)}
           label={intl.formatMessage({
             id: "vONi+O",
-            defaultMessage: "Country"
+            defaultMessage: "Country / Region"
           })}
           name={"country" as keyof AddressTypeInput}
           onChange={onCountryChange}
@@ -189,7 +189,7 @@ const CompanyAddressForm: React.FC<CompanyAddressFormProps> = props => {
           helperText={getErrorMessage(formErrors.countryArea, intl)}
           label={intl.formatMessage({
             id: "AuwpCm",
-            defaultMessage: "Country area"
+            defaultMessage: "State / Province"
           })}
           name={"countryArea" as keyof AddressTypeInput}
           onChange={onChange}


### PR DESCRIPTION
I want to merge this change because...
1. Replace defaultMessage "Country" to avoid some disputed countries and regions.
2. Replace defaultMessage "Country Area" to make it easier to understand
<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->
saleor 3.4
dashboard 3.4
### Screenshots
![20220607193601](https://user-images.githubusercontent.com/65403988/172370180-07139379-bc6f-46e2-a9f5-3410fe1944b4.png)
![20220607193624](https://user-images.githubusercontent.com/65403988/172370195-824bc3db-b262-45fb-86d5-121f62611f0b.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
