### PR TITLE
Add test to check app permission.

### DIFF
--- a/cypress/e2e/apps.js
+++ b/cypress/e2e/apps.js
@@ -9,20 +9,28 @@ import { WEBHOOK_DETAILS } from "../elements/apps/webhookDetails";
 import { BUTTON_SELECTORS } from "../elements/shared/button-selectors";
 import { appDetailsUrl, urlList } from "../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../fixtures/users";
-import { createApp, getApp } from "../support/api/requests/Apps";
+import { createApp, getApp, updateApp } from "../support/api/requests/Apps";
+import { createVoucher } from "../support/api/requests/Discounts/Vouchers";
+import { createGiftCard } from "../support/api/requests/GiftCard";
 import { deleteAppsStartsWith } from "../support/api/utils/appUtils";
+import { getDefaultChannel } from "../support/api/utils/channelsUtils";
+import { discountOptions } from "../support/pages/discounts/vouchersPage";
 
-describe("Tests for apps", () => {
+describe("As a staff user I want to manage apps", () => {
   const startsWith = "Apps";
   const name = `${startsWith}${faker.datatype.number()}`;
 
   let createdApp;
+  let defaultChannel;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
     deleteAppsStartsWith(startsWith);
     createApp(name, "MANAGE_APPS").then(app => {
       createdApp = app;
+    });
+    getDefaultChannel().then(channel => {
+      defaultChannel = channel;
     });
   });
 
@@ -31,16 +39,16 @@ describe("Tests for apps", () => {
   });
 
   it(
-    "should create app. TC: SALEOR_3001",
+    "should be able to create app. TC: SALEOR_3001",
     { tags: ["@app", "@allEnv", "@stable"] },
     () => {
-      const randomName = `${startsWith}${faker.datatype.number()}`;
+      const randomAppName = `${startsWith}${faker.datatype.number()}`;
 
       cy.visit(urlList.apps)
         .get(APPS_LIST.createLocalAppButton)
         .click()
         .get(APP_DETAILS.nameInput)
-        .type(randomName)
+        .type(randomAppName)
         .get(APP_DETAILS.manageAppsPermissionCheckbox)
         .click()
         .addAliasToGraphRequest("AppCreate")
@@ -53,7 +61,7 @@ describe("Tests for apps", () => {
           getApp(app.id);
         })
         .then(app => {
-          expect(app.name).to.eq(randomName);
+          expect(app.name).to.eq(randomAppName);
           const token = app.tokens.find(element => element.name === "Default");
           expect(token).to.be.ok;
         });
@@ -61,42 +69,42 @@ describe("Tests for apps", () => {
   );
 
   it(
-    "should create webhook. TC: SALEOR_3002",
+    "should be able to create webhook. TC: SALEOR_3002",
     { tags: ["@app", "@allEnv", "@stable"] },
     () => {
-      const randomName = `${startsWith}${faker.datatype.number()}`;
-      const targetUrl = `http://example.${randomName}`;
+      const randomWebhookName = `${startsWith}${faker.datatype.number()}`;
+      const targetUrl = `http://example.${randomWebhookName}`;
 
-      cy.visit(appDetailsUrl(createdApp.id))
+      cy.visit(appDetailsUrl(createdApp.app.id))
         .get(APP_DETAILS.createWebhookButton)
         .click()
         .get(WEBHOOK_DETAILS.nameInput)
-        .type(randomName)
+        .type(randomWebhookName)
         .get(WEBHOOK_DETAILS.targetUrlInput)
         .type(targetUrl)
         .get(BUTTON_SELECTORS.confirm)
         .click()
         .confirmationMessageShouldDisappear();
-      getApp(createdApp.id).then(({ webhooks }) => {
-        expect(webhooks[0].name).to.eq(randomName);
+      getApp(createdApp.app.id).then(({ webhooks }) => {
+        expect(webhooks[0].name).to.eq(randomWebhookName);
         expect(webhooks[0].targetUrl).to.eq(targetUrl);
       });
     },
   );
 
   it(
-    "should create token. TC: SALEOR_3003",
+    "should be able to create token. TC: SALEOR_3003",
     { tags: ["@app", "@allEnv", "@stable"] },
     () => {
-      const randomName = `${startsWith}${faker.datatype.number()}`;
+      const randomTokenName = `${startsWith}${faker.datatype.number()}`;
       let expectedToken;
 
-      cy.visit(appDetailsUrl(createdApp.id))
+      cy.visit(appDetailsUrl(createdApp.app.id))
         .get(APP_DETAILS.createTokenButton)
         .click()
         .get(APP_DETAILS.createTokenForm.tokenDialog)
         .find(APP_DETAILS.createTokenForm.nameInput)
-        .type(randomName)
+        .type(randomTokenName)
         .get(BUTTON_SELECTORS.submit)
         .click()
         .get(APP_DETAILS.createTokenForm.tokenToCopy)
@@ -104,15 +112,49 @@ describe("Tests for apps", () => {
         .then(text => {
           expectedToken = text;
           cy.get(APP_DETAILS.createTokenForm.doneButton).click();
-          getApp(createdApp.id);
+          getApp(createdApp.app.id);
         })
         .then(app => {
-          const token = app.tokens.find(element => element.name === randomName);
+          const token = app.tokens.find(
+            element => element.name === randomTokenName,
+          );
           const tokenLastFourDigits = expectedToken.slice(
             expectedToken.length - 4,
           );
           expect(token.authToken).to.eq(tokenLastFourDigits);
         });
+    },
+  );
+
+  it(
+    "should be able to use app only to manage giftCards. TC: SALEOR_3004",
+    { tags: ["@app", "@allEnv", "@stable"] },
+    () => {
+      const startsWith = "AppPermission-";
+      const token = createdApp.authToken;
+      const voucherData = {
+        voucherCode: `${startsWith}${faker.datatype.number()}`,
+        voucherValue: 10,
+        discountOption: discountOptions.PERCENTAGE,
+        channelName: defaultChannel.name,
+      };
+      const giftCardData = {
+        tag: `${startsWith}${faker.datatype.number()}`,
+        amount: 150,
+        currency: "USD",
+      };
+
+      cy.clearSessionData().loginUserViaRequest();
+      updateApp(createdApp.app.id, "MANAGE_GIFT_CARD");
+      cy.clearSessionData();
+
+      createVoucher(voucherData, token).then(resp => {
+        expect(resp.voucherCreate).to.be.null;
+      });
+      createGiftCard(giftCardData, token).then(resp => {
+        expect(resp.code).to.be.not.empty;
+        expect(resp.isActive).to.eq(true);
+      });
     },
   );
 });

--- a/cypress/e2e/configuration/siteSettings.js
+++ b/cypress/e2e/configuration/siteSettings.js
@@ -4,7 +4,6 @@
 import faker from "faker";
 
 import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
-import { SITE_SETTINGS_DETAILS } from "../../elements/siteSettings/site-settings-details";
 import { urlList } from "../../fixtures/urlList";
 import {
   getShopInfo,
@@ -23,47 +22,14 @@ xdescribe("Tests for site settings", () => {
     });
   });
 
-  beforeEach(() => {
-    cy.clearSessionData()
-      .loginUserViaRequest()
-      .visit(urlList.siteSettings);
-  });
-
-  it("should change store name", { tags: ["@siteSettings", "@allEnv"] }, () => {
-    const name = `Cypress-${faker.datatype.number()}`;
-
-    cy.get(SITE_SETTINGS_DETAILS.nameInput)
-      .clearAndType(name)
-      .get(BUTTON_SELECTORS.confirm)
-      .click()
-      .confirmationMessageShouldDisappear();
-    getShopInfo().then(shopInfo => {
-      expect(shopInfo.name).to.eq(name);
-    });
-  });
-
-  it(
-    "should change store description",
-    { tags: ["@siteSettings", "@allEnv"] },
-    () => {
-      const description = faker.lorem.sentence();
-
-      cy.get(SITE_SETTINGS_DETAILS.descriptionInput)
-        .clearAndType(description)
-        .get(BUTTON_SELECTORS.confirm)
-        .click()
-        .confirmationMessageShouldDisappear();
-      getShopInfo().then(shopInfo => {
-        expect(shopInfo.description).to.eq(description);
-      });
-    },
-  );
-
   it(
     "should change store address",
     { tags: ["@siteSettings", "@allEnv"] },
     () => {
-      cy.fillUpBasicAddress(address)
+      cy.clearSessionData()
+        .loginUserViaRequest()
+        .visit(urlList.siteSettings)
+        .fillUpBasicAddress(address)
         .get(BUTTON_SELECTORS.confirm)
         .click()
         .confirmationMessageShouldDisappear();

--- a/cypress/e2e/discounts/vouchers/updateVouchers.js
+++ b/cypress/e2e/discounts/vouchers/updateVouchers.js
@@ -59,7 +59,7 @@ describe("As an admin I want to update vouchers", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const voucherValue = 50;
 
-      let voucher;
+      let voucherCreate;
 
       cy.clearSessionData().loginUserViaRequest();
       createVoucherInChannel({
@@ -69,16 +69,16 @@ describe("As an admin I want to update vouchers", () => {
         value: voucherValue,
       })
         .then(voucherResp => {
-          voucher = voucherResp;
-          expect(voucher.id).to.be.ok;
-          cy.visit(voucherDetailsUrl(voucher.id))
+          voucherCreate = voucherResp;
+          expect(voucherCreate.voucher.id).to.be.ok;
+          cy.visit(voucherDetailsUrl(voucherCreate.voucher.id))
             .addAliasToGraphRequest("VoucherDelete")
             .get(BUTTON_SELECTORS.deleteButton)
             .click()
             .get(BUTTON_SELECTORS.submit)
             .click()
             .wait("@VoucherDelete");
-          dataForCheckout.voucherCode = voucher.code;
+          dataForCheckout.voucherCode = voucherCreate.code;
           window.sessionStorage.setItem("token", "");
           dataForCheckout.auth = "token";
           createCheckoutWithVoucher(dataForCheckout);
@@ -102,7 +102,7 @@ describe("As an admin I want to update vouchers", () => {
         shippingPrice -
         (productPrice * voucherUpdatedValue) / 100;
 
-      let voucher;
+      let voucherCreate;
 
       cy.clearSessionData().loginUserViaRequest();
       createVoucherInChannel({
@@ -112,9 +112,9 @@ describe("As an admin I want to update vouchers", () => {
         value: voucherValue,
       })
         .then(voucherResp => {
-          voucher = voucherResp;
-          expect(voucher.id).to.be.ok;
-          cy.visit(voucherDetailsUrl(voucher.id))
+          voucherCreate = voucherResp;
+          expect(voucherCreate.voucher.id).to.be.ok;
+          cy.visit(voucherDetailsUrl(voucherCreate.voucher.id))
             .addAliasToGraphRequest("VoucherUpdate")
             .get(VOUCHERS_SELECTORS.percentageDiscountRadioButton)
             .click()
@@ -123,7 +123,7 @@ describe("As an admin I want to update vouchers", () => {
             .get(BUTTON_SELECTORS.confirm)
             .click()
             .wait("@VoucherUpdate");
-          dataForCheckout.voucherCode = voucher.code;
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           window.sessionStorage.setItem("token", "");
           dataForCheckout.auth = "token";
           createCheckoutWithVoucher(dataForCheckout);
@@ -146,7 +146,7 @@ describe("As an admin I want to update vouchers", () => {
       const todayDate = formatDate(today);
       const tomorrowDate = formatDate(tomorrow.setDate(tomorrow.getDate() + 1));
 
-      let voucher;
+      let voucherCreate;
 
       cy.clearSessionData().loginUserViaRequest();
       createVoucherInChannel({
@@ -156,17 +156,23 @@ describe("As an admin I want to update vouchers", () => {
         value: voucherValue,
       })
         .then(voucherResp => {
-          voucher = voucherResp;
-          expect(voucher.id).to.be.ok;
-          setVoucherDate({ voucherId: voucher.id, startDate: tomorrowDate });
-          dataForCheckout.voucherCode = voucher.code;
+          voucherCreate = voucherResp;
+          expect(voucherCreate.voucher.id).to.be.ok;
+          setVoucherDate({
+            voucherId: voucherCreate.voucher.id,
+            startDate: tomorrowDate,
+          });
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           createCheckoutWithVoucher(dataForCheckout);
         })
         .then(({ addPromoCodeResp }) => {
           const errorField = addPromoCodeResp.errors[0].field;
           expect(errorField).to.be.eq("promoCode");
-          setVoucherDate({ voucherId: voucher.id, startDate: todayDate });
-          dataForCheckout.voucherCode = voucher.code;
+          setVoucherDate({
+            voucherId: voucherCreate.voucher.id,
+            startDate: todayDate,
+          });
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           window.sessionStorage.setItem("token", "");
           dataForCheckout.auth = "token";
           createCheckoutWithVoucher(dataForCheckout);
@@ -188,7 +194,7 @@ describe("As an admin I want to update vouchers", () => {
       const tomorrow = new Date(today);
       const tomorrowDate = formatDate(tomorrow.setDate(tomorrow.getDate() + 1));
 
-      let voucher;
+      let voucherCreate;
 
       cy.clearSessionData().loginUserViaRequest();
       createVoucherInChannel({
@@ -198,15 +204,15 @@ describe("As an admin I want to update vouchers", () => {
         value: voucherValue,
       })
         .then(voucherResp => {
-          voucher = voucherResp;
-          expect(voucher.id).to.be.ok;
+          voucherCreate = voucherResp;
+          expect(voucherCreate.voucher.id).to.be.ok;
           setVoucherDate({
-            voucherId: voucher.id,
+            voucherId: voucherCreate.voucher.id,
             endDate: todayDate,
             endTime: formatTime(today),
             hasEndDate: true,
           });
-          dataForCheckout.voucherCode = voucher.code;
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           window.sessionStorage.setItem("token", "");
           dataForCheckout.auth = "token";
           createCheckoutWithVoucher(dataForCheckout);
@@ -215,11 +221,11 @@ describe("As an admin I want to update vouchers", () => {
           const errorField = addPromoCodeResp.errors[0].field;
           expect(errorField).to.be.eq("promoCode");
           setVoucherDate({
-            voucherId: voucher.id,
+            voucherId: voucherCreate.voucher.id,
             endDate: tomorrowDate,
             endTime: formatTime(tomorrow),
           });
-          dataForCheckout.voucherCode = voucher.code;
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           createCheckoutWithVoucher(dataForCheckout);
         })
         .then(({ addPromoCodeResp }) => {
@@ -235,7 +241,7 @@ describe("As an admin I want to update vouchers", () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const voucherValue = 50;
 
-      let voucher;
+      let voucherCreate;
 
       cy.clearSessionData().loginUserViaRequest();
       createVoucherInChannel({
@@ -247,16 +253,16 @@ describe("As an admin I want to update vouchers", () => {
         country: "US",
       })
         .then(voucherResp => {
-          voucher = voucherResp;
-          expect(voucher.id).to.be.ok;
-          dataForCheckout.voucherCode = voucher.code;
+          voucherCreate = voucherResp;
+          expect(voucherCreate.voucher.id).to.be.ok;
+          dataForCheckout.voucherCode = voucherCreate.voucher.code;
           window.sessionStorage.setItem("token", "");
           dataForCheckout.auth = "token";
           createCheckoutWithVoucher(dataForCheckout);
         })
         .then(({ addPromoCodeResp }) => {
           expect(addPromoCodeResp.errors).to.be.empty;
-          cy.visit(voucherDetailsUrl(voucher.id))
+          cy.visit(voucherDetailsUrl(voucherCreate.voucher.id))
             .get(VOUCHERS_SELECTORS.shippingDiscountRadioButton)
             .click()
             .get(VOUCHERS_SELECTORS.countriesDropdownIcon)

--- a/cypress/elements/apps/appDetails.js
+++ b/cypress/elements/apps/appDetails.js
@@ -7,6 +7,6 @@ export const APP_DETAILS = {
     tokenDialog: '[role="dialog"]',
     nameInput: '[name="name"]',
     tokenToCopy: '[data-test-id="generated-token"]',
-    doneButton: '[data-test-id="done"]'
-  }
+    doneButton: '[data-test-id="done"]',
+  },
 };

--- a/cypress/elements/siteSettings/site-settings-details.js
+++ b/cypress/elements/siteSettings/site-settings-details.js
@@ -1,8 +1,6 @@
 export const SITE_SETTINGS_DETAILS = {
-  nameInput: '[name="name"]',
-  descriptionInput: '[name="description"]',
   stockReservationAuthenticatedUserInput:
     '[name="reserveStockDurationAuthenticatedUser"]',
   stockReservationAnonymousUserInput:
-    '[name="reserveStockDurationAnonymousUser"]'
+    '[name="reserveStockDurationAnonymousUser"]',
 };

--- a/cypress/support/api/requests/Apps.js
+++ b/cypress/support/api/requests/Apps.js
@@ -11,7 +11,7 @@ export function createApp(name, permission) {
       }
     }
   }`;
-  return cy.sendRequestWithQuery(mutation).its("body.data.appCreate.app");
+  return cy.sendRequestWithQuery(mutation).its("body.data.appCreate");
 }
 
 export function getApps(first, search) {
@@ -60,4 +60,20 @@ export function getApp(appId) {
     }
   }`;
   return cy.sendRequestWithQuery(query).its("body.data.app");
+}
+
+export function updateApp(appId, permission) {
+  const mutation = `mutation{
+    appUpdate(id:"${appId}" input:{permissions: [${permission}]}){
+      errors{
+        code
+      }
+      app{
+        permissions{
+          name
+        }
+      }
+    }
+  }`;
+  return cy.sendRequestWithQuery(mutation);
 }

--- a/cypress/support/api/requests/Discounts/Vouchers.js
+++ b/cypress/support/api/requests/Discounts/Vouchers.js
@@ -30,7 +30,10 @@ export function deleteVouchers(voucherId) {
   return cy.sendRequestWithQuery(mutation);
 }
 
-export function createVoucher({ name, productId, code = name, type, country }) {
+export function createVoucher(
+  { name, productId, code = name, type, country },
+  token,
+) {
   const discountTypeLines = getValueWithDefault(type, `type:${type}`);
   const countryLine = getValueWithDefault(country, `countries:["${country}"]`);
 
@@ -52,7 +55,7 @@ export function createVoucher({ name, productId, code = name, type, country }) {
       }
     }
   }`;
-  return cy.sendRequestWithQuery(mutation).its("body.data.voucherCreate");
+  return cy.sendRequestWithQuery(mutation, token).its("body.data");
 }
 
 export function addChannelToVoucher(voucherId, channelId, value) {

--- a/cypress/support/api/requests/GiftCard.js
+++ b/cypress/support/api/requests/GiftCard.js
@@ -107,7 +107,10 @@ export function getGiftCardWithId(id) {
   return cy.sendRequestWithQuery(query).its("body.data.giftCard");
 }
 
-export function createGiftCard({ tag, currency, amount, isActive = true }) {
+export function createGiftCard(
+  { tag, currency, amount, isActive = true },
+  token,
+) {
   const mutation = `mutation{
     giftCardCreate(input:{
       addTags:"${tag}"
@@ -129,7 +132,7 @@ export function createGiftCard({ tag, currency, amount, isActive = true }) {
     }
   }`;
   return cy
-    .sendRequestWithQuery(mutation)
+    .sendRequestWithQuery(mutation, token)
     .its("body.data.giftCardCreate.giftCard");
 }
 

--- a/cypress/support/api/requests/utils/index.js
+++ b/cypress/support/api/requests/utils/index.js
@@ -1,0 +1,46 @@
+// / <reference types="cypress" />
+
+import { urlList } from "../../../../fixtures/urlList";
+
+Cypress.Commands.add(
+  "sendRequestWithQuery",
+  (query, authorization = "auth", variables = "") => {
+    if (authorization.length !== 30) {
+      cy.request({
+        body: {
+          variables,
+          query,
+        },
+        headers: {
+          Authorization: `JWT ${window.sessionStorage.getItem(authorization)}`,
+        },
+        method: "POST",
+        url: urlList.apiUri,
+        log: true,
+      }).then(response => {
+        const respInSting = JSON.stringify(response.body);
+        if (respInSting.includes(`"errors":[{`)) {
+          cy.log(query).log(JSON.stringify(response.body));
+        }
+      });
+    } else {
+      cy.request({
+        body: {
+          variables,
+          query,
+        },
+        headers: {
+          Authorization: `Bearer ${authorization}`,
+        },
+        method: "POST",
+        url: urlList.apiUri,
+        log: true,
+      }).then(response => {
+        const respInSting = JSON.stringify(response.body);
+        if (respInSting.includes(`"errors":[{`)) {
+          cy.log(query).log(JSON.stringify(response.body));
+        }
+      });
+    }
+  },
+);

--- a/cypress/support/api/utils/discounts/vouchersUtils.js
+++ b/cypress/support/api/utils/discounts/vouchersUtils.js
@@ -2,7 +2,7 @@ import {
   addChannelToVoucher,
   createVoucher,
   deleteVouchers,
-  getVouchers
+  getVouchers,
 } from "../../requests/Discounts/Vouchers";
 
 export function deleteVouchersStartsWith(startsWith) {
@@ -16,13 +16,14 @@ export function createVoucherInChannel({
   value,
   code = name,
   type,
-  country
+  country,
 }) {
-  let voucher;
+  let voucherCreate;
+
   return createVoucher({ name, productId, code, type, country })
-    .then(({ voucher: voucherResp }) => {
-      voucher = voucherResp;
-      addChannelToVoucher(voucher.id, channelId, value);
+    .then(({ voucherCreate: voucherResp }) => {
+      voucherCreate = voucherResp;
+      addChannelToVoucher(voucherCreate.voucher.id, channelId, value);
     })
-    .then(() => voucher);
+    .then(() => voucherCreate);
 }

--- a/cypress/support/customCommands/user/index.js
+++ b/cypress/support/customCommands/user/index.js
@@ -1,3 +1,5 @@
+import "../../api/requests/utils/index";
+
 import { LOGIN_SELECTORS } from "../../../elements/account/login-selectors";
 import { TEST_ADMIN_USER } from "../../../fixtures/users";
 
@@ -8,7 +10,7 @@ Cypress.Commands.add("loginUser", () =>
     .get(LOGIN_SELECTORS.emailPasswordInput)
     .type(Cypress.env("USER_PASSWORD"), { log: false })
     .get(LOGIN_SELECTORS.signInButton)
-    .click()
+    .click(),
 );
 
 Cypress.Commands.add("loginInShop", () => {
@@ -36,12 +38,12 @@ Cypress.Commands.add(
     return cy.sendRequestWithQuery(mutation, authorization).then(resp => {
       window.localStorage.setItem(
         "_saleorCSRFToken",
-        resp.body.data.tokenCreate.csrfToken
+        resp.body.data.tokenCreate.csrfToken,
       );
       window.sessionStorage.setItem(
         authorization,
-        resp.body.data.tokenCreate.token
+        resp.body.data.tokenCreate.token,
       );
     });
-  }
+  },
 );

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -47,29 +47,6 @@ Cypress.Commands.add("addAliasToGraphRequest", operationName => {
   });
 });
 
-Cypress.Commands.add(
-  "sendRequestWithQuery",
-  (query, authorization = "auth", variables = "") =>
-    cy
-      .request({
-        body: {
-          variables,
-          query,
-        },
-        headers: {
-          Authorization: `JWT ${window.sessionStorage.getItem(authorization)}`,
-        },
-        method: "POST",
-        url: urlList.apiUri,
-        log: true,
-      })
-      .then(response => {
-        const respInSting = JSON.stringify(response.body);
-        if (respInSting.includes(`"errors":[{`)) {
-          cy.log(query).log(JSON.stringify(response.body));
-        }
-      }),
-);
 Cypress.on(
   "uncaught:exception",
   (err, runnable) =>

--- a/cypress/support/pages/siteSettings.js
+++ b/cypress/support/pages/siteSettings.js
@@ -17,5 +17,5 @@ export function enterSiteSettingAndSetStockReservation(userType, stockAmount) {
 
 export const userType = {
   anonymous: SITE_SETTINGS_DETAILS.stockReservationAnonymousUserInput,
-  authenticated: SITE_SETTINGS_DETAILS.stockReservationAuthenticatedUserInput
+  authenticated: SITE_SETTINGS_DETAILS.stockReservationAuthenticatedUserInput,
 };


### PR DESCRIPTION
I want to merge this change because:
- test to check if app with one permission e.g. `MANAGE_GIFT_CARD` cannot create voucher,
- moved custom command from e2e.js to index.js in support/api/requests/utils and adding condition for appToken,
- remove tests from siteSettings - user cannot change store name/description only address is available, also test is still blocked by bug so it is excluded 
- cleanup with var names.

Please check if tests for gitfCards and Vouchers are working - I've checked and it was OK. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
