### PR TITLE
Disable Saleor_0702 on 3.5 version and add new test Saleor_0712

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -171,6 +171,8 @@ jobs:
           CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
           CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_PUBLIC_KEY: ${{ secrets.STRIPE_PUBLIC_KEY }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_mailHogUrl: ${{ secrets.CYPRESS_MAILHOG }}

--- a/cypress/e2e/configuration/channels/channels.js
+++ b/cypress/e2e/configuration/channels/channels.js
@@ -54,7 +54,7 @@ describe("Channels", () => {
     );
   });
 
-  xit(
+  it(
     "should create new channel. TC: SALEOR_0701",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -155,7 +155,7 @@ describe("Channels", () => {
     );
   }
 
-  xit(
+  it(
     "should validate slug name. TC: SALEOR_0703",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -175,7 +175,7 @@ describe("Channels", () => {
     },
   );
 
-  xit(
+  it(
     "should validate not existing currency. TC: SALEOR_0704",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -192,7 +192,7 @@ describe("Channels", () => {
     },
   );
 
-  xit(
+  it(
     "should delete channel. TC: SALEOR_0705",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {

--- a/cypress/e2e/configuration/channels/channels.js
+++ b/cypress/e2e/configuration/channels/channels.js
@@ -16,22 +16,34 @@ import {
   createShippingZone,
   getShippingZone,
 } from "../../../support/api/requests/ShippingMethod";
+import { createWarehouse as createWarehouseViaApi } from "../../../support/api/requests/Warehouse";
 import { deleteChannelsStartsWith } from "../../../support/api/utils/channelsUtils";
 import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
+import { deleteWarehouseStartsWith } from "../../../support/api/utils/warehouseUtils";
+import { returnValueDependsOnShopVersion } from "../../../support/formatData/dataDependingOnVersion";
 import { createChannelByView } from "../../../support/pages/channelsPage";
 
 describe("Channels", () => {
   const channelStartsWith = `CyChannels`;
-  const randomName = `${channelStartsWith} ${faker.datatype.number()}`;
+  const randomName = `${channelStartsWith}${faker.datatype.number()}`;
   const currency = "PLN";
   let shippingZone;
+  let usAddress;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
     deleteChannelsStartsWith(channelStartsWith);
     deleteShippingStartsWith(channelStartsWith);
+    deleteWarehouseStartsWith(channelStartsWith);
     createShippingZone(randomName, "US").then(shippingZoneResp => {
       shippingZone = shippingZoneResp;
+    });
+    cy.fixture("addresses").then(addresses => {
+      usAddress = addresses.usAddress;
+      createWarehouseViaApi({
+        name: randomName,
+        address: usAddress,
+      });
     });
   });
 
@@ -42,7 +54,7 @@ describe("Channels", () => {
     );
   });
 
-  it(
+  xit(
     "should create new channel. TC: SALEOR_0701",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -86,34 +98,64 @@ describe("Channels", () => {
     },
   );
 
-  it(
-    "should create channel with shippingZone. TC: SALEOR_0702",
-    { tags: ["@channel", "@allEnv"] },
-    () => {
-      // remove login after fixing SALEOR-3162
-      cy.clearSessionData().loginUserViaRequest();
+  if (returnValueDependsOnShopVersion("3.5", true, false)) {
+    it(
+      "should create channel with shippingZone and warehouse TC: SALEOR_0712",
+      { tags: ["@channel", "@allEnv"] },
+      () => {
+        // remove login after fixing SALEOR-3162
+        cy.clearSessionData().loginUserViaRequest();
 
-      const randomChannel = `${channelStartsWith} ${faker.datatype.number()}`;
-      cy.addAliasToGraphRequest("Channels");
-      cy.visit(urlList.channels);
-      cy.expectSkeletonIsVisible();
-      cy.wait("@Channels");
-      createChannelByView({
-        name: randomChannel,
-        currency,
-        shippingZone: shippingZone.name,
-      });
-      cy.waitForRequestAndCheckIfNoErrors("@Channel");
-      getShippingZone(shippingZone.id).then(shippingZoneResp => {
-        const assignedChannel = shippingZoneResp.channels.find(
-          channel => channel.name === randomChannel,
-        );
-        expect(assignedChannel).to.be.ok;
-      });
-    },
-  );
+        const randomChannel = `${channelStartsWith} ${faker.datatype.number()}`;
+        cy.addAliasToGraphRequest("Channels");
+        cy.visit(urlList.channels);
+        cy.expectSkeletonIsVisible();
+        cy.wait("@Channels");
+        createChannelByView({
+          name: randomChannel,
+          currency,
+          shippingZone: shippingZone.name,
+          warehouse: randomName,
+        });
+        cy.waitForRequestAndCheckIfNoErrors("@Channel");
+        getShippingZone(shippingZone.id).then(shippingZoneResp => {
+          const assignedChannel = shippingZoneResp.channels.find(
+            channel => channel.name === randomChannel,
+          );
+          expect(assignedChannel).to.be.ok;
+        });
+      },
+    );
+  } else {
+    it(
+      "should create channel with shippingZone. TC: SALEOR_0702",
+      { tags: ["@channel", "@allEnv"] },
+      () => {
+        // remove login after fixing SALEOR-3162
+        cy.clearSessionData().loginUserViaRequest();
 
-  it(
+        const randomChannel = `${channelStartsWith} ${faker.datatype.number()}`;
+        cy.addAliasToGraphRequest("Channels");
+        cy.visit(urlList.channels);
+        cy.expectSkeletonIsVisible();
+        cy.wait("@Channels");
+        createChannelByView({
+          name: randomChannel,
+          currency,
+          shippingZone: shippingZone.name,
+        });
+        cy.waitForRequestAndCheckIfNoErrors("@Channel");
+        getShippingZone(shippingZone.id).then(shippingZoneResp => {
+          const assignedChannel = shippingZoneResp.channels.find(
+            channel => channel.name === randomChannel,
+          );
+          expect(assignedChannel).to.be.ok;
+        });
+      },
+    );
+  }
+
+  xit(
     "should validate slug name. TC: SALEOR_0703",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -133,7 +175,7 @@ describe("Channels", () => {
     },
   );
 
-  it(
+  xit(
     "should validate not existing currency. TC: SALEOR_0704",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {
@@ -150,7 +192,7 @@ describe("Channels", () => {
     },
   );
 
-  it(
+  xit(
     "should delete channel. TC: SALEOR_0705",
     { tags: ["@channel", "@allEnv", "@stable"] },
     () => {

--- a/cypress/e2e/configuration/plugins/stripe.js
+++ b/cypress/e2e/configuration/plugins/stripe.js
@@ -8,11 +8,15 @@ import {
 } from "../../../support/api/requests/Checkout";
 import { getOrder } from "../../../support/api/requests/Order";
 import { confirmThreeDSecure } from "../../../support/api/requests/stripe";
+import { deleteCollectionsStartsWith } from "../../../support/api/utils/catalog/collectionsUtils";
 import {
   addStripePaymentAndGetConfirmationData,
   getShippingMethodIdFromCheckout,
 } from "../../../support/api/utils/ordersUtils";
-import { createProductWithShipping } from "../../../support/api/utils/products/productsUtils";
+import {
+  createProductWithShipping,
+  deleteProductsStartsWith,
+} from "../../../support/api/utils/products/productsUtils";
 import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
 
 describe("Stripe payments", () => {
@@ -29,7 +33,9 @@ describe("Stripe payments", () => {
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
+    deleteProductsStartsWith(startsWith);
     deleteShippingStartsWith(startsWith);
+    deleteCollectionsStartsWith(startsWith);
     cy.fixture("cards").then(({ stripe }) => {
       paymentCards = stripe;
       cardData = {

--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -106,7 +106,7 @@ describe("Orders", () => {
   });
 
   xit(
-    "should create order with selected channel",
+    "should create order with selected channel. TC: SALEOR_2104",
     { tags: ["@orders", "@allEnv"] },
     () => {
       cy.visit(urlList.orders)
@@ -124,7 +124,7 @@ describe("Orders", () => {
   );
 
   it(
-    "should not be possible to change channel in order",
+    "should not be possible to change channel in order. TC: SALEOR_2105",
     { tags: ["@orders", "@allEnv", "@stable"] },
     () => {
       createOrder({
@@ -143,42 +143,47 @@ describe("Orders", () => {
     },
   );
 
-  it("should cancel fulfillment", { tags: ["@orders", "@allEnv"] }, () => {
-    let order;
-    createFulfilledOrder({
-      customerId: customer.id,
-      channelId: defaultChannel.id,
-      shippingMethodId: shippingMethod.id,
-      variantsList,
-      address,
-      warehouse: warehouse.id,
-    })
-      .then(({ order: orderResp }) => {
-        order = orderResp;
-        cy.visit(urlList.orders);
-        cy.expectSkeletonIsVisible();
-        cy.contains(ORDERS_SELECTORS.orderRow, order.number).click();
-        cy.get(SHARED_ELEMENTS.skeleton)
-          .should("not.exist")
-          .get(ORDERS_SELECTORS.cancelFulfillment)
-          .click()
-          .fillAutocompleteSelect(
-            ORDERS_SELECTORS.cancelFulfillmentSelectField,
-            warehouse.name,
-          )
-          .addAliasToGraphRequest("OrderFulfillmentCancel")
-          .get(BUTTON_SELECTORS.submit)
-          .click()
-          .waitForRequestAndCheckIfNoErrors("@OrderFulfillmentCancel");
-        getOrder(order.id);
+  it(
+    "should cancel fulfillment. TC: SALEOR_2106",
+    { tags: ["@orders", "@allEnv"] },
+    () => {
+      let order;
+      createFulfilledOrder({
+        customerId: customer.id,
+        channelId: defaultChannel.id,
+        shippingMethodId: shippingMethod.id,
+        variantsList,
+        address,
+        warehouse: warehouse.id,
       })
-      .then(orderResp => {
-        expect(orderResp.status).to.be.eq("UNFULFILLED");
-      });
-  });
+        .then(({ order: orderResp }) => {
+          order = orderResp;
+          cy.visit(urlList.orders);
+          cy.expectSkeletonIsVisible();
+          cy.contains(ORDERS_SELECTORS.orderRow, order.number).click();
+          cy.get(SHARED_ELEMENTS.skeleton)
+            .should("not.exist")
+            .get(ORDERS_SELECTORS.cancelFulfillment)
+            .click()
+            .get(ORDERS_SELECTORS.cancelFulfillmentSelectField)
+            .click()
+            .get(BUTTON_SELECTORS.selectOption)
+            .first()
+            .click()
+            .addAliasToGraphRequest("OrderFulfillmentCancel")
+            .get(BUTTON_SELECTORS.submit)
+            .click()
+            .waitForRequestAndCheckIfNoErrors("@OrderFulfillmentCancel");
+          getOrder(order.id);
+        })
+        .then(orderResp => {
+          expect(orderResp.status).to.be.eq("UNFULFILLED");
+        });
+    },
+  );
 
   it(
-    "should make a refund",
+    "should make a refund. TC: 2107",
     { tags: ["@orders", "@allEnv", "@stable"] },
     () => {
       let order;

--- a/cypress/elements/channels/add-channel-form-selectors.js
+++ b/cypress/elements/channels/add-channel-form-selectors.js
@@ -9,8 +9,8 @@ export const ADD_CHANNEL_FORM_SELECTORS = {
   slugValidationMessage: "[data-test-id='slug-text-input-helper-text']",
   currencyAutocompleteDropdown:
     "[data-test-id='single-autocomplete-select-option'][data-test-type='custom']",
-  addShippingZoneButton: '[data-test-id="shipping-add-button"]',
-  addWarehouseButton: '[data-test-id="warehouse-add-button"]',
+  addShippingZoneButton: '[data-test-id="add-shipping-zone-button"]',
+  addWarehouseButton: '[data-test-id="add-warehouse-zone-button"]',
   shippingAutocompleteSelect: "[data-test-id='shipping-auto-complete-select']",
   warehouseAutocompleteSelect:
     "[data-test-id='warehouse-auto-complete-select']",

--- a/cypress/support/api/utils/warehouseUtils.js
+++ b/cypress/support/api/utils/warehouseUtils.js
@@ -1,0 +1,9 @@
+import * as warehouseRequest from "../requests/Warehouse";
+
+export function deleteWarehouseStartsWith(startsWith) {
+  cy.deleteElementsStartsWith(
+    warehouseRequest.deleteWarehouse,
+    warehouseRequest.getWarehouses,
+    startsWith,
+  );
+}

--- a/cypress/support/pages/channelsPage.js
+++ b/cypress/support/pages/channelsPage.js
@@ -13,7 +13,8 @@ export function createChannelByView({
   currency,
   slug = name,
   shippingZone,
-  defaultCountry = "Poland"
+  defaultCountry = "Poland",
+  warehouse,
 }) {
   cy.addAliasToGraphRequest("Channel")
     .get(CHANNELS_SELECTORS.createChannelButton)
@@ -34,22 +35,38 @@ export function createChannelByView({
   });
   cy.fillAutocompleteSelect(
     ADD_CHANNEL_FORM_SELECTORS.countryAutocompleteInput,
-    defaultCountry
+    defaultCountry,
   );
   if (shippingZone) {
     addShippingZone(shippingZone);
+  }
+  if (warehouse) {
+    addWarehouse(warehouse);
   }
   cy.get(ADD_CHANNEL_FORM_SELECTORS.saveButton).click();
 }
 
 export function addShippingZone(shippingZone) {
   cy.get(BUTTON_SELECTORS.expandIcon)
+    .first()
     .click()
     .get(ADD_CHANNEL_FORM_SELECTORS.addShippingZoneButton)
     .click()
     .fillAutocompleteSelect(
       ADD_CHANNEL_FORM_SELECTORS.shippingAutocompleteSelect,
-      shippingZone
+      shippingZone,
+    );
+}
+
+export function addWarehouse(warehouse) {
+  cy.get(BUTTON_SELECTORS.expandIcon)
+    .last()
+    .click()
+    .get(ADD_CHANNEL_FORM_SELECTORS.addWarehouseButton)
+    .click()
+    .fillAutocompleteSelect(
+      ADD_CHANNEL_FORM_SELECTORS.warehouseAutocompleteSelect,
+      warehouse,
     );
 }
 

--- a/src/channels/components/AssignmentList/AssignmentListFooter.tsx
+++ b/src/channels/components/AssignmentList/AssignmentListFooter.tsx
@@ -77,8 +77,8 @@ const AssignmentListFooter: React.FC<AssignmentListFooterProps> = ({
         itemsName,
       })}
       testIds={{
-        link: `${dataTestId}-add-link`,
-        button: `${dataTestId}-add-button`,
+        link: `add-${dataTestId}-zone-link`,
+        button: `add-${dataTestId}-zone-button`,
       }}
     />
   );


### PR DESCRIPTION
I want to merge this change because:

- it fixes selectors for the SALEOR_0702 test on versions below 3.5, 
- it disables SALEOR_0702 on version 3.5 and higher 
- adds SALEOR_0712 for 3.5 and greater

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
