### PR TITLE
Add test for sorting by price, unification of productList folder

### DIFF
--- a/cypress/e2e/products/productsList/filteringProducts.js
+++ b/cypress/e2e/products/productsList/filteringProducts.js
@@ -23,7 +23,7 @@ import {
   selectProductsOutOfStock,
 } from "../../../support/pages/catalog/products/productsListPage";
 
-describe("Filtering products", () => {
+describe("As an admin I should be able to filter products", () => {
   const startsWith = "CyFilterProducts-";
   const name = `${startsWith}${faker.datatype.number()}`;
   const stockQuantity = 747;
@@ -89,15 +89,18 @@ describe("Filtering products", () => {
       .visit(urlList.products);
   });
 
-  // const filterProductsBy = ["category", "collection", "productType"];
-  const filterProductsBy = ["category", "productType"];
+  const filterProductsBy = [
+    { type: "category", testCase: "SALEOR_2601" },
+    { type: "productType", testCase: "SALEOR_2602" },
+    { type: "collection", testCase: "SALEOR_2603" },
+  ];
   filterProductsBy.forEach(filterBy => {
     it(
-      `should filter products by ${filterBy}`,
+      `should filter products by ${filterBy.type}. ${filterBy.testCase}`,
       { tags: ["@productsList", "@allEnv"] },
       () => {
         cy.expectSkeletonIsVisible().waitForProgressBarToNotExist();
-        selectFilterOption(filterBy, name);
+        selectFilterOption(filterBy.type, name);
         cy.getTextFromElement(PRODUCTS_LIST.productsNames).then(product => {
           expect(product).to.includes(name);
         });
@@ -106,7 +109,7 @@ describe("Filtering products", () => {
   });
 
   it(
-    "should filter products out of stock",
+    "should filter products out of stock. SALEOR_2604",
     { tags: ["@productsList", "@allEnv"] },
     () => {
       cy.expectSkeletonIsVisible();

--- a/cypress/e2e/products/productsList/filteringProducts.js
+++ b/cypress/e2e/products/productsList/filteringProducts.js
@@ -96,7 +96,7 @@ describe("As an admin I should be able to filter products", () => {
   ];
   filterProductsBy.forEach(filterBy => {
     it(
-      `should filter products by ${filterBy.type}. ${filterBy.testCase}`,
+      `should filter products by ${filterBy.type}. TC: ${filterBy.testCase}`,
       { tags: ["@productsList", "@allEnv"] },
       () => {
         cy.expectSkeletonIsVisible().waitForProgressBarToNotExist();
@@ -109,7 +109,7 @@ describe("As an admin I should be able to filter products", () => {
   });
 
   it(
-    "should filter products out of stock. SALEOR_2604",
+    "should filter products out of stock. TC: SALEOR_2604",
     { tags: ["@productsList", "@allEnv"] },
     () => {
       cy.expectSkeletonIsVisible();

--- a/cypress/e2e/products/productsList/pagination.js
+++ b/cypress/e2e/products/productsList/pagination.js
@@ -16,7 +16,7 @@ describe("As an admin I should be able to manage products table", () => {
   });
 
   it(
-    "should be able go to the next page on product list. SALEOR_2605",
+    "should be able go to the next page on product list. TC: SALEOR_2605",
     { tags: ["@productsList", "@allEnv"] },
     () => {
       cy.expectSkeletonIsVisible()
@@ -52,7 +52,7 @@ describe("As an admin I should be able to manage products table", () => {
   );
 
   it(
-    "should see correct amount of products per page. SALEOR_2606",
+    "should see correct amount of products per page. TC: SALEOR_2606",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
       cy.expectSkeletonIsVisible();

--- a/cypress/e2e/products/productsList/pagination.js
+++ b/cypress/e2e/products/productsList/pagination.js
@@ -9,14 +9,14 @@ import {
   isNumberOfProductsSameAsInSelectResultsOnPage,
 } from "../../../support/pages/catalog/products/productsListPage";
 
-describe("Products", () => {
+describe("As an admin I should be able to manage products table", () => {
   beforeEach(() => {
     cy.clearSessionData().loginUserViaRequest();
     cy.visit(urlList.products);
   });
 
   it(
-    "should be able go to the next page on product list. TC: SALEOR_2605",
+    "should be able go to the next page on product list. SALEOR_2605",
     { tags: ["@productsList", "@allEnv"] },
     () => {
       cy.expectSkeletonIsVisible()
@@ -52,7 +52,7 @@ describe("Products", () => {
   );
 
   it(
-    "should see correct amount of products per page. TC: SALEOR_2606",
+    "should see correct amount of products per page. SALEOR_2606",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
       cy.expectSkeletonIsVisible();

--- a/cypress/e2e/products/productsList/sortingProducts.js
+++ b/cypress/e2e/products/productsList/sortingProducts.js
@@ -7,7 +7,7 @@ import { urlList } from "../../../fixtures/urlList";
 import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
 import {
   selectChannel,
-  sortProducstBy,
+  sortProductsBy,
   submitFilters,
 } from "../../../support/pages/catalog/products/productsListPage";
 
@@ -39,7 +39,7 @@ describe("As an admin I should be able to sort products", () => {
       cy.get(PRODUCTS_LIST.tableHeaders.price)
         .click()
         .waitForProgressBarToNotExist();
-      sortProducstBy("price");
+      sortProductsBy("price");
     },
   );
 
@@ -50,7 +50,7 @@ describe("As an admin I should be able to sort products", () => {
       cy.get(PRODUCTS_LIST.tableHeaders.type)
         .click()
         .waitForProgressBarToNotExist();
-      sortProducstBy("type");
+      sortProductsBy("type");
     },
   );
 
@@ -58,7 +58,7 @@ describe("As an admin I should be able to sort products", () => {
     "should be able to sort products by name. TC: SALEOR_2609",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
-      sortProducstBy("name");
+      sortProductsBy("name");
     },
   );
 });

--- a/cypress/e2e/products/productsList/sortingProducts.js
+++ b/cypress/e2e/products/productsList/sortingProducts.js
@@ -12,7 +12,6 @@ import {
 } from "../../../support/pages/catalog/products/productsListPage";
 
 describe("As an admin I should be able to sort products", () => {
-  const sortByList = ["price", "type", "name"];
   let defaultChannel;
 
   beforeEach(() => {

--- a/cypress/e2e/products/productsList/sortingProducts.js
+++ b/cypress/e2e/products/productsList/sortingProducts.js
@@ -7,7 +7,7 @@ import { urlList } from "../../../fixtures/urlList";
 import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
 import {
   selectChannel,
-  sortProductBy,
+  sortProducstBy,
   submitFilters,
 } from "../../../support/pages/catalog/products/productsListPage";
 
@@ -32,34 +32,34 @@ describe("As an admin I should be able to sort products", () => {
   });
 
   it(
-    "should be able to sort products by price. SALEOR_2607",
+    "should be able to sort products by price. TC: SALEOR_2607",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
       selectChannel(defaultChannel.slug);
       submitFilters();
-      cy.get(PRODUCTS_LIST.tableHeaders[sortByList[0]])
+      cy.get(PRODUCTS_LIST.tableHeaders.price)
         .click()
         .waitForProgressBarToNotExist();
-      sortProductBy(sortByList[0]);
+      sortProducstBy("price");
     },
   );
 
   it(
-    "should be able to sort products by type. SALEOR_2608",
+    "should be able to sort products by type. TC: SALEOR_2608",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
-      cy.get(PRODUCTS_LIST.tableHeaders[sortByList[1]])
+      cy.get(PRODUCTS_LIST.tableHeaders.type)
         .click()
         .waitForProgressBarToNotExist();
-      sortProductBy(sortByList[1]);
+      sortProducstBy("type");
     },
   );
 
   it(
-    "should be able to sort products by name. SALEOR_2609",
+    "should be able to sort products by name. TC: SALEOR_2609",
     { tags: ["@productsList", "@allEnv", "@stable"] },
     () => {
-      sortProductBy(sortByList[2]);
+      sortProducstBy("name");
     },
   );
 });

--- a/cypress/e2e/products/productsList/sortingProducts.js
+++ b/cypress/e2e/products/productsList/sortingProducts.js
@@ -4,33 +4,62 @@
 import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
 import { SHARED_ELEMENTS } from "../../../elements/shared/sharedElements";
 import { urlList } from "../../../fixtures/urlList";
-import { expectProductsSortedBy } from "../../../support/api/utils/products/productsListUtils";
+import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
+import {
+  selectChannel,
+  sortProductBy,
+  submitFilters,
+} from "../../../support/pages/catalog/products/productsListPage";
 
-describe("Sorting products", () => {
-  const sortByList = ["name", "type"];
-  sortByList.forEach(sortBy => {
-    it(
-      `Sorting by ${sortBy}`,
-      { tags: ["@productsList", "@allEnv", "@stable"] },
-      () => {
-        cy.clearSessionData()
-          .loginUserViaRequest()
-          .visit(urlList.products);
-        cy.expectSkeletonIsVisible();
-        cy.get(SHARED_ELEMENTS.header).should("be.visible");
-        if (sortBy !== "name") {
-          cy.get(PRODUCTS_LIST.tableHeaders[sortBy])
-            .click()
-            .waitForProgressBarToNotExist();
-        }
-        expectProductsSortedBy(sortBy);
-        cy.addAliasToGraphRequest("ProductList")
-          .get(PRODUCTS_LIST.tableHeaders[sortBy])
-          .click()
-          .waitForProgressBarToNotExist()
-          .waitForRequestAndCheckIfNoErrors("@ProductList");
-        expectProductsSortedBy(sortBy, false);
-      },
-    );
+describe("As an admin I should be able to sort products", () => {
+  const sortByList = ["price", "type", "name"];
+  let defaultChannel;
+
+  beforeEach(() => {
+    cy.clearSessionData()
+      .loginUserViaRequest()
+      .visit(urlList.products)
+      .expectSkeletonIsVisible()
+      .get(SHARED_ELEMENTS.header)
+      .should("be.visible");
   });
+
+  before(() => {
+    cy.clearSessionData().loginUserViaRequest();
+    getDefaultChannel().then(channel => {
+      defaultChannel = channel;
+    });
+  });
+
+  it(
+    "should be able to sort products by price. SALEOR_2607",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      selectChannel(defaultChannel.slug);
+      submitFilters();
+      cy.get(PRODUCTS_LIST.tableHeaders[sortByList[0]])
+        .click()
+        .waitForProgressBarToNotExist();
+      sortProductBy(sortByList[0]);
+    },
+  );
+
+  it(
+    "should be able to sort products by type. SALEOR_2608",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      cy.get(PRODUCTS_LIST.tableHeaders[sortByList[1]])
+        .click()
+        .waitForProgressBarToNotExist();
+      sortProductBy(sortByList[1]);
+    },
+  );
+
+  it(
+    "should be able to sort products by name. SALEOR_2609",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      sortProductBy(sortByList[2]);
+    },
+  );
 });

--- a/cypress/elements/catalog/products/products-list.js
+++ b/cypress/elements/catalog/products/products-list.js
@@ -10,13 +10,13 @@ export const PRODUCTS_LIST = {
     name: '[data-test-id="name"]',
     type: '[data-test-id="product-type"]',
     availability: '[data-test-id="availability"]',
-    price: '[data-test-id="price"]'
+    price: '[data-test-id="price"]',
   },
   tableHeaders: {
     name: "[data-test-id='col-name-header']",
     type: "[data-test-id='col-type-header']",
     availability: "[data-test-id='col-availability-header']",
-    price: "[data-test-id='col-price-header']"
+    price: "[data-test-id='col-price-header']",
   },
   showFiltersButton: '[data-test-id="show-filters-button"]',
   filters: {
@@ -27,7 +27,7 @@ export const PRODUCTS_LIST = {
       collection: '[data-test-id="filter-group-active-collections"]',
       productType: '[data-test-id="filter-group-active-productType"]',
       stock: '[data-test-id="filter-group-active-stock"]',
-      channel: '[data-test-id="filter-group-active-channel"]'
+      channel: '[data-test-id="filter-group-active-channel"]',
     },
     filterField: {
       filterField: '[data-test-id*="filter-field"]',
@@ -35,12 +35,12 @@ export const PRODUCTS_LIST = {
       collection: '[data-test-id="filter-field-collections"]',
       productType: '[data-test-id="filter-field-productType"]',
       stock: '[data-test-id="filter-field-stock"]',
-      channel: '[data-test-id="filter-field-channel"]'
+      channel: '[data-test-id="filter-field-channel"]',
     },
-    filterBySearchInput: '[data-test-id="filter-field-autocomplete-input"]'
+    filterBySearchInput: '[data-test-id="filter-field-autocomplete-input"]',
   },
   nextPageButton: "[data-test='button-pagination-next']",
   previousPagePagination: "[data-test='button-pagination-back']",
   resultsOnPageSelect: "[data-test-id='PaginationRowNumberSelect']",
-  rowNumberOption: "[data-test-id='rowNumberOption']"
+  rowNumberOption: "[data-test-id='rowNumberOption']",
 };

--- a/cypress/support/api/utils/products/productsListUtils.js
+++ b/cypress/support/api/utils/products/productsListUtils.js
@@ -1,4 +1,5 @@
 import { PRODUCTS_LIST } from "../../../../elements/catalog/products/products-list";
+
 export function getDisplayedColumnArray(columnName) {
   let productsList = new Array();
   return cy
@@ -16,6 +17,7 @@ export function getDisplayedColumnArray(columnName) {
 export function expectProductsSortedBy(columnName, inAscOrder = true) {
   let sortedProductsArray;
   let productsArray;
+
   cy.get(PRODUCTS_LIST.emptyProductRow).should("not.exist");
   getDisplayedColumnArray(columnName)
     .then(productsArrayResp => {
@@ -23,7 +25,7 @@ export function expectProductsSortedBy(columnName, inAscOrder = true) {
       sortedProductsArray = productsArray.slice();
       if (columnName !== "price") {
         sortedProductsArray = sortedProductsArray.sort((a, b) =>
-          a.localeCompare(b, undefined, { ignorePunctuation: true })
+          a.localeCompare(b, undefined, { ignorePunctuation: true }),
         );
         if (!inAscOrder) {
           sortedProductsArray.reverse();
@@ -31,13 +33,16 @@ export function expectProductsSortedBy(columnName, inAscOrder = true) {
       } else {
         sortedProductsArray = getSortedPriceColumn(
           sortedProductsArray,
-          inAscOrder
+          inAscOrder,
         );
+        if (!inAscOrder) {
+          sortedProductsArray.reverse();
+        }
       }
     })
     .then(() => {
       expect(
-        JSON.stringify(productsArray) === JSON.stringify(sortedProductsArray)
+        JSON.stringify(productsArray) === JSON.stringify(sortedProductsArray),
       ).to.be.eq(true);
     });
 }

--- a/cypress/support/pages/catalog/products/productsListPage.js
+++ b/cypress/support/pages/catalog/products/productsListPage.js
@@ -5,9 +5,11 @@ import {
   SHARED_ELEMENTS,
 } from "../../../../elements/shared/sharedElements";
 import { urlList } from "../../../../fixtures/urlList";
+import { expectProductsSortedBy } from "../../../api/utils/products/productsListUtils";
 
 export function isNumberOfProductsSameAsInSelectResultsOnPage() {
   let numberOfResults;
+
   return cy
     .get(PRODUCTS_LIST.productsList)
     .should("be.visible")
@@ -27,6 +29,7 @@ export function isNumberOfProductsSameAsInSelectResultsOnPage() {
 
 export function getDisplayedColumnArray(columnName) {
   let productsList = new Array();
+
   return cy
     .get(PRODUCTS_LIST.productsList)
     .each($product => {
@@ -97,11 +100,12 @@ export function showFilters() {
 }
 
 export function selectChannel(channelSlug) {
+  cy.waitForProgressBarToNotExist();
   selectFilterBy("channel");
   cy.get(getElementByDataTestId(channelSlug)).click();
 }
 
-function submitFilters() {
+export function submitFilters() {
   cy.get(BUTTON_SELECTORS.submit)
     .click()
     .waitForProgressBarToNotExist()
@@ -113,4 +117,14 @@ export function enterProductListPage() {
   cy.visit(urlList.products)
     .expectSkeletonIsVisible()
     .waitForProgressBarToNotExist();
+}
+
+export function sortProductBy(sortBy) {
+  expectProductsSortedBy(sortBy);
+  cy.addAliasToGraphRequest("ProductList")
+    .get(PRODUCTS_LIST.tableHeaders[sortBy])
+    .click()
+    .waitForProgressBarToNotExist()
+    .waitForRequestAndCheckIfNoErrors("@ProductList");
+  expectProductsSortedBy(sortBy, false);
 }

--- a/cypress/support/pages/catalog/products/productsListPage.js
+++ b/cypress/support/pages/catalog/products/productsListPage.js
@@ -119,7 +119,7 @@ export function enterProductListPage() {
     .waitForProgressBarToNotExist();
 }
 
-export function sortProducstBy(sortBy) {
+export function sortProductsBy(sortBy) {
   expectProductsSortedBy(sortBy);
   cy.addAliasToGraphRequest("ProductList")
     .get(PRODUCTS_LIST.tableHeaders[sortBy])

--- a/cypress/support/pages/catalog/products/productsListPage.js
+++ b/cypress/support/pages/catalog/products/productsListPage.js
@@ -119,7 +119,7 @@ export function enterProductListPage() {
     .waitForProgressBarToNotExist();
 }
 
-export function sortProductBy(sortBy) {
+export function sortProducstBy(sortBy) {
   expectProductsSortedBy(sortBy);
   cy.addAliasToGraphRequest("ProductList")
     .get(PRODUCTS_LIST.tableHeaders[sortBy])


### PR DESCRIPTION
I want to merge this change because I am adding new test for sorting by price, clean up in productList folder that contains tests for filtering, sorting and pagination. Adding function `sortProductBy`.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
