### PR TITLE
Fix tests for home page for 3.6

### DIFF
--- a/cypress/e2e/homePage/homePageAnalitics.js
+++ b/cypress/e2e/homePage/homePageAnalitics.js
@@ -6,13 +6,14 @@ import faker from "faker";
 import { HOMEPAGE_SELECTORS } from "../../elements/homePage/homePage-selectors";
 import { urlList } from "../../fixtures/urlList";
 import { createCustomer } from "../../support/api/requests/Customer";
+import { deleteChannelsStartsWith } from "../../support/api/utils/channelsUtils";
 import * as homePageUtils from "../../support/api/utils/homePageUtils";
 import {
   createReadyToFulfillOrder,
   createWaitingForCaptureOrder,
 } from "../../support/api/utils/ordersUtils";
 import * as productsUtils from "../../support/api/utils/products/productsUtils";
-import filterTests from "../../support/filterTests";
+import { deleteShippingStartsWith } from "../../support/api/utils/shippingUtils";
 import {
   changeChannel,
   getOrdersReadyForCaptureRegex,
@@ -46,6 +47,9 @@ describe("As an admin I want to see correct information on dashboard home page",
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
+    productsUtils.deleteProductsStartsWith(startsWith);
+    deleteShippingStartsWith(startsWith);
+    deleteChannelsStartsWith(startsWith);
 
     productsUtils
       .createProductWithShipping({
@@ -98,7 +102,7 @@ describe("As an admin I want to see correct information on dashboard home page",
         homePageUtils.getSalesAmount(defaultChannel.slug).then(salesAmount => {
           salesAmountRegexp = getSalesAmountRegex(
             salesAmount,
-            productPrice * 2 + shippingPrice,
+            (productPrice + shippingPrice) * 2,
           );
         });
 


### PR DESCRIPTION
I want to merge this change because I want to fix test for home page. This PR has cherry-picked commits from https://github.com/saleor/saleor-dashboard/pull/2216

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
