### PR TITLE
Add optional 'allow-popups' to app's iframe

### DIFF
--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -12,9 +12,12 @@ interface Props {
   appToken: string;
   appId: string;
   className?: string;
+  allowPopups?: boolean;
   onLoad?(): void;
   onError?(): void;
 }
+
+const baseSandbox = "allow-same-origin allow-forms allow-scripts";
 
 const getOrigin = (url: string) => new URL(url).origin;
 
@@ -23,6 +26,7 @@ export const AppFrame: React.FC<Props> = ({
   appToken,
   appId,
   className,
+  allowPopups = false,
   onLoad,
   onError
 }) => {
@@ -52,6 +56,10 @@ export const AppFrame: React.FC<Props> = ({
     return null;
   }
 
+  const iframeSandbox = allowPopups
+    ? `${baseSandbox} allow-popups`
+    : baseSandbox;
+
   return (
     <iframe
       ref={frameRef}
@@ -59,7 +67,7 @@ export const AppFrame: React.FC<Props> = ({
       onError={onError}
       onLoad={handleLoad}
       className={clsx(classes.iframe, className)}
-      sandbox="allow-same-origin allow-forms allow-scripts"
+      sandbox={iframeSandbox}
     />
   );
 };

--- a/src/marketplace/index.tsx
+++ b/src/marketplace/index.tsx
@@ -29,6 +29,7 @@ const Component = () => {
           appToken=""
           appId=""
           className={classes.iframe}
+          allowPopups
         />
       </Container>
     </>


### PR DESCRIPTION
I want to merge this change because it allows for optional 'allow-popups' to be passed to iframe's sandbox.

Related PR: https://github.com/saleor/saleor-app-marketplace/pull/28

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-git-saleor-7182-marketplace-link-fix-saleorcommerce.vercel.app/
