### PR TITLE
Expose marketplace in Dashboard builds

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -17,6 +17,7 @@ jobs:
       REGION: ${{ github.event.client_payload.region }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       IS_CLOUD_INSTANCE: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -17,7 +17,7 @@ jobs:
       REGION: ${{ github.event.client_payload.region }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
+      MARKETPLACE_URL: "https://apps.saleor.io/"
       IS_CLOUD_INSTANCE: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy-demo-staging.yaml
+++ b/.github/workflows/deploy-demo-staging.yaml
@@ -20,7 +20,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
+      MARKETPLACE_URL: "https://apps.saleor.io/"
       ENVIRONMENT: demo-staging
       DEMO_MODE: true
     steps:

--- a/.github/workflows/deploy-demo-staging.yaml
+++ b/.github/workflows/deploy-demo-staging.yaml
@@ -20,6 +20,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       ENVIRONMENT: demo-staging
       DEMO_MODE: true
     steps:

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -15,7 +15,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
+      MARKETPLACE_URL: "https://apps.saleor.io/"
       ENVIRONMENT: demo
       DEMO_MODE: true
     steps:

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -15,6 +15,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       ENVIRONMENT: demo
       DEMO_MODE: true
     steps:

--- a/.github/workflows/deploy-master-staging.yaml
+++ b/.github/workflows/deploy-master-staging.yaml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       API_URI: /graphql/
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       APP_MOUNT_URI: /dashboard/
       STATIC_URL: /dashboard/static/
       SENTRY_ORG: saleor
@@ -18,6 +17,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       ENVIRONMENT: saleor-master-staging
       IS_CLOUD_INSTANCE: true
     steps:

--- a/.github/workflows/deploy-master-staging.yaml
+++ b/.github/workflows/deploy-master-staging.yaml
@@ -17,7 +17,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
+      MARKETPLACE_URL: "https://apps.saleor.io/"
       ENVIRONMENT: saleor-master-staging
       IS_CLOUD_INSTANCE: true
     steps:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -22,6 +22,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
       VERSION: ${{ github.event.inputs.git_ref || github.ref_name }}
       IS_CLOUD_INSTANCE: true
     steps:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -22,7 +22,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      MARKETPLACE_URL: "https://marketplace-gray.vercel.app/"
+      MARKETPLACE_URL: "https://apps.saleor.io/"
       VERSION: ${{ github.event.inputs.git_ref || github.ref_name }}
       IS_CLOUD_INSTANCE: true
     steps:


### PR DESCRIPTION
I want to merge this change because we want to expose Marketplace (AKA App templates) in Saleor dashboar beyond staging build of main branch.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
