### PR TITLE
cherry pick with fix test for create channel with shipping zone

### DIFF
--- a/cypress/support/api/utils/warehouseUtils.js
+++ b/cypress/support/api/utils/warehouseUtils.js
@@ -1,0 +1,9 @@
+import * as warehouseRequest from "../requests/Warehouse";
+
+export function deleteWarehouseStartsWith(startsWith) {
+  cy.deleteElementsStartsWith(
+    warehouseRequest.deleteWarehouse,
+    warehouseRequest.getWarehouses,
+    startsWith,
+  );
+}

--- a/cypress/support/pages/channelsPage.js
+++ b/cypress/support/pages/channelsPage.js
@@ -13,7 +13,8 @@ export function createChannelByView({
   currency,
   slug = name,
   shippingZone,
-  defaultCountry = "Poland"
+  defaultCountry = "Poland",
+  warehouse,
 }) {
   cy.addAliasToGraphRequest("Channel")
     .get(CHANNELS_SELECTORS.createChannelButton)
@@ -34,22 +35,38 @@ export function createChannelByView({
   });
   cy.fillAutocompleteSelect(
     ADD_CHANNEL_FORM_SELECTORS.countryAutocompleteInput,
-    defaultCountry
+    defaultCountry,
   );
   if (shippingZone) {
     addShippingZone(shippingZone);
+  }
+  if (warehouse) {
+    addWarehouse(warehouse);
   }
   cy.get(ADD_CHANNEL_FORM_SELECTORS.saveButton).click();
 }
 
 export function addShippingZone(shippingZone) {
   cy.get(BUTTON_SELECTORS.expandIcon)
+    .first()
     .click()
     .get(ADD_CHANNEL_FORM_SELECTORS.addShippingZoneButton)
     .click()
     .fillAutocompleteSelect(
       ADD_CHANNEL_FORM_SELECTORS.shippingAutocompleteSelect,
-      shippingZone
+      shippingZone,
+    );
+}
+
+export function addWarehouse(warehouse) {
+  cy.get(BUTTON_SELECTORS.expandIcon)
+    .last()
+    .click()
+    .get(ADD_CHANNEL_FORM_SELECTORS.addWarehouseButton)
+    .click()
+    .fillAutocompleteSelect(
+      ADD_CHANNEL_FORM_SELECTORS.warehouseAutocompleteSelect,
+      warehouse,
     );
 }
 


### PR DESCRIPTION
I want to merge this change because it fixes the test for creating channel with a shipping zone for 3.5 [PR](https://github.com/saleor/saleor-dashboard/pull/2182)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
