### PR TITLE
Taxes - add API calls in channels view

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4078,6 +4078,10 @@
     "context": "no gift card products and types alert message",
     "string": "{createGiftCardProductType} and {giftCardProduct} to start selling gift cards in your store."
   },
+  "UBuKZ9": {
+    "context": "searchbar placeholder",
+    "string": "Country"
+  },
   "UCHtG6": {
     "context": "button",
     "string": "About"
@@ -7038,6 +7042,10 @@
     "context": "option label",
     "string": "Change address"
   },
+  "s6p+rD": {
+    "context": "add country dialog header",
+    "string": "Choose countries you want to assign"
+  },
   "s8FlDW": {
     "context": "hide error log label in notification",
     "string": "Hide log"
@@ -7272,6 +7280,10 @@
   },
   "u24Ppd": {
     "string": "This attribute cannot be assigned to this product type"
+  },
+  "u34css": {
+    "context": "label for empty list in channels list",
+    "string": "There are no exceptions for this channel"
   },
   "u3sYPH": {
     "context": "independent of any particular day, eg. 11:35",

--- a/src/components/Navigator/modes/default/views.ts
+++ b/src/components/Navigator/modes/default/views.ts
@@ -16,7 +16,7 @@ import { productTypeListUrl } from "@saleor/productTypes/urls";
 import { shippingZonesListUrl } from "@saleor/shipping/urls";
 import { siteSettingsUrl } from "@saleor/siteSettings/urls";
 import { staffListUrl } from "@saleor/staff/urls";
-import { channelsListUrl as taxesListUrl } from "@saleor/taxes/urls";
+import { taxConfigurationListUrl } from "@saleor/taxes/urls";
 import { languageListUrl } from "@saleor/translations/urls";
 import { warehouseListUrl } from "@saleor/warehouses/urls";
 import { score } from "fuzzaldrin";
@@ -108,7 +108,7 @@ function searchInViews(
     },
     {
       label: intl.formatMessage(sectionNames.taxes),
-      url: taxesListUrl()
+      url: taxConfigurationListUrl()
     },
     {
       label: intl.formatMessage(sectionNames.translations),

--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -27,7 +27,7 @@ import { productTypeListUrl } from "@saleor/productTypes/urls";
 import { shippingZonesListUrl } from "@saleor/shipping/urls";
 import { siteSettingsUrl } from "@saleor/siteSettings/urls";
 import { staffListUrl } from "@saleor/staff/urls";
-import { channelsListUrl as taxesListUrl } from "@saleor/taxes/urls";
+import { taxConfigurationListUrl } from "@saleor/taxes/urls";
 import { warehouseSection } from "@saleor/warehouses/urls";
 import React from "react";
 import { IntlShape, useIntl } from "react-intl";
@@ -83,7 +83,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
           icon: <Taxes />,
           permissions: [PermissionEnum.MANAGE_SETTINGS],
           title: intl.formatMessage(sectionNames.taxes),
-          url: taxesListUrl(),
+          url: taxConfigurationListUrl(),
           testId: "configuration-menu-taxes"
         }
       ]

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -490,7 +490,6 @@ export const shippingPriceTranslateErrorFragment = gql`
 export const taxConfigurationUpdateError = gql`
   fragment TaxConfigurationUpdateErrorFragment on TaxConfigurationUpdateError {
     field
-    message
     code
   }
 `;

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -486,3 +486,11 @@ export const shippingPriceTranslateErrorFragment = gql`
     message
   }
 `;
+
+export const taxConfigurationUpdateError = gql`
+  fragment TaxConfigurationUpdateErrorFragment on TaxConfigurationUpdateError {
+    field
+    message
+    code
+  }
+`;

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -942,6 +942,13 @@ export const ShippingPriceTranslateErrorFragmentFragmentDoc = gql`
   message
 }
     `;
+export const TaxConfigurationUpdateErrorFragmentFragmentDoc = gql`
+    fragment TaxConfigurationUpdateErrorFragment on TaxConfigurationUpdateError {
+  field
+  message
+  code
+}
+    `;
 export const GiftCardsSettingsFragmentDoc = gql`
     fragment GiftCardsSettings on GiftCardSettings {
   expiryType
@@ -14727,6 +14734,46 @@ export function useFetchTaxesMutation(baseOptions?: ApolloReactHooks.MutationHoo
 export type FetchTaxesMutationHookResult = ReturnType<typeof useFetchTaxesMutation>;
 export type FetchTaxesMutationResult = Apollo.MutationResult<Types.FetchTaxesMutation>;
 export type FetchTaxesMutationOptions = Apollo.BaseMutationOptions<Types.FetchTaxesMutation, Types.FetchTaxesMutationVariables>;
+export const TaxConfigurationUpdateDocument = gql`
+    mutation TaxConfigurationUpdate($id: ID!, $input: TaxConfigurationUpdateInput!) {
+  taxConfigurationUpdate(id: $id, input: $input) {
+    errors {
+      ...TaxConfigurationUpdateErrorFragment
+    }
+    taxConfiguration {
+      ...TaxConfiguration
+    }
+  }
+}
+    ${TaxConfigurationUpdateErrorFragmentFragmentDoc}
+${TaxConfigurationFragmentDoc}`;
+export type TaxConfigurationUpdateMutationFn = Apollo.MutationFunction<Types.TaxConfigurationUpdateMutation, Types.TaxConfigurationUpdateMutationVariables>;
+
+/**
+ * __useTaxConfigurationUpdateMutation__
+ *
+ * To run a mutation, you first call `useTaxConfigurationUpdateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useTaxConfigurationUpdateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [taxConfigurationUpdateMutation, { data, loading, error }] = useTaxConfigurationUpdateMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useTaxConfigurationUpdateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<Types.TaxConfigurationUpdateMutation, Types.TaxConfigurationUpdateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<Types.TaxConfigurationUpdateMutation, Types.TaxConfigurationUpdateMutationVariables>(TaxConfigurationUpdateDocument, options);
+      }
+export type TaxConfigurationUpdateMutationHookResult = ReturnType<typeof useTaxConfigurationUpdateMutation>;
+export type TaxConfigurationUpdateMutationResult = Apollo.MutationResult<Types.TaxConfigurationUpdateMutation>;
+export type TaxConfigurationUpdateMutationOptions = Apollo.BaseMutationOptions<Types.TaxConfigurationUpdateMutation, Types.TaxConfigurationUpdateMutationVariables>;
 export const CountryListDocument = gql`
     query CountryList {
   shop {

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14849,7 +14849,7 @@ export type TaxConfigurationListQueryHookResult = ReturnType<typeof useTaxConfig
 export type TaxConfigurationListLazyQueryHookResult = ReturnType<typeof useTaxConfigurationListLazyQuery>;
 export type TaxConfigurationListQueryResult = Apollo.QueryResult<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>;
 export const TaxCountriesListDocument = gql`
-    query taxCountriesList {
+    query TaxCountriesList {
   taxCountryConfigurations {
     ...TaxCountryConfiguration
   }
@@ -14882,6 +14882,57 @@ export function useTaxCountriesListLazyQuery(baseOptions?: ApolloReactHooks.Lazy
 export type TaxCountriesListQueryHookResult = ReturnType<typeof useTaxCountriesListQuery>;
 export type TaxCountriesListLazyQueryHookResult = ReturnType<typeof useTaxCountriesListLazyQuery>;
 export type TaxCountriesListQueryResult = Apollo.QueryResult<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>;
+export const TaxClassesListDocument = gql`
+    query TaxClassesList($before: String, $after: String, $first: Int, $last: Int, $filter: TaxClassFilterInput, $sortBy: TaxClassSortingInput) {
+  taxClasses(
+    before: $before
+    after: $after
+    first: $first
+    last: $last
+    filter: $filter
+    sortBy: $sortBy
+  ) {
+    edges {
+      node {
+        ...TaxClass
+      }
+    }
+  }
+}
+    ${TaxClassFragmentDoc}`;
+
+/**
+ * __useTaxClassesListQuery__
+ *
+ * To run a query within a React component, call `useTaxClassesListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTaxClassesListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTaxClassesListQuery({
+ *   variables: {
+ *      before: // value for 'before'
+ *      after: // value for 'after'
+ *      first: // value for 'first'
+ *      last: // value for 'last'
+ *      filter: // value for 'filter'
+ *      sortBy: // value for 'sortBy'
+ *   },
+ * });
+ */
+export function useTaxClassesListQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<Types.TaxClassesListQuery, Types.TaxClassesListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.TaxClassesListQuery, Types.TaxClassesListQueryVariables>(TaxClassesListDocument, options);
+      }
+export function useTaxClassesListLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.TaxClassesListQuery, Types.TaxClassesListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.TaxClassesListQuery, Types.TaxClassesListQueryVariables>(TaxClassesListDocument, options);
+        }
+export type TaxClassesListQueryHookResult = ReturnType<typeof useTaxClassesListQuery>;
+export type TaxClassesListLazyQueryHookResult = ReturnType<typeof useTaxClassesListLazyQuery>;
+export type TaxClassesListQueryResult = Apollo.QueryResult<Types.TaxClassesListQuery, Types.TaxClassesListQueryVariables>;
 export const UpdateProductTranslationsDocument = gql`
     mutation UpdateProductTranslations($id: ID!, $input: TranslationInput!, $language: LanguageCodeEnum!) {
   productTranslate(id: $id, input: $input, languageCode: $language) {

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -945,7 +945,6 @@ export const ShippingPriceTranslateErrorFragmentFragmentDoc = gql`
 export const TaxConfigurationUpdateErrorFragmentFragmentDoc = gql`
     fragment TaxConfigurationUpdateErrorFragment on TaxConfigurationUpdateError {
   field
-  message
   code
 }
     `;

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14799,6 +14799,55 @@ export function useTaxTypeListLazyQuery(baseOptions?: ApolloReactHooks.LazyQuery
 export type TaxTypeListQueryHookResult = ReturnType<typeof useTaxTypeListQuery>;
 export type TaxTypeListLazyQueryHookResult = ReturnType<typeof useTaxTypeListLazyQuery>;
 export type TaxTypeListQueryResult = Apollo.QueryResult<Types.TaxTypeListQuery, Types.TaxTypeListQueryVariables>;
+export const TaxConfigurationListDocument = gql`
+    query taxConfigurationList($before: String, $after: String, $first: Int, $last: Int, $filter: TaxConfigurationFilterInput) {
+  taxConfigurations(
+    before: $before
+    after: $after
+    first: $first
+    last: $last
+    filter: $filter
+  ) {
+    edges {
+      node {
+        ...TaxConfiguration
+      }
+    }
+  }
+}
+    ${TaxConfigurationFragmentDoc}`;
+
+/**
+ * __useTaxConfigurationListQuery__
+ *
+ * To run a query within a React component, call `useTaxConfigurationListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTaxConfigurationListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTaxConfigurationListQuery({
+ *   variables: {
+ *      before: // value for 'before'
+ *      after: // value for 'after'
+ *      first: // value for 'first'
+ *      last: // value for 'last'
+ *      filter: // value for 'filter'
+ *   },
+ * });
+ */
+export function useTaxConfigurationListQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>(TaxConfigurationListDocument, options);
+      }
+export function useTaxConfigurationListLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>(TaxConfigurationListDocument, options);
+        }
+export type TaxConfigurationListQueryHookResult = ReturnType<typeof useTaxConfigurationListQuery>;
+export type TaxConfigurationListLazyQueryHookResult = ReturnType<typeof useTaxConfigurationListLazyQuery>;
+export type TaxConfigurationListQueryResult = Apollo.QueryResult<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>;
 export const UpdateProductTranslationsDocument = gql`
     mutation UpdateProductTranslations($id: ID!, $input: TranslationInput!, $language: LanguageCodeEnum!) {
   productTranslate(id: $id, input: $input, languageCode: $language) {

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14799,8 +14799,8 @@ export function useTaxTypeListLazyQuery(baseOptions?: ApolloReactHooks.LazyQuery
 export type TaxTypeListQueryHookResult = ReturnType<typeof useTaxTypeListQuery>;
 export type TaxTypeListLazyQueryHookResult = ReturnType<typeof useTaxTypeListLazyQuery>;
 export type TaxTypeListQueryResult = Apollo.QueryResult<Types.TaxTypeListQuery, Types.TaxTypeListQueryVariables>;
-export const TaxConfigurationListDocument = gql`
-    query taxConfigurationList($before: String, $after: String, $first: Int, $last: Int, $filter: TaxConfigurationFilterInput) {
+export const TaxConfigurationsListDocument = gql`
+    query TaxConfigurationsList($before: String, $after: String, $first: Int, $last: Int, $filter: TaxConfigurationFilterInput) {
   taxConfigurations(
     before: $before
     after: $after
@@ -14818,16 +14818,16 @@ export const TaxConfigurationListDocument = gql`
     ${TaxConfigurationFragmentDoc}`;
 
 /**
- * __useTaxConfigurationListQuery__
+ * __useTaxConfigurationsListQuery__
  *
- * To run a query within a React component, call `useTaxConfigurationListQuery` and pass it any options that fit your needs.
- * When your component renders, `useTaxConfigurationListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTaxConfigurationsListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTaxConfigurationsListQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTaxConfigurationListQuery({
+ * const { data, loading, error } = useTaxConfigurationsListQuery({
  *   variables: {
  *      before: // value for 'before'
  *      after: // value for 'after'
@@ -14837,17 +14837,17 @@ export const TaxConfigurationListDocument = gql`
  *   },
  * });
  */
-export function useTaxConfigurationListQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>) {
+export function useTaxConfigurationsListQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<Types.TaxConfigurationsListQuery, Types.TaxConfigurationsListQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return ApolloReactHooks.useQuery<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>(TaxConfigurationListDocument, options);
+        return ApolloReactHooks.useQuery<Types.TaxConfigurationsListQuery, Types.TaxConfigurationsListQueryVariables>(TaxConfigurationsListDocument, options);
       }
-export function useTaxConfigurationListLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>) {
+export function useTaxConfigurationsListLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.TaxConfigurationsListQuery, Types.TaxConfigurationsListQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return ApolloReactHooks.useLazyQuery<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>(TaxConfigurationListDocument, options);
+          return ApolloReactHooks.useLazyQuery<Types.TaxConfigurationsListQuery, Types.TaxConfigurationsListQueryVariables>(TaxConfigurationsListDocument, options);
         }
-export type TaxConfigurationListQueryHookResult = ReturnType<typeof useTaxConfigurationListQuery>;
-export type TaxConfigurationListLazyQueryHookResult = ReturnType<typeof useTaxConfigurationListLazyQuery>;
-export type TaxConfigurationListQueryResult = Apollo.QueryResult<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>;
+export type TaxConfigurationsListQueryHookResult = ReturnType<typeof useTaxConfigurationsListQuery>;
+export type TaxConfigurationsListLazyQueryHookResult = ReturnType<typeof useTaxConfigurationsListLazyQuery>;
+export type TaxConfigurationsListQueryResult = Apollo.QueryResult<Types.TaxConfigurationsListQuery, Types.TaxConfigurationsListQueryVariables>;
 export const TaxCountriesListDocument = gql`
     query TaxCountriesList {
   taxCountryConfigurations {

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14848,6 +14848,40 @@ export function useTaxConfigurationListLazyQuery(baseOptions?: ApolloReactHooks.
 export type TaxConfigurationListQueryHookResult = ReturnType<typeof useTaxConfigurationListQuery>;
 export type TaxConfigurationListLazyQueryHookResult = ReturnType<typeof useTaxConfigurationListLazyQuery>;
 export type TaxConfigurationListQueryResult = Apollo.QueryResult<Types.TaxConfigurationListQuery, Types.TaxConfigurationListQueryVariables>;
+export const TaxCountriesListDocument = gql`
+    query taxCountriesList {
+  taxCountryConfigurations {
+    ...TaxCountryConfiguration
+  }
+}
+    ${TaxCountryConfigurationFragmentDoc}`;
+
+/**
+ * __useTaxCountriesListQuery__
+ *
+ * To run a query within a React component, call `useTaxCountriesListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTaxCountriesListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTaxCountriesListQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useTaxCountriesListQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>(TaxCountriesListDocument, options);
+      }
+export function useTaxCountriesListLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>(TaxCountriesListDocument, options);
+        }
+export type TaxCountriesListQueryHookResult = ReturnType<typeof useTaxCountriesListQuery>;
+export type TaxCountriesListLazyQueryHookResult = ReturnType<typeof useTaxCountriesListLazyQuery>;
+export type TaxCountriesListQueryResult = Apollo.QueryResult<Types.TaxCountriesListQuery, Types.TaxCountriesListQueryVariables>;
 export const UpdateProductTranslationsDocument = gql`
     mutation UpdateProductTranslations($id: ID!, $input: TranslationInput!, $language: LanguageCodeEnum!) {
   productTranslate(id: $id, input: $input, languageCode: $language) {

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -4557,7 +4557,6 @@ export enum TimePeriodTypeEnum {
  *     CHARGE - Represents the charge action.
  *     REFUND - Represents a refund action.
  *     VOID - Represents a void action.
- *
  */
 export enum TransactionActionEnum {
   CHARGE = 'CHARGE',
@@ -6602,6 +6601,8 @@ export type TaxCountryConfigurationFragment = { __typename: 'TaxCountryConfigura
 export type TaxRateFragment = { __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } };
 
 export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } }> };
+
+export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', countryCode: string, rate: number }> | null };
 
 export type TimePeriodFragment = { __typename: 'TimePeriod', amount: number, type: TimePeriodTypeEnum };
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8195,6 +8195,18 @@ export type TaxCountriesListQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type TaxCountriesListQuery = { __typename: 'Query', taxCountryConfigurations: Array<{ __typename: 'TaxCountryConfiguration', country: { __typename: 'CountryDisplay', country: string, code: string }, taxClassCountryRates: Array<{ __typename: 'TaxClassCountryRate', rate: number, taxClass: { __typename: 'TaxClass', id: string, name: string, isDefault: boolean } }> }> | null };
 
+export type TaxClassesListQueryVariables = Exact<{
+  before?: InputMaybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<TaxClassFilterInput>;
+  sortBy?: InputMaybe<TaxClassSortingInput>;
+}>;
+
+
+export type TaxClassesListQuery = { __typename: 'Query', taxClasses: { __typename: 'TaxClassCountableConnection', edges: Array<{ __typename: 'TaxClassCountableEdge', node: { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } }> } }> } | null };
+
 export type UpdateProductTranslationsMutationVariables = Exact<{
   id: Scalars['ID'];
   input: TranslationInput;

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8179,6 +8179,17 @@ export type TaxTypeListQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type TaxTypeListQuery = { __typename: 'Query', taxTypes: Array<{ __typename: 'TaxType', description: string | null, taxCode: string | null }> | null };
 
+export type TaxConfigurationListQueryVariables = Exact<{
+  before?: InputMaybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<TaxConfigurationFilterInput>;
+}>;
+
+
+export type TaxConfigurationListQuery = { __typename: 'Query', taxConfigurations: { __typename: 'TaxConfigurationCountableConnection', edges: Array<{ __typename: 'TaxConfigurationCountableEdge', node: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } }> } | null };
+
 export type UpdateProductTranslationsMutationVariables = Exact<{
   id: Scalars['ID'];
   input: TranslationInput;

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8179,7 +8179,7 @@ export type TaxTypeListQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type TaxTypeListQuery = { __typename: 'Query', taxTypes: Array<{ __typename: 'TaxType', description: string | null, taxCode: string | null }> | null };
 
-export type TaxConfigurationListQueryVariables = Exact<{
+export type TaxConfigurationsListQueryVariables = Exact<{
   before?: InputMaybe<Scalars['String']>;
   after?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
@@ -8188,7 +8188,7 @@ export type TaxConfigurationListQueryVariables = Exact<{
 }>;
 
 
-export type TaxConfigurationListQuery = { __typename: 'Query', taxConfigurations: { __typename: 'TaxConfigurationCountableConnection', edges: Array<{ __typename: 'TaxConfigurationCountableEdge', node: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } }> } | null };
+export type TaxConfigurationsListQuery = { __typename: 'Query', taxConfigurations: { __typename: 'TaxConfigurationCountableConnection', edges: Array<{ __typename: 'TaxConfigurationCountableEdge', node: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } }> } | null };
 
 export type TaxCountriesListQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -4557,6 +4557,7 @@ export enum TimePeriodTypeEnum {
  *     CHARGE - Represents the charge action.
  *     REFUND - Represents a refund action.
  *     VOID - Represents a void action.
+ *
  */
 export enum TransactionActionEnum {
   CHARGE = 'CHARGE',
@@ -6601,10 +6602,6 @@ export type TaxCountryConfigurationFragment = { __typename: 'TaxCountryConfigura
 export type TaxRateFragment = { __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } };
 
 export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } }> };
-
-export type TaxRateFragment = { __typename: 'TaxClassCountryRate', countryCode: string, rate: number };
-
-export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', countryCode: string, rate: number }> | null };
 
 export type TimePeriodFragment = { __typename: 'TimePeriod', amount: number, type: TimePeriodTypeEnum };
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -6602,6 +6602,8 @@ export type TaxRateFragment = { __typename: 'TaxClassCountryRate', rate: number,
 
 export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', rate: number, country: { __typename: 'CountryDisplay', country: string, code: string } }> };
 
+export type TaxRateFragment = { __typename: 'TaxClassCountryRate', countryCode: string, rate: number };
+
 export type TaxClassFragment = { __typename: 'TaxClass', id: string, name: string, isDefault: boolean, countries: Array<{ __typename: 'TaxClassCountryRate', countryCode: string, rate: number }> | null };
 
 export type TimePeriodFragment = { __typename: 'TimePeriod', amount: number, type: TimePeriodTypeEnum };

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -6391,6 +6391,8 @@ export type AttributeValueTranslateErrorFragmentFragment = { __typename: 'Transl
 
 export type ShippingPriceTranslateErrorFragmentFragment = { __typename: 'TranslationError', code: TranslationErrorCode, field: string | null, message: string | null };
 
+export type TaxConfigurationUpdateErrorFragmentFragment = { __typename: 'TaxConfigurationUpdateError', field: string | null, message: string | null, code: TaxConfigurationUpdateErrorCode };
+
 export type FileFragment = { __typename: 'File', url: string, contentType: string | null };
 
 export type GiftCardsSettingsFragment = { __typename: 'GiftCardSettings', expiryType: GiftCardSettingsExpiryTypeEnum, expiryPeriod: { __typename: 'TimePeriod', type: TimePeriodTypeEnum, amount: number } | null };
@@ -8165,6 +8167,14 @@ export type FetchTaxesMutationVariables = Exact<{ [key: string]: never; }>;
 
 
 export type FetchTaxesMutation = { __typename: 'Mutation', shopFetchTaxRates: { __typename: 'ShopFetchTaxRates', errors: Array<{ __typename: 'ShopError', code: ShopErrorCode, field: string | null, message: string | null }>, shop: { __typename: 'Shop', countries: Array<{ __typename: 'CountryDisplay', country: string, code: string }> } | null } | null };
+
+export type TaxConfigurationUpdateMutationVariables = Exact<{
+  id: Scalars['ID'];
+  input: TaxConfigurationUpdateInput;
+}>;
+
+
+export type TaxConfigurationUpdateMutation = { __typename: 'Mutation', taxConfigurationUpdate: { __typename: 'TaxConfigurationUpdate', errors: Array<{ __typename: 'TaxConfigurationUpdateError', field: string | null, message: string | null, code: TaxConfigurationUpdateErrorCode }>, taxConfiguration: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } | null } | null };
 
 export type CountryListQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8190,6 +8190,11 @@ export type TaxConfigurationListQueryVariables = Exact<{
 
 export type TaxConfigurationListQuery = { __typename: 'Query', taxConfigurations: { __typename: 'TaxConfigurationCountableConnection', edges: Array<{ __typename: 'TaxConfigurationCountableEdge', node: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } }> } | null };
 
+export type TaxCountriesListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TaxCountriesListQuery = { __typename: 'Query', taxCountryConfigurations: Array<{ __typename: 'TaxCountryConfiguration', country: { __typename: 'CountryDisplay', country: string, code: string }, taxClassCountryRates: Array<{ __typename: 'TaxClassCountryRate', rate: number, taxClass: { __typename: 'TaxClass', id: string, name: string, isDefault: boolean } }> }> | null };
+
 export type UpdateProductTranslationsMutationVariables = Exact<{
   id: Scalars['ID'];
   input: TranslationInput;

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -6391,7 +6391,7 @@ export type AttributeValueTranslateErrorFragmentFragment = { __typename: 'Transl
 
 export type ShippingPriceTranslateErrorFragmentFragment = { __typename: 'TranslationError', code: TranslationErrorCode, field: string | null, message: string | null };
 
-export type TaxConfigurationUpdateErrorFragmentFragment = { __typename: 'TaxConfigurationUpdateError', field: string | null, message: string | null, code: TaxConfigurationUpdateErrorCode };
+export type TaxConfigurationUpdateErrorFragmentFragment = { __typename: 'TaxConfigurationUpdateError', field: string | null, code: TaxConfigurationUpdateErrorCode };
 
 export type FileFragment = { __typename: 'File', url: string, contentType: string | null };
 
@@ -8174,7 +8174,7 @@ export type TaxConfigurationUpdateMutationVariables = Exact<{
 }>;
 
 
-export type TaxConfigurationUpdateMutation = { __typename: 'Mutation', taxConfigurationUpdate: { __typename: 'TaxConfigurationUpdate', errors: Array<{ __typename: 'TaxConfigurationUpdateError', field: string | null, message: string | null, code: TaxConfigurationUpdateErrorCode }>, taxConfiguration: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } | null } | null };
+export type TaxConfigurationUpdateMutation = { __typename: 'Mutation', taxConfigurationUpdate: { __typename: 'TaxConfigurationUpdate', errors: Array<{ __typename: 'TaxConfigurationUpdateError', field: string | null, code: TaxConfigurationUpdateErrorCode }>, taxConfiguration: { __typename: 'TaxConfiguration', id: string, displayGrossPrices: boolean, pricesEnteredWithTax: boolean, chargeTaxes: boolean, channel: { __typename: 'Channel', id: string, name: string }, countries: Array<{ __typename: 'TaxConfigurationPerCountry', chargeTaxes: boolean, displayGrossPrices: boolean, country: { __typename: 'CountryDisplay', country: string, code: string } }> } | null } | null };
 
 export type CountryListQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/hooks/useLocalSearch.ts
+++ b/src/hooks/useLocalSearch.ts
@@ -1,8 +1,23 @@
 import React from "react";
 
+/**
+ * This function removes characters which break
+ * regexps but are rarely useful in searches
+ */
 const parseQuery = (query: string) =>
   query.replace(/([.?*+\-=:^$\\[\]<>(){}|])/g, "\\$&");
 
+/**
+ * useLocalSearch is a hook that is useful when client-side
+ * search is used on particular array of items.
+ *
+ * @param array Array to search through
+ * @param getStringToSearch Function which specifies object
+ * property (possibly nested) on which search is used, eg:
+ * (element) => element.name where name is a string
+ * @returns query, setQuery - useState result
+ * searchResult - filtered array
+ */
 export function useLocalSearch<T>(
   array: T[] | undefined,
   getStringToSearch: (element: T) => string

--- a/src/hooks/useLocalSearch.ts
+++ b/src/hooks/useLocalSearch.ts
@@ -1,0 +1,22 @@
+import React from "react";
+
+const parseQuery = (query: string) =>
+  query.replace(/([.?*+\-=:^$\\[\]<>(){}|])/g, "\\$&");
+
+export function useLocalSearch<T>(
+  array: T[] | undefined,
+  getStringToSearch: (element: T) => string
+) {
+  const [query, setQuery] = React.useState("");
+  const searchResult = React.useMemo(
+    () =>
+      array?.filter(
+        element =>
+          getStringToSearch(element).search(
+            new RegExp(parseQuery(query), "i")
+          ) >= 0
+      ),
+    [array, query]
+  );
+  return { query, setQuery, searchResult };
+}

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -9,6 +9,7 @@ import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import { CountryFragment } from "@saleor/graphql";
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import { useLocalSearch } from "@saleor/hooks/useLocalSearch";
+import useModalDialogOpen from "@saleor/hooks/useModalDialogOpen";
 import { buttonMessages } from "@saleor/intl";
 import { Button, DialogHeader, SearchIcon } from "@saleor/macaw-ui";
 import { taxesMessages } from "@saleor/taxes/messages";
@@ -52,19 +53,20 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
     [countries, setCountriesWithState]
   );
 
-  const handleClose = () => {
-    onClose();
-    setCountriesWithState([]);
-    setQuery("");
-  };
+  useModalDialogOpen(open, {
+    onClose: () => {
+      setCountriesWithState([]);
+      setQuery("");
+    }
+  });
 
   const { query, setQuery, searchResult: filteredCountries } = useLocalSearch<
     CountryFragmentWithState
   >(countriesWithState, country => country.country);
 
   return (
-    <Dialog open={open} fullWidth onClose={handleClose}>
-      <DialogHeader onClose={handleClose}>
+    <Dialog open={open} fullWidth onClose={onClose}>
+      <DialogHeader onClose={onClose}>
         <FormattedMessage {...taxesMessages.chooseCountries} />
       </DialogHeader>
       <DialogContent className={classes.wrapper}>
@@ -100,7 +102,6 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
           variant="primary"
           onClick={() => {
             onConfirm(countriesWithState.filter(country => country.checked));
-            handleClose();
           }}
         >
           <FormattedMessage {...buttonMessages.select} />

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -9,7 +9,6 @@ import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import { CountryFragment } from "@saleor/graphql";
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import { useLocalSearch } from "@saleor/hooks/useLocalSearch";
-import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
 import { Button, DialogHeader, SearchIcon } from "@saleor/macaw-ui";
 import { taxesMessages } from "@saleor/taxes/messages";
@@ -19,14 +18,15 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useStyles } from "./styles";
 import { TaxCountryDialogLine } from "./TaxCountryDialogLine";
 
-export interface CountryFragmentWithState extends CountryFragment {
-  checked: boolean;
-}
 interface TaxCountryDialogProps {
   open: boolean;
-  countries: CountryFragmentWithState[];
+  countries: CountryFragment[];
   onConfirm: (countries: CountryFragment[]) => void;
   onClose: () => void;
+}
+
+export interface CountryFragmentWithState extends CountryFragment {
+  checked: boolean;
 }
 
 export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
@@ -38,10 +38,16 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   const classes = useStyles();
   const intl = useIntl();
 
-  const [countriesWithState, setCountriesWithState] = useStateFromProps<
+  const [countriesWithState, setCountriesWithState] = React.useState<
     CountryFragmentWithState[]
-  >(countries);
-
+  >([]);
+  React.useEffect(
+    () =>
+      setCountriesWithState(
+        countries.map(country => ({ checked: false, ...country }))
+      ),
+    [countries]
+  );
   const handleChange = React.useCallback(
     (e: ChangeEvent) => {
       const countriesUpdate = [...countriesWithState];

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -22,6 +22,7 @@ interface TaxCountryDialogProps {
   open: boolean;
   countries: CountryFragment[];
   onConfirm: (countries: CountryFragment[]) => void;
+  onClose: () => void;
 }
 
 export interface CountryFragmentWithState extends CountryFragment {
@@ -31,7 +32,8 @@ export interface CountryFragmentWithState extends CountryFragment {
 export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   open,
   countries,
-  onConfirm
+  onConfirm,
+  onClose
 }) => {
   const classes = useStyles();
   const intl = useIntl();
@@ -54,8 +56,8 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   >(countriesWithState, country => country.country);
 
   return (
-    <Dialog open={open} fullWidth>
-      <DialogHeader onClose={() => null}>
+    <Dialog open={open} fullWidth onClose={onClose}>
+      <DialogHeader onClose={onClose}>
         <FormattedMessage {...taxesMessages.chooseCountries} />
       </DialogHeader>
       <DialogContent className={classes.wrapper}>

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -87,7 +87,7 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
         <div className={classes.scrollable}>
           {filteredCountries.map(country => (
             <TaxCountryDialogLine
-              key={"modal" + country.code}
+              key={country.code}
               country={country}
               checked={country.checked}
               handleChange={handleChange}

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -108,6 +108,7 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
           variant="primary"
           onClick={() => {
             onConfirm(countriesWithState.filter(country => country.checked));
+            onClose();
           }}
         >
           <FormattedMessage {...buttonMessages.select} />

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -18,15 +18,14 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useStyles } from "./styles";
 import { TaxCountryDialogLine } from "./TaxCountryDialogLine";
 
-interface TaxCountryDialogProps {
-  open: boolean;
-  countries: CountryFragment[];
-  onConfirm: (countries: CountryFragment[]) => void;
-  onClose: () => void;
-}
-
 export interface CountryFragmentWithState extends CountryFragment {
   checked: boolean;
+}
+interface TaxCountryDialogProps {
+  open: boolean;
+  countries: CountryFragmentWithState[];
+  onConfirm: (countries: CountryFragment[]) => void;
+  onClose: () => void;
 }
 
 export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
@@ -41,13 +40,8 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   const [countriesWithState, setCountriesWithState] = React.useState<
     CountryFragmentWithState[]
   >([]);
-  React.useEffect(
-    () =>
-      setCountriesWithState(
-        countries.map(country => ({ checked: false, ...country }))
-      ),
-    [countries]
-  );
+  React.useEffect(() => setCountriesWithState(countries), [countries, open]);
+
   const handleChange = React.useCallback(
     (e: ChangeEvent) => {
       const countriesUpdate = [...countriesWithState];

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -45,10 +45,16 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
 
   const handleChange = React.useCallback(
     (e: ChangeEvent) => {
-      const countriesUpdate = [...countriesWithState];
-      countriesUpdate.find(country => country.code === e.target.name).checked =
-        e.target.value;
-      setCountriesWithState(countriesUpdate);
+      setCountriesWithState(prevCountries =>
+        prevCountries.map(country =>
+          country.code === e.target.name
+            ? {
+                ...country,
+                checked: e.target.value
+              }
+            : country
+        )
+      );
     },
     [countries, setCountriesWithState]
   );

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -9,6 +9,7 @@ import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import { CountryFragment } from "@saleor/graphql";
 import { ChangeEvent } from "@saleor/hooks/useForm";
 import { useLocalSearch } from "@saleor/hooks/useLocalSearch";
+import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
 import { Button, DialogHeader, SearchIcon } from "@saleor/macaw-ui";
 import { taxesMessages } from "@saleor/taxes/messages";
@@ -18,15 +19,14 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useStyles } from "./styles";
 import { TaxCountryDialogLine } from "./TaxCountryDialogLine";
 
-interface TaxCountryDialogProps {
-  open: boolean;
-  countries: CountryFragment[];
-  onConfirm: (countries: CountryFragment[]) => void;
-  onClose: () => void;
-}
-
 export interface CountryFragmentWithState extends CountryFragment {
   checked: boolean;
+}
+interface TaxCountryDialogProps {
+  open: boolean;
+  countries: CountryFragmentWithState[];
+  onConfirm: (countries: CountryFragment[]) => void;
+  onClose: () => void;
 }
 
 export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
@@ -38,16 +38,10 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   const classes = useStyles();
   const intl = useIntl();
 
-  const [countriesWithState, setCountriesWithState] = React.useState<
+  const [countriesWithState, setCountriesWithState] = useStateFromProps<
     CountryFragmentWithState[]
-  >([]);
-  React.useEffect(
-    () =>
-      setCountriesWithState(
-        countries.map(country => ({ checked: false, ...country }))
-      ),
-    [countries]
-  );
+  >(countries);
+
   const handleChange = React.useCallback(
     (e: ChangeEvent) => {
       const countriesUpdate = [...countriesWithState];

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -1,0 +1,103 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  InputAdornment,
+  TextField
+} from "@material-ui/core";
+import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
+import { CountryFragment } from "@saleor/graphql";
+import { ChangeEvent } from "@saleor/hooks/useForm";
+import { useLocalSearch } from "@saleor/hooks/useLocalSearch";
+import { buttonMessages } from "@saleor/intl";
+import { Button, DialogHeader, SearchIcon } from "@saleor/macaw-ui";
+import { taxesMessages } from "@saleor/taxes/messages";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { useStyles } from "./styles";
+import { TaxCountryDialogLine } from "./TaxCountryDialogLine";
+
+interface TaxCountryDialogProps {
+  open: boolean;
+  countries: CountryFragment[];
+  onConfirm: (countries: CountryFragment[]) => void;
+}
+
+export interface CountryFragmentWithState extends CountryFragment {
+  checked: boolean;
+}
+
+export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
+  open,
+  countries,
+  onConfirm
+}) => {
+  const classes = useStyles();
+  const intl = useIntl();
+
+  const [countriesWithState, setCountriesWithState] = React.useState(
+    countries.map(country => ({ checked: false, ...country }))
+  );
+  const handleChange = React.useCallback(
+    (e: ChangeEvent) => {
+      const countriesUpdate = [...countriesWithState];
+      countriesUpdate.find(country => country.code === e.target.name).checked =
+        e.target.value;
+      setCountriesWithState(countriesUpdate);
+    },
+    [setCountriesWithState]
+  );
+
+  const { query, setQuery, searchResult: filteredCountries } = useLocalSearch<
+    CountryFragmentWithState
+  >(countriesWithState, country => country.country);
+
+  return (
+    <Dialog open={open} fullWidth>
+      <DialogHeader onClose={() => null}>
+        <FormattedMessage {...taxesMessages.chooseCountries} />
+      </DialogHeader>
+      <DialogContent className={classes.wrapper}>
+        <TextField
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          variant="outlined"
+          placeholder={intl.formatMessage(taxesMessages.country)}
+          fullWidth
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            )
+          }}
+          inputProps={{ className: classes.inputPadding }}
+        />
+        <VerticalSpacer spacing={2} />
+        <div className={classes.scrollable}>
+          {filteredCountries.map(country => (
+            <TaxCountryDialogLine
+              key={"modal" + country.code}
+              country={country}
+              checked={country.checked}
+              handleChange={handleChange}
+            />
+          ))}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="primary"
+          onClick={() =>
+            onConfirm(countriesWithState.filter(country => country.checked))
+          }
+        >
+          <FormattedMessage {...buttonMessages.select} />
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TaxCountryDialog;

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -38,8 +38,15 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
   const classes = useStyles();
   const intl = useIntl();
 
-  const [countriesWithState, setCountriesWithState] = React.useState(
-    countries.map(country => ({ checked: false, ...country }))
+  const [countriesWithState, setCountriesWithState] = React.useState<
+    CountryFragmentWithState[]
+  >([]);
+  React.useEffect(
+    () =>
+      setCountriesWithState(
+        countries.map(country => ({ checked: false, ...country }))
+      ),
+    [countries]
   );
   const handleChange = React.useCallback(
     (e: ChangeEvent) => {
@@ -48,16 +55,22 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
         e.target.value;
       setCountriesWithState(countriesUpdate);
     },
-    [setCountriesWithState]
+    [countries, setCountriesWithState]
   );
+
+  const handleClose = () => {
+    onClose();
+    setCountriesWithState([]);
+    setQuery("");
+  };
 
   const { query, setQuery, searchResult: filteredCountries } = useLocalSearch<
     CountryFragmentWithState
   >(countriesWithState, country => country.country);
 
   return (
-    <Dialog open={open} fullWidth onClose={onClose}>
-      <DialogHeader onClose={onClose}>
+    <Dialog open={open} fullWidth onClose={handleClose}>
+      <DialogHeader onClose={handleClose}>
         <FormattedMessage {...taxesMessages.chooseCountries} />
       </DialogHeader>
       <DialogContent className={classes.wrapper}>
@@ -91,9 +104,10 @@ export const TaxCountryDialog: React.FC<TaxCountryDialogProps> = ({
       <DialogActions>
         <Button
           variant="primary"
-          onClick={() =>
-            onConfirm(countriesWithState.filter(country => country.checked))
-          }
+          onClick={() => {
+            onConfirm(countriesWithState.filter(country => country.checked));
+            handleClose();
+          }}
         >
           <FormattedMessage {...buttonMessages.select} />
         </Button>

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialogLine.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialogLine.tsx
@@ -1,0 +1,26 @@
+import { Divider } from "@material-ui/core";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import { ChangeEvent } from "@saleor/hooks/useForm";
+import React from "react";
+
+import { CountryFragmentWithState } from "./TaxCountryDialog";
+
+export interface TaxCountryDialogLineProps {
+  country: CountryFragmentWithState;
+  handleChange: (e: ChangeEvent) => void;
+  checked: boolean;
+}
+
+export const TaxCountryDialogLine: React.FC<TaxCountryDialogLineProps> = React.memo(
+  ({ country, handleChange, checked }) => (
+    <>
+      <ControlledCheckbox
+        name={country.code}
+        checked={checked}
+        onChange={handleChange}
+        label={country.country}
+      />
+      <Divider />
+    </>
+  )
+);

--- a/src/taxes/components/TaxCountryDialog/index.ts
+++ b/src/taxes/components/TaxCountryDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TaxCountryDialog";
+export * from "./TaxCountryDialog";

--- a/src/taxes/components/TaxCountryDialog/styles.ts
+++ b/src/taxes/components/TaxCountryDialog/styles.ts
@@ -1,0 +1,22 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    inputPadding: {
+      padding: "16px 0 16px 0"
+    },
+    wrapper: {
+      overflowX: "visible",
+      padding: 0
+    },
+    scrollable: {
+      display: "flex",
+      flexDirection: "column",
+      overflowY: "scroll",
+      maxHeight: 450,
+      marginLeft: -15,
+      paddingLeft: 15
+    }
+  }),
+  { name: "TaxCountryDialog" }
+);

--- a/src/taxes/components/TaxCountryDialog/styles.ts
+++ b/src/taxes/components/TaxCountryDialog/styles.ts
@@ -1,9 +1,9 @@
 import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
-  () => ({
+  theme => ({
     inputPadding: {
-      padding: "16px 0 16px 0"
+      padding: theme.spacing(2, 0)
     },
     wrapper: {
       overflowX: "visible",

--- a/src/taxes/index.tsx
+++ b/src/taxes/index.tsx
@@ -1,17 +1,33 @@
 import { sectionNames } from "@saleor/intl";
+import { parse as parseQs } from "qs";
 import React from "react";
 import { useIntl } from "react-intl";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
-import { channelsListUrl, countriesListUrl, taxClassesListUrl } from "./urls";
+import {
+  channelsListPath,
+  countriesListUrl,
+  taxClassesListUrl,
+  TaxesUrlQueryParams
+} from "./urls";
 import ChannelsListComponent from "./views/ChannelsList";
 import CountriesListComponent from "./views/CountriesList";
 import TaxClassesListComponent from "./views/TaxClassesList";
 
 const ChannelsList: React.FC<RouteComponentProps<{ id: string }>> = ({
-  match
-}) => <ChannelsListComponent id={decodeURIComponent(match.params.id)} />;
+  match,
+  location
+}) => {
+  const qs: TaxesUrlQueryParams = parseQs(location.search.substring(1));
+
+  return (
+    <ChannelsListComponent
+      id={decodeURIComponent(match.params.id)}
+      params={qs}
+    />
+  );
+};
 
 const CountriesList: React.FC<RouteComponentProps<{ id: string }>> = ({
   match
@@ -28,8 +44,8 @@ const Component = () => {
     <>
       <WindowTitle title={intl.formatMessage(sectionNames.taxes)} />
       <Switch>
-        <Route path={channelsListUrl(":id")} component={ChannelsList} />
-        <Route path={channelsListUrl()} component={ChannelsList} />
+        <Route path={channelsListPath(":id")} component={ChannelsList} />
+        <Route path={channelsListPath()} component={ChannelsList} />
         <Route path={countriesListUrl(":id")} component={CountriesList} />
         <Route path={countriesListUrl()} component={CountriesList} />
         <Route path={taxClassesListUrl(":id")} component={TaxClassesList} />

--- a/src/taxes/index.tsx
+++ b/src/taxes/index.tsx
@@ -6,9 +6,9 @@ import { Route, RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
 import {
-  channelsListPath,
   countriesListUrl,
   taxClassesListUrl,
+  taxConfigurationListPath,
   TaxesUrlQueryParams
 } from "./urls";
 import ChannelsListComponent from "./views/ChannelsList";
@@ -44,8 +44,11 @@ const Component = () => {
     <>
       <WindowTitle title={intl.formatMessage(sectionNames.taxes)} />
       <Switch>
-        <Route path={channelsListPath(":id")} component={ChannelsList} />
-        <Route path={channelsListPath()} component={ChannelsList} />
+        <Route
+          path={taxConfigurationListPath(":id")}
+          component={ChannelsList}
+        />
+        <Route path={taxConfigurationListPath()} component={ChannelsList} />
         <Route path={countriesListUrl(":id")} component={CountriesList} />
         <Route path={countriesListUrl()} component={CountriesList} />
         <Route path={taxClassesListUrl(":id")} component={TaxClassesList} />

--- a/src/taxes/messages.ts
+++ b/src/taxes/messages.ts
@@ -135,5 +135,10 @@ export const taxesMessages = defineMessages({
     id: "/ILyIf",
     defaultMessage: "Tax class label",
     description: "tax classes menu header"
+  },
+  noExceptionsForChannel: {
+    id: "u34css",
+    defaultMessage: "There are no exceptions for this channel",
+    description: "label for empty list in channels list"
   }
 });

--- a/src/taxes/messages.ts
+++ b/src/taxes/messages.ts
@@ -140,5 +140,15 @@ export const taxesMessages = defineMessages({
     id: "u34css",
     defaultMessage: "There are no exceptions for this channel",
     description: "label for empty list in channels list"
+  },
+  chooseCountries: {
+    id: "s6p+rD",
+    defaultMessage: "Choose countries you want to assign",
+    description: "add country dialog header"
+  },
+  country: {
+    id: "UBuKZ9",
+    defaultMessage: "Country",
+    description: "searchbar placeholder"
   }
 });

--- a/src/taxes/mutations.ts
+++ b/src/taxes/mutations.ts
@@ -27,3 +27,19 @@ export const fetchTaxes = gql`
     }
   }
 `;
+
+export const taxConfigurationUpdate = gql`
+  mutation TaxConfigurationUpdate(
+    $id: ID!
+    $input: TaxConfigurationUpdateInput!
+  ) {
+    taxConfigurationUpdate(id: $id, input: $input) {
+      errors {
+        ...TaxConfigurationUpdateErrorFragment
+      }
+      taxConfiguration {
+        ...TaxConfiguration
+      }
+    }
+  }
+`;

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/TaxChannelsMenu.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/TaxChannelsMenu.tsx
@@ -23,28 +23,28 @@ export const TaxChannelsMenu: React.FC<TaxChannelsMenuProps> = ({
   const classes = useStyles();
   return (
     <Card>
-      <div className={classes.scrollWrapper}>
-        <List gridTemplate={["1fr"]}>
-          <ListHeader>
-            <ListItem>
-              <ListItemCell>
-                <FormattedMessage {...taxesMessages.channelList} />
-              </ListItemCell>
-            </ListItem>
-          </ListHeader>
-          {configurations?.map(configuration => (
-            <ListItemLink
-              key={configuration.id}
-              className={clsx(classes.clickable, {
-                [classes.selected]: configuration.id === selectedConfigurationId
-              })}
-              href={taxConfigurationListUrl(configuration.id)}
-            >
-              <ListItemCell>{configuration.channel.name}</ListItemCell>
-            </ListItemLink>
-          )) ?? <Skeleton />}
-        </List>
-      </div>
+      <List gridTemplate={["1fr"]}>
+        <ListHeader>
+          <ListItem>
+            <ListItemCell>
+              <FormattedMessage {...taxesMessages.channelList} />
+            </ListItemCell>
+          </ListItem>
+        </ListHeader>
+        {configurations?.map(configuration => (
+          <ListItemLink
+            key={configuration.id}
+            className={clsx(classes.clickable, {
+              [classes.selected]: configuration.id === selectedConfigurationId
+            })}
+            href={taxConfigurationListUrl(configuration.id)}
+          >
+            <ListItemCell className={classes.ellipsis}>
+              {configuration.channel.name}
+            </ListItemCell>
+          </ListItemLink>
+        )) ?? <Skeleton />}
+      </List>
     </Card>
   );
 };

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/TaxChannelsMenu.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/TaxChannelsMenu.tsx
@@ -4,7 +4,7 @@ import Skeleton from "@saleor/components/Skeleton";
 import { TaxConfigurationFragment } from "@saleor/graphql";
 import { List, ListHeader, ListItem, ListItemCell } from "@saleor/macaw-ui";
 import { taxesMessages } from "@saleor/taxes/messages";
-import { channelsListUrl } from "@saleor/taxes/urls";
+import { taxConfigurationListUrl } from "@saleor/taxes/urls";
 import clsx from "classnames";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -38,7 +38,7 @@ export const TaxChannelsMenu: React.FC<TaxChannelsMenuProps> = ({
               className={clsx(classes.clickable, {
                 [classes.selected]: configuration.id === selectedConfigurationId
               })}
-              href={channelsListUrl(configuration.id)}
+              href={taxConfigurationListUrl(configuration.id)}
             >
               <ListItemCell>{configuration.channel.name}</ListItemCell>
             </ListItemLink>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/styles.ts
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsMenu/styles.ts
@@ -5,9 +5,9 @@ export const useStyles = makeStyles(
     clickable: {
       cursor: "pointer"
     },
-    scrollWrapper: {
-      overflowY: "scroll",
-      maxHeight: 600
+    ellipsis: {
+      textOverflow: "ellipsis",
+      overflow: "hidden"
     },
     selected: {
       "&&&&::before": {

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
@@ -22,7 +22,8 @@ const props = {
   allCountries: castedCountries,
   isDialogOpen: false,
   openDialog: () => undefined,
-  closeDialog: () => undefined
+  closeDialog: () => undefined,
+  onSubmit: () => undefined
 };
 
 storiesOf("Views / Taxes / Channels view", module)

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
@@ -1,3 +1,5 @@
+import { countries } from "@saleor/fixtures";
+import { CountryFragment } from "@saleor/graphql";
 import Decorator from "@saleor/storybook/Decorator";
 import { taxConfigurations } from "@saleor/taxes/fixtures";
 import { storiesOf } from "@storybook/react";
@@ -5,10 +7,22 @@ import React from "react";
 
 import TaxChannelsPage from "./TaxChannelsPage";
 
+const castedCountries = countries.map(
+  ({ code, name }): CountryFragment => ({
+    code,
+    country: name,
+    __typename: "CountryDisplay"
+  })
+);
+
 const props = {
   taxConfigurations,
   selectedConfigurationId: taxConfigurations[0].id,
-  handleTabChange: () => undefined
+  handleTabChange: () => undefined,
+  allCountries: castedCountries,
+  isDialogOpen: false,
+  openDialog: () => undefined,
+  closeDialog: () => undefined
 };
 
 storiesOf("Views / Taxes / Channels view", module)
@@ -16,5 +30,5 @@ storiesOf("Views / Taxes / Channels view", module)
   .add("loading", () => (
     <TaxChannelsPage {...props} taxConfigurations={undefined} />
   ))
-  .add("default", () => <TaxChannelsPage {...props} />);
-// .add("add country", () => <TaxChannelsPage {...props} />); // TODO: add country modal
+  .add("default", () => <TaxChannelsPage {...props} />)
+  .add("add country", () => <TaxChannelsPage {...props} isDialogOpen={true} />);

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.stories.tsx
@@ -23,7 +23,9 @@ const props = {
   isDialogOpen: false,
   openDialog: () => undefined,
   closeDialog: () => undefined,
-  onSubmit: () => undefined
+  onSubmit: () => undefined,
+  savebarState: "default" as const,
+  disabled: false
 };
 
 storiesOf("Views / Taxes / Channels view", module)

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -228,12 +228,14 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
             {allCountries && (
               <TaxCountryDialog
                 open={isDialogOpen}
-                countries={allCountries.filter(
-                  ({ code }) =>
-                    !countryExceptions?.some(
-                      ({ country }) => country.code === code
-                    )
-                )}
+                countries={allCountries
+                  .filter(
+                    ({ code }) =>
+                      !countryExceptions?.some(
+                        ({ country }) => country.code === code
+                      )
+                  )
+                  .map(country => ({ checked: false, ...country }))}
                 onConfirm={countries => {
                   const input = countries.map(country => ({
                     country,

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -8,6 +8,7 @@ import PageHeader from "@saleor/components/PageHeader";
 import Savebar from "@saleor/components/Savebar";
 import Skeleton from "@saleor/components/Skeleton";
 import {
+  CountryFragment,
   TaxConfigurationFragment,
   TaxConfigurationUpdateInput
 } from "@saleor/graphql";
@@ -21,6 +22,7 @@ import {
   PageTab,
   PageTabs
 } from "@saleor/macaw-ui";
+import TaxCountryDialog from "@saleor/taxes/components/TaxCountryDialog";
 import { taxesMessages } from "@saleor/taxes/messages";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -33,10 +35,18 @@ interface TaxChannelsPageProps {
   taxConfigurations: TaxConfigurationFragment[] | undefined;
   selectedConfigurationId: string;
   handleTabChange: (tab: string) => void;
+  allCountries: CountryFragment[] | undefined;
+  dialogOpen: boolean;
 }
 
 export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
-  const { taxConfigurations, selectedConfigurationId, handleTabChange } = props;
+  const {
+    taxConfigurations,
+    selectedConfigurationId,
+    handleTabChange,
+    allCountries,
+    dialogOpen
+  } = props;
 
   const intl = useIntl();
 
@@ -135,6 +145,14 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
             onSubmit={submit}
             onCancel={() => null}
           />
+          {allCountries && (
+            <TaxCountryDialog
+              open={true}
+              countries={allCountries}
+              // eslint-disable-next-line no-console
+              onConfirm={countries => console.log(countries)}
+            />
+          )}
         </Container>
       )}
     </Form>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -120,6 +120,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
             [name]: value
           };
           currentExceptions[index] = exceptionToChange;
+          triggerChange();
           set({ updateCountriesConfiguration: currentExceptions });
         };
 

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -7,6 +7,7 @@ import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
 import Savebar from "@saleor/components/Savebar";
 import Skeleton from "@saleor/components/Skeleton";
+import { configurationMenuUrl } from "@saleor/configuration";
 import {
   CountryCode,
   CountryFragment,
@@ -14,6 +15,7 @@ import {
   TaxConfigurationPerCountryFragment,
   TaxConfigurationUpdateInput
 } from "@saleor/graphql";
+import useNavigator from "@saleor/hooks/useNavigator";
 import { sectionNames } from "@saleor/intl";
 import {
   Button,
@@ -70,6 +72,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
   } = props;
 
   const intl = useIntl();
+  const navigate = useNavigator();
 
   const currentTaxConfiguration = taxConfigurations?.find(
     taxConfigurations => taxConfigurations.id === selectedConfigurationId
@@ -103,7 +106,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
   };
 
   return (
-    <Form initial={initialForm} onSubmit={handleSubmit}>
+    <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
       {({ data, change, submit, set }) => {
         const countryExceptions = data.updateCountriesConfiguration;
 
@@ -220,7 +223,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
               state={savebarState}
               disabled={disabled}
               onSubmit={submit}
-              onCancel={() => null}
+              onCancel={() => navigate(configurationMenuUrl)}
             />
             {allCountries && (
               <TaxCountryDialog

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -32,6 +32,7 @@ import { taxesMessages } from "@saleor/taxes/messages";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { useStyles } from "./styles";
 import TaxChannelsMenu from "./TaxChannelsMenu";
 import TaxCountryExceptionListItem from "./TaxCountryExceptionListItem";
 import TaxSettingsCard from "./TaxSettingsCard";
@@ -72,6 +73,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
   } = props;
 
   const intl = useIntl();
+  const classes = useStyles();
   const navigate = useNavigator();
 
   const currentTaxConfiguration = taxConfigurations?.find(
@@ -174,15 +176,19 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                               {...taxesMessages.countryNameHeader}
                             />
                           </ListItemCell>
-                          <ListItemCell>
+                          <ListItemCell className={classes.center}>
                             <FormattedMessage
                               {...taxesMessages.chargeTaxesHeader}
                             />
                           </ListItemCell>
-                          <ListItemCell>
+                          <ListItemCell className={classes.center}>
                             <FormattedMessage
                               {...taxesMessages.showGrossHeader}
                             />
+                          </ListItemCell>
+                          <ListItemCell>
+                            {/* This is required for the header row to be aligned with list items */}
+                            <div className={classes.dummy}></div>
                           </ListItemCell>
                         </ListItem>
                       </ListHeader>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -142,10 +142,12 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
             </PageTabs>
             <VerticalSpacer spacing={2} />
             <Grid variant="inverted">
-              <TaxChannelsMenu
-                configurations={taxConfigurations}
-                selectedConfigurationId={selectedConfigurationId}
-              />
+              <div>
+                <TaxChannelsMenu
+                  configurations={taxConfigurations}
+                  selectedConfigurationId={selectedConfigurationId}
+                />
+              </div>
               <div>
                 <TaxSettingsCard values={data} onChange={change} />
                 <VerticalSpacer spacing={3} />

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -228,14 +228,12 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
             {allCountries && (
               <TaxCountryDialog
                 open={isDialogOpen}
-                countries={allCountries
-                  .filter(
-                    ({ code }) =>
-                      !countryExceptions?.some(
-                        ({ country }) => country.code === code
-                      )
-                  )
-                  .map(country => ({ checked: false, ...country }))}
+                countries={allCountries.filter(
+                  ({ code }) =>
+                    !countryExceptions?.some(
+                      ({ country }) => country.code === code
+                    )
+                )}
                 onConfirm={countries => {
                   const input = countries.map(country => ({
                     country,

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -109,7 +109,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
 
   return (
     <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
-      {({ data, change, submit, set }) => {
+      {({ data, change, submit, set, triggerChange }) => {
         const countryExceptions = data.updateCountriesConfiguration;
 
         const handleExceptionChange = (event, index) => {
@@ -219,6 +219,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                                   country.country.code
                               )
                             });
+                            triggerChange();
                           }}
                           onChange={event =>
                             handleExceptionChange(event, countryIndex)
@@ -255,6 +256,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                     displayGrossPrices: data.displayGrossPrices
                   })) as TaxConfigurationPerCountryFragment[];
                   const currentExceptions = data.updateCountriesConfiguration;
+                  triggerChange();
                   set({
                     updateCountriesConfiguration: [
                       ...currentExceptions,

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@material-ui/core";
+import { Card, CardContent } from "@material-ui/core";
 import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import Container from "@saleor/components/Container";
@@ -74,32 +74,34 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                 </Button>
               }
             />
-            <List gridTemplate={["4fr 3fr 3fr 1fr"]}>
-              <ListHeader>
-                <ListItem>
-                  <ListItemCell>
-                    <FormattedMessage {...taxesMessages.countryNameHeader} />
-                  </ListItemCell>
-                  <ListItemCell>
-                    <FormattedMessage {...taxesMessages.chargeTaxesHeader} />
-                  </ListItemCell>
-                  <ListItemCell>
-                    <FormattedMessage {...taxesMessages.showGrossHeader} />
-                  </ListItemCell>
-                </ListItem>
-              </ListHeader>
-              {currentTaxConfiguration?.countries.map(country => (
-                <TaxCountryExceptionListItem
-                  country={country.country}
-                  key={country.country.code}
-                />
-              )) ?? (
-                <>
-                  <Skeleton />
-                  <VerticalSpacer />
-                </>
-              )}
-            </List>
+            {currentTaxConfiguration?.countries.length === 0 ? (
+              <CardContent>
+                <FormattedMessage {...taxesMessages.noExceptionsForChannel} />
+              </CardContent>
+            ) : (
+              <List gridTemplate={["4fr 3fr 3fr 1fr"]}>
+                <ListHeader>
+                  <ListItem>
+                    <ListItemCell>
+                      <FormattedMessage {...taxesMessages.countryNameHeader} />
+                    </ListItemCell>
+                    <ListItemCell>
+                      <FormattedMessage {...taxesMessages.chargeTaxesHeader} />
+                    </ListItemCell>
+                    <ListItemCell>
+                      <FormattedMessage {...taxesMessages.showGrossHeader} />
+                    </ListItemCell>
+                  </ListItem>
+                </ListHeader>
+                {currentTaxConfiguration?.countries.map(country => (
+                  <TaxCountryExceptionListItem
+                    country={country.country}
+                    key={country.country.code}
+                  />
+                )) ?? <Skeleton />}
+              </List>
+            )}
+            <VerticalSpacer />
           </Card>
         </div>
       </Grid>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -36,7 +36,9 @@ interface TaxChannelsPageProps {
   selectedConfigurationId: string;
   handleTabChange: (tab: string) => void;
   allCountries: CountryFragment[] | undefined;
-  dialogOpen: boolean;
+  isDialogOpen: boolean;
+  openDialog: (action?: string) => void;
+  closeDialog: () => void;
 }
 
 export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
@@ -45,7 +47,9 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
     selectedConfigurationId,
     handleTabChange,
     allCountries,
-    dialogOpen
+    isDialogOpen,
+    openDialog,
+    closeDialog
   } = props;
 
   const intl = useIntl();
@@ -95,7 +99,10 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                 <CardTitle
                   title={intl.formatMessage(taxesMessages.countryExceptions)}
                   toolbar={
-                    <Button variant="secondary">
+                    <Button
+                      variant="secondary"
+                      onClick={() => openDialog("add-country")}
+                    >
                       <FormattedMessage {...taxesMessages.addCountryLabel} />
                     </Button>
                   }
@@ -147,10 +154,11 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
           />
           {allCountries && (
             <TaxCountryDialog
-              open={true}
+              open={isDialogOpen}
               countries={allCountries}
               // eslint-disable-next-line no-console
               onConfirm={countries => console.log(countries)}
+              onClose={closeDialog}
             />
           )}
         </Container>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -17,6 +17,7 @@ import {
 import { sectionNames } from "@saleor/intl";
 import {
   Button,
+  ConfirmButtonTransitionState,
   List,
   ListHeader,
   ListItem,
@@ -42,6 +43,8 @@ interface TaxChannelsPageProps {
   openDialog: (action?: string) => void;
   closeDialog: () => void;
   onSubmit: (input: TaxConfigurationUpdateInput) => void;
+  savebarState: ConfirmButtonTransitionState;
+  disabled: boolean;
 }
 
 export interface TaxConfigurationFormData {
@@ -61,7 +64,9 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
     isDialogOpen,
     openDialog,
     closeDialog,
-    onSubmit
+    onSubmit,
+    savebarState,
+    disabled
   } = props;
 
   const intl = useIntl();
@@ -212,8 +217,8 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
               </div>
             </Grid>
             <Savebar
-              state={"default"}
-              disabled={false}
+              state={savebarState}
+              disabled={disabled}
               onSubmit={submit}
               onCancel={() => null}
             />

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -2,10 +2,15 @@ import { Card, CardContent } from "@material-ui/core";
 import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import Container from "@saleor/components/Container";
+import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
+import Savebar from "@saleor/components/Savebar";
 import Skeleton from "@saleor/components/Skeleton";
-import { TaxConfigurationFragment } from "@saleor/graphql";
+import {
+  TaxConfigurationFragment,
+  TaxConfigurationUpdateInput
+} from "@saleor/graphql";
 import { sectionNames } from "@saleor/intl";
 import {
   Button,
@@ -39,73 +44,100 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
     taxConfigurations => taxConfigurations.id === selectedConfigurationId
   );
 
+  const initialForm: TaxConfigurationUpdateInput = {
+    chargeTaxes: currentTaxConfiguration?.chargeTaxes ?? false,
+    displayGrossPrices: currentTaxConfiguration?.displayGrossPrices ?? false,
+    pricesEnteredWithTax:
+      currentTaxConfiguration?.pricesEnteredWithTax ?? false,
+    updateCountriesConfiguration: [],
+    removeCountriesConfiguration: []
+  };
+
   return (
-    <Container>
-      <PageHeader title={intl.formatMessage(sectionNames.taxes)} />
-      <PageTabs value="channels" onChange={handleTabChange}>
-        <PageTab
-          label={intl.formatMessage(taxesMessages.channelsSection)}
-          value="channels"
-        />
-        <PageTab
-          label={intl.formatMessage(taxesMessages.countriesSection)}
-          value="countries"
-        />
-        <PageTab
-          label={intl.formatMessage(taxesMessages.taxClassesSection)}
-          value="tax-classes"
-        />
-      </PageTabs>
-      <VerticalSpacer spacing={2} />
-      <Grid variant="inverted">
-        <TaxChannelsMenu
-          configurations={taxConfigurations}
-          selectedConfigurationId={selectedConfigurationId}
-        />
-        <div>
-          <TaxSettingsCard />
-          <VerticalSpacer spacing={3} />
-          <Card>
-            <CardTitle
-              title={intl.formatMessage(taxesMessages.countryExceptions)}
-              toolbar={
-                <Button variant="secondary">
-                  <FormattedMessage {...taxesMessages.addCountryLabel} />
-                </Button>
-              }
+    <Form initial={initialForm} onSubmit={() => null}>
+      {({ data, change, submit }) => (
+        <Container>
+          <PageHeader title={intl.formatMessage(sectionNames.taxes)} />
+          <PageTabs value="channels" onChange={handleTabChange}>
+            <PageTab
+              label={intl.formatMessage(taxesMessages.channelsSection)}
+              value="channels"
             />
-            {currentTaxConfiguration?.countries.length === 0 ? (
-              <CardContent>
-                <FormattedMessage {...taxesMessages.noExceptionsForChannel} />
-              </CardContent>
-            ) : (
-              <List gridTemplate={["4fr 3fr 3fr 1fr"]}>
-                <ListHeader>
-                  <ListItem>
-                    <ListItemCell>
-                      <FormattedMessage {...taxesMessages.countryNameHeader} />
-                    </ListItemCell>
-                    <ListItemCell>
-                      <FormattedMessage {...taxesMessages.chargeTaxesHeader} />
-                    </ListItemCell>
-                    <ListItemCell>
-                      <FormattedMessage {...taxesMessages.showGrossHeader} />
-                    </ListItemCell>
-                  </ListItem>
-                </ListHeader>
-                {currentTaxConfiguration?.countries.map(country => (
-                  <TaxCountryExceptionListItem
-                    country={country.country}
-                    key={country.country.code}
-                  />
-                )) ?? <Skeleton />}
-              </List>
-            )}
-            <VerticalSpacer />
-          </Card>
-        </div>
-      </Grid>
-    </Container>
+            <PageTab
+              label={intl.formatMessage(taxesMessages.countriesSection)}
+              value="countries"
+            />
+            <PageTab
+              label={intl.formatMessage(taxesMessages.taxClassesSection)}
+              value="tax-classes"
+            />
+          </PageTabs>
+          <VerticalSpacer spacing={2} />
+          <Grid variant="inverted">
+            <TaxChannelsMenu
+              configurations={taxConfigurations}
+              selectedConfigurationId={selectedConfigurationId}
+            />
+            <div>
+              <TaxSettingsCard values={data} onChange={change} />
+              <VerticalSpacer spacing={3} />
+              <Card>
+                <CardTitle
+                  title={intl.formatMessage(taxesMessages.countryExceptions)}
+                  toolbar={
+                    <Button variant="secondary">
+                      <FormattedMessage {...taxesMessages.addCountryLabel} />
+                    </Button>
+                  }
+                />
+                {currentTaxConfiguration?.countries.length === 0 ? (
+                  <CardContent>
+                    <FormattedMessage
+                      {...taxesMessages.noExceptionsForChannel}
+                    />
+                  </CardContent>
+                ) : (
+                  <List gridTemplate={["4fr 3fr 3fr 1fr"]}>
+                    <ListHeader>
+                      <ListItem>
+                        <ListItemCell>
+                          <FormattedMessage
+                            {...taxesMessages.countryNameHeader}
+                          />
+                        </ListItemCell>
+                        <ListItemCell>
+                          <FormattedMessage
+                            {...taxesMessages.chargeTaxesHeader}
+                          />
+                        </ListItemCell>
+                        <ListItemCell>
+                          <FormattedMessage
+                            {...taxesMessages.showGrossHeader}
+                          />
+                        </ListItemCell>
+                      </ListItem>
+                    </ListHeader>
+                    {currentTaxConfiguration?.countries.map(country => (
+                      <TaxCountryExceptionListItem
+                        country={country.country}
+                        key={country.country.code}
+                      />
+                    )) ?? <Skeleton />}
+                  </List>
+                )}
+                <VerticalSpacer />
+              </Card>
+            </div>
+          </Grid>
+          <Savebar
+            state={"default"}
+            disabled={false}
+            onSubmit={submit}
+            onCancel={() => null}
+          />
+        </Container>
+      )}
+    </Form>
   );
 };
 export default TaxChannelsPage;

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -187,8 +187,8 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                             />
                           </ListItemCell>
                           <ListItemCell>
-                            {/* This is required for the header row to be aligned with list items
-                            <div className={classes.dummy}></div> */}
+                            {/* This is required for the header row to be aligned with list items */}
+                            <div className={classes.dummy}></div>
                           </ListItemCell>
                         </ListItem>
                       </ListHeader>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -151,6 +151,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                 <VerticalSpacer spacing={3} />
                 <Card>
                   <CardTitle
+                    className={classes.toolbarMargin}
                     title={intl.formatMessage(taxesMessages.countryExceptions)}
                     toolbar={
                       <Button

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -187,8 +187,8 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                             />
                           </ListItemCell>
                           <ListItemCell>
-                            {/* This is required for the header row to be aligned with list items */}
-                            <div className={classes.dummy}></div>
+                            {/* This is required for the header row to be aligned with list items
+                            <div className={classes.dummy}></div> */}
                           </ListItemCell>
                         </ListItem>
                       </ListHeader>

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -194,6 +194,9 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
                       </ListHeader>
                       {countryExceptions?.map((country, countryIndex) => (
                         <TaxCountryExceptionListItem
+                          divider={
+                            countryIndex + 1 !== countryExceptions.length
+                          }
                           country={country}
                           key={country.country.code}
                           onDelete={() => {

--- a/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
@@ -1,5 +1,9 @@
-import { Checkbox } from "@material-ui/core";
-import { TaxConfigurationPerCountryFragment } from "@saleor/graphql";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import {
+  TaxConfigurationPerCountryFragment,
+  TaxConfigurationUpdateInput
+} from "@saleor/graphql";
+import { FormChange } from "@saleor/hooks/useForm";
 import {
   DeleteIcon,
   IconButton,
@@ -9,21 +13,31 @@ import {
 import React from "react";
 
 interface TaxCountryExceptionListItemProps {
-  country: TaxConfigurationPerCountryFragment["country"] | undefined;
+  country: TaxConfigurationPerCountryFragment | undefined;
   onDelete: () => void;
+  onChange: FormChange;
 }
 
 export const TaxCountryExceptionListItem: React.FC<TaxCountryExceptionListItemProps> = ({
   country,
-  onDelete
+  onDelete,
+  onChange
 }) => (
   <ListItem hover={false}>
-    <ListItemCell>{country.country}</ListItemCell>
+    <ListItemCell>{country.country.country}</ListItemCell>
     <ListItemCell>
-      <Checkbox />
+      <ControlledCheckbox
+        checked={country.chargeTaxes}
+        name={"chargeTaxes" as keyof TaxConfigurationUpdateInput}
+        onChange={onChange}
+      />
     </ListItemCell>
     <ListItemCell>
-      <Checkbox />
+      <ControlledCheckbox
+        checked={country.displayGrossPrices}
+        name={"displayGrossPrices" as keyof TaxConfigurationUpdateInput}
+        onChange={onChange}
+      />
     </ListItemCell>
     <ListItemCell>
       <IconButton onClick={onDelete} variant="secondary">

--- a/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
@@ -10,10 +10,12 @@ import React from "react";
 
 interface TaxCountryExceptionListItemProps {
   country: TaxConfigurationPerCountryFragment["country"] | undefined;
+  onDelete: () => void;
 }
 
 export const TaxCountryExceptionListItem: React.FC<TaxCountryExceptionListItemProps> = ({
-  country
+  country,
+  onDelete
 }) => (
   <ListItem hover={false}>
     <ListItemCell>{country.country}</ListItemCell>
@@ -24,7 +26,7 @@ export const TaxCountryExceptionListItem: React.FC<TaxCountryExceptionListItemPr
       <Checkbox />
     </ListItemCell>
     <ListItemCell>
-      <IconButton variant="secondary">
+      <IconButton onClick={onDelete} variant="secondary">
         <DeleteIcon />
       </IconButton>
     </ListItemCell>

--- a/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
@@ -12,6 +12,8 @@ import {
 } from "@saleor/macaw-ui";
 import React from "react";
 
+import { useStyles } from "../styles";
+
 interface TaxCountryExceptionListItemProps {
   country: TaxConfigurationPerCountryFragment | undefined;
   onDelete: () => void;
@@ -22,29 +24,33 @@ export const TaxCountryExceptionListItem: React.FC<TaxCountryExceptionListItemPr
   country,
   onDelete,
   onChange
-}) => (
-  <ListItem hover={false}>
-    <ListItemCell>{country.country.country}</ListItemCell>
-    <ListItemCell>
-      <ControlledCheckbox
-        checked={country.chargeTaxes}
-        name={"chargeTaxes" as keyof TaxConfigurationUpdateInput}
-        onChange={onChange}
-      />
-    </ListItemCell>
-    <ListItemCell>
-      <ControlledCheckbox
-        checked={country.displayGrossPrices}
-        name={"displayGrossPrices" as keyof TaxConfigurationUpdateInput}
-        onChange={onChange}
-      />
-    </ListItemCell>
-    <ListItemCell>
-      <IconButton onClick={onDelete} variant="secondary">
-        <DeleteIcon />
-      </IconButton>
-    </ListItemCell>
-  </ListItem>
-);
-
+}) => {
+  const classes = useStyles();
+  return (
+    <ListItem hover={false}>
+      <ListItemCell>{country.country.country}</ListItemCell>
+      <ListItemCell className={classes.center}>
+        <ControlledCheckbox
+          className={classes.center}
+          checked={country.chargeTaxes}
+          name={"chargeTaxes" as keyof TaxConfigurationUpdateInput}
+          onChange={onChange}
+        />
+      </ListItemCell>
+      <ListItemCell className={classes.center}>
+        <ControlledCheckbox
+          className={classes.center}
+          checked={country.displayGrossPrices}
+          name={"displayGrossPrices" as keyof TaxConfigurationUpdateInput}
+          onChange={onChange}
+        />
+      </ListItemCell>
+      <ListItemCell>
+        <IconButton onClick={onDelete} variant="secondary">
+          <DeleteIcon />
+        </IconButton>
+      </ListItemCell>
+    </ListItem>
+  );
+};
 export default TaxCountryExceptionListItem;

--- a/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
@@ -18,16 +18,18 @@ interface TaxCountryExceptionListItemProps {
   country: TaxConfigurationPerCountryFragment | undefined;
   onDelete: () => void;
   onChange: FormChange;
+  divider: boolean;
 }
 
 export const TaxCountryExceptionListItem: React.FC<TaxCountryExceptionListItemProps> = ({
   country,
   onDelete,
-  onChange
+  onChange,
+  divider = true
 }) => {
   const classes = useStyles();
   return (
-    <ListItem hover={false}>
+    <ListItem hover={false} className={divider ? undefined : classes.noDivider}>
       <ListItemCell>{country.country.country}</ListItemCell>
       <ListItemCell className={classes.center}>
         <ControlledCheckbox

--- a/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
@@ -1,7 +1,6 @@
 import {
   Card,
   CardContent,
-  Checkbox,
   Divider,
   FormControlLabel,
   Radio,
@@ -9,18 +8,27 @@ import {
   Typography
 } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import Grid from "@saleor/components/Grid";
+import { TaxConfigurationUpdateInput } from "@saleor/graphql";
+import { FormChange } from "@saleor/hooks/useForm";
 import { taxesMessages } from "@saleor/taxes/messages";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useStyles } from "./styles";
 
-export const TaxSettingsCard: React.FC = () => {
+export interface TaxSettingsCardProps {
+  values: TaxConfigurationUpdateInput;
+  onChange: FormChange;
+}
+
+export const TaxSettingsCard: React.FC<TaxSettingsCardProps> = ({
+  values,
+  onChange
+}) => {
   const intl = useIntl();
   const classes = useStyles();
-
-  const [radioTest, setRadioTest] = React.useState("test1");
 
   return (
     <Card>
@@ -29,8 +37,10 @@ export const TaxSettingsCard: React.FC = () => {
         <Typography className={classes.supportHeader}>
           <FormattedMessage {...taxesMessages.taxCharging} />
         </Typography>
-        <FormControlLabel
-          control={<Checkbox />}
+        <ControlledCheckbox
+          checked={values.chargeTaxes}
+          name={"chargeTaxes" as keyof TaxConfigurationUpdateInput}
+          onChange={onChange}
           label={intl.formatMessage(taxesMessages.chargeTaxes)}
         />
       </CardContent>
@@ -38,31 +48,41 @@ export const TaxSettingsCard: React.FC = () => {
       <CardContent>
         <Grid variant="uniform">
           <RadioGroup
-            value={radioTest}
-            onChange={e => setRadioTest(e.target.value)}
+            value={values.pricesEnteredWithTax}
+            name={"pricesEnteredWithTax" as keyof TaxConfigurationUpdateInput}
+            onChange={e => {
+              onChange({
+                target: {
+                  name: e.target.name,
+                  value: e.target.value === "true"
+                }
+              });
+            }}
             className={classes.showCheckboxShadows}
           >
             <Typography className={classes.supportHeader}>
               <FormattedMessage {...taxesMessages.enteredPrices} />
             </Typography>
             <FormControlLabel
+              value={true}
               control={<Radio />}
               label={intl.formatMessage(taxesMessages.pricesWithTaxLabel)}
-              value="test1"
             />
             <FormControlLabel
+              value={false}
               control={<Radio />}
               label={intl.formatMessage(taxesMessages.pricesWithoutTaxLabel)}
-              value="test2"
             />
           </RadioGroup>
           <div className={classes.showCheckboxShadows}>
             <Typography className={classes.supportHeader}>
               <FormattedMessage {...taxesMessages.renderedPrices} />
             </Typography>
-            <FormControlLabel
-              control={<Checkbox />}
+            <ControlledCheckbox
               label={intl.formatMessage(taxesMessages.showGrossHeader)}
+              name={"displayGrossPrices" as keyof TaxConfigurationUpdateInput}
+              checked={values.displayGrossPrices}
+              onChange={onChange}
             />
           </div>
         </Grid>

--- a/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
@@ -16,10 +16,11 @@ import { taxesMessages } from "@saleor/taxes/messages";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { TaxConfigurationFormData } from "../TaxChannelsPage";
 import { useStyles } from "./styles";
 
 export interface TaxSettingsCardProps {
-  values: TaxConfigurationUpdateInput;
+  values: TaxConfigurationFormData;
   onChange: FormChange;
 }
 

--- a/src/taxes/pages/TaxChannelsPage/styles.ts
+++ b/src/taxes/pages/TaxChannelsPage/styles.ts
@@ -1,0 +1,18 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    center: {
+      margin: 0,
+      display: "flex",
+      placeContent: "center",
+      textAlign: "center"
+    },
+    dummy: {
+      width: "40px",
+      height: "40px",
+      visiblity: "hidden"
+    }
+  }),
+  { name: "TaxChannelsPage" }
+);

--- a/src/taxes/pages/TaxChannelsPage/styles.ts
+++ b/src/taxes/pages/TaxChannelsPage/styles.ts
@@ -15,6 +15,11 @@ export const useStyles = makeStyles(
     },
     noDivider: {
       "&::after": { display: "none" }
+    },
+    toolbarMargin: {
+      "&:last-child": {
+        marginRight: 0
+      }
     }
   }),
   { name: "TaxChannelsPage" }

--- a/src/taxes/pages/TaxChannelsPage/styles.ts
+++ b/src/taxes/pages/TaxChannelsPage/styles.ts
@@ -12,6 +12,9 @@ export const useStyles = makeStyles(
       width: "40px",
       height: "40px",
       visiblity: "hidden"
+    },
+    noDivider: {
+      "&::after": { display: "none" }
     }
   }),
   { name: "TaxChannelsPage" }

--- a/src/taxes/queries.ts
+++ b/src/taxes/queries.ts
@@ -42,3 +42,11 @@ export const taxConfigurationList = gql`
     }
   }
 `;
+
+export const taxCountriesList = gql`
+  query TaxCountriesList {
+    taxCountryConfigurations {
+      ...TaxCountryConfiguration
+    }
+  }
+`;

--- a/src/taxes/queries.ts
+++ b/src/taxes/queries.ts
@@ -18,3 +18,27 @@ export const taxTypeList = gql`
     }
   }
 `;
+
+export const taxConfigurationList = gql`
+  query taxConfigurationList(
+    $before: String
+    $after: String
+    $first: Int
+    $last: Int
+    $filter: TaxConfigurationFilterInput
+  ) {
+    taxConfigurations(
+      before: $before
+      after: $after
+      first: $first
+      last: $last
+      filter: $filter
+    ) {
+      edges {
+        node {
+          ...TaxConfiguration
+        }
+      }
+    }
+  }
+`;

--- a/src/taxes/queries.ts
+++ b/src/taxes/queries.ts
@@ -50,3 +50,29 @@ export const taxCountriesList = gql`
     }
   }
 `;
+
+export const taxClassesList = gql`
+  query TaxClassesList(
+    $before: String
+    $after: String
+    $first: Int
+    $last: Int
+    $filter: TaxClassFilterInput
+    $sortBy: TaxClassSortingInput
+  ) {
+    taxClasses(
+      before: $before
+      after: $after
+      first: $first
+      last: $last
+      filter: $filter
+      sortBy: $sortBy
+    ) {
+      edges {
+        node {
+          ...TaxClass
+        }
+      }
+    }
+  }
+`;

--- a/src/taxes/queries.ts
+++ b/src/taxes/queries.ts
@@ -19,8 +19,8 @@ export const taxTypeList = gql`
   }
 `;
 
-export const taxConfigurationList = gql`
-  query taxConfigurationList(
+export const taxConfigurationsList = gql`
+  query TaxConfigurationsList(
     $before: String
     $after: String
     $first: Int

--- a/src/taxes/urls.ts
+++ b/src/taxes/urls.ts
@@ -1,17 +1,23 @@
+import { Dialog } from "@saleor/types";
+import { stringifyQs } from "@saleor/utils/urls";
 import urlJoin from "url-join";
 
-export const taxSection = "/taxes/";
-export const taxTabSectionUrl = (tab: string) => urlJoin(taxSection, tab);
+export type TaxTab = "channels" | "countries" | "tax-classes";
 
-export const channelsListUrl = (id?: string) =>
-  id ? urlJoin(taxTabSectionUrl("channels"), id) : taxTabSectionUrl("channels");
+export const taxSection = "/taxes/";
+export const taxTabPath = (tab: TaxTab) => urlJoin(taxSection, tab);
+
+export type TaxesUrlDialog = "add-country";
+export type TaxesUrlQueryParams = Dialog<TaxesUrlDialog>;
+
+export const channelsListPath = (id?: string) =>
+  id ? urlJoin(taxTabPath("channels"), id) : taxTabPath("channels");
+
+export const channelsListUrl = (id?: string, params?: TaxesUrlQueryParams) =>
+  channelsListPath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 
 export const countriesListUrl = (id?: string) =>
-  id
-    ? urlJoin(taxTabSectionUrl("countries"), id)
-    : taxTabSectionUrl("countries");
+  id ? urlJoin(taxTabPath("countries"), id) : taxTabPath("countries");
 
 export const taxClassesListUrl = (id?: string) =>
-  id
-    ? urlJoin(taxTabSectionUrl("tax-classes"), id)
-    : taxTabSectionUrl("tax-classes");
+  id ? urlJoin(taxTabPath("tax-classes"), id) : taxTabPath("tax-classes");

--- a/src/taxes/urls.ts
+++ b/src/taxes/urls.ts
@@ -2,6 +2,8 @@ import { Dialog } from "@saleor/types";
 import { stringifyQs } from "@saleor/utils/urls";
 import urlJoin from "url-join";
 
+import { encodeURIComponentOptional } from "./utils/utils";
+
 export type TaxTab = "channels" | "countries" | "tax-classes";
 
 export const taxSection = "/taxes/";
@@ -14,7 +16,7 @@ export const channelsListPath = (id?: string) =>
   id ? urlJoin(taxTabPath("channels"), id) : taxTabPath("channels");
 
 export const channelsListUrl = (id?: string, params?: TaxesUrlQueryParams) =>
-  channelsListPath(encodeURIComponent(id)) + "?" + stringifyQs(params);
+  channelsListPath(encodeURIComponentOptional(id)) + "?" + stringifyQs(params);
 
 export const countriesListUrl = (id?: string) =>
   id ? urlJoin(taxTabPath("countries"), id) : taxTabPath("countries");

--- a/src/taxes/urls.ts
+++ b/src/taxes/urls.ts
@@ -12,11 +12,16 @@ export const taxTabPath = (tab: TaxTab) => urlJoin(taxSection, tab);
 export type TaxesUrlDialog = "add-country";
 export type TaxesUrlQueryParams = Dialog<TaxesUrlDialog>;
 
-export const channelsListPath = (id?: string) =>
+export const taxConfigurationListPath = (id?: string) =>
   id ? urlJoin(taxTabPath("channels"), id) : taxTabPath("channels");
 
-export const channelsListUrl = (id?: string, params?: TaxesUrlQueryParams) =>
-  channelsListPath(encodeURIComponentOptional(id)) + "?" + stringifyQs(params);
+export const taxConfigurationListUrl = (
+  id?: string,
+  params?: TaxesUrlQueryParams
+) =>
+  taxConfigurationListPath(encodeURIComponentOptional(id)) +
+  "?" +
+  stringifyQs(params);
 
 export const countriesListUrl = (id?: string) =>
   id ? urlJoin(taxTabPath("countries"), id) : taxTabPath("countries");

--- a/src/taxes/utils/utils.ts
+++ b/src/taxes/utils/utils.ts
@@ -12,3 +12,8 @@ export const getDefaultTaxRateInCountry = (
     ?.find(taxClass => taxClass.isDefault)
     .countries.find(country => country.country.code === selectedCountry.code)
     .rate;
+
+export const encodeURIComponentOptional = (
+  uriComponent: string | number | boolean | undefined
+): string | undefined =>
+  uriComponent ? encodeURIComponent(uriComponent) : undefined;

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -3,11 +3,15 @@ import {
   useTaxConfigurationUpdateMutation
 } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
+import useNotifier from "@saleor/hooks/useNotifier";
 import useShop from "@saleor/hooks/useShop";
+import { commonMessages } from "@saleor/intl";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
+import { useIntl } from "react-intl";
 
+import { taxesMessages } from "../messages";
 import TaxChannelsPage from "../pages/TaxChannelsPage";
 import {
   channelsListUrl,
@@ -25,6 +29,8 @@ interface ChannelsListProps {
 
 export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   const navigate = useNavigator();
+  const notify = useNotifier();
+  const intl = useIntl();
 
   const handleTabChange = (tab: TaxTab) => {
     navigate(taxTabPath(tab));
@@ -33,7 +39,22 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   const [
     taxConfigurationUpdateMutation,
     { status: mutationStatus, loading: mutationInProgress }
-  ] = useTaxConfigurationUpdateMutation();
+  ] = useTaxConfigurationUpdateMutation({
+    onCompleted: data => {
+      const errors = data?.taxConfigurationUpdate?.errors;
+      if (errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+      } else {
+        notify({
+          status: "error",
+          text: intl.formatMessage(commonMessages.defaultErrorTitle)
+        });
+      }
+    }
+  });
 
   const shop = useShop();
 

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -1,4 +1,7 @@
-import { useTaxConfigurationsListQuery } from "@saleor/graphql";
+import {
+  useTaxConfigurationsListQuery,
+  useTaxConfigurationUpdateMutation
+} from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useShop from "@saleor/hooks/useShop";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
@@ -26,6 +29,9 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   const handleTabChange = (tab: TaxTab) => {
     navigate(taxTabPath(tab));
   };
+
+  const [taxConfigurationUpdateMutation] = useTaxConfigurationUpdateMutation();
+
   const shop = useShop();
 
   const [openDialog, closeDialog] = createDialogActionHandlers<
@@ -57,6 +63,14 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
       isDialogOpen={params?.action === "add-country"}
       openDialog={openDialog}
       closeDialog={closeDialog}
+      onSubmit={input =>
+        taxConfigurationUpdateMutation({
+          variables: {
+            id,
+            input
+          }
+        })
+      }
     />
   );
 };

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -1,24 +1,37 @@
 import { useTaxConfigurationsListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useShop from "@saleor/hooks/useShop";
+import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
 import TaxChannelsPage from "../pages/TaxChannelsPage";
-import { channelsListUrl, taxTabSectionUrl } from "../urls";
+import {
+  channelsListUrl,
+  TaxesUrlDialog,
+  TaxesUrlQueryParams,
+  TaxTab,
+  taxTabPath
+} from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
 
 interface ChannelsListProps {
   id: string | undefined;
+  params: TaxesUrlQueryParams | undefined;
 }
 
-export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
+export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   const navigate = useNavigator();
 
-  const handleTabChange = (tab: string) => {
-    navigate(taxTabSectionUrl(tab));
+  const handleTabChange = (tab: TaxTab) => {
+    navigate(taxTabPath(tab));
   };
   const shop = useShop();
+
+  const [openDialog, closeDialog] = createDialogActionHandlers<
+    TaxesUrlDialog,
+    TaxesUrlQueryParams
+  >(navigate, params => channelsListUrl(id, params), params);
 
   const { data } = useTaxConfigurationsListQuery({ variables: { first: 20 } });
 
@@ -41,7 +54,9 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
       selectedConfigurationId={id!}
       handleTabChange={handleTabChange}
       allCountries={shop?.countries}
-      dialogOpen={false}
+      isDialogOpen={params?.action === "add-country"}
+      openDialog={openDialog}
+      closeDialog={closeDialog}
     />
   );
 };

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -13,7 +13,7 @@ import { useIntl } from "react-intl";
 
 import TaxChannelsPage from "../pages/TaxChannelsPage";
 import {
-  channelsListUrl,
+  taxConfigurationListUrl,
   TaxesUrlDialog,
   TaxesUrlQueryParams,
   TaxTab,
@@ -55,7 +55,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   const [openDialog, closeDialog] = createDialogActionHandlers<
     TaxesUrlDialog,
     TaxesUrlQueryParams
-  >(navigate, params => channelsListUrl(id, params), params);
+  >(navigate, params => taxConfigurationListUrl(id, params), params);
 
   const { data } = useTaxConfigurationsListQuery({ variables: { first: 20 } });
 
@@ -64,7 +64,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
   useTaxUrlRedirect({
     id,
     data: taxConfigurations,
-    urlFunction: channelsListUrl,
+    urlFunction: taxConfigurationListUrl,
     navigate
   });
 

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -30,7 +30,10 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
     navigate(taxTabPath(tab));
   };
 
-  const [taxConfigurationUpdateMutation] = useTaxConfigurationUpdateMutation();
+  const [
+    taxConfigurationUpdateMutation,
+    { status: mutationStatus, loading: mutationInProgress }
+  ] = useTaxConfigurationUpdateMutation();
 
   const shop = useShop();
 
@@ -71,6 +74,8 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
           }
         })
       }
+      savebarState={mutationStatus}
+      disabled={mutationInProgress}
     />
   );
 };

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -1,7 +1,8 @@
+import { useTaxConfigurationListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
+import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
-import { taxConfigurations } from "../fixtures";
 import TaxChannelsPage from "../pages/TaxChannelsPage";
 import { channelsListUrl, taxTabSectionUrl } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
@@ -17,6 +18,10 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
     navigate(taxTabSectionUrl(tab));
   };
 
+  const { data } = useTaxConfigurationListQuery({ variables: { first: 20 } });
+
+  const taxConfigurations = mapEdgesToItems(data?.taxConfigurations);
+
   useTaxUrlRedirect({
     id,
     data: taxConfigurations,
@@ -30,7 +35,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
 
   return (
     <TaxChannelsPage
-      taxConfigurations={taxConfigurations} // TODO: change fixture to query data
+      taxConfigurations={taxConfigurations}
       selectedConfigurationId={id!}
       handleTabChange={handleTabChange}
     />

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -46,11 +46,6 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id, params }) => {
           status: "success",
           text: intl.formatMessage(commonMessages.savedChanges)
         });
-      } else {
-        notify({
-          status: "error",
-          text: intl.formatMessage(commonMessages.defaultErrorTitle)
-        });
       }
     }
   });

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -11,7 +11,6 @@ import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { taxesMessages } from "../messages";
 import TaxChannelsPage from "../pages/TaxChannelsPage";
 import {
   channelsListUrl,

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -1,4 +1,4 @@
-import { useTaxConfigurationListQuery } from "@saleor/graphql";
+import { useTaxConfigurationsListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
@@ -18,7 +18,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
     navigate(taxTabSectionUrl(tab));
   };
 
-  const { data } = useTaxConfigurationListQuery({ variables: { first: 20 } });
+  const { data } = useTaxConfigurationsListQuery({ variables: { first: 20 } });
 
   const taxConfigurations = mapEdgesToItems(data?.taxConfigurations);
 

--- a/src/taxes/views/ChannelsList.tsx
+++ b/src/taxes/views/ChannelsList.tsx
@@ -1,5 +1,6 @@
 import { useTaxConfigurationsListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
+import useShop from "@saleor/hooks/useShop";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
@@ -17,6 +18,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
   const handleTabChange = (tab: string) => {
     navigate(taxTabSectionUrl(tab));
   };
+  const shop = useShop();
 
   const { data } = useTaxConfigurationsListQuery({ variables: { first: 20 } });
 
@@ -38,6 +40,8 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ id }) => {
       taxConfigurations={taxConfigurations}
       selectedConfigurationId={id!}
       handleTabChange={handleTabChange}
+      allCountries={shop?.countries}
+      dialogOpen={false}
     />
   );
 };

--- a/src/taxes/views/CountriesList.tsx
+++ b/src/taxes/views/CountriesList.tsx
@@ -3,7 +3,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 
 import TaxCountriesPage from "../pages/TaxCountriesPage";
-import { countriesListUrl, taxTabPath } from "../urls";
+import { countriesListUrl, TaxTab, taxTabPath } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
 
 interface CountriesListProps {
@@ -13,7 +13,7 @@ interface CountriesListProps {
 export const CountriesList: React.FC<CountriesListProps> = ({ id }) => {
   const navigate = useNavigator();
 
-  const handleTabChange = (tab: string) => {
+  const handleTabChange = (tab: TaxTab) => {
     navigate(taxTabPath(tab));
   };
 

--- a/src/taxes/views/CountriesList.tsx
+++ b/src/taxes/views/CountriesList.tsx
@@ -3,7 +3,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 
 import TaxCountriesPage from "../pages/TaxCountriesPage";
-import { countriesListUrl, taxTabSectionUrl } from "../urls";
+import { countriesListUrl, taxTabPath } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
 
 interface CountriesListProps {
@@ -14,7 +14,7 @@ export const CountriesList: React.FC<CountriesListProps> = ({ id }) => {
   const navigate = useNavigator();
 
   const handleTabChange = (tab: string) => {
-    navigate(taxTabSectionUrl(tab));
+    navigate(taxTabPath(tab));
   };
 
   const { data } = useTaxCountriesListQuery();

--- a/src/taxes/views/CountriesList.tsx
+++ b/src/taxes/views/CountriesList.tsx
@@ -1,7 +1,7 @@
+import { useTaxCountriesListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 
-import { taxCountryConfigurations } from "../fixtures";
 import TaxCountriesPage from "../pages/TaxCountriesPage";
 import { countriesListUrl, taxTabSectionUrl } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
@@ -16,6 +16,9 @@ export const CountriesList: React.FC<CountriesListProps> = ({ id }) => {
   const handleTabChange = (tab: string) => {
     navigate(taxTabSectionUrl(tab));
   };
+
+  const { data } = useTaxCountriesListQuery();
+  const taxCountryConfigurations = data?.taxCountryConfigurations;
 
   useTaxUrlRedirect({
     id,

--- a/src/taxes/views/TaxClassesList.tsx
+++ b/src/taxes/views/TaxClassesList.tsx
@@ -4,7 +4,7 @@ import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
 import TaxClassesPage from "../pages/TaxClassesPage";
-import { taxClassesListUrl, taxTabPath } from "../urls";
+import { taxClassesListUrl, TaxTab, taxTabPath } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
 
 interface TaxClassesListProps {
@@ -14,7 +14,7 @@ interface TaxClassesListProps {
 export const TaxClassesList: React.FC<TaxClassesListProps> = ({ id }) => {
   const navigate = useNavigator();
 
-  const handleTabChange = (tab: string) => {
+  const handleTabChange = (tab: TaxTab) => {
     navigate(taxTabPath(tab));
   };
 

--- a/src/taxes/views/TaxClassesList.tsx
+++ b/src/taxes/views/TaxClassesList.tsx
@@ -4,7 +4,7 @@ import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
 import TaxClassesPage from "../pages/TaxClassesPage";
-import { taxClassesListUrl, taxTabSectionUrl } from "../urls";
+import { taxClassesListUrl, taxTabPath } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
 
 interface TaxClassesListProps {
@@ -15,7 +15,7 @@ export const TaxClassesList: React.FC<TaxClassesListProps> = ({ id }) => {
   const navigate = useNavigator();
 
   const handleTabChange = (tab: string) => {
-    navigate(taxTabSectionUrl(tab));
+    navigate(taxTabPath(tab));
   };
 
   const { data } = useTaxClassesListQuery({ variables: { first: 20 } });

--- a/src/taxes/views/TaxClassesList.tsx
+++ b/src/taxes/views/TaxClassesList.tsx
@@ -1,7 +1,8 @@
+import { useTaxClassesListQuery } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
+import { mapEdgesToItems } from "@saleor/utils/maps";
 import React from "react";
 
-import { taxClasses } from "../fixtures";
 import TaxClassesPage from "../pages/TaxClassesPage";
 import { taxClassesListUrl, taxTabSectionUrl } from "../urls";
 import { useTaxUrlRedirect } from "../utils/useTaxUrlRedirect";
@@ -16,6 +17,9 @@ export const TaxClassesList: React.FC<TaxClassesListProps> = ({ id }) => {
   const handleTabChange = (tab: string) => {
     navigate(taxTabSectionUrl(tab));
   };
+
+  const { data } = useTaxClassesListQuery({ variables: { first: 20 } });
+  const taxClasses = mapEdgesToItems(data?.taxClasses);
 
   useTaxUrlRedirect({
     id,


### PR DESCRIPTION
I want to merge this change because it:
- adds modal for adding country exceptions in channels view
- adds story for this modal
- adds list queries for all taxes views
- adds mutation for channels view
- adds form in channels view

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-6391-simple-taxes.api.saleor.rocks/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
