### PR TITLE
Saleor 7517 Fixes not being able to update site settings

### DIFF
--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14201,7 +14201,7 @@ export type ShippingZonesCountQueryHookResult = ReturnType<typeof useShippingZon
 export type ShippingZonesCountLazyQueryHookResult = ReturnType<typeof useShippingZonesCountLazyQuery>;
 export type ShippingZonesCountQueryResult = Apollo.QueryResult<Types.ShippingZonesCountQuery, Types.ShippingZonesCountQueryVariables>;
 export const ShopSettingsUpdateDocument = gql`
-    mutation ShopSettingsUpdate($shopSettingsInput: ShopSettingsInput!, $addressInput: AddressInput, $isCloudInstance: Boolean!) {
+    mutation ShopSettingsUpdate($shopSettingsInput: ShopSettingsInput!, $addressInput: AddressInput) {
   shopSettingsUpdate(input: $shopSettingsInput) {
     errors {
       ...ShopError
@@ -14241,7 +14241,6 @@ export type ShopSettingsUpdateMutationFn = Apollo.MutationFunction<Types.ShopSet
  *   variables: {
  *      shopSettingsInput: // value for 'shopSettingsInput'
  *      addressInput: // value for 'addressInput'
- *      isCloudInstance: // value for 'isCloudInstance'
  *   },
  * });
  */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8149,7 +8149,6 @@ export type ShippingZonesCountQuery = { __typename: 'Query', shippingZones: { __
 export type ShopSettingsUpdateMutationVariables = Exact<{
   shopSettingsInput: ShopSettingsInput;
   addressInput?: InputMaybe<AddressInput>;
-  isCloudInstance: Scalars['Boolean'];
 }>;
 
 

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -4,7 +4,6 @@ export const shopSettingsUpdate = gql`
   mutation ShopSettingsUpdate(
     $shopSettingsInput: ShopSettingsInput!
     $addressInput: AddressInput
-    $isCloudInstance: Boolean!
   ) {
     shopSettingsUpdate(input: $shopSettingsInput) {
       errors {

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -1,5 +1,4 @@
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { IS_CLOUD_INSTANCE } from "@saleor/config";
 import {
   CountryCode,
   useShopSettingsUpdateMutation,
@@ -79,7 +78,6 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
             reserveStockDurationAuthenticatedUser:
               data.reserveStockDurationAuthenticatedUser || null,
           },
-          isCloudInstance: IS_CLOUD_INSTANCE,
         },
       }),
     );


### PR DESCRIPTION
I want to merge this change because...
Fixes being able to change your site settings in the dashboard. I am unsure how this interacts with your Cloud instance and changing those settings post this update. This fixes local hosts though.
<!-- Please mention all relevant issue numbers. -->
fixes #2039
**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
