### PR TITLE
Assigning warehouses by channel in product and variant pages

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -166,6 +166,10 @@
     "context": "dialog header",
     "string": "Add Tracking Code"
   },
+  "/C//FB": {
+    "context": "header, allocated product quantity",
+    "string": "Allocated"
+  },
   "/JENWS": {
     "string": "Reduced Tax Rates"
   },
@@ -2013,6 +2017,10 @@
   "ErNH3D": {
     "string": "Define where this attribute should be used in Saleor system"
   },
+  "ErvPaM": {
+    "context": "header",
+    "string": "Warehouse Name"
+  },
   "EsZH44": {
     "context": "VariantDetailsChannelsAvailabilityCard item subtitle hidden",
     "string": "Hidden"
@@ -2834,10 +2842,6 @@
   "KSp+8B": {
     "context": "product available for purchase date",
     "string": "will become available on {date}"
-  },
-  "KTAg0f": {
-    "context": "tabel column header",
-    "string": "Warehouse Name"
   },
   "KXkdMH": {
     "context": "order discount removed title",
@@ -3821,6 +3825,10 @@
   "SKFr04": {
     "string": "Attribute not found."
   },
+  "SM+yG0": {
+    "context": "input label",
+    "string": "SKU (Stock Keeping Unit)"
+  },
   "SMakqb": {
     "context": "customer contact section, header",
     "string": "Contact Information"
@@ -4457,6 +4465,10 @@
   "WyPitj": {
     "context": "gift card bulk create success dialog title",
     "string": "Bulk Issue Gift Cards"
+  },
+  "Wyl25+": {
+    "context": "product inventory, checkbox description",
+    "string": "Active inventory tracking will automatically calculate changes of stock"
   },
   "WzA5Ll": {
     "string": "Cannot remove user from last group"
@@ -5534,10 +5546,6 @@
   "g/BrOt": {
     "string": "Url has invalid format"
   },
-  "g/FRtd": {
-    "context": "table column header, allocated product quantity",
-    "string": "Allocated"
-  },
   "g1WQlC": {
     "context": "page title",
     "string": "Summary"
@@ -5595,10 +5603,6 @@
   "gZHmaV": {
     "context": "plugin filters error messages channels",
     "string": "No channels selected"
-  },
-  "ge/xFX": {
-    "context": "table column header",
-    "string": "Quantity"
   },
   "ghGLbJ": {
     "context": "OrderPayment click&collect shipping method",
@@ -5865,9 +5869,6 @@
   "j8PV7E": {
     "context": "attribute values",
     "string": "Values"
-  },
-  "jABdx1": {
-    "string": "Active inventory tracking will automatically calculate changes of stock"
   },
   "jBu2yj": {
     "context": "acre-inch unit",
@@ -7150,6 +7151,10 @@
     "context": "Header row stock label",
     "string": "Stock"
   },
+  "taS/08": {
+    "context": "variant stocks section subtitle",
+    "string": "Assign this variant to a channel in the product channel manager to define warehouses allocation"
+  },
   "taX/V3": {
     "context": "order total amount",
     "string": "Total"
@@ -7607,9 +7612,6 @@
   "xAHOGV": {
     "context": "dialog header",
     "string": "Assign Variant"
-  },
-  "xB7BTp": {
-    "string": "SKU (Stock Keeping Unit)"
   },
   "xHj9Qe": {
     "context": "gift card settings header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -224,6 +224,10 @@
   "/glQgs": {
     "string": "No channels found"
   },
+  "/iijFq": {
+    "context": "input label",
+    "string": "Global threshold"
+  },
   "/kWzY1": {
     "string": "Are you sure you want to delete this address from users address book?"
   },
@@ -596,9 +600,6 @@
   "2pw5dQ": {
     "context": "payment status",
     "string": "Fully paid"
-  },
-  "2qJc9y": {
-    "string": "CANCEL END DATE"
   },
   "2r4cTE": {
     "context": "button",
@@ -1122,9 +1123,6 @@
     "context": "attribute value deleted",
     "string": "Value deleted"
   },
-  "7Ii5ZQ": {
-    "string": "SETUP END DATE"
-  },
   "7JAAul": {
     "context": "product field",
     "string": "Export Product Weight"
@@ -1201,10 +1199,6 @@
   "7v8suW": {
     "context": "info text",
     "string": "This rate will apply to all orders"
-  },
-  "7wkGxW": {
-    "context": "app has been installed",
-    "string": "{unitsLeft} units left"
   },
   "7yKZvp": {
     "context": "section header",
@@ -1322,6 +1316,10 @@
   "9EMudJ": {
     "context": "option",
     "string": "Create single variant"
+  },
+  "9IWg/f": {
+    "context": "button",
+    "string": "SETUP END DATE"
   },
   "9OtpHt": {
     "string": "Order line deleted"
@@ -1697,10 +1695,6 @@
   "C9pcQx": {
     "context": "dialog content",
     "string": "{counter,plural,one{Are you sure you want to delete this shipping zone?} other{Are you sure you want to delete {displayQuantity} shipping zones?}}"
-  },
-  "CEavJt": {
-    "context": "section header",
-    "string": "Unlimited"
   },
   "CG+awx": {
     "context": "dialog content",
@@ -2420,6 +2414,10 @@
     "context": "number of variants",
     "string": "Variants ({quantity})"
   },
+  "HYC6cH": {
+    "context": "input description",
+    "string": "Threshold that cannot be exceeded even if per channel thresholds are still available"
+  },
   "HYHLsB": {
     "context": "product field",
     "string": "Export Variant ID"
@@ -2744,6 +2742,10 @@
     "context": "section header",
     "string": "Organize Product"
   },
+  "JkO0jp": {
+    "context": "input description",
+    "string": "{unitsLeft} units left"
+  },
   "JnzDrI": {
     "context": "discount type",
     "string": "Fixed Amount"
@@ -2774,10 +2776,6 @@
   "Jwuu4X": {
     "context": "select product informations to be exported",
     "string": "Information exported:"
-  },
-  "JyQEHU": {
-    "context": "tabel column header",
-    "string": "Channels"
   },
   "JyQoES": {
     "context": "delete attribute value",
@@ -3193,9 +3191,6 @@
   "NZtcLb": {
     "context": "gift card bulk create success dialog content",
     "string": "We have issued all of your requested gift cards. You can download the list of new gift cards using the button below."
-  },
-  "NcY4ph": {
-    "string": "Threshold that cannot be exceeded even if per channel thresholds are still available"
   },
   "Nfh9QM": {
     "context": "checkbox gift cards label description",
@@ -3690,9 +3685,6 @@
   "RH+aOF": {
     "context": "use attribute in filtering",
     "string": "Use in Filtering"
-  },
-  "RJ5QxE": {
-    "string": "Global threshold"
   },
   "RLBLPQ": {
     "context": "no warehouses info",
@@ -5394,9 +5386,6 @@
   "eWcvOc": {
     "context": "button",
     "string": "Choose file"
-  },
-  "ekXood": {
-    "string": "Unlimited"
   },
   "erC44f": {
     "context": "filters error messages dependencies missing",
@@ -7159,6 +7148,10 @@
     "context": "order total amount",
     "string": "Total"
   },
+  "tlGXkh": {
+    "context": "input description",
+    "string": "Unlimited"
+  },
   "toDL5R": {
     "context": "order status",
     "string": "Draft"
@@ -7348,6 +7341,10 @@
   },
   "v3WWK+": {
     "string": "Status is invalid"
+  },
+  "v9ILn/": {
+    "context": "button",
+    "string": "CANCEL END DATE"
   },
   "vC8vyb": {
     "context": "enabled status option label",

--- a/src/products/components/ProductStocks/ProductStocks.tsx
+++ b/src/products/components/ProductStocks/ProductStocks.tsx
@@ -28,6 +28,7 @@ import PreviewPill from "@saleor/components/PreviewPill";
 import { ProductErrorFragment, WarehouseFragment } from "@saleor/graphql";
 import { FormChange, FormErrors } from "@saleor/hooks/useForm";
 import { FormsetAtomicData, FormsetChange } from "@saleor/hooks/useFormset";
+import { sectionNames } from "@saleor/intl";
 import { Button, DeleteIcon, IconButton, PlusIcon } from "@saleor/macaw-ui";
 import { renderCollection } from "@saleor/misc";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -346,12 +347,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
       {data.isPreorder && (
         <CardContent>
           <Typography variant="caption" className={classes.caption}>
-            {intl.formatMessage({
-              id: "REVk27",
-              defaultMessage:
-                "Set up an end date of preorder. When end date will be reached product will be automatically taken from preorder to standard selling",
-              description: "info text",
-            })}
+            <FormattedMessage {...messages.preorderEndDateSetup} />
           </Typography>
 
           {data.hasPreorderEndDate && (
@@ -388,22 +384,11 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
             }
           >
             {data.hasPreorderEndDate
-              ? intl.formatMessage({
-                  id: "2qJc9y",
-                  defaultMessage: "CANCEL END DATE",
-                })
-              : intl.formatMessage({
-                  id: "7Ii5ZQ",
-                  defaultMessage: "SETUP END DATE",
-                })}
+              ? intl.formatMessage(messages.endDateCancel)
+              : intl.formatMessage(messages.endDateSetup)}
           </Button>
           <Typography variant="caption" className={classes.preorderLimitInfo}>
-            {intl.formatMessage({
-              id: "Gz+4CI",
-              defaultMessage:
-                "Preordered products will be available in all warehouses. You can set a threshold for sold quantity. Leaving input blank will be interpreted as no limit to sale. Sold items will be allocated at the warehouse assigned to chosen shipping zone.",
-              description: "info text",
-            })}
+            <FormattedMessage {...messages.preorderProductsAvailability} />
           </Typography>
           <div className={classes.thresholdRow}>
             <TextField
@@ -412,15 +397,10 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
               }}
               disabled={disabled}
               fullWidth
-              helperText={intl.formatMessage({
-                id: "NcY4ph",
-                defaultMessage:
-                  "Threshold that cannot be exceeded even if per channel thresholds are still available",
-              })}
-              label={intl.formatMessage({
-                id: "RJ5QxE",
-                defaultMessage: "Global threshold",
-              })}
+              helperText={intl.formatMessage(
+                messages.preorderTresholdDescription,
+              )}
+              label={intl.formatMessage(messages.preorderTresholdLabel)}
               name="globalThreshold"
               onChange={onThresholdChange}
               value={data.globalThreshold ?? ""}
@@ -432,19 +412,10 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
                 className={classes.preorderItemsLeftCount}
               >
                 {data.globalThreshold
-                  ? intl.formatMessage(
-                      {
-                        id: "7wkGxW",
-                        defaultMessage: "{unitsLeft} units left",
-                        description: "app has been installed",
-                      },
-                      { unitsLeft },
-                    )
-                  : intl.formatMessage({
-                      id: "CEavJt",
-                      defaultMessage: "Unlimited",
-                      description: "section header",
-                    })}
+                  ? intl.formatMessage(messages.preorderTresholdUnitsLeft, {
+                      unitsLeft,
+                    })
+                  : intl.formatMessage(messages.preorderTresholdUnlimited)}
               </Typography>
             )}
           </div>
@@ -461,25 +432,13 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
           <TableHead>
             <TableRow>
               <TableCell className={classes.colName}>
-                <FormattedMessage
-                  id="JyQEHU"
-                  defaultMessage="Channels"
-                  description="tabel column header"
-                />
+                <FormattedMessage {...sectionNames.channels} />
               </TableCell>
               <TableCell className={classes.colSoldUnits}>
-                <FormattedMessage
-                  id="HcQEUk"
-                  defaultMessage="Sold units"
-                  description="table column header, sold units preorder quantity"
-                />
+                <FormattedMessage {...messages.soldUnits} />
               </TableCell>
               <TableCell className={classes.colThreshold}>
-                <FormattedMessage
-                  id="MNZY28"
-                  defaultMessage="Channel threshold"
-                  description="table column header"
-                />
+                <FormattedMessage {...messages.channelTreshold} />
               </TableCell>
             </TableRow>
           </TableHead>
@@ -507,10 +466,9 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
                         min: 0,
                         type: "number",
                       }}
-                      placeholder={intl.formatMessage({
-                        id: "ekXood",
-                        defaultMessage: "Unlimited",
-                      })}
+                      placeholder={intl.formatMessage(
+                        messages.preorderTresholdUnlimited,
+                      )}
                       onChange={e => {
                         onVariantChannelListingChange(listing.id, {
                           costPrice: listing.costPrice,

--- a/src/products/components/ProductStocks/ProductStocks.tsx
+++ b/src/products/components/ProductStocks/ProductStocks.tsx
@@ -28,14 +28,7 @@ import PreviewPill from "@saleor/components/PreviewPill";
 import { ProductErrorFragment, WarehouseFragment } from "@saleor/graphql";
 import { FormChange, FormErrors } from "@saleor/hooks/useForm";
 import { FormsetAtomicData, FormsetChange } from "@saleor/hooks/useFormset";
-import {
-  Button,
-  DeleteIcon,
-  IconButton,
-  ICONBUTTON_SIZE,
-  makeStyles,
-  PlusIcon,
-} from "@saleor/macaw-ui";
+import { Button, DeleteIcon, IconButton, PlusIcon } from "@saleor/macaw-ui";
 import { renderCollection } from "@saleor/misc";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
 import createNonNegativeValueChangeHandler from "@saleor/utils/handlers/nonNegativeValueChangeHandler";
@@ -46,6 +39,8 @@ import { ProductCreateData } from "../ProductCreatePage";
 import { ProductUpdateSubmitData } from "../ProductUpdatePage/form";
 import { ProductVariantCreateData } from "../ProductVariantCreatePage/form";
 import { ProductVariantUpdateData } from "../ProductVariantPage/form";
+import { messages } from "./messages";
+import { useStyles } from "./styles";
 
 export interface ProductStockFormsetData {
   quantityAllocated: number;
@@ -90,98 +85,6 @@ export interface ProductStocksProps {
   onWarehouseConfigure: () => void;
 }
 
-const useStyles = makeStyles(
-  theme => ({
-    colAction: {
-      padding: 0,
-      width: `calc(${ICONBUTTON_SIZE}px + ${theme.spacing(1)})`,
-    },
-    colName: {},
-    colQuantity: {
-      textAlign: "right",
-      width: 150,
-    },
-    colSoldUnits: {
-      textAlign: "right",
-      width: 150,
-    },
-    colThreshold: {
-      textAlign: "right",
-      width: 180,
-    },
-    editWarehouses: {
-      marginRight: theme.spacing(-1),
-    },
-    input: {
-      padding: theme.spacing(1.5),
-      textAlign: "right",
-    },
-    menuItem: {
-      "&:not(:last-of-type)": {
-        marginBottom: theme.spacing(2),
-      },
-    },
-    noWarehouseInfo: {
-      marginTop: theme.spacing(),
-    },
-    paper: {
-      padding: theme.spacing(2),
-    },
-    popper: {
-      marginTop: theme.spacing(1),
-      zIndex: 2,
-    },
-    quantityContainer: {
-      paddingTop: theme.spacing(),
-    },
-    quantityHeader: {
-      alignItems: "center",
-      display: "flex",
-      justifyContent: "space-between",
-    },
-    skuInputContainer: {
-      display: "grid",
-      gridColumnGap: theme.spacing(3),
-      gridTemplateColumns: "repeat(2, 1fr)",
-    },
-    dateTimeInputs: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2),
-    },
-    preorderInfo: {
-      marginBottom: theme.spacing(2),
-      marginTop: theme.spacing(2),
-      display: "block",
-    },
-    caption: {
-      fontSize: 14,
-    },
-    thresholdRow: {
-      display: "grid",
-      gridColumnGap: theme.spacing(3),
-      gridTemplateColumns: "3fr 1fr",
-      marginTop: theme.spacing(1),
-    },
-    thresholdInput: {
-      maxWidth: 400,
-    },
-    preorderItemsLeftCount: {
-      fontSize: 14,
-      paddingTop: theme.spacing(2),
-      textAlign: "center",
-    },
-    preorderLimitInfo: {
-      marginTop: theme.spacing(3),
-    },
-    preview: {
-      marginLeft: theme.spacing(1),
-    },
-  }),
-  {
-    name: "ProductStocks",
-  },
-);
-
 const ProductStocks: React.FC<ProductStocksProps> = ({
   data,
   disabled,
@@ -200,7 +103,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
   onWarehouseStockDelete,
   onWarehouseConfigure,
 }) => {
-  const classes = useStyles({});
+  const classes = useStyles();
   const intl = useIntl();
   const anchor = React.useRef<HTMLDivElement>();
   const [isExpanded, setExpansionState] = React.useState(false);
@@ -218,13 +121,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
 
   return (
     <Card>
-      <CardTitle
-        title={intl.formatMessage({
-          id: "4qe6hO",
-          defaultMessage: "Inventory",
-          description: "product stock, section header",
-        })}
-      />
+      <CardTitle title={intl.formatMessage(messages.title)} />
       <CardContent>
         <div className={classes.skuInputContainer}>
           <TextField
@@ -232,10 +129,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
             error={!!formErrors.sku}
             fullWidth
             helperText={getProductErrorMessage(formErrors.sku, intl)}
-            label={intl.formatMessage({
-              id: "xB7BTp",
-              defaultMessage: "SKU (Stock Keeping Unit)",
-            })}
+            label={intl.formatMessage(messages.sku)}
             name="sku"
             onChange={onFormDataChange}
             value={data.sku}
@@ -252,11 +146,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
           disabled={disabled}
           label={
             <>
-              <FormattedMessage
-                id="eAFU/E"
-                defaultMessage="Variant currently in preorder"
-                description="product inventory, checkbox"
-              />
+              <FormattedMessage {...messages.variantInPreorder} />
               <PreviewPill className={classes.preview} />
             </>
           }
@@ -272,16 +162,9 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
               disabled={disabled}
               label={
                 <>
-                  <FormattedMessage
-                    id="TjGYna"
-                    defaultMessage="Track Inventory"
-                    description="product inventory, checkbox"
-                  />
+                  <FormattedMessage {...messages.trackInventory} />
                   <Typography variant="caption">
-                    <FormattedMessage
-                      id="jABdx1"
-                      defaultMessage="Active inventory tracking will automatically calculate changes of stock"
-                    />
+                    <FormattedMessage {...messages.trackInventoryDescription} />
                   </Typography>
                 </>
               }
@@ -295,14 +178,18 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
           <Typography>
             <div className={classes.quantityHeader}>
               <span>
-                <FormattedMessage
-                  id="bp/i0x"
-                  defaultMessage="Quantity"
-                  description="header"
-                />
+                <FormattedMessage {...messages.quantity} />
               </span>
             </div>
           </Typography>
+          {!productVariantChannelListings?.length && (
+            <>
+              <FormSpacer />
+              <Typography variant="caption">
+                <FormattedMessage {...messages.noChannelWarehousesAllocation} />
+              </Typography>
+            </>
+          )}
 
           {!warehouses?.length && (
             <Typography
@@ -312,9 +199,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
               {hasVariants ? (
                 <>
                   <FormattedMessage
-                    id="D8nsBc"
-                    defaultMessage="There are no warehouses set up for your store. To add stock quantity to the variant please <a>configure a warehouse</a>"
-                    description="no warehouses info"
+                    {...messages.configureWarehouseForVariant}
                     values={{
                       a: chunks => (
                         <Link onClick={onWarehouseConfigure}>{chunks}</Link>
@@ -325,9 +210,7 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
               ) : (
                 <>
                   <FormattedMessage
-                    id="RLBLPQ"
-                    defaultMessage="There are no warehouses set up for your store. To add stock quantity to the product please <a>configure a warehouse</a>"
-                    description="no warehouses info"
+                    {...messages.configureWarehouseForProduct}
                     values={{
                       a: chunks => (
                         <Link onClick={onWarehouseConfigure}>{chunks}</Link>
@@ -340,140 +223,126 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
           )}
         </CardContent>
       )}
-      {warehouses?.length > 0 && !data.isPreorder && (
-        <Table>
-          <colgroup>
-            <col className={classes.colName} />
-            <col className={classes.colQuantity} />
-            <col className={classes.colQuantity} />
-          </colgroup>
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.colName}>
-                <FormattedMessage
-                  id="KTAg0f"
-                  defaultMessage="Warehouse Name"
-                  description="tabel column header"
-                />
-              </TableCell>
-              <TableCell className={classes.colQuantity}>
-                <FormattedMessage
-                  id="g/FRtd"
-                  defaultMessage="Allocated"
-                  description="table column header, allocated product quantity"
-                />
-              </TableCell>
-              <TableCell className={classes.colQuantity}>
-                <FormattedMessage
-                  id="ge/xFX"
-                  defaultMessage="Quantity"
-                  description="table column header"
-                />
-              </TableCell>
-              <TableCell className={classes.colAction} />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {renderCollection(stocks, stock => {
-              const handleQuantityChange = createNonNegativeValueChangeHandler(
-                event => onChange(stock.id, event.target.value),
-              );
+      {productVariantChannelListings?.length > 0 &&
+        warehouses?.length > 0 &&
+        !data.isPreorder && (
+          <Table>
+            <colgroup>
+              <col className={classes.colName} />
+              <col className={classes.colQuantity} />
+              <col className={classes.colQuantity} />
+            </colgroup>
+            <TableHead>
+              <TableRow>
+                <TableCell className={classes.colName}>
+                  <FormattedMessage {...messages.warehouseName} />
+                </TableCell>
+                <TableCell className={classes.colQuantity}>
+                  <FormattedMessage {...messages.allocated} />
+                </TableCell>
+                <TableCell className={classes.colQuantity}>
+                  <FormattedMessage {...messages.quantity} />
+                </TableCell>
+                <TableCell className={classes.colAction} />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {renderCollection(stocks, stock => {
+                const handleQuantityChange = createNonNegativeValueChangeHandler(
+                  event => onChange(stock.id, event.target.value),
+                );
 
-              return (
-                <TableRow key={stock.id}>
-                  <TableCell className={classes.colName}>
-                    {stock.label}
-                  </TableCell>
-                  <TableCell className={classes.colQuantity}>
-                    {stock.data?.quantityAllocated || 0}
-                  </TableCell>
-                  <TableCell className={classes.colQuantity}>
-                    <TextField
-                      data-test-id="stock-input"
-                      disabled={disabled}
-                      fullWidth
-                      inputProps={{
-                        className: classes.input,
-                        min: 0,
-                        type: "number",
-                      }}
-                      onChange={handleQuantityChange}
-                      value={stock.value}
-                    />
+                return (
+                  <TableRow key={stock.id}>
+                    <TableCell className={classes.colName}>
+                      {stock.label}
+                    </TableCell>
+                    <TableCell className={classes.colQuantity}>
+                      {stock.data?.quantityAllocated || 0}
+                    </TableCell>
+                    <TableCell className={classes.colQuantity}>
+                      <TextField
+                        data-test-id="stock-input"
+                        disabled={disabled}
+                        fullWidth
+                        inputProps={{
+                          className: classes.input,
+                          min: 0,
+                          type: "number",
+                        }}
+                        onChange={handleQuantityChange}
+                        value={stock.value}
+                      />
+                    </TableCell>
+                    <TableCell className={classes.colAction}>
+                      <IconButton
+                        variant="secondary"
+                        color="primary"
+                        onClick={() => onWarehouseStockDelete(stock.id)}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {warehousesToAssign.length > 0 && (
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <Typography variant="body2">
+                      <FormattedMessage {...messages.assignWarehouse} />
+                    </Typography>
                   </TableCell>
                   <TableCell className={classes.colAction}>
-                    <IconButton
-                      variant="secondary"
-                      color="primary"
-                      onClick={() => onWarehouseStockDelete(stock.id)}
+                    <ClickAwayListener
+                      onClickAway={() => setExpansionState(false)}
                     >
-                      <DeleteIcon />
-                    </IconButton>
+                      <div ref={anchor}>
+                        <IconButton
+                          data-test-id="add-warehouse"
+                          color="primary"
+                          variant="secondary"
+                          onClick={() => setExpansionState(!isExpanded)}
+                        >
+                          <PlusIcon />
+                        </IconButton>
+                        <Popper
+                          className={classes.popper}
+                          open={isExpanded}
+                          anchorEl={anchor.current}
+                          transition
+                          placement="top-end"
+                        >
+                          {({ TransitionProps }) => (
+                            <Grow
+                              {...TransitionProps}
+                              style={{
+                                transformOrigin: "right top",
+                              }}
+                            >
+                              <Paper className={classes.paper} elevation={8}>
+                                {warehousesToAssign.map(warehouse => (
+                                  <MenuItem
+                                    className={classes.menuItem}
+                                    onClick={() =>
+                                      onWarehouseStockAdd(warehouse.id)
+                                    }
+                                  >
+                                    {warehouse.name}
+                                  </MenuItem>
+                                ))}
+                              </Paper>
+                            </Grow>
+                          )}
+                        </Popper>
+                      </div>
+                    </ClickAwayListener>
                   </TableCell>
                 </TableRow>
-              );
-            })}
-            {warehousesToAssign.length > 0 && (
-              <TableRow>
-                <TableCell colSpan={3}>
-                  <Typography variant="body2">
-                    <FormattedMessage
-                      id="cBHRxx"
-                      defaultMessage="Assign Warehouse"
-                      description="button"
-                    />
-                  </Typography>
-                </TableCell>
-                <TableCell className={classes.colAction}>
-                  <ClickAwayListener
-                    onClickAway={() => setExpansionState(false)}
-                  >
-                    <div ref={anchor}>
-                      <IconButton
-                        data-test-id="add-warehouse"
-                        color="primary"
-                        variant="secondary"
-                        onClick={() => setExpansionState(!isExpanded)}
-                      >
-                        <PlusIcon />
-                      </IconButton>
-                      <Popper
-                        className={classes.popper}
-                        open={isExpanded}
-                        anchorEl={anchor.current}
-                        transition
-                        placement="top-end"
-                      >
-                        {({ TransitionProps }) => (
-                          <Grow
-                            {...TransitionProps}
-                            style={{
-                              transformOrigin: "right top",
-                            }}
-                          >
-                            <Paper className={classes.paper} elevation={8}>
-                              {warehousesToAssign.map(warehouse => (
-                                <MenuItem
-                                  className={classes.menuItem}
-                                  onClick={() =>
-                                    onWarehouseStockAdd(warehouse.id)
-                                  }
-                                >
-                                  {warehouse.name}
-                                </MenuItem>
-                              ))}
-                            </Paper>
-                          </Grow>
-                        )}
-                      </Popper>
-                    </div>
-                  </ClickAwayListener>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      )}
+              )}
+            </TableBody>
+          </Table>
+        )}
       {data.isPreorder && (
         <CardContent>
           <Typography variant="caption" className={classes.caption}>

--- a/src/products/components/ProductStocks/messages.ts
+++ b/src/products/components/ProductStocks/messages.ts
@@ -1,0 +1,68 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  title: {
+    id: "4qe6hO",
+    defaultMessage: "Inventory",
+    description: "product stock, section header",
+  },
+  sku: {
+    id: "SM+yG0",
+    defaultMessage: "SKU (Stock Keeping Unit)",
+    description: "input label",
+  },
+  variantInPreorder: {
+    id: "eAFU/E",
+    defaultMessage: "Variant currently in preorder",
+    description: "product inventory, checkbox",
+  },
+  trackInventory: {
+    id: "TjGYna",
+    defaultMessage: "Track Inventory",
+    description: "product inventory, checkbox",
+  },
+  trackInventoryDescription: {
+    id: "Wyl25+",
+    defaultMessage:
+      "Active inventory tracking will automatically calculate changes of stock",
+    description: "product inventory, checkbox description",
+  },
+  quantity: {
+    id: "bp/i0x",
+    defaultMessage: "Quantity",
+    description: "header",
+  },
+  warehouseName: {
+    id: "ErvPaM",
+    defaultMessage: "Warehouse Name",
+    description: "header",
+  },
+  allocated: {
+    id: "/C//FB",
+    defaultMessage: "Allocated",
+    description: "header, allocated product quantity",
+  },
+  noChannelWarehousesAllocation: {
+    id: "taS/08",
+    defaultMessage:
+      "Assign this variant to a channel in the product channel manager to define warehouses allocation",
+    description: "variant stocks section subtitle",
+  },
+  configureWarehouseForVariant: {
+    id: "D8nsBc",
+    defaultMessage:
+      "There are no warehouses set up for your store. To add stock quantity to the variant please <a>configure a warehouse</a>",
+    description: "no warehouses info",
+  },
+  configureWarehouseForProduct: {
+    id: "RLBLPQ",
+    defaultMessage:
+      "There are no warehouses set up for your store. To add stock quantity to the product please <a>configure a warehouse</a>",
+    description: "no warehouses info",
+  },
+  assignWarehouse: {
+    id: "cBHRxx",
+    defaultMessage: "Assign Warehouse",
+    description: "button",
+  },
+});

--- a/src/products/components/ProductStocks/messages.ts
+++ b/src/products/components/ProductStocks/messages.ts
@@ -65,4 +65,57 @@ export const messages = defineMessages({
     defaultMessage: "Assign Warehouse",
     description: "button",
   },
+  preorderEndDateSetup: {
+    id: "REVk27",
+    defaultMessage:
+      "Set up an end date of preorder. When end date will be reached product will be automatically taken from preorder to standard selling",
+    description: "info text",
+  },
+  endDateCancel: {
+    id: "v9ILn/",
+    defaultMessage: "CANCEL END DATE",
+    description: "button",
+  },
+  endDateSetup: {
+    id: "9IWg/f",
+    defaultMessage: "SETUP END DATE",
+    description: "button",
+  },
+  preorderProductsAvailability: {
+    id: "Gz+4CI",
+    defaultMessage:
+      "Preordered products will be available in all warehouses. You can set a threshold for sold quantity. Leaving input blank will be interpreted as no limit to sale. Sold items will be allocated at the warehouse assigned to chosen shipping zone.",
+    description: "info text",
+  },
+  preorderTresholdLabel: {
+    id: "/iijFq",
+    defaultMessage: "Global threshold",
+    description: "input label",
+  },
+  preorderTresholdDescription: {
+    id: "HYC6cH",
+    defaultMessage:
+      "Threshold that cannot be exceeded even if per channel thresholds are still available",
+    description: "input description",
+  },
+  preorderTresholdUnitsLeft: {
+    id: "JkO0jp",
+    defaultMessage: "{unitsLeft} units left",
+    description: "input description",
+  },
+  preorderTresholdUnlimited: {
+    id: "tlGXkh",
+    defaultMessage: "Unlimited",
+    description: "input description",
+  },
+  soldUnits: {
+    id: "HcQEUk",
+    defaultMessage: "Sold units",
+    description: "table column header, sold units preorder quantity",
+  },
+  channelTreshold: {
+    id: "MNZY28",
+    defaultMessage: "Channel threshold",
+    description: "table column header",
+  },
 });

--- a/src/products/components/ProductStocks/styles.ts
+++ b/src/products/components/ProductStocks/styles.ts
@@ -1,0 +1,93 @@
+import { ICONBUTTON_SIZE, makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    colAction: {
+      padding: 0,
+      width: `calc(${ICONBUTTON_SIZE}px + ${theme.spacing(1)})`,
+    },
+    colName: {},
+    colQuantity: {
+      textAlign: "right",
+      width: 150,
+    },
+    colSoldUnits: {
+      textAlign: "right",
+      width: 150,
+    },
+    colThreshold: {
+      textAlign: "right",
+      width: 180,
+    },
+    editWarehouses: {
+      marginRight: theme.spacing(-1),
+    },
+    input: {
+      padding: theme.spacing(1.5),
+      textAlign: "right",
+    },
+    menuItem: {
+      "&:not(:last-of-type)": {
+        marginBottom: theme.spacing(2),
+      },
+    },
+    noWarehouseInfo: {
+      marginTop: theme.spacing(),
+    },
+    paper: {
+      padding: theme.spacing(2),
+    },
+    popper: {
+      marginTop: theme.spacing(1),
+      zIndex: 2,
+    },
+    quantityContainer: {
+      paddingTop: theme.spacing(),
+    },
+    quantityHeader: {
+      alignItems: "center",
+      display: "flex",
+      justifyContent: "space-between",
+    },
+    skuInputContainer: {
+      display: "grid",
+      gridColumnGap: theme.spacing(3),
+      gridTemplateColumns: "repeat(2, 1fr)",
+    },
+    dateTimeInputs: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+    },
+    preorderInfo: {
+      marginBottom: theme.spacing(2),
+      marginTop: theme.spacing(2),
+      display: "block",
+    },
+    caption: {
+      fontSize: 14,
+    },
+    thresholdRow: {
+      display: "grid",
+      gridColumnGap: theme.spacing(3),
+      gridTemplateColumns: "3fr 1fr",
+      marginTop: theme.spacing(1),
+    },
+    thresholdInput: {
+      maxWidth: 400,
+    },
+    preorderItemsLeftCount: {
+      fontSize: 14,
+      paddingTop: theme.spacing(2),
+      textAlign: "center",
+    },
+    preorderLimitInfo: {
+      marginTop: theme.spacing(3),
+    },
+    preview: {
+      marginLeft: theme.spacing(1),
+    },
+  }),
+  {
+    name: "ProductStocks",
+  },
+);

--- a/src/products/views/ProductCreate/ProductCreate.tsx
+++ b/src/products/views/ProductCreate/ProductCreate.tsx
@@ -112,12 +112,6 @@ export const ProductCreateView: React.FC<ProductCreateProps> = ({ params }) => {
     result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
-  const warehouses = useWarehouseListQuery({
-    displayLoader: true,
-    variables: {
-      first: 50,
-    },
-  });
   const [updateMetadata] = useUpdateMetadataMutation({});
   const [updatePrivateMetadata] = useUpdatePrivateMetadataMutation({});
   const taxTypes = useTaxTypeListQuery({});
@@ -159,6 +153,16 @@ export const ProductCreateView: React.FC<ProductCreateProps> = ({ params }) => {
       formId: PRODUCT_CREATE_FORM_ID,
     },
   );
+
+  const warehouses = useWarehouseListQuery({
+    displayLoader: true,
+    variables: {
+      first: 50,
+      filter: {
+        channels: currentChannels.map(channel => channel.id),
+      },
+    },
+  });
 
   const handleSuccess = (productId: string) => {
     notify({

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -156,12 +156,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
-  const warehouses = useWarehouseListQuery({
-    displayLoader: true,
-    variables: {
-      first: 50,
-    },
-  });
   const shop = useShop();
   const [updateMetadata] = useUpdateMetadataMutation({});
   const [updatePrivateMetadata] = useUpdatePrivateMetadataMutation({});
@@ -323,6 +317,16 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     },
     { formId: PRODUCT_UPDATE_FORM_ID },
   );
+
+  const warehouses = useWarehouseListQuery({
+    displayLoader: true,
+    variables: {
+      first: 50,
+      filter: {
+        channels: currentChannels.map(channel => channel.id),
+      },
+    },
+  });
 
   const [
     updateChannels,

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -82,13 +82,6 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
     setErrors([]);
   }, [variantId]);
 
-  const warehouses = useWarehouseListQuery({
-    displayLoader: true,
-    variables: {
-      first: 50,
-    },
-  });
-
   const { data, loading } = useProductVariantDetailsQuery({
     displayLoader: true,
     variables: {
@@ -195,6 +188,16 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
 
   const variant = data?.productVariant;
   const channels = createVariantChannels(variant);
+
+  const warehouses = useWarehouseListQuery({
+    displayLoader: true,
+    variables: {
+      first: 50,
+      filter: {
+        channels: channels.map(channel => channel.id),
+      },
+    },
+  });
 
   const [
     deactivatePreorder,


### PR DESCRIPTION
It adds assigning warehouses filtered by channel in:
- product create page
- product update page
- variant update page
- variant create page (disabled as none channel selected)

Still every warehouse can be assigned, no matter what channel is used, in:
- variant creator

Backend PR: https://github.com/saleor/saleor/pull/10043/

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> `SALEOR-7213-improve-click-and-collect-and-stock-allocation`

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="653" alt="Screenshot 2022-07-04 at 13 45 31" src="https://user-images.githubusercontent.com/9825562/177148376-93df59a0-bccf-43ba-aa2f-b76d79eeb51f.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-7213-improve-click-and-collect-and-stock-allocation.api.saleor.rocks/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
