### PR TITLE
Pass query params for product and order details app mounting points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/saleor/saleor-dashboard/releases) page.
 
 ## [Unreleased]
+
+## 3.4
+
 - Added links instead of imperative navigation with onClick - #1969 by @taniotanio7
 - Fixed clearing attribute values - #2047 by @witoszekdev
 - Fixed EditorJS integration in RichTextEditor input - #2052 by @witoszekdev
 - Improvements to the app list page: added toggle and permision preview - #2035 by @witoszekdev
+### 3.4.1
+
 - Added links to table pagination buttons - #2063 by @witoszekdev
 - Using push instead of replace to history stack for pagination navigation - #2063 by @witoszekdev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Pass query params in `ORDER_DETAILS_MORE_ACTIONS` and `PRODUCT_DETAILS_MORE_ACTIONS` mounting points - #2100 by @witoszekdev
+
 ## 3.4
 
 - Added links instead of imperative navigation with onClick - #1969 by @taniotanio7

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -58,7 +58,7 @@ export const AppFrame: React.FC<Props> = ({
       src={urlJoin(
         src,
         window.location.search,
-        `?domain=${shop.domain.host}&id=${appId}`
+        `?domain=${shop.domain.host}&id=${appId}`,
       )}
       onError={onError}
       onLoad={handleLoad}

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -55,7 +55,11 @@ export const AppFrame: React.FC<Props> = ({
   return (
     <iframe
       ref={frameRef}
-      src={urlJoin(src, `?domain=${shop.domain.host}&id=${appId}`)}
+      src={urlJoin(
+        src,
+        window.location.search,
+        `?domain=${shop.domain.host}&id=${appId}`
+      )}
       onError={onError}
       onLoad={handleLoad}
       className={clsx(classes.iframe, className)}

--- a/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
+++ b/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
@@ -57,7 +57,7 @@ export const useExternalApp = () => {
       setAppData(appData);
     } else {
       navigate(appDeepUrl(appData.id, appData.src, appData.params), {
-        resetScroll: true
+        resetScroll: true,
       });
     }
   };

--- a/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
+++ b/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
@@ -1,4 +1,4 @@
-import { appDeepUrl } from "@saleor/apps/urls";
+import { appDeepUrl, AppDetailsUrlMountQueryParams } from "@saleor/apps/urls";
 import { AppExtensionTargetEnum } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
@@ -12,6 +12,7 @@ export interface AppData {
   src: string;
   label: string;
   target: AppExtensionTargetEnum;
+  params?: AppDetailsUrlMountQueryParams;
 }
 
 const ExternalAppContext = React.createContext<{
@@ -55,7 +56,9 @@ export const useExternalApp = () => {
       setOpen(true);
       setAppData(appData);
     } else {
-      navigate(appDeepUrl(appData.id, appData.src), { resetScroll: true });
+      navigate(appDeepUrl(appData.id, appData.src, appData.params), {
+        resetScroll: true
+      });
     }
   };
 

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -19,8 +19,14 @@ export type AppListUrlQueryParams = ActiveTab &
   SingleAction &
   Pagination;
 
+export interface AppDetailsUrlMountQueryParams {
+  productId?: string;
+  orderId?: string;
+}
+
 export type AppDetailsUrlQueryParams = Dialog<AppDetailsUrlDialog> &
-  SingleAction;
+  SingleAction &
+  AppDetailsUrlMountQueryParams;
 
 export type AppInstallUrlQueryParams = Partial<{ [MANIFEST_ATTR]: string }>;
 

--- a/src/apps/useExtensions.ts
+++ b/src/apps/useExtensions.ts
@@ -49,7 +49,7 @@ export const extensionMountPoints = {
 
 const filterAndMapToTarget = (
   extensions: RelayToFlat<ExtensionListQuery["appExtensions"]>,
-  openApp: (appData: AppData) => void
+  openApp: (appData: AppData) => void,
 ): ExtensionWithParams[] =>
   extensions.map(
     ({ id, accessToken, permissions, url, label, mount, target, app }) => ({
@@ -67,15 +67,15 @@ const filterAndMapToTarget = (
           src: url,
           label,
           target,
-          params
-        })
-    })
+          params,
+        }),
+    }),
   );
 
 const mapToMenuItem = ({ label, id, open }: Extension) => ({
   label,
   testId: `extension-${id}`,
-  onSelect: open
+  onSelect: open,
 });
 
 export const mapToMenuItems = (extensions: ExtensionWithParams[]) =>
@@ -83,21 +83,21 @@ export const mapToMenuItems = (extensions: ExtensionWithParams[]) =>
 
 export const mapToMenuItemsForProductDetails = (
   extensions: ExtensionWithParams[],
-  productId: string
+  productId: string,
 ) =>
   extensions.map(extension =>
-    mapToMenuItem({ ...extension, open: () => extension.open({ productId }) })
+    mapToMenuItem({ ...extension, open: () => extension.open({ productId }) }),
   );
 
 export const mapToMenuItemsForOrderDetails = (
   extensions: ExtensionWithParams[],
-  orderId?: string
+  orderId?: string,
 ) =>
   extensions.map(extension =>
     mapToMenuItem({
       ...extension,
-      open: () => extension.open({ orderId })
-    })
+      open: () => extension.open({ orderId }),
+    }),
   );
 
 export const useExtensions = <T extends AppExtensionMountEnum>(

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -1,8 +1,8 @@
 import { Typography } from "@material-ui/core";
 import {
   extensionMountPoints,
-  mapToMenuItems,
   useExtensions,
+  mapToMenuItemsForOrderDetails,
 } from "@saleor/apps/useExtensions";
 import { Backlink } from "@saleor/components/Backlink";
 import CardMenu from "@saleor/components/CardMenu";
@@ -225,7 +225,10 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     extensionMountPoints.ORDER_DETAILS,
   );
 
-  const extensionMenuItems = mapToMenuItems(ORDER_DETAILS_MORE_ACTIONS);
+  const extensionMenuItems = mapToMenuItemsForOrderDetails(
+    ORDER_DETAILS_MORE_ACTIONS,
+    order?.id
+  );
 
   return (
     <Form confirmLeave initial={initial} onSubmit={handleSubmit}>

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -1,8 +1,8 @@
 import { Typography } from "@material-ui/core";
 import {
   extensionMountPoints,
-  useExtensions,
   mapToMenuItemsForOrderDetails,
+  useExtensions,
 } from "@saleor/apps/useExtensions";
 import { Backlink } from "@saleor/components/Backlink";
 import CardMenu from "@saleor/components/CardMenu";
@@ -227,7 +227,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
 
   const extensionMenuItems = mapToMenuItemsForOrderDetails(
     ORDER_DETAILS_MORE_ACTIONS,
-    order?.id
+    order?.id,
   );
 
   return (

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -1,8 +1,8 @@
 import { OutputData } from "@editorjs/editorjs";
 import {
   extensionMountPoints,
-  useExtensions,
   mapToMenuItemsForProductDetails,
+  useExtensions,
 } from "@saleor/apps/useExtensions";
 import {
   getAttributeValuesFromReferences,

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -1,8 +1,8 @@
 import { OutputData } from "@editorjs/editorjs";
 import {
   extensionMountPoints,
-  mapToMenuItems,
   useExtensions,
+  mapToMenuItemsForProductDetails,
 } from "@saleor/apps/useExtensions";
 import {
   getAttributeValuesFromReferences,
@@ -252,7 +252,10 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
     extensionMountPoints.PRODUCT_DETAILS,
   );
 
-  const extensionMenuItems = mapToMenuItems(PRODUCT_DETAILS_MORE_ACTIONS);
+  const extensionMenuItems = mapToMenuItemsForProductDetails(
+    PRODUCT_DETAILS_MORE_ACTIONS,
+    productId,
+  );
 
   return (
     <ProductUpdateForm


### PR DESCRIPTION
I want to merge this change because it enables passing query params to app iframe from dashboard. It also adds query params for app mounting points:
- `ORDER_DETAILS_MORE_ACTIONS` - `orderId` with the ID of the opened order
- `PRODUCT_DETAILS_MORE_ACTIONS` - `productId` with ID of the opened product

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
