### PR TITLE
Fix for tests connected with changes for relation between channel-warehouse-shippingZone

### DIFF
--- a/cypress/e2e/configuration/shippingMethods/channelsInShipping.js
+++ b/cypress/e2e/configuration/shippingMethods/channelsInShipping.js
@@ -31,7 +31,7 @@ describe("As a staff user I want have different shipping method prices for each 
 
   it(
     "should be able to display different price for each channel. TC: SALEOR_0805",
-    { tags: ["@shipping", "@allEnv"] },
+    { tags: ["@shipping", "@allEnv", "@stable"] },
     () => {
       const shippingName = `${startsWith}${faker.datatype.number()}`;
       const defaultChannelPrice = 11;

--- a/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
+++ b/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
@@ -5,6 +5,7 @@ import faker from "faker";
 
 import { urlList } from "../../../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../../../fixtures/users";
+import { updateChannelWarehouses } from "../../../support/api/requests/Channels";
 import { createCheckout } from "../../../support/api/requests/Checkout";
 import { createVariant } from "../../../support/api/requests/Product";
 import { createWarehouse } from "../../../support/api/requests/Warehouse";
@@ -44,14 +45,18 @@ describe("As a staff user I want to create shipping zone and rate", () => {
       .getDefaultChannel()
       .then(channel => {
         defaultChannel = channel;
+
         cy.fixture("addresses");
       })
       .then(addresses => {
         address = addresses.usAddress;
+
         createWarehouse({ name, address });
       })
       .then(warehouseResp => {
         warehouse = warehouseResp;
+
+        updateChannelWarehouses(defaultChannel.id, warehouse.id);
         productsUtils.createTypeAttributeAndCategoryForProduct({
           name: startsWith,
         });
@@ -103,7 +108,7 @@ describe("As a staff user I want to create shipping zone and rate", () => {
 
   it(
     "should be able to create price based shipping method. TC: SALEOR_0803",
-    { tags: ["@shipping", "@allEnv"] },
+    { tags: ["@shipping", "@allEnv", "@stable"] },
     () => {
       const shippingName = `${startsWith}${faker.datatype.number()}`;
       cy.clearSessionData().loginUserViaRequest(
@@ -153,7 +158,7 @@ describe("As a staff user I want to create shipping zone and rate", () => {
 
   it(
     "should be able to create weight based shipping method. TC: SALEOR_0804",
-    { tags: ["@shipping", "@allEnv"] },
+    { tags: ["@shipping", "@allEnv", "@stable"] },
     () => {
       const shippingName = `${startsWith}${faker.datatype.number()}`;
       cy.clearSessionData().loginUserViaRequest(

--- a/cypress/e2e/configuration/shippingMethods/editShippingMethod.js
+++ b/cypress/e2e/configuration/shippingMethods/editShippingMethod.js
@@ -4,12 +4,14 @@
 import faker from "faker";
 
 import { shippingRateUrl } from "../../../fixtures/urlList";
+import { updateChannelWarehouses } from "../../../support/api/requests/Channels";
 import {
   addChannelToShippingMethod,
   createShippingRate,
   createShippingZone,
   getShippingZone,
 } from "../../../support/api/requests/ShippingMethod";
+import { createWarehouse } from "../../../support/api/requests/Warehouse";
 import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
 import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
 import {
@@ -25,6 +27,8 @@ describe("As a user I should be able to update and delete shipping method", () =
   let defaultChannel;
   let shippingZone;
   let shippingMethod;
+  let usAddress;
+  let warehouse;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
@@ -33,10 +37,22 @@ describe("As a user I should be able to update and delete shipping method", () =
     getDefaultChannel()
       .then(channel => {
         defaultChannel = channel;
-        createShippingZone(name, "US", defaultChannel.id);
+
+        cy.fixture("addresses");
       })
-      .then(shippingZoneResp => {
-        shippingZone = shippingZoneResp;
+      .then(({ usAddress: usAddressResp }) => {
+        usAddress = usAddressResp;
+
+        createWarehouse({ name, address: usAddress }).then(warehouseResp => {
+          warehouse = warehouseResp;
+
+          updateChannelWarehouses(defaultChannel.id, warehouse.id);
+          createShippingZone(name, "US", defaultChannel.id, warehouse.id).then(
+            shippingZoneResp => {
+              shippingZone = shippingZoneResp;
+            },
+          );
+        });
       });
   });
 

--- a/cypress/e2e/configuration/shippingMethods/postalCodes.js
+++ b/cypress/e2e/configuration/shippingMethods/postalCodes.js
@@ -44,6 +44,7 @@ describe("As a user I want to create shipping method with postal codes", () => {
     getDefaultChannel()
       .then(channel => {
         defaultChannel = channel;
+
         cy.fixture("addresses");
       })
       .then(
@@ -53,24 +54,24 @@ describe("As a user I want to create shipping method with postal codes", () => {
         }) => {
           usAddress = usAddressResp;
           secondUsAddress = secondUsAddressResp;
-          createShippingZone(name, "US", defaultChannel.id);
+
+          createWarehouse({ name, address: usAddress }).then(warehouseResp => {
+            warehouse = warehouseResp;
+
+            updateChannelWarehouses(defaultChannel.id, warehouse.id);
+            createShippingZone(
+              name,
+              "US",
+              defaultChannel.id,
+              warehouse.id,
+            ).then(shippingZoneResp => {
+              shippingZone = shippingZoneResp;
+
+              createTypeAttributeAndCategoryForProduct({ name });
+            });
+          });
         },
       )
-      .then(shippingZoneResp => {
-        shippingZone = shippingZoneResp;
-        createWarehouse({
-          name,
-          shippingZone: shippingZone.id,
-          address: usAddress,
-        });
-      })
-      .then(warehouseResp => {
-        warehouse = warehouseResp;
-        if (returnValueDependsOnShopVersion("3.5", true, false)) {
-          updateChannelWarehouses(defaultChannel.id, warehouse.id);
-        }
-        createTypeAttributeAndCategoryForProduct({ name });
-      })
       .then(({ attribute, productType, category }) => {
         createProductInChannel({
           name,

--- a/cypress/e2e/configuration/shippingMethods/shippingWeights/shippingWeightsLimits.js
+++ b/cypress/e2e/configuration/shippingMethods/shippingWeights/shippingWeightsLimits.js
@@ -17,7 +17,6 @@ import {
 } from "../../../../support/api/utils/products/productsUtils";
 import { deleteShippingStartsWith } from "../../../../support/api/utils/shippingUtils";
 import { isShippingAvailableInCheckout } from "../../../../support/api/utils/storeFront/checkoutUtils";
-import { returnValueDependsOnShopVersion } from "../../../../support/formatData/dataDependingOnVersion";
 import {
   createShippingRate,
   rateOptions,
@@ -43,26 +42,24 @@ describe("As a staff user I want to manage shipping weights", () => {
     getDefaultChannel()
       .then(channel => {
         defaultChannel = channel;
+
         cy.fixture("addresses");
       })
       .then(({ usAddress: usAddressResp }) => {
         usAddress = usAddressResp;
-        createShippingZone(name, "US", defaultChannel.id);
-      })
-      .then(shippingZoneResp => {
-        shippingZone = shippingZoneResp;
-        createWarehouse({
-          name,
-          shippingZone: shippingZone.id,
-          address: usAddress,
-        });
-      })
-      .then(warehouseResp => {
-        warehouse = warehouseResp;
-        if (returnValueDependsOnShopVersion("3.5", true, false)) {
+
+        createWarehouse({ name, address: usAddress }).then(warehouseResp => {
+          warehouse = warehouseResp;
+
           updateChannelWarehouses(defaultChannel.id, warehouse.id);
-        }
-        createTypeAttributeAndCategoryForProduct({ name });
+          createShippingZone(name, "US", defaultChannel.id, warehouse.id).then(
+            shippingZoneResp => {
+              shippingZone = shippingZoneResp;
+
+              createTypeAttributeAndCategoryForProduct({ name });
+            },
+          );
+        });
       })
       .then(({ attribute, productType, category }) => {
         createProductInChannel({

--- a/cypress/support/api/requests/ShippingMethod.js
+++ b/cypress/support/api/requests/ShippingMethod.js
@@ -5,15 +5,15 @@ export function createShippingRate({
   shippingZone,
   type = "PRICE",
   maxWeight,
-  minWeight
+  minWeight,
 }) {
   const maxOrderWeight = getValueWithDefault(
     maxWeight,
-    `maximumOrderWeight: ${maxWeight}`
+    `maximumOrderWeight: ${maxWeight}`,
   );
   const minOrderWeight = getValueWithDefault(
     minWeight,
-    `minimumOrderWeight: ${minWeight}`
+    `minimumOrderWeight: ${minWeight}`,
   );
 
   const mutation = `mutation{
@@ -37,10 +37,37 @@ export function createShippingRate({
   return cy.sendRequestWithQuery(mutation).its("body.data.shippingPriceCreate");
 }
 
-export function createShippingZone(name, country, channelId) {
+export function createShippingZone(name, country, channelId, warehouseId) {
   const channelsLines = getValueWithDefault(
     channelId,
-    `addChannels:["${channelId}"]`
+    `addChannels:["${channelId}"]`,
+  );
+  const mutation = `mutation{
+    shippingZoneCreate(input:{
+      name: "${name}"
+      countries: "${country}"
+      ${channelsLines}
+      addWarehouses: ["${warehouseId}"]
+    }){
+      shippingZone{
+        id
+        name
+      }
+      errors{
+        field
+        message
+      }
+    }
+  }`;
+  return cy
+    .sendRequestWithQuery(mutation)
+    .its("body.data.shippingZoneCreate.shippingZone");
+}
+
+export function createShippingZoneWithoutWarehouse(name, country, channelId) {
+  const channelsLines = getValueWithDefault(
+    channelId,
+    `addChannels:["${channelId}"]`,
   );
   const mutation = `mutation{
     shippingZoneCreate(input:{
@@ -81,7 +108,7 @@ export function addChannelToShippingMethod(
   shippingRateId,
   channelId,
   price,
-  minProductPrice = 0
+  minProductPrice = 0,
 ) {
   const mutation = `mutation{
     shippingMethodChannelListingUpdate(id:"${shippingRateId}", input:{

--- a/cypress/support/api/utils/shippingUtils.js
+++ b/cypress/support/api/utils/shippingUtils.js
@@ -15,25 +15,25 @@ export function createShipping({
   let shippingZone;
   let warehouse;
 
-  return shippingMethodRequest
-    .createShippingZone(name, address.country, channelId)
-    .then(shippingZoneResp => {
-      shippingZone = shippingZoneResp;
-      warehouseRequest.createWarehouse({
-        name,
-        shippingZone: shippingZone.id,
-        address,
-      });
+  return warehouseRequest
+    .createWarehouse({
+      name,
+      address,
     })
     .then(warehouseResp => {
       warehouse = warehouseResp;
-      if (returnValueDependsOnShopVersion("3.5", true, false)) {
-        updateChannelWarehouses(channelId, warehouse.id);
-      }
-      shippingMethodRequest.createShippingRate({
-        name,
-        shippingZone: shippingZone.id,
-      });
+
+      updateChannelWarehouses(channelId, warehouse.id);
+      shippingMethodRequest
+        .createShippingZone(name, address.country, channelId, warehouse.id)
+        .then(shippingZoneResp => {
+          shippingZone = shippingZoneResp;
+
+          shippingMethodRequest.createShippingRate({
+            name,
+            shippingZone: shippingZone.id,
+          });
+        });
     })
     .then(({ shippingMethod: sippingMethodResp }) => {
       shippingMethod = sippingMethodResp;

--- a/cypress/support/customCommands/sharedElementsOperations/selects.js
+++ b/cypress/support/customCommands/sharedElementsOperations/selects.js
@@ -1,7 +1,7 @@
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import {
   selectorWithDataValue,
-  SHARED_ELEMENTS
+  SHARED_ELEMENTS,
 } from "../../../elements/shared/sharedElements";
 
 Cypress.Commands.add("createNewOption", (selectSelector, newOption) => {
@@ -26,6 +26,7 @@ Cypress.Commands.add("fillMultiSelect", (selectSelector, option) => {
 
 Cypress.Commands.add("fillBaseSelect", (selectSelector, value) => {
   cy.get(selectSelector)
+    .should("not.have.attr", "aria-disabled", "true")
     .click()
     .get(selectorWithDataValue(value))
     .click();

--- a/cypress/support/pages/shippingMethodPage.js
+++ b/cypress/support/pages/shippingMethodPage.js
@@ -9,14 +9,14 @@ export function createShippingZone(
   shippingName,
   warehouseName,
   country,
-  channelName
+  channelName,
 ) {
   cy.get(SHIPPING_ZONES_LIST.addShippingZone).click();
   fillUpShippingZoneData({
     shippingName,
     warehouseName,
     country,
-    channelName
+    channelName,
   });
 }
 
@@ -24,7 +24,7 @@ export function fillUpShippingZoneData({
   shippingName,
   warehouseName,
   country,
-  channelName
+  channelName,
 }) {
   cy.get(SHIPPING_ZONE_DETAILS.nameInput)
     .clearAndType(shippingName)
@@ -79,7 +79,7 @@ export function createShippingRate({
   rateOption,
   weightLimits,
   deliveryTime,
-  priceLimits
+  priceLimits,
 }) {
   enterAndFillUpShippingRate({
     rateName,
@@ -87,7 +87,7 @@ export function createShippingRate({
     rateOption,
     weightLimits,
     deliveryTime,
-    priceLimits
+    priceLimits,
   });
   return saveRate();
 }
@@ -98,7 +98,7 @@ export function enterAndFillUpShippingRate({
   rateOption,
   weightLimits,
   priceLimits,
-  deliveryTime
+  deliveryTime,
 }) {
   cy.get(rateOption).click();
   fillUpShippingRate({
@@ -106,7 +106,7 @@ export function enterAndFillUpShippingRate({
     price,
     weightLimits,
     priceLimits,
-    deliveryTime
+    deliveryTime,
   });
 }
 
@@ -115,7 +115,7 @@ export function fillUpShippingRate({
   price,
   weightLimits,
   priceLimits,
-  deliveryTime
+  deliveryTime,
 }) {
   cy.waitForProgressBarToNotBeVisible()
     .get(SHARED_ELEMENTS.richTextEditor.empty)
@@ -142,7 +142,7 @@ export function createRateWithPostalCode({
   rateOption = rateOptions.PRICE_OPTION,
   minPostalCode,
   maxPostalCode,
-  postalCodeOption
+  postalCodeOption,
 }) {
   enterAndFillUpShippingRate({ rateName, price, rateOption });
   cy.get(postalCodeOption)
@@ -195,10 +195,10 @@ export function fillUpDeliveryTime({ min, max }) {
 
 export const rateOptions = {
   PRICE_OPTION: SHIPPING_ZONE_DETAILS.addPriceRateButton,
-  WEIGHT_OPTION: SHIPPING_ZONE_DETAILS.addWeightRateButton
+  WEIGHT_OPTION: SHIPPING_ZONE_DETAILS.addWeightRateButton,
 };
 
 export const postalCodesOptions = {
   INCLUDE_OPTION: SHIPPING_RATE_DETAILS.includePostalCodesCheckbox,
-  EXCLUDE_OPTION: SHIPPING_RATE_DETAILS.excludePostalCodesCheckbox
+  EXCLUDE_OPTION: SHIPPING_RATE_DETAILS.excludePostalCodesCheckbox,
 };


### PR DESCRIPTION

I want to merge this change because:
- it fix tests in `shippingMethods` folder - because there were changes in relation `channel-warehouse-shippingZone`
- it fix tests in `warehouse` folder - same reason as above, 
- adding function to `createShippingZoneWithoutWarehouse`, 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
