### PR TITLE
Fix saving permission groups

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -945,10 +945,6 @@
     "context": "translations section name",
     "string": "Translations"
   },
-  "5ftg/B": {
-    "context": "button",
-    "string": "create permission group"
-  },
   "5kvaFR": {
     "context": "product field",
     "string": "Export Variant SKU"
@@ -4993,6 +4989,10 @@
   "bPFp8B": {
     "context": "product type",
     "string": "Product Type"
+  },
+  "bRJD/v": {
+    "context": "button",
+    "string": "Create permission group"
   },
   "bS7A8u": {
     "context": "add tracking button",

--- a/src/permissionGroups/components/PermissionGroupDetailsPage/PermissionGroupDetailsPage.stories.tsx
+++ b/src/permissionGroups/components/PermissionGroupDetailsPage/PermissionGroupDetailsPage.stories.tsx
@@ -16,7 +16,6 @@ const props: PermissionGroupDetailsPageProps = {
   errors: [],
   isChecked: () => false,
   members: users,
-  membersModified: false,
   onAssign: () => undefined,
   onSort: () => undefined,
   onSubmit: () => undefined,

--- a/src/permissionGroups/components/PermissionGroupDetailsPage/PermissionGroupDetailsPage.tsx
+++ b/src/permissionGroups/components/PermissionGroupDetailsPage/PermissionGroupDetailsPage.tsx
@@ -53,7 +53,6 @@ export interface PermissionGroupDetailsPageProps
   disabled: boolean;
   errors: PermissionGroupErrorFragment[];
   members: PermissionGroupDetailsFragment["users"];
-  membersModified: boolean;
   permissionGroup: PermissionGroupDetailsFragment;
   permissions: PermissionData[];
   permissionsExceeded: boolean;
@@ -67,7 +66,6 @@ const PermissionGroupDetailsPage: React.FC<PermissionGroupDetailsPageProps> = ({
   disabled,
   errors,
   members,
-  membersModified,
   onSubmit,
   permissionGroup,
   permissions,
@@ -143,7 +141,7 @@ const PermissionGroupDetailsPage: React.FC<PermissionGroupDetailsPageProps> = ({
               onCancel={() => navigate(permissionGroupListUrl())}
               onSubmit={submit}
               state={saveButtonBarState}
-              disabled={disabled || !membersModified}
+              disabled={disabled}
             />
           </div>
         </Container>

--- a/src/permissionGroups/components/PermissionGroupListPage/PermissionGroupListPage.tsx
+++ b/src/permissionGroups/components/PermissionGroupListPage/PermissionGroupListPage.tsx
@@ -38,8 +38,8 @@ const PermissionGroupListPage: React.FC<PermissionGroupListPageProps> = listProp
           data-test-id="create-permission-group"
         >
           <FormattedMessage
-            id="5ftg/B"
-            defaultMessage="create permission group"
+            id="bRJD/v"
+            defaultMessage="Create permission group"
             description="button"
           />
         </Button>

--- a/src/permissionGroups/components/PermissionGroupMemberList/PermissionGroupMemberList.tsx
+++ b/src/permissionGroups/components/PermissionGroupMemberList/PermissionGroupMemberList.tsx
@@ -110,7 +110,7 @@ const PermissionGroupMemberList: React.FC<PermissionGroupProps> = props => {
   const classes = useStyles(props);
   const intl = useIntl();
 
-  const members = users?.sort(sortMembers(sort?.sort, sort?.asc));
+  const members = [...users].sort(sortMembers(sort?.sort, sort?.asc));
 
   return (
     <Card>

--- a/src/permissionGroups/views/PermissionGroupDetails/PermissionGroupDetails.tsx
+++ b/src/permissionGroups/views/PermissionGroupDetails/PermissionGroupDetails.tsx
@@ -23,7 +23,7 @@ import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandl
 import createSortHandler from "@saleor/utils/handlers/sortHandler";
 import { mapEdgesToItems } from "@saleor/utils/maps";
 import { getSortParams } from "@saleor/utils/sort";
-import React, { useState } from "react";
+import React from "react";
 import { useIntl } from "react-intl";
 
 import AssignMembersDialog from "../../components/AssignMembersDialog";

--- a/src/permissionGroups/views/PermissionGroupDetails/PermissionGroupDetails.tsx
+++ b/src/permissionGroups/views/PermissionGroupDetails/PermissionGroupDetails.tsx
@@ -61,8 +61,6 @@ export const PermissionGroupDetails: React.FC<PermissionGroupDetailsProps> = ({
     data?.permissionGroup.users,
   );
 
-  const [membersModified, setMembersModified] = useState(false);
-
   const { search, result: searchResult, loadMore } = useStaffMemberSearch({
     variables: DEFAULT_INITIAL_SEARCH_DATA,
   });
@@ -104,7 +102,6 @@ export const PermissionGroupDetails: React.FC<PermissionGroupDetailsProps> = ({
 
   const unassignMembers = () => {
     setMembersList(membersList?.filter(m => !listElements.includes(m.id)));
-    setMembersModified(true);
     closeModal();
   };
 
@@ -153,7 +150,6 @@ export const PermissionGroupDetails: React.FC<PermissionGroupDetailsProps> = ({
         permissionGroup={data?.permissionGroup}
         permissionsExceeded={permissionsExceeded}
         members={membersList || []}
-        membersModified={membersModified}
         onAssign={() => openModal("assign")}
         onUnassign={ids => openModal("unassign", { ids })}
         errors={
@@ -198,7 +194,6 @@ export const PermissionGroupDetails: React.FC<PermissionGroupDetailsProps> = ({
             ...membersList,
             ...formData.filter(member => !membersList.includes(member)),
           ]);
-          setMembersModified(true);
           closeModal();
         }}
       />


### PR DESCRIPTION
I want to merge this change because it:
- fixes a bug with disabled save button in permission groups view,
- fixes a bug in permission groups view where prop is mutated which leads to crash,
- fixes button message in permission group list which wasn't capitalised


**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
