### PR TITLE
Fix app deep url redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5293,8 +5293,9 @@
       }
     },
     "@saleor/app-bridge": {
-      "version": "github:saleor/app-bridge#dcf80389fc03d3e93132275cf731389acfec8c75",
-      "from": "github:saleor/app-bridge#dcf8038",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@saleor/app-bridge/-/app-bridge-0.1.9.tgz",
+      "integrity": "sha512-p0+rXVAyOMrW6IfSrQg91UA330yO8xcCdSI73VcPpwFQb7es9i4Iqr/eFC4UsHTsQn/qZYp8Mnw+6TMnh4YjTQ==",
       "dev": true,
       "requires": {
         "uuid": "^8.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5293,9 +5293,8 @@
       }
     },
     "@saleor/app-bridge": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@saleor/app-bridge/-/app-bridge-0.1.7.tgz",
-      "integrity": "sha512-EXNNAZD1g79fCtoaNLqoTKg9GiB1Lj26E7iKz4PmUOQZyDeBEBxc6CLpUwNptb4Xw7+KULMHdtxJVkp/RTC2TQ==",
+      "version": "github:saleor/app-bridge#dcf80389fc03d3e93132275cf731389acfec8c75",
+      "from": "github:saleor/app-bridge#dcf8038",
       "dev": true,
       "requires": {
         "uuid": "^8.3.2"
@@ -10097,7 +10096,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -14970,7 +14969,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -15453,7 +15452,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -23602,7 +23601,7 @@
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
-      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
       "dev": true
     },
     "p-cancelable": {
@@ -24155,7 +24154,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@pollyjs/core": "^5.0.0",
     "@pollyjs/persister-fs": "^5.0.0",
     "@release-it/bumper": "^2.0.0",
-    "@saleor/app-bridge": "^0.1.7",
+    "@saleor/app-bridge": "github:saleor/app-bridge#dcf8038",
     "@sentry/webpack-plugin": "^1.14.0",
     "@storybook/addon-storyshots": "^5.2.8",
     "@storybook/react": "^5.1.9",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@pollyjs/core": "^5.0.0",
     "@pollyjs/persister-fs": "^5.0.0",
     "@release-it/bumper": "^2.0.0",
-    "@saleor/app-bridge": "github:saleor/app-bridge#dcf8038",
+    "@saleor/app-bridge": "^0.1.9",
     "@sentry/webpack-plugin": "^1.14.0",
     "@storybook/addon-storyshots": "^5.2.8",
     "@storybook/react": "^5.1.9",

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -1,7 +1,9 @@
+import { getAppDeepPathFromDashboardUrl } from "@saleor/apps/urls";
 import useShop from "@saleor/hooks/useShop";
 import { useTheme } from "@saleor/macaw-ui";
 import clsx from "clsx";
-import React from "react";
+import React, { useEffect } from "react";
+import { useLocation } from "react-router";
 import urlJoin from "url-join";
 
 import { useStyles } from "./styles";
@@ -31,7 +33,17 @@ export const AppFrame: React.FC<Props> = ({
   const { sendThemeToExtension } = useTheme();
   const classes = useStyles();
   const appOrigin = getOrigin(src);
-  const { postToExtension } = useAppActions(frameRef, appOrigin);
+  const { postToExtension } = useAppActions(frameRef, appOrigin, appId);
+  const location = useLocation();
+
+  useEffect(() => {
+    postToExtension({
+      type: "redirect",
+      payload: {
+        path: getAppDeepPathFromDashboardUrl(location.pathname, appId),
+      },
+    });
+  }, [location.pathname]);
 
   const handleLoad = () => {
     postToExtension({

--- a/src/apps/components/AppFrame/useAppActions.ts
+++ b/src/apps/components/AppFrame/useAppActions.ts
@@ -1,7 +1,9 @@
 import { Actions, DispatchResponseEvent, Events } from "@saleor/app-bridge";
+import { appPath } from "@saleor/apps/urls";
 import useNavigator from "@saleor/hooks/useNavigator";
 import React from "react";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router";
 
 import { useExternalApp } from "../ExternalAppContext";
 
@@ -19,8 +21,10 @@ const sendResponseStatus = (
 export const useAppActions = (
   frameEl: React.MutableRefObject<HTMLIFrameElement>,
   appOrigin: string,
+  appId: string,
 ) => {
   const navigate = useNavigator();
+  const location = useLocation();
   const { closeApp } = useExternalApp();
   const intl = useIntl();
 
@@ -32,10 +36,17 @@ export const useAppActions = (
         const { to, newContext, actionId } = action.payload;
 
         let success = true;
+        const appCompletePath = appPath(encodeURIComponent(appId));
+        const isAppDeepUrlChange =
+          to.startsWith(appCompletePath) &&
+          location.pathname.startsWith(appCompletePath);
 
         try {
           if (newContext) {
             window.open(to);
+          } else if (isAppDeepUrlChange) {
+            // Change only url without reloading if we are in the same app
+            window.history.pushState(null, "", to);
           } else if (to.startsWith("/")) {
             navigate(to);
             closeApp();

--- a/src/apps/components/AppFrame/useAppActions.ts
+++ b/src/apps/components/AppFrame/useAppActions.ts
@@ -18,6 +18,12 @@ const sendResponseStatus = (
   },
 });
 
+const isAppDeepUrlChange = (appId: string, from: string, to: string) => {
+  const appCompletePath = appPath(encodeURIComponent(appId));
+
+  return to.startsWith(appCompletePath) && from.startsWith(appCompletePath);
+};
+
 export const useAppActions = (
   frameEl: React.MutableRefObject<HTMLIFrameElement>,
   appOrigin: string,
@@ -36,15 +42,16 @@ export const useAppActions = (
         const { to, newContext, actionId } = action.payload;
 
         let success = true;
-        const appCompletePath = appPath(encodeURIComponent(appId));
-        const isAppDeepUrlChange =
-          to.startsWith(appCompletePath) &&
-          location.pathname.startsWith(appCompletePath);
+        const appDeepUrlChange = isAppDeepUrlChange(
+          appId,
+          location.pathname,
+          to,
+        );
 
         try {
           if (newContext) {
             window.open(to);
-          } else if (isAppDeepUrlChange) {
+          } else if (appDeepUrlChange) {
             // Change only url without reloading if we are in the same app
             window.history.pushState(null, "", to);
           } else if (to.startsWith("/")) {

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -69,6 +69,16 @@ export const appDeepUrl = (
   params?: AppDetailsUrlQueryParams,
 ) => appDeepPath(encodeURIComponent(id), subPath) + "?" + stringifyQs(params);
 
+export const getAppDeepPathFromDashboardUrl = (
+  dashboardUrl: string,
+  appId: string,
+) => {
+  const deepSubPath = dashboardUrl.replace(
+    appPath(encodeURIComponent(appId)),
+    "",
+  );
+  return deepSubPath || "/";
+};
 export const getAppCompleteUrlFromDashboardUrl = (
   dashboardUrl: string,
   appUrl?: string,


### PR DESCRIPTION
It adds:
- sending events about dashboard path changes to the app
- listener for the app path changes (in ifram) in order to update the dashboard path (without reloading the dashboard page)

It requires new release of app-bridge with https://github.com/saleor/app-bridge/pull/14

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
