### PR TITLE
Add status pills to webhooks list

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -441,9 +441,6 @@
   "1div9r": {
     "string": "Search Attribute"
   },
-  "1eCau/": {
-    "string": "Unnamed webhook"
-  },
   "1eEyJv": {
     "context": "ExitFormPrompt continue editing button",
     "string": "Continue editing"
@@ -1650,6 +1647,10 @@
     "context": "section header",
     "string": "Unfulfilled Items"
   },
+  "Bkxrhw": {
+    "context": "no webhooks message",
+    "string": "No webhooks found"
+  },
   "BooQvo": {
     "context": "navigator placeholder",
     "string": "Type {key} to see available actions"
@@ -2398,6 +2399,9 @@
     "context": "pages section name",
     "string": "Pages"
   },
+  "HAlOn1": {
+    "string": "Name"
+  },
   "HLqWXA": {
     "context": "voucher value requirement",
     "string": "Usage Limit"
@@ -2970,6 +2974,10 @@
     "context": "metadata field value, header",
     "string": "Value"
   },
+  "Lm2Zw7": {
+    "context": "name placeholder",
+    "string": "Unnamed webhook"
+  },
   "LmKz3g": {
     "string": "Storefront"
   },
@@ -3256,6 +3264,10 @@
     "context": "gift card history message",
     "string": "Gift card was deactivated"
   },
+  "NwQXZp": {
+    "context": "status",
+    "string": "Not active"
+  },
   "NxRsHQ": {
     "context": "section header",
     "string": "Fulfillment - #{fulfilmentId}"
@@ -3306,10 +3318,6 @@
   "OTek3r": {
     "context": "product variant name",
     "string": "Variant"
-  },
-  "OTpV1t": {
-    "context": "webhook name",
-    "string": "Name"
   },
   "OVOU1z": {
     "context": "section header",
@@ -5135,6 +5143,10 @@
   "c0H45L": {
     "string": "{amount, plural,one {One order is ready to fulfill} other {{amount} orders are ready to fulfill}}"
   },
+  "c24hjq": {
+    "context": "status",
+    "string": "Active"
+  },
   "c4gbXr": {
     "string": "Draft order successfully finalized"
   },
@@ -5953,10 +5965,6 @@
   "jqJqdE": {
     "context": "VariantDetailsChannelsAvailabilityCard no items available",
     "string": "This variant is not available at any of the channels"
-  },
-  "jqnwW9": {
-    "context": "header",
-    "string": "Webhooks"
   },
   "jswILH": {
     "context": "add attribute as column in product list table",
@@ -7554,9 +7562,6 @@
   "wWYYBR": {
     "context": "product variant inventory",
     "string": "{numLocations,plural,one{{numAvailable} available at {numLocations} location} other{{numAvailable} available at {numLocations} locations}}"
-  },
-  "wbjuR4": {
-    "string": "No webhooks found"
   },
   "wgA48T": {
     "context": "country selection",

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -1,6 +1,16 @@
 import { defineMessages, IntlShape } from "react-intl";
 
 export const commonMessages = defineMessages({
+  active: {
+    id: "c24hjq",
+    defaultMessage: "Active",
+    description: "status",
+  },
+  notActive: {
+    id: "NwQXZp",
+    defaultMessage: "Not active",
+    description: "status",
+  },
   availability: {
     id: "hOxIeP",
     defaultMessage: "Availability",
@@ -84,6 +94,10 @@ export const commonMessages = defineMessages({
   limitReached: {
     id: "8oIbMI",
     defaultMessage: "Reached limit for this plan",
+  },
+  name: {
+    id: "HAlOn1",
+    defaultMessage: "Name",
   },
   no: {
     id: "oUWADl",

--- a/src/webhooks/components/WebhooksList/WebhooksList.tsx
+++ b/src/webhooks/components/WebhooksList/WebhooksList.tsx
@@ -13,7 +13,8 @@ import { TableButtonWrapper } from "@saleor/components/TableButtonWrapper/TableB
 import TableCellHeader from "@saleor/components/TableCellHeader";
 import TableRowLink from "@saleor/components/TableRowLink";
 import { AppQuery } from "@saleor/graphql";
-import { DeleteIcon, IconButton } from "@saleor/macaw-ui";
+import { commonMessages, sectionNames } from "@saleor/intl";
+import { DeleteIcon, IconButton, Pill } from "@saleor/macaw-ui";
 import { renderCollection, stopPropagation } from "@saleor/misc";
 import { webhookPath } from "@saleor/webhooks/urls";
 import { isUnnamed } from "@saleor/webhooks/utils";
@@ -21,6 +22,7 @@ import classNames from "classnames";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { messages } from "./messages";
 import { useStyles } from "./styles";
 
 export interface WebhooksListProps {
@@ -35,17 +37,13 @@ const WebhooksList: React.FC<WebhooksListProps> = ({
   onRemove,
 }) => {
   const intl = useIntl();
-  const classes = useStyles({});
+  const classes = useStyles();
   const numberOfColumns = webhooks?.length === 0 ? 2 : 3;
 
   return (
     <Card>
       <CardTitle
-        title={intl.formatMessage({
-          id: "jqnwW9",
-          defaultMessage: "Webhooks",
-          description: "header",
-        })}
+        title={intl.formatMessage(sectionNames.webhooks)}
         toolbar={
           !!createHref && (
             <Button
@@ -53,11 +51,7 @@ const WebhooksList: React.FC<WebhooksListProps> = ({
               href={createHref}
               data-test-id="create-webhook"
             >
-              <FormattedMessage
-                id="wlr0Si"
-                defaultMessage="Create Webhook"
-                description="button"
-              />
+              <FormattedMessage {...messages.createWebhook} />
             </Button>
           )
         }
@@ -66,20 +60,15 @@ const WebhooksList: React.FC<WebhooksListProps> = ({
         <TableHead>
           <TableRow>
             <TableCellHeader>
-              {intl.formatMessage({
-                id: "OTpV1t",
-                defaultMessage: "Name",
-                description: "webhook name",
-              })}
+              {intl.formatMessage(commonMessages.name)}
+            </TableCellHeader>
+            <TableCellHeader>
+              {intl.formatMessage(commonMessages.status)}
             </TableCellHeader>
             <TableCell
               className={classNames(classes.colAction, classes.colRight)}
             >
-              {intl.formatMessage({
-                id: "a/QJBx",
-                defaultMessage: "Action",
-                description: "user action bar",
-              })}
+              <FormattedMessage {...messages.action} />
             </TableCell>
           </TableRow>
         </TableHead>
@@ -99,12 +88,23 @@ const WebhooksList: React.FC<WebhooksListProps> = ({
                   })}
                 >
                   {isUnnamed(webhook) ? (
-                    <FormattedMessage
-                      id="1eCau/"
-                      defaultMessage="Unnamed webhook"
-                    />
+                    <FormattedMessage {...messages.unnamedWebhook} />
                   ) : (
                     webhook?.name || <Skeleton />
+                  )}
+                </TableCell>
+                <TableCell>
+                  {webhook ? (
+                    <Pill
+                      label={
+                        webhook.isActive
+                          ? intl.formatMessage(commonMessages.active)
+                          : intl.formatMessage(commonMessages.notActive)
+                      }
+                      color={webhook.isActive ? "success" : "error"}
+                    />
+                  ) : (
+                    <Skeleton />
                   )}
                 </TableCell>
                 <TableCell
@@ -129,10 +129,7 @@ const WebhooksList: React.FC<WebhooksListProps> = ({
             () => (
               <TableRow>
                 <TableCell colSpan={numberOfColumns}>
-                  {intl.formatMessage({
-                    id: "wbjuR4",
-                    defaultMessage: "No webhooks found",
-                  })}
+                  {intl.formatMessage(messages.noWebhooks)}
                 </TableCell>
               </TableRow>
             ),

--- a/src/webhooks/components/WebhooksList/messages.ts
+++ b/src/webhooks/components/WebhooksList/messages.ts
@@ -1,0 +1,24 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  createWebhook: {
+    id: "wlr0Si",
+    defaultMessage: "Create Webhook",
+    description: "button",
+  },
+  action: {
+    id: "a/QJBx",
+    defaultMessage: "Action",
+    description: "user action bar",
+  },
+  unnamedWebhook: {
+    id: "Lm2Zw7",
+    defaultMessage: "Unnamed webhook",
+    description: "name placeholder",
+  },
+  noWebhooks: {
+    id: "Bkxrhw",
+    defaultMessage: "No webhooks found",
+    description: "no webhooks message",
+  },
+});


### PR DESCRIPTION
I want to merge this change because... it adds status pills to webhooks list in custom app page.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="723" alt="Screenshot 2022-07-08 at 16 09 35" src="https://user-images.githubusercontent.com/9825562/178010957-72f99ed6-0704-4e07-bfab-24b6779da1aa.png">
<img width="724" alt="Screenshot 2022-07-08 at 16 09 18" src="https://user-images.githubusercontent.com/9825562/178010972-3a21ad08-32a7-4d81-85d2-c502c8ba0b4e.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
