### PR TITLE
Update simple product availability card

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1783,6 +1783,10 @@
   "ClFzoD": {
     "string": "Selected values will be used to create variants for the configurable product."
   },
+  "ClKKID": {
+    "context": "channel publication status",
+    "string": "Not published"
+  },
   "Co2U4u": {
     "string": "No plugins found"
   },
@@ -1853,10 +1857,6 @@
   },
   "DILs4b": {
     "string": "Unsupported media provider or incorrect URL"
-  },
-  "DIrxt7": {
-    "context": "channel publication date",
-    "string": "Visible since {date}"
   },
   "DJFPzq": {
     "context": "button",
@@ -2875,10 +2875,6 @@
   },
   "KRqgfo": {
     "string": "User is out of your permissions scope"
-  },
-  "KSp+8B": {
-    "context": "product available for purchase date",
-    "string": "will become available on {date}"
   },
   "KXkdMH": {
     "context": "order discount removed title",
@@ -5096,10 +5092,6 @@
     "context": "voucher",
     "string": "Applies to"
   },
-  "beuxAP": {
-    "context": "channel publication status",
-    "string": "Hidden"
-  },
   "bgO+7G": {
     "context": "order return amount button",
     "string": "Return & Replace products"
@@ -5681,10 +5673,6 @@
     "context": "voucher",
     "string": "Times used"
   },
-  "hAcUEl": {
-    "context": "product publication date label",
-    "string": "will become published on {date}"
-  },
   "hHOI7D": {
     "context": "product type name",
     "string": "Type Name"
@@ -5716,6 +5704,10 @@
   "hS+ZjH": {
     "context": "delete webhook",
     "string": "Are you sure you want to delete this webhook?"
+  },
+  "hTLCC2": {
+    "context": "channel publication date",
+    "string": "Will become published on {date}"
   },
   "hWO1SD": {
     "context": "order history message",
@@ -6079,6 +6071,10 @@
     "context": "product updated at",
     "string": "Last updated"
   },
+  "kYYbrv": {
+    "context": "channel publication date",
+    "string": "Published since {date}"
+  },
   "kZfIl/": {
     "string": "These are general information about this Content Type."
   },
@@ -6273,10 +6269,6 @@
     "context": "order draft creation date",
     "string": "Date"
   },
-  "mDgOmP": {
-    "context": "channel publication status",
-    "string": "Visible"
-  },
   "mE+fru": {
     "context": "tag filter label",
     "string": "Tags"
@@ -6463,10 +6455,6 @@
   "nf3XSt": {
     "context": "attribute internal name",
     "string": "Slug"
-  },
-  "nfbabo": {
-    "context": "channel publication date",
-    "string": "Will become available on {date}"
   },
   "njBulj": {
     "context": "check to require attribute to have value",
@@ -7828,6 +7816,10 @@
     "context": "button refreshing page",
     "string": "Refresh page"
   },
+  "ys0jH2": {
+    "context": "channel publication status",
+    "string": "Published"
+  },
   "yuiyES": {
     "string": "General Settings"
   },
@@ -7934,6 +7926,10 @@
   "zjkAMs": {
     "context": "header",
     "string": "Translation Sale \"{saleName}\" - {languageCode}"
+  },
+  "znbVYT": {
+    "context": "product available for purchase date",
+    "string": "Will become available on {date}"
   },
   "zqarUF": {
     "context": "modal information under title",

--- a/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
+++ b/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
@@ -98,9 +98,9 @@ const ChannelWithVariantsAvailabilityItemWrapper: React.FC<ChannelAvailabilityIt
   messages: commonChannelMessages,
   children,
 }) => {
-  const expanderClasses = useExpanderStyles({});
-  const summaryClasses = useSummaryStyles({});
-  const classes = useStyles({});
+  const expanderClasses = useExpanderStyles();
+  const summaryClasses = useSummaryStyles();
+  const classes = useStyles();
   const intl = useIntl();
 
   const { name } = channels.find(getById(channelId));

--- a/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemWrapper.tsx
+++ b/src/components/ChannelsAvailabilityCard/Channel/ChannelAvailabilityItemWrapper.tsx
@@ -2,6 +2,7 @@ import { Accordion, AccordionSummary, Typography } from "@material-ui/core";
 import { ChannelData } from "@saleor/channels/utils";
 import IconChevronDown from "@saleor/icons/ChevronDown";
 import { makeStyles } from "@saleor/macaw-ui";
+import Label from "@saleor/orders/components/OrderHistory/Label";
 import React from "react";
 
 import { Messages } from "../types";
@@ -55,6 +56,16 @@ const useSummaryStyles = makeStyles(
   { name: "ChannelContentWrapperExpanderSummary" },
 );
 
+const useStyles = makeStyles(
+  () => ({
+    container: {
+      display: "flex",
+      flexDirection: "column",
+    },
+  }),
+  { name: "ChannelWithVariantAvailabilityItemWrapper" },
+);
+
 export interface ChannelContentWrapperProps {
   data: ChannelData;
   children: React.ReactNode;
@@ -66,8 +77,9 @@ const ChannelContentWrapper: React.FC<ChannelContentWrapperProps> = ({
   messages,
   children,
 }) => {
-  const expanderClasses = useExpanderStyles({});
-  const summaryClasses = useSummaryStyles({});
+  const expanderClasses = useExpanderStyles();
+  const summaryClasses = useSummaryStyles();
+  const classes = useStyles();
 
   const { name } = data;
 
@@ -80,8 +92,10 @@ const ChannelContentWrapper: React.FC<ChannelContentWrapperProps> = ({
         expandIcon={<IconChevronDown />}
         classes={summaryClasses}
       >
-        <Typography>{name}</Typography>
-        <Typography variant="caption">{messages.availableDateText}</Typography>
+        <div className={classes.container}>
+          <Typography>{name}</Typography>
+          <Label text={messages.availableDateText} />
+        </div>
       </AccordionSummary>
       {children}
     </Accordion>

--- a/src/components/ChannelsAvailabilityCard/ChannelsAvailabilityCard.tsx
+++ b/src/components/ChannelsAvailabilityCard/ChannelsAvailabilityCard.tsx
@@ -70,7 +70,11 @@ export const ChannelsAvailability: React.FC<ChannelsAvailabilityCardProps> = pro
               errors?.filter(error => error.channels.includes(data.id)) || [];
 
             return (
-              <ChannelAvailabilityItemWrapper messages={messages} data={data}>
+              <ChannelAvailabilityItemWrapper
+                key={data.id}
+                messages={channelsMessages[data.id]}
+                data={data}
+              >
                 <ChannelAvailabilityItemContent
                   data={data}
                   onChange={onChange}

--- a/src/components/ChannelsAvailabilityCard/messages.ts
+++ b/src/components/ChannelsAvailabilityCard/messages.ts
@@ -1,0 +1,44 @@
+import { defineMessages } from "react-intl";
+
+export const publicationMessages = defineMessages({
+  published: {
+    id: "ys0jH2",
+    defaultMessage: "Published",
+    description: "channel publication status",
+  },
+  notPublished: {
+    id: "ClKKID",
+    defaultMessage: "Not published",
+    description: "channel publication status",
+  },
+  willBecomePublishedOn: {
+    id: "hTLCC2",
+    defaultMessage: "Will become published on {date}",
+    description: "channel publication date",
+  },
+  willBecomeAvailableOn: {
+    id: "znbVYT",
+    defaultMessage: "Will become available on {date}",
+    description: "product available for purchase date",
+  },
+  availableForPurchase: {
+    id: "P/oGtb",
+    defaultMessage: "Available for purchase",
+    description: "product availability",
+  },
+  unavailableForPurchase: {
+    id: "Y9lv8z",
+    defaultMessage: "Unavailable for purchase",
+    description: "product unavailability",
+  },
+  publishedSince: {
+    id: "kYYbrv",
+    defaultMessage: "Published since {date}",
+    description: "channel publication date",
+  },
+  setAvailabilityDate: {
+    id: "YFQBs1",
+    defaultMessage: "Set availability date",
+    description: "product availability date label",
+  },
+});

--- a/src/components/ChannelsAvailabilityCard/utils.ts
+++ b/src/components/ChannelsAvailabilityCard/utils.ts
@@ -2,6 +2,7 @@ import { ChannelData } from "@saleor/channels/utils";
 import { LocalizeDate } from "@saleor/hooks/useDateLocalize";
 import { IntlShape } from "react-intl";
 
+import { publicationMessages } from "./messages";
 import { Messages } from "./types";
 
 export const getChannelsAvailabilityMessages = ({
@@ -22,73 +23,37 @@ export const getChannelsAvailabilityMessages = ({
         ...messages,
         availableDateText:
           currVal.publicationDate && !currVal.isPublished
-            ? intl.formatMessage(
-                {
-                  id: "nfbabo",
-                  defaultMessage: "Will become available on {date}",
-                  description: "channel publication date",
-                },
-                {
-                  date: localizeDate(currVal.publicationDate),
-                },
-              )
-            : currVal.publicationDate
-            ? intl.formatMessage(
-                {
-                  id: "DIrxt7",
-                  defaultMessage: "Visible since {date}",
-                  description: "channel publication date",
-                },
-                {
-                  date: localizeDate(currVal.publicationDate),
-                },
-              )
-            : currVal.isPublished
-            ? intl.formatMessage({
-                id: "mDgOmP",
-                defaultMessage: "Visible",
-                description: "channel publication status",
+            ? intl.formatMessage(publicationMessages.willBecomePublishedOn, {
+                date: localizeDate(currVal.publicationDate),
               })
-            : intl.formatMessage({
-                id: "beuxAP",
-                defaultMessage: "Hidden",
-                description: "channel publication status",
-              }),
-        availableLabel: intl.formatMessage({
-          id: "P/oGtb",
-          defaultMessage: "Available for purchase",
-          description: "product availability",
-        }),
+            : currVal.publicationDate
+            ? intl.formatMessage(publicationMessages.publishedSince, {
+                date: localizeDate(currVal.publicationDate),
+              })
+            : currVal.isPublished
+            ? intl.formatMessage(publicationMessages.published)
+            : intl.formatMessage(publicationMessages.notPublished),
+        availableLabel: intl.formatMessage(
+          publicationMessages.availableForPurchase,
+        ),
         availableSecondLabel: intl.formatMessage(
-          {
-            id: "KSp+8B",
-            defaultMessage: "will become available on {date}",
-            description: "product available for purchase date",
-          },
+          publicationMessages.willBecomeAvailableOn,
           {
             date: localizeDate(currVal.availableForPurchase),
           },
         ),
         hiddenSecondLabel: intl.formatMessage(
-          {
-            id: "hAcUEl",
-            defaultMessage: "will become published on {date}",
-            description: "product publication date label",
-          },
+          publicationMessages.willBecomePublishedOn,
           {
             date: localizeDate(currVal.publicationDate),
           },
         ),
-        setAvailabilityDateLabel: intl.formatMessage({
-          id: "YFQBs1",
-          defaultMessage: "Set availability date",
-          description: "product availability date label",
-        }),
-        unavailableLabel: intl.formatMessage({
-          id: "Y9lv8z",
-          defaultMessage: "Unavailable for purchase",
-          description: "product unavailability",
-        }),
+        setAvailabilityDateLabel: intl.formatMessage(
+          publicationMessages.setAvailabilityDate,
+        ),
+        unavailableLabel: intl.formatMessage(
+          publicationMessages.unavailableForPurchase,
+        ),
       },
     }),
     {} as Messages,


### PR DESCRIPTION
I want to merge this change because... it adds labels to indicate availability of simple product for channels.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
Simple products (added labels):
<img width="342" alt="Screenshot 2022-07-06 at 15 59 11" src="https://user-images.githubusercontent.com/9825562/177568312-900c0182-9caa-4d56-9852-5b961f1b6fc5.png">

Products with variants (unchanged labels):
<img width="328" alt="Screenshot 2022-07-06 at 15 59 16" src="https://user-images.githubusercontent.com/9825562/177568351-6499a609-6f97-4fba-981a-b2371c8f9d80.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
