### PR TITLE
create simple product without sku

### DIFF
--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -45,6 +45,7 @@ describe("Creating variants", () => {
     cy.clearSessionData().loginUserViaRequest();
     shippingUtils.deleteShippingStartsWith(startsWith);
     productUtils.deleteProductsStartsWith(startsWith);
+    deleteChannelsStartsWith(startsWith);
 
     const name = `${startsWith}${faker.datatype.number()}`;
     const simpleProductTypeName = `${startsWith}${faker.datatype.number()}`;

--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -197,6 +197,7 @@ describe("Creating variants", () => {
     { tags: ["@products", "@allEnv"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
+
       cy.visit(urlList.products)
         .get(PRODUCTS_LIST.createProductBtn)
         .click()
@@ -246,7 +247,9 @@ describe("Creating variants", () => {
             variantsList: variants,
             shippingMethodName: shippingMethod.name,
             address,
-          });
+          })
+            .its("order.id")
+            .should("be.ok");
         });
     },
   );

--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -22,7 +22,6 @@ import { createWaitingForCaptureOrder } from "../../../support/api/utils/ordersU
 import * as productUtils from "../../../support/api/utils/products/productsUtils";
 import * as shippingUtils from "../../../support/api/utils/shippingUtils";
 import { getProductVariants } from "../../../support/api/utils/storeFront/storeFrontProductUtils";
-// import { deleteWarehouseStartsWith } from "../../../support/api/utils/warehouseUtils";
 import {
   createFirstVariant,
   createVariant,
@@ -46,7 +45,6 @@ describe("Creating variants", () => {
     cy.clearSessionData().loginUserViaRequest();
     shippingUtils.deleteShippingStartsWith(startsWith);
     productUtils.deleteProductsStartsWith(startsWith);
-    // deleteChannelsStartsWith(startsWith);
 
     const name = `${startsWith}${faker.datatype.number()}`;
     const simpleProductTypeName = `${startsWith}${faker.datatype.number()}`;
@@ -237,7 +235,7 @@ describe("Creating variants", () => {
         .addAliasToGraphRequest("ProductDetails")
         .get(BUTTON_SELECTORS.confirm)
         .click()
-        .reload()
+        .confirmationMessageShouldDisappear()
         .wait("@ProductDetails")
         .then(({ response }) => {
           const variants = [response.body.data.product.variants[0]];


### PR DESCRIPTION
I want to merge this change because it fixes test `SALEOR_2806 should create simple product without sku` 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
