### PR TITLE
Use browser locale when possible

### DIFF
--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -125,7 +125,7 @@ export function getMatchingLocale(languages: readonly string[]): Locale {
   return undefined;
 }
 
-const defaultLocale = Locale.EN;
+const defaultLocale = (navigator.language as Locale) || Locale.EN;
 
 export interface LocaleContextType {
   locale: Locale;


### PR DESCRIPTION
Users should see dates formatted in the locale of their browser