### PR TITLE
Add a general intro section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Saleor Dashboard](https://user-images.githubusercontent.com/249912/82305745-5c52fd00-99be-11ea-9ac6-cc04a6f28c91.png)
+![Saleor Dashboard](https://user-images.githubusercontent.com/44495184/185124554-c5538cdc-a33d-4def-8ae5-20781591ea34.png)
 
 <div align="center">
   <h1>Saleor Dashboard</h1>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-# Saleor Dashboard
-
 ![Saleor Dashboard](https://user-images.githubusercontent.com/249912/82305745-5c52fd00-99be-11ea-9ac6-cc04a6f28c91.png)
 
-A GraphQL-powered, single-page dashboard application for [Saleor](https://github.com/saleor/saleor/).
+<div align="center">
+  <h1>Saleor Dashboard</h1>
+</div>
+
+<div align="center">
+  <p>A GraphQL-powered, single-page dashboard application for <a href="https://github.com/saleor/saleor">Saleor</a>.</p>
+</div>
+
+<div align="center">
+  <a href="https://saleor.io/">🏠 Website</a>
+  <span> | </span>
+  <a href="https://docs.saleor.io/docs/3.x/">📚 Docs</a>
+  <span> | </span>
+  <a href="https://saleor.io/blog/">📰 Blog</a>
+  <span> | </span>
+  <a href="https://twitter.com/getsaleor">🐦 Twitter</a>
+</div>
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 <div align="center">
   <a href="https://saleor.io/">🏠 Website</a>
-  <span> | </span>
+  <span> • </span>
   <a href="https://docs.saleor.io/docs/3.x/">📚 Docs</a>
-  <span> | </span>
+  <span> • </span>
   <a href="https://saleor.io/blog/">📰 Blog</a>
-  <span> | </span>
+  <span> • </span>
   <a href="https://twitter.com/getsaleor">🐦 Twitter</a>
 </div>
 


### PR DESCRIPTION
EDIT: updated the image:
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/44495184/185125145-1a5f3192-5869-4c60-9a64-26eab66cd4ad.png">


Our [organization's overview tab](https://github.com/saleor) contains [an introductory section](https://github.com/saleor/.github/blob/main/profile/README.md), that follows a certain pattern:
1. Image
2. Title
3. Description
4. Links

I would like to begin the process of creating a "common README experience" by propagating that pattern across the READMEs for our main products (such as `saleor-dashboard`). The purpose is to create a structure in which the users feel more "at home", every time they visit a new repository. I figured this repository will be a good place to start.