### PR TITLE
Fix cypress test for enable gift card

### DIFF
--- a/cypress/e2e/catalog/giftCards/activateGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/activateGiftCards.js
@@ -72,7 +72,7 @@ describe("As a admin I want to use enabled gift card in checkout", () => {
 
   it(
     "should be able to enable gift card and use it in checkout. TC: SALEOR_1006",
-    { tags: ["@giftCard", "@allEnv"] },
+    { tags: ["@giftCard", "@allEnv", "@stable"] },
     () => {
       const expectedGiftCardBalance =
         giftCardData.amount - productPrice - shippingPrice;

--- a/cypress/e2e/catalog/giftCards/activateGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/activateGiftCards.js
@@ -26,7 +26,7 @@ import {
 } from "../../../support/pages/catalog/giftCardPage";
 
 describe("As a admin I want to use enabled gift card in checkout", () => {
-  const startsWith = "GiftCardsCheckout";
+  const startsWith = "ActivateGiftCards";
   const productPrice = 50;
   const shippingPrice = 50;
   const email = "example@example.com";

--- a/cypress/e2e/catalog/giftCards/createGiftCard.js
+++ b/cypress/e2e/catalog/giftCards/createGiftCard.js
@@ -16,7 +16,7 @@ import {
 } from "../../../support/pages/catalog/giftCardPage";
 
 describe("As an admin I want to create gift card", () => {
-  const startsWith = "GiftCards";
+  const startsWith = "CreateGCards";
   const amount = 50;
   const currency = "USD";
 

--- a/cypress/e2e/catalog/giftCards/updatingGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/updatingGiftCards.js
@@ -14,7 +14,7 @@ import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/cat
 import { formatDate } from "../../../support/formatData/formatDate";
 
 describe("As an admin I want to update gift card", () => {
-  const startsWith = "GiftCards";
+  const startsWith = "updateGCard";
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();

--- a/cypress/e2e/checkout/clickAndCollect.js
+++ b/cypress/e2e/checkout/clickAndCollect.js
@@ -30,7 +30,7 @@ import {
 } from "../../support/pages/warehousePage";
 
 describe("Warehouses in checkout", () => {
-  const startsWith = `CyWarehouseCheckout`;
+  const startsWith = `clickAndCollect`;
   let defaultChannel;
   let usAddress;
   let secondUsAddress;

--- a/cypress/e2e/configuration/attributes/filters.js
+++ b/cypress/e2e/configuration/attributes/filters.js
@@ -11,7 +11,6 @@ import {
   createTypeAttributeAndCategoryForProduct,
   deleteProductsStartsWith,
 } from "../../../support/api/utils/products/productsUtils";
-import filterTests from "../../../support/filterTests";
 import { enterAttributeAndChanegeIsFilterableInDashbord } from "../../../support/pages/attributesPage";
 import {
   enterProductListPage,

--- a/cypress/e2e/configuration/channels/channels.js
+++ b/cypress/e2e/configuration/channels/channels.js
@@ -20,7 +20,6 @@ import { createWarehouse as createWarehouseViaApi } from "../../../support/api/r
 import { deleteChannelsStartsWith } from "../../../support/api/utils/channelsUtils";
 import { deleteShippingStartsWith } from "../../../support/api/utils/shippingUtils";
 import { deleteWarehouseStartsWith } from "../../../support/api/utils/warehouseUtils";
-import { returnValueDependsOnShopVersion } from "../../../support/formatData/dataDependingOnVersion";
 import { createChannelByView } from "../../../support/pages/channelsPage";
 
 describe("Channels", () => {

--- a/cypress/e2e/configuration/plugins/adyen.js
+++ b/cypress/e2e/configuration/plugins/adyen.js
@@ -25,9 +25,9 @@ import {
 } from "../../../support/api/utils/shippingUtils";
 
 describe("Adyen payments", () => {
-  const startsWith = "CyChannelInDraftOrders-";
+  const startsWith = "Adyen";
   const name = startsWith + faker.datatype.number();
-  const email = `CyChannelInDraftOrders@example.com`;
+  const email = `example@example.com`;
 
   let address;
   let defaultChannel;

--- a/cypress/e2e/configuration/productTypes/attributesInProduductTypes.js
+++ b/cypress/e2e/configuration/productTypes/attributesInProduductTypes.js
@@ -17,7 +17,7 @@ import { getDefaultChannel } from "../../../support/api/utils/channelsUtils";
 import { deleteProductsStartsWith } from "../../../support/api/utils/products/productsUtils";
 
 describe("As an admin I want to manage attributes in product types", () => {
-  const startsWith = "productType";
+  const startsWith = "attrProdType";
   let category;
   let channel;
   let attribute;

--- a/cypress/e2e/configuration/productTypes/deleteProductType.js
+++ b/cypress/e2e/configuration/productTypes/deleteProductType.js
@@ -19,7 +19,7 @@ import {
 } from "../../../support/api/utils/products/productsUtils";
 
 describe("As an admin I want to manage product types", () => {
-  const startsWith = "productType";
+  const startsWith = "delProdType";
   let category;
   let channel;
   let attribute;

--- a/cypress/e2e/configuration/shippingMethods/editShippingZone.js
+++ b/cypress/e2e/configuration/shippingMethods/editShippingZone.js
@@ -17,7 +17,7 @@ import { fillUpShippingZoneData } from "../../../support/pages/shippingMethodPag
 import { enterAndSelectShippings } from "../../../support/pages/shippingZones";
 
 describe("As a user I should be able to update and delete shipping zone", () => {
-  const startsWith = "EditShipping-";
+  const startsWith = "EditShippingZ-";
   const name = `${startsWith}${faker.datatype.number()}`;
 
   let defaultChannel;

--- a/cypress/e2e/configuration/shippingMethods/postalCodes.js
+++ b/cypress/e2e/configuration/shippingMethods/postalCodes.js
@@ -23,7 +23,7 @@ import {
 } from "../../../support/pages/shippingMethodPage";
 
 describe("As a user I want to create shipping method with postal codes", () => {
-  const startsWith = "CyShippingMethods-";
+  const startsWith = "postalCodes-";
   const name = `${startsWith}${faker.datatype.number()}`;
 
   const price = 10;

--- a/cypress/e2e/configuration/shippingMethods/shippingWeights/shippingWeightsLimits.js
+++ b/cypress/e2e/configuration/shippingMethods/shippingWeights/shippingWeightsLimits.js
@@ -23,7 +23,7 @@ import {
 } from "../../../../support/pages/shippingMethodPage";
 
 describe("As a staff user I want to manage shipping weights", () => {
-  const startsWith = "CyWeightRates-";
+  const startsWith = "weightsLimits";
   const name = `${startsWith}${faker.datatype.number()}`;
 
   const price = 10;

--- a/cypress/e2e/discounts/salesForProducts.js
+++ b/cypress/e2e/discounts/salesForProducts.js
@@ -22,7 +22,7 @@ import {
 } from "../../support/pages/discounts/salesPage";
 
 xdescribe("Sales discounts for products", () => {
-  const startsWith = "CySales-";
+  const startsWith = "SalesProd-";
 
   let productType;
   let attribute;

--- a/cypress/e2e/discounts/salesForVariants.js
+++ b/cypress/e2e/discounts/salesForVariants.js
@@ -16,7 +16,7 @@ import {
 } from "../../support/pages/discounts/salesPage";
 
 xdescribe("Sales discounts for variant", () => {
-  const startsWith = "CySales-";
+  const startsWith = "SalesVar-";
 
   let productType;
   let attribute;

--- a/cypress/e2e/discounts/vouchers/createVouchersWithLimits.js
+++ b/cypress/e2e/discounts/vouchers/createVouchersWithLimits.js
@@ -17,7 +17,7 @@ import {
 } from "../../../support/pages/discounts/vouchersPage";
 
 describe("As an admin I want to create voucher", () => {
-  const startsWith = "CyVou-";
+  const startsWith = "CyVouLimit-";
   const productPrice = 100;
   const shippingPrice = 100;
 

--- a/cypress/e2e/discounts/vouchers/updateVouchers.js
+++ b/cypress/e2e/discounts/vouchers/updateVouchers.js
@@ -16,7 +16,7 @@ import { formatDate, formatTime } from "../../../support/formatData/formatDate";
 import { setVoucherDate } from "../../../support/pages/discounts/vouchersPage";
 
 describe("As an admin I want to update vouchers", () => {
-  const startsWith = "CyVou-";
+  const startsWith = "UpdateVou-";
   const productPrice = 100;
   const shippingPrice = 100;
 

--- a/cypress/e2e/login.js
+++ b/cypress/e2e/login.js
@@ -3,7 +3,6 @@
 
 import { LOGIN_SELECTORS } from "../elements/account/login-selectors";
 import { urlList } from "../fixtures/urlList";
-import filterTests from "../support/filterTests";
 
 describe("User authorization", () => {
   beforeEach(() => {

--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -29,7 +29,7 @@ import {
 import { selectChannelInDetailsPages } from "../../../support/pages/channelsPage";
 
 describe("Creating variants", () => {
-  const startsWith = "CyCreateVariants-";
+  const startsWith = "CreateProdSku";
   const attributeValues = ["value1", "value2"];
 
   let defaultChannel;

--- a/cypress/e2e/translations.js
+++ b/cypress/e2e/translations.js
@@ -14,7 +14,6 @@ import { updateTranslationToCategory } from "../support/pages/translationsPage";
 xdescribe("As an admin I want to manage translations", () => {
   const startsWith = "TestTranslations";
   const randomNumber = faker.datatype.number();
-  const name = `${startsWith}${randomNumber}`;
 
   let category;
 


### PR DESCRIPTION
I want to merge this change because I couldn't reproduce why the test is failing sometimes, I think was possibility for this test to fail if at the same time another spec for the gift card was executing in parallel. To prevent this situation, I changed the names used for data creation, in all specs to be unique. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
