### PR TITLE
Deprecate secret key in webhooks

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -7832,6 +7832,9 @@
     "context": "button",
     "string": "View products"
   },
+  "z9c6/C": {
+    "string": "Deprecated"
+  },
   "z9wQ/U": {
     "context": "no variant stock in warehouse",
     "string": "No Stock"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -324,6 +324,10 @@
     "context": "field is optional",
     "string": "(Optional)"
   },
+  "0kPdlb": {
+    "context": "deprecated secret key toolbar label",
+    "string": "Use RS256 signature instead."
+  },
   "0krqBj": {
     "context": "page header",
     "string": "Order no. {orderNumber} - Refund"
@@ -5709,6 +5713,10 @@
   "hnBvH7": {
     "context": "copied to clipboard alert title",
     "string": "Copied to clipboard"
+  },
+  "hnRRUe": {
+    "context": "docs link label",
+    "string": "Learn more..."
   },
   "ho75Lr": {
     "context": "status label deactivated",

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -178,6 +178,10 @@ export const commonMessages = defineMessages({
     defaultMessage: "Can’t fulfill until payment is captured",
     description: "disabled option description",
   },
+  deprecated: {
+    id: "z9c6/C",
+    defaultMessage: "Deprecated",
+  },
 });
 
 export const errorMessages = defineMessages({

--- a/src/webhooks/components/WebhookDetailsPage/WebhookDetailsPage.tsx
+++ b/src/webhooks/components/WebhookDetailsPage/WebhookDetailsPage.tsx
@@ -64,7 +64,7 @@ const WebhookDetailsPage: React.FC<WebhookDetailsPageProps> = ({
   const initialForm: FormData = {
     syncEvents: webhook?.syncEvents?.map(event => event.eventType) || [],
     asyncEvents: webhook?.asyncEvents?.map(event => event.eventType) || [],
-    isActive: !!webhook?.isActive,
+    isActive: webhook?.isActive ?? true,
     name: webhook?.name || "",
     secretKey: webhook?.secretKey || "",
     targetUrl: webhook?.targetUrl || "",

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -92,26 +92,16 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
           InputProps={{
             endAdornment: (
               <div
-                onClick={e => {
-                  // e.preventDefault();
-                  e.stopPropagation();
-                }}
                 ref={anchor}
                 onMouseOver={() => setPopupOpen(true)}
                 onMouseLeave={() => setPopupOpen(false)}
               >
-                <div
-                  aria-controls="availability-menu"
-                  aria-haspopup="true"
-                  role="button"
-                >
-                  <Pill
-                    label={intl.formatMessage(commonMessages.deprecated)}
-                    color={"error"}
-                    outlined
-                    size="small"
-                  />
-                </div>
+                <Pill
+                  label={intl.formatMessage(commonMessages.deprecated)}
+                  color={"error"}
+                  outlined
+                  size="small"
+                />
                 <Popper
                   anchorEl={anchor.current}
                   open={isPopupOpen}

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -112,6 +112,8 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
                       <FormattedMessage {...messages.useSignature} />
                     </Typography>
                     <Link
+                      target="_blank"
+                      rel="noopener noreferrer"
                       href={
                         "https://docs.saleor.io/docs/3.x/developer/extending/apps/synchronous-webhooks#payload-signature"
                       }

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -114,9 +114,7 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
                     <Link
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={
-                        "https://docs.saleor.io/docs/3.x/developer/extending/apps/synchronous-webhooks#payload-signature"
-                      }
+                      href="https://docs.saleor.io/docs/3.x/developer/extending/apps/synchronous-webhooks#payload-signature"
                     >
                       <FormattedMessage {...messages.learnMore} />
                     </Link>

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -1,17 +1,25 @@
-import { Card, CardContent, TextField, Typography } from "@material-ui/core";
+import {
+  Card,
+  CardContent,
+  Popper,
+  TextField,
+  Typography,
+} from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
+import Link from "@saleor/components/Link";
 import { WebhookErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { Pill } from "@saleor/macaw-ui";
 import { getFormErrors } from "@saleor/utils/errors";
 import getWebhookErrorMessage from "@saleor/utils/errors/webhooks";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { WebhookFormData } from "../WebhooksDetailsPage/WebhooksDetailsPage";
 import { messages } from "./messages";
+import { useStyles } from "./styles";
 
 interface WebhookInfoProps {
   data: WebhookFormData;
@@ -27,8 +35,12 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
   onChange,
 }) => {
   const intl = useIntl();
+  const classes = useStyles();
 
   const formErrors = getFormErrors(["name", "targetUrl", "secretKey"], errors);
+
+  const [isPopupOpen, setPopupOpen] = React.useState(false);
+  const anchor = React.useRef<HTMLDivElement>(null);
 
   return (
     <Card>
@@ -79,11 +91,46 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
           onChange={onChange}
           InputProps={{
             endAdornment: (
-              <Pill
-                color="error"
-                label={intl.formatMessage(commonMessages.deprecated)}
-                size={"small"}
-              />
+              <div
+                onClick={e => {
+                  // e.preventDefault();
+                  e.stopPropagation();
+                }}
+                ref={anchor}
+                onMouseOver={() => setPopupOpen(true)}
+                onMouseLeave={() => setPopupOpen(false)}
+              >
+                <div
+                  aria-controls="availability-menu"
+                  aria-haspopup="true"
+                  role="button"
+                >
+                  <Pill
+                    label={intl.formatMessage(commonMessages.deprecated)}
+                    color={"error"}
+                    outlined
+                    size="small"
+                  />
+                </div>
+                <Popper
+                  anchorEl={anchor.current}
+                  open={isPopupOpen}
+                  placement={"top"}
+                >
+                  <Card elevation={8} className={classes.toolbar}>
+                    <Typography>
+                      <FormattedMessage {...messages.useSignature} />
+                    </Typography>
+                    <Link
+                      href={
+                        "https://docs.saleor.io/docs/3.x/developer/extending/apps/synchronous-webhooks#payload-signature"
+                      }
+                    >
+                      <FormattedMessage {...messages.learnMore} />
+                    </Link>
+                  </Card>
+                </Popper>
+              </div>
             ),
           }}
         />

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -4,6 +4,7 @@ import FormSpacer from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
 import { WebhookErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
+import { Pill } from "@saleor/macaw-ui";
 import { getFormErrors } from "@saleor/utils/errors";
 import getWebhookErrorMessage from "@saleor/utils/errors/webhooks";
 import React from "react";
@@ -76,6 +77,15 @@ const WebhookInfo: React.FC<WebhookInfoProps> = ({
           name="secretKey"
           value={data.secretKey}
           onChange={onChange}
+          InputProps={{
+            endAdornment: (
+              <Pill
+                color="error"
+                label={intl.formatMessage(commonMessages.deprecated)}
+                size={"small"}
+              />
+            ),
+          }}
         />
       </CardContent>
     </Card>

--- a/src/webhooks/components/WebhookInfo/messages.ts
+++ b/src/webhooks/components/WebhookInfo/messages.ts
@@ -32,4 +32,14 @@ export const messages = defineMessages({
       "secret key is used to create a hash signature with each payload. *optional field",
     description: "webhook input help text",
   },
+  useSignature: {
+    id: "0kPdlb",
+    defaultMessage: "Use RS256 signature instead.",
+    description: "deprecated secret key toolbar label",
+  },
+  learnMore: {
+    id: "hnRRUe",
+    defaultMessage: "Learn more...",
+    description: "docs link label",
+  },
 });

--- a/src/webhooks/components/WebhookInfo/styles.ts
+++ b/src/webhooks/components/WebhookInfo/styles.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    toolbar: {
+      padding: theme.spacing(2),
+      backgroundColor: theme.palette.saleor.fail.mid,
+      color: theme.palette.common.black,
+      marginBottom: theme.spacing(2),
+    },
+  }),
+  { name: "WebhookInfo" },
+);


### PR DESCRIPTION
I want to merge this change because it:
- adds "deprecated" status pill in webhook secret key input
- changes default status from inactive to active when creating a new webhook

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> main

### Screenshots

Before:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/41952692/175962332-444ad7b1-b8da-4801-92fe-1035321d06ba.png">

After:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/41952692/175978518-e54062f7-7023-4aa5-a9c4-feca8daf7450.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
