### PR TITLE
Fix sales/voucher page styles and fix date tooltips styles

### DIFF
--- a/src/components/Date/Date.tsx
+++ b/src/components/Date/Date.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import { LocaleConsumer } from "../Locale";
 import { Consumer } from "./DateContext";
+import { useStyles } from "./styles";
 
 interface DateProps {
   date: string;
@@ -12,7 +13,10 @@ interface DateProps {
 }
 
 export const Date: React.FC<DateProps> = ({ date, plain }) => {
+  const classes = useStyles();
+
   const localizeDate = useDateLocalize();
+
   const getHumanized = (value: string, locale: string, currentDate: number) =>
     moment(value)
       .locale(locale)
@@ -26,7 +30,12 @@ export const Date: React.FC<DateProps> = ({ date, plain }) => {
             plain ? (
               localizeDate(date)
             ) : (
-              <Tooltip title={localizeDate(date)}>
+              <Tooltip
+                title={localizeDate(date)}
+                PopperProps={{
+                  className: classes.tooltip,
+                }}
+              >
                 <time dateTime={date}>
                   {getHumanized(date, locale, currentDate)}
                 </time>

--- a/src/components/Date/DateTime.tsx
+++ b/src/components/Date/DateTime.tsx
@@ -6,6 +6,7 @@ import ReactMoment from "react-moment";
 import { LocaleConsumer } from "../Locale";
 import { TimezoneConsumer } from "../Timezone";
 import { Consumer } from "./DateContext";
+import { useStyles } from "./styles";
 
 interface DateTimeProps {
   date: string;
@@ -13,6 +14,8 @@ interface DateTimeProps {
 }
 
 export const DateTime: React.FC<DateTimeProps> = ({ date, plain }) => {
+  const classes = useStyles();
+
   const getTitle = (value: string, locale?: string, tz?: string) => {
     let date = moment(value).locale(locale);
     if (tz !== undefined) {
@@ -20,6 +23,7 @@ export const DateTime: React.FC<DateTimeProps> = ({ date, plain }) => {
     }
     return date.format("lll");
   };
+
   return (
     <TimezoneConsumer>
       {tz => (
@@ -30,7 +34,12 @@ export const DateTime: React.FC<DateTimeProps> = ({ date, plain }) => {
                 plain ? (
                   getTitle(date, locale, tz)
                 ) : (
-                  <Tooltip title={getTitle(date, locale, tz)}>
+                  <Tooltip
+                    title={getTitle(date, locale, tz)}
+                    PopperProps={{
+                      className: classes.tooltip,
+                    }}
+                  >
                     <ReactMoment from={currentDate} locale={locale} tz={tz}>
                       {date}
                     </ReactMoment>

--- a/src/components/Date/styles.ts
+++ b/src/components/Date/styles.ts
@@ -1,0 +1,14 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    tooltip: {
+      "& .MuiTooltip-tooltip": {
+        color: theme.palette.getContrastText(theme.palette.text.primary),
+      },
+    },
+  }),
+  {
+    name: "DateTime",
+  },
+);

--- a/src/discounts/components/VoucherValue/VoucherValue.tsx
+++ b/src/discounts/components/VoucherValue/VoucherValue.tsx
@@ -9,7 +9,6 @@ import {
 import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import { FormSpacer } from "@saleor/components/FormSpacer";
-import Hr from "@saleor/components/Hr";
 import RadioGroupField from "@saleor/components/RadioGroupField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
@@ -172,7 +171,6 @@ const VoucherValue: React.FC<VoucherValueProps> = props => {
         <FormSpacer />
         {variant === "update" && (
           <>
-            <Hr className={classes.hr} />
             <RadioGroupField
               choices={voucherTypeChoices}
               disabled={disabled}

--- a/src/discounts/components/VoucherValue/styles.ts
+++ b/src/discounts/components/VoucherValue/styles.ts
@@ -15,16 +15,11 @@ export const useStyles = makeStyles(
       textAlign: "right",
       width: 300,
     },
-    hr: {
-      margin: theme.spacing(2, -3),
-      width: `calc(100% + ${theme.spacing(6)}px)`,
-    },
     table: {
       tableLayout: "fixed",
     },
     tableContainer: {
-      margin: theme.spacing(0, -3),
-      width: `calc(100% + ${theme.spacing(6)}px)`,
+      margin: theme.spacing(0, -4),
     },
   }),
   {


### PR DESCRIPTION
I want to merge this change because... it fixes styles in:
- sales/voucher pages - SALEOR-7559
- date tooltips on sales/voucher list - SALEOR-6015

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="587" alt="Screenshot 2022-07-08 at 16 41 08" src="https://user-images.githubusercontent.com/9825562/178023109-3df26835-c443-4e8d-9bf4-65d3af025a0e.png">
<img width="582" alt="Screenshot 2022-07-08 at 16 41 41" src="https://user-images.githubusercontent.com/9825562/178023117-e36a7f78-edac-4672-af10-b6b77e69088f.png">
<img width="289" alt="Screenshot 2022-07-08 at 17 09 55" src="https://user-images.githubusercontent.com/9825562/178022890-5d4fe471-fa49-4835-997c-a8fa616e7172.png">
<img width="257" alt="Screenshot 2022-07-08 at 17 10 07" src="https://user-images.githubusercontent.com/9825562/178022895-43544297-bbf0-4476-a80f-04742b09dff6.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
