### PR TITLE
Add customer extensions mount points and pass object IDs to extensions

### DIFF
--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -100,17 +100,18 @@ export const AppFrame: React.FC<Props> = ({
     return null;
   }
 
+  const prepareAppUrl = () => {
+    const iframeContextQueryString = `?${stringifyQs(
+      { domain: shop.domain.host, id: appId, ...params },
+      "comma",
+    )}`;
+    return urlJoin(src, window.location.search, iframeContextQueryString);
+  };
+
   return (
     <iframe
       ref={frameRef}
-      src={urlJoin(
-        src,
-        window.location.search,
-        `?${stringifyQs(
-          { domain: shop.domain.host, id: appId, ...params },
-          "comma",
-        )}`,
-      )}
+      src={prepareAppUrl()}
       onError={onError}
       onLoad={handleLoad}
       className={clsx(classes.iframe, className)}

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -1,15 +1,14 @@
 import {
   AppDetailsUrlQueryParams,
+  appIframeUrl,
   getAppDeepPathFromDashboardUrl,
 } from "@saleor/apps/urls";
 import useLocale from "@saleor/hooks/useLocale";
 import useShop from "@saleor/hooks/useShop";
 import { useTheme } from "@saleor/macaw-ui";
-import { stringifyQs } from "@saleor/utils/urls";
 import clsx from "clsx";
 import React, { useEffect } from "react";
 import { useLocation } from "react-router";
-import urlJoin from "url-join";
 
 import { useStyles } from "./styles";
 import { useAppActions } from "./useAppActions";
@@ -100,18 +99,10 @@ export const AppFrame: React.FC<Props> = ({
     return null;
   }
 
-  const prepareAppUrl = () => {
-    const iframeContextQueryString = `?${stringifyQs(
-      { domain: shop.domain.host, id: appId, ...params },
-      "comma",
-    )}`;
-    return urlJoin(src, window.location.search, iframeContextQueryString);
-  };
-
   return (
     <iframe
       ref={frameRef}
-      src={prepareAppUrl()}
+      src={appIframeUrl(appId, src, shop.domain.host, params)}
       onError={onError}
       onLoad={handleLoad}
       className={clsx(classes.iframe, className)}

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -106,7 +106,10 @@ export const AppFrame: React.FC<Props> = ({
       src={urlJoin(
         src,
         window.location.search,
-        `?${stringifyQs({ domain: shop.domain.host, id: appId, ...params })}`,
+        `?${stringifyQs(
+          { domain: shop.domain.host, id: appId, ...params },
+          "comma",
+        )}`,
       )}
       onError={onError}
       onLoad={handleLoad}

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -1,7 +1,11 @@
-import { getAppDeepPathFromDashboardUrl } from "@saleor/apps/urls";
+import {
+  AppDetailsUrlQueryParams,
+  getAppDeepPathFromDashboardUrl,
+} from "@saleor/apps/urls";
 import useLocale from "@saleor/hooks/useLocale";
 import useShop from "@saleor/hooks/useShop";
 import { useTheme } from "@saleor/macaw-ui";
+import { stringifyQs } from "@saleor/utils/urls";
 import clsx from "clsx";
 import React, { useEffect } from "react";
 import { useLocation } from "react-router";
@@ -16,6 +20,7 @@ interface Props {
   appToken: string;
   appId: string;
   className?: string;
+  params?: AppDetailsUrlQueryParams;
   refetch?: () => void;
   onLoad?(): void;
   onError?(): void;
@@ -28,6 +33,7 @@ export const AppFrame: React.FC<Props> = ({
   appToken,
   appId,
   className,
+  params = {},
   onLoad,
   onError,
   refetch,
@@ -100,7 +106,7 @@ export const AppFrame: React.FC<Props> = ({
       src={urlJoin(
         src,
         window.location.search,
-        `?domain=${shop.domain.host}&id=${appId}&locale=${locale}`,
+        `?${stringifyQs({ domain: shop.domain.host, id: appId, ...params })}`,
       )}
       onError={onError}
       onLoad={handleLoad}

--- a/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
+++ b/src/apps/components/ExternalAppContext/ExternalAppContext.tsx
@@ -40,6 +40,7 @@ export const ExternalAppProvider: React.FC = ({ children }) => {
             src={appData.src}
             appToken={appData.appToken}
             appId={appData.id}
+            params={appData.params}
           />
         )}
       </AppDialog>

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -22,6 +22,7 @@ export type AppListUrlQueryParams = ActiveTab &
 export interface AppDetailsUrlMountQueryParams {
   productId?: string;
   orderId?: string;
+  customerId?: string;
 }
 
 export type AppDetailsUrlQueryParams = Dialog<AppDetailsUrlDialog> &

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -21,8 +21,10 @@ export type AppListUrlQueryParams = ActiveTab &
 
 export interface AppDetailsUrlMountQueryParams {
   productId?: string;
+  productIds?: string[];
   orderId?: string;
   customerId?: string;
+  customerIds?: string[];
 }
 
 export type AppDetailsUrlQueryParams = Dialog<AppDetailsUrlDialog> &

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -116,3 +116,16 @@ export const customAppAddUrl = customAppAddPath;
 
 export const appsListUrl = (params?: AppListUrlQueryParams) =>
   appsListPath + "?" + stringifyQs(params);
+
+export const appIframeUrl = (
+  appId: string,
+  appUrl: string,
+  shopDomainHost: string,
+  params: AppDetailsUrlQueryParams,
+) => {
+  const iframeContextQueryString = `?${stringifyQs(
+    { domain: shopDomainHost, id: appId, ...params },
+    "comma",
+  )}`;
+  return urlJoin(appUrl, window.location.search, iframeContextQueryString);
+};

--- a/src/apps/useExtensions.ts
+++ b/src/apps/useExtensions.ts
@@ -27,6 +27,10 @@ export interface ExtensionWithParams extends Omit<Extension, "open"> {
 }
 
 export const extensionMountPoints = {
+  CUSTOMER_LIST: [
+    AppExtensionMountEnum.CUSTOMER_OVERVIEW_CREATE,
+    AppExtensionMountEnum.CUSTOMER_OVERVIEW_MORE_ACTIONS,
+  ],
   PRODUCT_LIST: [
     AppExtensionMountEnum.PRODUCT_OVERVIEW_CREATE,
     AppExtensionMountEnum.PRODUCT_OVERVIEW_MORE_ACTIONS,
@@ -35,6 +39,7 @@ export const extensionMountPoints = {
     AppExtensionMountEnum.ORDER_OVERVIEW_CREATE,
     AppExtensionMountEnum.ORDER_OVERVIEW_MORE_ACTIONS,
   ],
+  CUSTOMER_DETAILS: [AppExtensionMountEnum.CUSTOMER_DETAILS_MORE_ACTIONS],
   ORDER_DETAILS: [AppExtensionMountEnum.ORDER_DETAILS_MORE_ACTIONS],
   PRODUCT_DETAILS: [AppExtensionMountEnum.PRODUCT_DETAILS_MORE_ACTIONS],
   NAVIGATION_SIDEBAR: [
@@ -87,6 +92,14 @@ export const mapToMenuItemsForProductDetails = (
 ) =>
   extensions.map(extension =>
     mapToMenuItem({ ...extension, open: () => extension.open({ productId }) }),
+  );
+
+export const mapToMenuItemsForCustomerDetails = (
+  extensions: ExtensionWithParams[],
+  customerId: string,
+) =>
+  extensions.map(extension =>
+    mapToMenuItem({ ...extension, open: () => extension.open({ customerId }) }),
   );
 
 export const mapToMenuItemsForOrderDetails = (

--- a/src/apps/useExtensions.ts
+++ b/src/apps/useExtensions.ts
@@ -86,6 +86,14 @@ const mapToMenuItem = ({ label, id, open }: Extension) => ({
 export const mapToMenuItems = (extensions: ExtensionWithParams[]) =>
   extensions.map(mapToMenuItem);
 
+export const mapToMenuItemsForProductOverviewActions = (
+  extensions: ExtensionWithParams[],
+  productIds: string[],
+) =>
+  extensions.map(extension =>
+    mapToMenuItem({ ...extension, open: () => extension.open({ productIds }) }),
+  );
+
 export const mapToMenuItemsForProductDetails = (
   extensions: ExtensionWithParams[],
   productId: string,
@@ -100,6 +108,17 @@ export const mapToMenuItemsForCustomerDetails = (
 ) =>
   extensions.map(extension =>
     mapToMenuItem({ ...extension, open: () => extension.open({ customerId }) }),
+  );
+
+export const mapToMenuItemsForCustomerOverviewActions = (
+  extensions: ExtensionWithParams[],
+  customerIds: string[],
+) =>
+  extensions.map(extension =>
+    mapToMenuItem({
+      ...extension,
+      open: () => extension.open({ customerIds }),
+    }),
   );
 
 export const mapToMenuItemsForOrderDetails = (

--- a/src/components/AppLayout/menuStructure.ts
+++ b/src/components/AppLayout/menuStructure.ts
@@ -276,7 +276,7 @@ function useMenuStructure(
     const userPermissions = (user?.userPermissions || []).map(
       permission => permission.code,
     );
-    if (!menuItem?.permissions) {
+    if (!menuItem?.permissions || menuItem?.permissions?.length < 1) {
       return true;
     }
     return menuItem.permissions.some(permission =>

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -1,4 +1,10 @@
+import {
+  extensionMountPoints,
+  mapToMenuItemsForCustomerDetails,
+  useExtensions,
+} from "@saleor/apps/useExtensions";
 import { Backlink } from "@saleor/components/Backlink";
+import CardMenu from "@saleor/components/CardMenu/CardMenu";
 import { CardSpacer } from "@saleor/components/CardSpacer";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
@@ -78,6 +84,15 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
     makeChangeHandler: makeMetadataChangeHandler,
   } = useMetadataChangeTrigger();
 
+  const { CUSTOMER_DETAILS_MORE_ACTIONS } = useExtensions(
+    extensionMountPoints.CUSTOMER_DETAILS,
+  );
+
+  const extensionMenuItems = mapToMenuItemsForCustomerDetails(
+    CUSTOMER_DETAILS_MORE_ACTIONS,
+    customerId,
+  );
+
   return (
     <Form
       confirmLeave
@@ -93,7 +108,14 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
             <Backlink href={customerListUrl()}>
               {intl.formatMessage(sectionNames.customers)}
             </Backlink>
-            <PageHeader title={getUserName(customer, true)} />
+            <PageHeader
+              title={getUserName(customer, true)}
+              cardMenu={
+                extensionMenuItems.length > 0 && (
+                  <CardMenu outlined menuItems={extensionMenuItems} />
+                )
+              }
+            />
             <Grid>
               <div>
                 <CustomerDetails

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -2,6 +2,7 @@ import { Card } from "@material-ui/core";
 import {
   extensionMountPoints,
   mapToMenuItems,
+  mapToMenuItemsForCustomerOverviewActions,
   useExtensions,
 } from "@saleor/apps/useExtensions";
 import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
@@ -52,6 +53,7 @@ export interface CustomerListPageProps
     SortPage<CustomerListUrlSortField>,
     TabPageProps {
   customers: RelayToFlat<ListCustomersQuery["customers"]>;
+  selectedCustomerIds: string[];
 }
 
 const CustomerListPage: React.FC<CustomerListPageProps> = ({
@@ -65,6 +67,7 @@ const CustomerListPage: React.FC<CustomerListPageProps> = ({
   onTabDelete,
   onTabSave,
   tabs,
+  selectedCustomerIds,
   ...customerListProps
 }) => {
   const intl = useIntl();
@@ -78,7 +81,10 @@ const CustomerListPage: React.FC<CustomerListPageProps> = ({
     CUSTOMER_OVERVIEW_CREATE,
     CUSTOMER_OVERVIEW_MORE_ACTIONS,
   } = useExtensions(extensionMountPoints.CUSTOMER_LIST);
-  const extensionMenuItems = mapToMenuItems(CUSTOMER_OVERVIEW_MORE_ACTIONS);
+  const extensionMenuItems = mapToMenuItemsForCustomerOverviewActions(
+    CUSTOMER_OVERVIEW_MORE_ACTIONS,
+    selectedCustomerIds,
+  );
   const extensionCreateButtonItems = mapToMenuItems(CUSTOMER_OVERVIEW_CREATE);
 
   return (

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -95,7 +95,7 @@ const CustomerListPage: React.FC<CustomerListPageProps> = ({
           extensionMenuItems.length > 0 && (
             <CardMenu
               className={classes.settings}
-              menuItems={[...extensionMenuItems]}
+              menuItems={extensionMenuItems}
             />
           )
         }

--- a/src/customers/views/CustomerList/CustomerList.tsx
+++ b/src/customers/views/CustomerList/CustomerList.tsx
@@ -181,6 +181,7 @@ export const CustomerList: React.FC<CustomerListProps> = ({ params }) => {
         }
         isChecked={isSelected}
         selected={listElements.length}
+        selectedCustomerIds={listElements}
         sort={getSortParams(params)}
         toggle={toggle}
         toggleAll={toggleAll}

--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -2,6 +2,7 @@ import { Card } from "@material-ui/core";
 import {
   extensionMountPoints,
   mapToMenuItems,
+  mapToMenuItemsForProductOverviewActions,
   useExtensions,
 } from "@saleor/apps/useExtensions";
 import { ButtonWithSelect } from "@saleor/components/ButtonWithSelect";
@@ -61,6 +62,7 @@ export interface ProductListPageProps
   gridAttributes: RelayToFlat<GridAttributesQuery["grid"]>;
   limits: RefreshLimitsQuery["shop"]["limits"];
   products: RelayToFlat<ProductListQuery["products"]>;
+  selectedProductIds: string[];
   onAdd: () => void;
   onExport: () => void;
   onColumnQueryChange: (query: string) => void;
@@ -113,6 +115,7 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
     onTabSave,
     onUpdateListSettings,
     selectedChannelId,
+    selectedProductIds,
     ...listProps
   } = props;
   const intl = useIntl();
@@ -173,7 +176,10 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
     PRODUCT_OVERVIEW_MORE_ACTIONS,
   } = useExtensions(extensionMountPoints.PRODUCT_LIST);
 
-  const extensionMenuItems = mapToMenuItems(PRODUCT_OVERVIEW_MORE_ACTIONS);
+  const extensionMenuItems = mapToMenuItemsForProductOverviewActions(
+    PRODUCT_OVERVIEW_MORE_ACTIONS,
+    selectedProductIds,
+  );
   const extensionCreateButtonItems = mapToMenuItems(PRODUCT_OVERVIEW_CREATE);
 
   return (

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -400,6 +400,7 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
         disabled={loading}
         limits={limitOpts.data?.shop.limits}
         products={mapEdgesToItems(data?.products)}
+        selectedProductIds={listElements}
         onColumnQueryChange={availableInGridAttributesOpts.search}
         onFetchMore={availableInGridAttributesOpts.loadMore}
         onUpdateListSettings={updateListSettings}

--- a/src/storybook/stories/customers/CustomerListPage.tsx
+++ b/src/storybook/stories/customers/CustomerListPage.tsx
@@ -26,6 +26,7 @@ const props: CustomerListPageProps = {
   ...sortPageProps,
   ...tabPageProps,
   customers: customerList,
+  selectedCustomerIds: ["123"],
   filterOpts: {
     joined: {
       active: false,

--- a/src/storybook/stories/products/ProductListPage.tsx
+++ b/src/storybook/stories/products/ProductListPage.tsx
@@ -49,6 +49,7 @@ const props: ProductListPageProps = {
   onExport: () => undefined,
   products,
   selectedChannelId: "123",
+  selectedProductIds: ["123"],
   settings: {
     ...pageListProps.default.settings,
     columns: ["availability", "productType", "price"],

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,9 +1,9 @@
 import isArray from "lodash/isArray";
 import { stringify } from "qs";
 
-export function stringifyQs(params: {}): string {
+export function stringifyQs(params: {}, arrayFormat?: string): string {
   return stringify(params, {
-    arrayFormat: "indices",
+    arrayFormat: arrayFormat || "indices",
   });
 }
 


### PR DESCRIPTION
I want to merge this change because there is a new app mount that has to be handled.

Additional change: app popups displayed on the detail pages will receive object id. For example: the product details extension popup will get the id of the currently viewed product, so it will be able to display data related to it. Since it's an additional query param, it is a nonbreaking change for the apps.  

How to test:

Added example app which use all available mounting points: https://github.com/saleor/saleor-app-template/pull/106

1. start dashboard dev server with this branch, connect it to saleor cloud instance
2. clone the example app
3. `pnpm i`, `pnpm dev` the app to start it
4. in the app directory run `saleor app tunnel`
5. now you can go to the dev dashboard and witness full glory of available app extensions

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
6. [ ] All visible strings are translated with proper context including data-formatting
7. [ ] Attributes `[data-test-id]` are added for new elements
8. [x] Changes are mentioned in the changelog
9. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1