### PR TITLE
Named months

### DIFF
--- a/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemContent.tsx
+++ b/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemContent.tsx
@@ -54,7 +54,7 @@ const ChannelContent: React.FC<ChannelContentProps> = ({
   const intl = useIntl();
   const classes = useStyles({});
 
-  const todayDate = localizeDate(new Date(dateNow).toISOString(), "YYYY-MM-DD");
+  const todayDate = localizeDate(new Date(dateNow).toISOString());
 
   const visibleMessage = (date: string) =>
     intl.formatMessage(
@@ -64,7 +64,7 @@ const ChannelContent: React.FC<ChannelContentProps> = ({
         description: "date",
       },
       {
-        date: localizeDate(date, "L"),
+        date: localizeDate(date),
       },
     );
   const formErrors = getFormErrors(

--- a/src/components/ChannelsAvailabilityCard/utils.ts
+++ b/src/components/ChannelsAvailabilityCard/utils.ts
@@ -29,7 +29,7 @@ export const getChannelsAvailabilityMessages = ({
                   description: "channel publication date",
                 },
                 {
-                  date: localizeDate(currVal.publicationDate, "L"),
+                  date: localizeDate(currVal.publicationDate),
                 },
               )
             : currVal.publicationDate
@@ -40,7 +40,7 @@ export const getChannelsAvailabilityMessages = ({
                   description: "channel publication date",
                 },
                 {
-                  date: localizeDate(currVal.publicationDate, "L"),
+                  date: localizeDate(currVal.publicationDate),
                 },
               )
             : currVal.isPublished
@@ -66,7 +66,7 @@ export const getChannelsAvailabilityMessages = ({
             description: "product available for purchase date",
           },
           {
-            date: localizeDate(currVal.availableForPurchase, "L"),
+            date: localizeDate(currVal.availableForPurchase),
           },
         ),
         hiddenSecondLabel: intl.formatMessage(
@@ -76,7 +76,7 @@ export const getChannelsAvailabilityMessages = ({
             description: "product publication date label",
           },
           {
-            date: localizeDate(currVal.publicationDate, "L"),
+            date: localizeDate(currVal.publicationDate),
           },
         ),
         setAvailabilityDateLabel: intl.formatMessage({

--- a/src/components/VisibilityCard/VisibilityCard.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.tsx
@@ -115,7 +115,7 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
         description: "date",
       },
       {
-        date: localizeDate(date, "L"),
+        date: localizeDate(date),
       },
     );
 

--- a/src/giftCards/GiftCardCreateDialog/GiftCardCreateExpirySelect/GiftCardCreateExpirySelect.tsx
+++ b/src/giftCards/GiftCardCreateDialog/GiftCardCreateExpirySelect/GiftCardCreateExpirySelect.tsx
@@ -125,7 +125,7 @@ const GiftCardCreateExpirySelect: React.FC<GiftCardCreateExpirySelectProps> = ({
                     currentDate,
                     expiryPeriodType,
                     expiryPeriodAmount,
-                  )?.format("L")}
+                  )?.format("ll")}
                 </Typography>
               </div>
             </div>

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdateInfoCard/GiftCardUpdateInfoCardContent.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdateInfoCard/GiftCardUpdateInfoCardContent.tsx
@@ -115,7 +115,7 @@ const GiftCardUpdateInfoCardContent: React.FC = () => {
   return (
     <>
       <Label text={intl.formatMessage(messages.creationLabel)} />
-      <Typography>{localizeDate(created, "DD MMMM YYYY")}</Typography>
+      <Typography>{localizeDate(created)}</Typography>
       <CardSpacer />
 
       <Label text={intl.formatMessage(messages.orderNumberLabel)} />

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -230,7 +230,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
                       description: "page",
                     },
                     {
-                      date: localizeDate(data.publicationDate, "L"),
+                      date: localizeDate(data.publicationDate),
                     },
                   ),
                   visibleLabel: intl.formatMessage({


### PR DESCRIPTION
Use named months to avoid ambiguous dates ```01/02/2022``` can mean Jan or Feb things depending on your locale.

Components affected:
[PageDetailsPage](https://github.com/saleor/saleor-dashboard/pull/2130/commits/936e6fc13e0da6caa2262e9d8ecd963d0f47a338#diff-c7265de1a1601b8ff8cced5bbd86d0680dd60af0ec534da2244f186afe70f52d)
[GiftCardUpdateInfoCardContent](https://github.com/saleor/saleor-dashboard/pull/2130/commits/936e6fc13e0da6caa2262e9d8ecd963d0f47a338#diff-4a9d4ca20b928118c13a63d37a4f7e1d6caf54aedbfca8fa566df3297d7fac7b)
[VisibilityCard](https://github.com/saleor/saleor-dashboard/pull/2130/commits/936e6fc13e0da6caa2262e9d8ecd963d0f47a338#diff-91ebf46aea7ab96e3222c4250eb1de5772963432573fc0b04de00ac0b475c8f5)
[ChannelsAvailabilityCard](https://github.com/saleor/saleor-dashboard/pull/2130/commits/936e6fc13e0da6caa2262e9d8ecd963d0f47a338#diff-311a6853801aaa30c801d35e03d94e1d828ededa80f864bc52c0b21284c13eba)
[ChannelAvailabilityItemContent](https://github.com/saleor/saleor-dashboard/pull/2130/commits/936e6fc13e0da6caa2262e9d8ecd963d0f47a338#diff-c244d967200edca631bab19da95d6861fd0d6d80ab1abd6fabed94354ce69af7)