### PR TITLE
fix get env from version regex

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -158,8 +158,7 @@ jobs:
         env:
           version: ${{github.event.client_payload.version}}
         run: |
-              echo "::set-output name=formatted_version::$(echo $version | grep -Eo "\d\.\d" | sed s/\\.// | head -n 1 | { read formatted; echo "$formatted"; })"
-              echo "$formatted_version"
+              echo "::set-output name=formatted_version::$(echo $version | grep -ohE "[0-9]\.[0-9]" | sed s/\\.// )" 
               
       - name: Cypress run - automatically
         uses: cypress-io/github-action@v4


### PR DESCRIPTION
I want to merge this change because I want to automatically run cypress tests

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
