### PR TITLE
Add product variant reference attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Pass query params in `ORDER_DETAILS_MORE_ACTIONS` and `PRODUCT_DETAILS_MORE_ACTIONS` mounting points - #2100 by @witoszekdev
+- Add product variant reference attribute - #2268 by @droniu
 
 ## 3.4
 

--- a/introspection.json
+++ b/introspection.json
@@ -2481,7 +2481,7 @@
       {
         "kind": "ENUM",
         "name": "AllocationStrategyEnum",
-        "description": "Determine the allocation strategy for the channel.\n\n    PRIORITIZE_SORTING_ORDER - the allocation is prioritized by the warehouses' sort\n    order within the channel\n\n    PRIORITIZE_HIGH_STOCK - the allocation is prioritized by the highest available\n    quantity in stocks\n    ",
+        "description": "Determine the allocation strategy for the channel.\n\n    PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order\n    within the channel\n\n    PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock\n    ",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -51812,7 +51812,7 @@
               },
               {
                 "name": "moves",
-                "description": "The list of reordering operations for given channel warehouses.",
+                "description": "The list of reordering operations for the given channel warehouses.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -67134,7 +67134,7 @@
           },
           {
             "name": "variants",
-            "description": "List of varint IDs which causes the error.",
+            "description": "List of variant IDs which causes the error.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -93940,7 +93940,7 @@
         "fields": [
           {
             "name": "allocationStrategy",
-            "description": "Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.",
+            "description": "Allocation strategy defines the preference of warehouses for allocations and reservations.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -102033,7 +102033,7 @@
           },
           {
             "name": "shippingZones",
-            "description": "Shipping zones supported by the warehouse.",
+            "description": "Shipping zones supported by the warehouse.\n\nDEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will raise a ValidationError.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -102321,6 +102321,26 @@
                 "kind": "ENUM",
                 "name": "WarehouseErrorCode",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingZones",
+            "description": "List of shipping zones IDs which causes the error.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,

--- a/introspection.json
+++ b/introspection.json
@@ -7065,6 +7065,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "PRODUCTVARIANT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -9104,9 +9110,13 @@
             "name": "id",
             "description": "ID of the selected attribute.",
             "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/introspection.json
+++ b/introspection.json
@@ -7067,7 +7067,7 @@
             "deprecationReason": null
           },
           {
-            "name": "PRODUCTVARIANT",
+            "name": "PRODUCT_VARIANT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -10113,6 +10113,87 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CalculateTaxes",
+        "description": "Synchronous webhook for calculating checkout/order taxes.\n\nAdded in Saleor 3.7.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+        "fields": [
+          {
+            "name": "issuedAt",
+            "description": "Time of the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Saleor version that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuingPrincipal",
+            "description": "The user or application that triggered the event.",
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "IssuingPrincipal",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recipient",
+            "description": "The application receiving the webhook.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "taxBase",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TaxableObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Event",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -25096,6 +25177,11 @@
           {
             "kind": "OBJECT",
             "name": "AttributeValueUpdated",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CalculateTaxes",
             "ofType": null
           },
           {
@@ -56131,7 +56217,7 @@
           },
           {
             "name": "deliveryMethod",
-            "description": "The delivery method selected for this checkout.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+            "description": "The delivery method selected for this order.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "args": [],
             "type": {
               "kind": "UNION",
@@ -94040,6 +94126,48 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "TaxSourceLine",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "CheckoutLine",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "OrderLine",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "UNION",
+        "name": "TaxSourceObject",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Checkout",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Order",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "OBJECT",
         "name": "TaxType",
         "description": "Representation of tax types fetched from tax gateway.",
@@ -94064,6 +94192,331 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TaxableObject",
+        "description": "Taxable object.",
+        "fields": [
+          {
+            "name": "sourceObject",
+            "description": "The source object related to this tax object.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "TaxSourceObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pricesEnteredWithTax",
+            "description": "Determines if prices contain entered tax..",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currency",
+            "description": "The currency of the object.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingPrice",
+            "description": "The price of shipping method.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "address",
+            "description": "The address data.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Address",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discounts",
+            "description": "List of discounts.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TaxableObjectDiscount",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lines",
+            "description": "List of lines assigned to the object.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TaxableObjectLine",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Channel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TaxableObjectDiscount",
+        "description": "Taxable object discount.",
+        "fields": [
+          {
+            "name": "name",
+            "description": "The name of the discount.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "amount",
+            "description": "The amount of the discount.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TaxableObjectLine",
+        "description": null,
+        "fields": [
+          {
+            "name": "sourceLine",
+            "description": "The source line related to this tax line.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "TaxSourceLine",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quantity",
+            "description": "Number of items.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "chargeTaxes",
+            "description": "Determines if taxes are being charged for the product.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productName",
+            "description": "The product name.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variantName",
+            "description": "The variant name.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "productSku",
+            "description": "The product sku.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unitPrice",
+            "description": "Price of the single item in the order line.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalPrice",
+            "description": "Price of the order line.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -7515,6 +7515,10 @@
     "context": "WarehouseSettings private stock label",
     "string": "Private Stock"
   },
+  "wsDF7X": {
+    "context": "product variant attribute entity type",
+    "string": "Product variants"
+  },
   "wyvzh9": {
     "context": "dialog header",
     "string": "Publish Pages"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -889,6 +889,10 @@
     "context": "alert",
     "string": "Warehouse limit reached"
   },
+  "5I7Lc2": {
+    "context": "dialog header",
+    "string": "Assign page"
+  },
   "5JT4v2": {
     "context": "dialog header",
     "string": "Send Invoice"
@@ -2261,10 +2265,6 @@
   "GOdq5V": {
     "string": "Catalog"
   },
-  "GUlwXU": {
-    "context": "dialog header",
-    "string": "Assign Attribute Value"
-  },
   "GVM/fi": {
     "context": "order history message",
     "string": "Payment was authorized"
@@ -3231,10 +3231,6 @@
     "context": "navigator placeholder",
     "string": "Type Command"
   },
-  "NsgWhZ": {
-    "context": "placeholder",
-    "string": "Search by value name, etc..."
-  },
   "NtFVFS": {
     "context": "weight",
     "string": "{value} {unit}"
@@ -3288,6 +3284,10 @@
   "OBQ+th": {
     "context": "WarehouseSettings disabled warehouse label",
     "string": "Disabled"
+  },
+  "OFW7nq": {
+    "context": "placeholder",
+    "string": "Search by page name, etc..."
   },
   "OGemtu": {
     "context": "payment status",
@@ -3752,10 +3752,6 @@
   },
   "RlfqSV": {
     "string": "No orders found"
-  },
-  "RoKOQJ": {
-    "context": "label",
-    "string": "Search Attribute Value"
   },
   "Rp/Okl": {
     "string": "Shipping Weight Unit"
@@ -5276,10 +5272,6 @@
     "context": "product",
     "string": "Digital"
   },
-  "dTCDMn": {
-    "context": "dialog header",
-    "string": "Assign Product"
-  },
   "dTCWqt": {
     "string": "You are about to end your products preorder. You have sold {variantGlobalSoldUnits} units of this variant. Sold units will be allocated at appropriate warehouses. Remember to add remaining threshold stock to warehouses."
   },
@@ -5782,6 +5774,10 @@
     "context": "customer",
     "string": "Join Date"
   },
+  "idr+JK": {
+    "context": "assign reference to a page, button",
+    "string": "Assign and save"
+  },
   "ij7olm": {
     "context": "error message",
     "string": "This fulfillment cannot be cancelled"
@@ -5811,6 +5807,10 @@
   },
   "ixjvkM": {
     "string": "We’ve created your default token. Make sure to copy your new personal access token now. You won’t be able to see it again."
+  },
+  "izJvcM": {
+    "context": "label",
+    "string": "Search pages"
   },
   "j/vV0n": {
     "context": "channel name",
@@ -5909,6 +5909,10 @@
   },
   "juBV+h": {
     "string": "End Hour"
+  },
+  "juxCV3": {
+    "context": "dialog header",
+    "string": "Assign product"
   },
   "jvKNMP": {
     "string": "Discount Code"
@@ -7246,6 +7250,9 @@
   "umsU70": {
     "string": "Search Page Type"
   },
+  "un+VWt": {
+    "string": "Search products"
+  },
   "usSkzP": {
     "context": "navigator order mode description",
     "string": "Search Orders"
@@ -7731,10 +7738,6 @@
   "yhv3HX": {
     "context": "voucher requirements, header",
     "string": "Minimum Requirements"
-  },
-  "ylobu9": {
-    "context": "assign reference to product, button",
-    "string": "Assign"
   },
   "ypW4Mi": {
     "context": "button refreshing page",

--- a/schema.graphql
+++ b/schema.graphql
@@ -414,11 +414,10 @@ type Allocation implements Node {
 """
 Determine the allocation strategy for the channel.
 
-    PRIORITIZE_SORTING_ORDER - the allocation is prioritized by the warehouses' sort
-    order within the channel
+    PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order
+    within the channel
 
-    PRIORITIZE_HIGH_STOCK - the allocation is prioritized by the highest available
-    quantity in stocks
+    PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock
     
 """
 enum AllocationStrategyEnum {
@@ -11558,7 +11557,7 @@ type Mutation {
     """ID of a channel."""
     channelId: ID!
 
-    """The list of reordering operations for given channel warehouses."""
+    """The list of reordering operations for the given channel warehouses."""
     moves: [ReorderInput!]!
   ): ChannelReorderWarehouses
 
@@ -14910,7 +14909,7 @@ type PaymentError {
   """The error code."""
   code: PaymentErrorCode!
 
-  """List of varint IDs which causes the error."""
+  """List of variant IDs which causes the error."""
   variants: [ID!]
 }
 
@@ -21152,7 +21151,7 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 """
 type StockSettings {
   """
-  Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.
+  Allocation strategy defines the preference of warehouses for allocations and reservations.
   """
   allocationStrategy: AllocationStrategyEnum!
 }
@@ -22857,7 +22856,11 @@ input WarehouseCreateInput {
   """Address of the warehouse."""
   address: AddressInput!
 
-  """Shipping zones supported by the warehouse."""
+  """
+  Shipping zones supported by the warehouse.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will raise a ValidationError.
+  """
   shippingZones: [ID!]
 }
 
@@ -22931,6 +22934,9 @@ type WarehouseError {
 
   """The error code."""
   code: WarehouseErrorCode!
+
+  """List of shipping zones IDs which causes the error."""
+  shippingZones: [ID!]
 }
 
 """An enumeration."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -1385,6 +1385,7 @@ type AttributeDeleted implements Event {
 enum AttributeEntityTypeEnum {
   PAGE
   PRODUCT
+  PRODUCTVARIANT
 }
 
 type AttributeError {
@@ -1824,7 +1825,7 @@ input AttributeValueFilterInput {
 
 input AttributeValueInput {
   """ID of the selected attribute."""
-  id: ID
+  id: ID!
 
   """
   The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.

--- a/schema.graphql
+++ b/schema.graphql
@@ -1384,7 +1384,7 @@ type AttributeDeleted implements Event {
 enum AttributeEntityTypeEnum {
   PAGE
   PRODUCT
-  PRODUCTVARIANT
+  PRODUCT_VARIANT
 }
 
 type AttributeError {
@@ -2051,6 +2051,28 @@ type BulkStockError {
 
   """Index of an input list item that caused the error."""
   index: Int
+}
+
+"""
+Synchronous webhook for calculating checkout/order taxes.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type CalculateTaxes implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+  taxBase: TaxableObject!
 }
 
 input CardInput {
@@ -12541,7 +12563,7 @@ type Order implements Node & ObjectWithMetadata {
   isShippingRequired: Boolean!
 
   """
-  The delivery method selected for this checkout.
+  The delivery method selected for this order.
   
   Added in Saleor 3.1.
   
@@ -21190,6 +21212,10 @@ type Subscription {
   event: Event
 }
 
+union TaxSourceLine = CheckoutLine | OrderLine
+
+union TaxSourceObject = Checkout | Order
+
 """Representation of tax types fetched from tax gateway."""
 type TaxType {
   """Description of the tax type."""
@@ -21197,6 +21223,66 @@ type TaxType {
 
   """External tax code used to identify given tax group."""
   taxCode: String
+}
+
+"""Taxable object."""
+type TaxableObject {
+  """The source object related to this tax object."""
+  sourceObject: TaxSourceObject!
+
+  """Determines if prices contain entered tax.."""
+  pricesEnteredWithTax: Boolean!
+
+  """The currency of the object."""
+  currency: String!
+
+  """The price of shipping method."""
+  shippingPrice: Money!
+
+  """The address data."""
+  address: Address
+
+  """List of discounts."""
+  discounts: [TaxableObjectDiscount!]!
+
+  """List of lines assigned to the object."""
+  lines: [TaxableObjectLine!]!
+  channel: Channel!
+}
+
+"""Taxable object discount."""
+type TaxableObjectDiscount {
+  """The name of the discount."""
+  name: String
+
+  """The amount of the discount."""
+  amount: Money!
+}
+
+type TaxableObjectLine {
+  """The source line related to this tax line."""
+  sourceLine: TaxSourceLine!
+
+  """Number of items."""
+  quantity: Int!
+
+  """Determines if taxes are being charged for the product."""
+  chargeTaxes: Boolean!
+
+  """The product name."""
+  productName: String!
+
+  """The variant name."""
+  variantName: String!
+
+  """The product sku."""
+  productSku: String
+
+  """Price of the single item in the order line."""
+  unitPrice: Money!
+
+  """Price of the order line."""
+  totalPrice: Money!
 }
 
 """

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -33,6 +33,11 @@ const entityTypeMessages = defineMessages({
     defaultMessage: "Products",
     description: "product attribute entity type",
   },
+  productVariant: {
+    id: "wsDF7X",
+    defaultMessage: "Product variants",
+    description: "product variant attribute entity type",
+  },
 });
 
 const useStyles = makeStyles(
@@ -128,6 +133,10 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
     {
       label: intl.formatMessage(entityTypeMessages.product),
       value: AttributeEntityTypeEnum.PRODUCT,
+    },
+    {
+      label: intl.formatMessage(entityTypeMessages.productVariant),
+      value: AttributeEntityTypeEnum.PRODUCTVARIANT,
     },
   ];
 

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -136,7 +136,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
     },
     {
       label: intl.formatMessage(entityTypeMessages.productVariant),
-      value: AttributeEntityTypeEnum.PRODUCTVARIANT,
+      value: AttributeEntityTypeEnum.PRODUCT_VARIANT,
     },
   ];
 

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -420,6 +420,27 @@ export const getProductReferenceAttributeDisplayData = (
   },
 });
 
+export const getProductVariantReferenceAttributeDisplayData = (
+  attribute: AttributeInput,
+  referenceProducts: RelayToFlat<SearchProductsQuery["search"]>,
+) => ({
+  ...attribute,
+  data: {
+    ...attribute.data,
+    references:
+      referenceProducts?.length > 0 && attribute.value?.length > 0
+        ? mapNodeToChoice(
+            attribute.value.map(value => {
+              const reference = mapReferenceProductsToVariants(
+                referenceProducts,
+              ).find(reference => reference.id === value);
+              return { ...reference };
+            }),
+          )
+        : [],
+  },
+});
+
 export const getReferenceAttributeDisplayData = (
   attribute: AttributeInput,
   referencePages: RelayToFlat<SearchPagesQuery["search"]>,
@@ -429,6 +450,13 @@ export const getReferenceAttributeDisplayData = (
     return getPageReferenceAttributeDisplayData(attribute, referencePages);
   } else if (attribute.data.entityType === AttributeEntityTypeEnum.PRODUCT) {
     return getProductReferenceAttributeDisplayData(
+      attribute,
+      referenceProducts,
+    );
+  } else if (
+    attribute.data.entityType === AttributeEntityTypeEnum.PRODUCTVARIANT
+  ) {
+    return getProductVariantReferenceAttributeDisplayData(
       attribute,
       referenceProducts,
     );
@@ -480,6 +508,25 @@ export const getAttributeValuesFromReferences = (
     return mapNodeToChoice(
       getSelectedReferencesFromAttribute(attribute, referenceProducts),
     );
+  } else if (
+    attribute?.data?.entityType === AttributeEntityTypeEnum.PRODUCTVARIANT
+  ) {
+    return mapNodeToChoice(
+      getSelectedReferencesFromAttribute(
+        attribute,
+        mapReferenceProductsToVariants(referenceProducts),
+      ),
+    );
   }
   return [];
 };
+
+export const mapReferenceProductsToVariants = (
+  referenceProducts: RelayToFlat<SearchProductsQuery["search"]>,
+) =>
+  referenceProducts.flatMap(product =>
+    product.variants.map(variant => ({
+      ...variant,
+      name: product.name + " " + variant.name,
+    })),
+  );

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -454,7 +454,7 @@ export const getReferenceAttributeDisplayData = (
       referenceProducts,
     );
   } else if (
-    attribute.data.entityType === AttributeEntityTypeEnum.PRODUCTVARIANT
+    attribute.data.entityType === AttributeEntityTypeEnum.PRODUCT_VARIANT
   ) {
     return getProductVariantReferenceAttributeDisplayData(
       attribute,
@@ -509,7 +509,7 @@ export const getAttributeValuesFromReferences = (
       getSelectedReferencesFromAttribute(attribute, referenceProducts),
     );
   } else if (
-    attribute?.data?.entityType === AttributeEntityTypeEnum.PRODUCTVARIANT
+    attribute?.data?.entityType === AttributeEntityTypeEnum.PRODUCT_VARIANT
   ) {
     return mapNodeToChoice(
       getSelectedReferencesFromAttribute(

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -492,34 +492,11 @@ export const getSelectedReferencesFromAttribute = <T extends Node>(
       !attribute?.value?.some(selectedValue => selectedValue === value.id),
   ) || [];
 
-export const getAttributeValuesFromReferences = (
+export const getReferenceAttributeEntityTypeFromAttribute = (
   attributeId: string,
   attributes?: AttributeInput[],
-  referencePages?: RelayToFlat<SearchPagesQuery["search"]>,
-  referenceProducts?: RelayToFlat<SearchProductsQuery["search"]>,
-) => {
-  const attribute = attributes?.find(attribute => attribute.id === attributeId);
-
-  if (attribute?.data?.entityType === AttributeEntityTypeEnum.PAGE) {
-    return mapPagesToChoices(
-      getSelectedReferencesFromAttribute(attribute, referencePages),
-    );
-  } else if (attribute?.data?.entityType === AttributeEntityTypeEnum.PRODUCT) {
-    return mapNodeToChoice(
-      getSelectedReferencesFromAttribute(attribute, referenceProducts),
-    );
-  } else if (
-    attribute?.data?.entityType === AttributeEntityTypeEnum.PRODUCT_VARIANT
-  ) {
-    return mapNodeToChoice(
-      getSelectedReferencesFromAttribute(
-        attribute,
-        mapReferenceProductsToVariants(referenceProducts),
-      ),
-    );
-  }
-  return [];
-};
+): AttributeEntityTypeEnum | undefined =>
+  attributes?.find(attribute => attribute.id === attributeId)?.data?.entityType;
 
 export const mapReferenceProductsToVariants = (
   referenceProducts: RelayToFlat<SearchProductsQuery["search"]>,

--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -90,7 +90,7 @@ export function createFetchReferencesHandler(
     } else if (
       [
         AttributeEntityTypeEnum.PRODUCT,
-        AttributeEntityTypeEnum.PRODUCTVARIANT,
+        AttributeEntityTypeEnum.PRODUCT_VARIANT,
       ].includes(attribute.data.entityType) &&
       fetchReferenceProducts
     ) {
@@ -118,7 +118,7 @@ export function createFetchMoreReferencesHandler(
   } else if (
     [
       AttributeEntityTypeEnum.PRODUCT,
-      AttributeEntityTypeEnum.PRODUCTVARIANT,
+      AttributeEntityTypeEnum.PRODUCT_VARIANT,
     ].includes(attribute.data.entityType)
   ) {
     return fetchMoreReferenceProducts;

--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -88,7 +88,10 @@ export function createFetchReferencesHandler(
     ) {
       fetchReferencePages(value);
     } else if (
-      attribute.data.entityType === AttributeEntityTypeEnum.PRODUCT &&
+      [
+        AttributeEntityTypeEnum.PRODUCT,
+        AttributeEntityTypeEnum.PRODUCTVARIANT,
+      ].includes(attribute.data.entityType) &&
       fetchReferenceProducts
     ) {
       fetchReferenceProducts(value);
@@ -112,7 +115,12 @@ export function createFetchMoreReferencesHandler(
 
   if (attribute.data.entityType === AttributeEntityTypeEnum.PAGE) {
     return fetchMoreReferencePages;
-  } else if (attribute.data.entityType === AttributeEntityTypeEnum.PRODUCT) {
+  } else if (
+    [
+      AttributeEntityTypeEnum.PRODUCT,
+      AttributeEntityTypeEnum.PRODUCTVARIANT,
+    ].includes(attribute.data.entityType)
+  ) {
     return fetchMoreReferenceProducts;
   }
 }

--- a/src/components/AssignAttributeValueDialog/AssignAttributeValueDialog.tsx
+++ b/src/components/AssignAttributeValueDialog/AssignAttributeValueDialog.tsx
@@ -1,65 +1,69 @@
-import { AttributeReference } from "@saleor/attributes/utils/data";
+import { AttributeEntityTypeEnum, SearchPagesQuery } from "@saleor/graphql";
+import { RelayToFlat } from "@saleor/types";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
-import AssignContainerDialog, {
-  AssignContainerDialogProps,
-} from "../AssignContainerDialog";
+import AssignContainerDialog from "../AssignContainerDialog";
+import AssignProductDialog, {
+  AssignProductDialogProps,
+} from "../AssignProductDialog";
+import AssignVariantDialog from "../AssignVariantDialog";
 
-const messages = defineMessages({
+const pagesMessages = defineMessages({
   confirmBtn: {
-    id: "ylobu9",
-    defaultMessage: "Assign",
-    description: "assign reference to product, button",
+    id: "idr+JK",
+    defaultMessage: "Assign and save",
+    description: "assign reference to a page, button",
   },
   header: {
-    id: "GUlwXU",
-    defaultMessage: "Assign Attribute Value",
+    id: "5I7Lc2",
+    defaultMessage: "Assign page",
     description: "dialog header",
   },
   searchLabel: {
-    id: "RoKOQJ",
-    defaultMessage: "Search Attribute Value",
+    id: "izJvcM",
+    defaultMessage: "Search pages",
     description: "label",
   },
   searchPlaceholder: {
-    id: "NsgWhZ",
-    defaultMessage: "Search by value name, etc...",
+    id: "OFW7nq",
+    defaultMessage: "Search by page name, etc...",
     description: "placeholder",
   },
 });
 
-interface AssignAttributeValueDialogProps
-  extends Omit<
-    AssignContainerDialogProps,
-    "containers" | "title" | "search" | "confirmButtonState" | "labels"
-  > {
-  attributeValues: AttributeReference[];
-}
+type AssignAttributeValueDialogProps = AssignProductDialogProps & {
+  entityType: AttributeEntityTypeEnum;
+  pages: RelayToFlat<SearchPagesQuery["search"]>;
+};
 
 const AssignAttributeValueDialog: React.FC<AssignAttributeValueDialogProps> = ({
-  attributeValues,
+  entityType,
+  pages,
+  products,
   ...rest
 }) => {
   const intl = useIntl();
 
-  return (
-    <AssignContainerDialog
-      containers={attributeValues.map(value => ({
-        id: value.value,
-        name: value.label,
-      }))}
-      labels={{
-        confirmBtn: intl.formatMessage(messages.confirmBtn),
-        label: intl.formatMessage(messages.searchLabel),
-        placeholder: intl.formatMessage(messages.searchPlaceholder),
-        title: intl.formatMessage(messages.header),
-      }}
-      confirmButtonState="default"
-      {...rest}
-    />
-  );
+  switch (entityType) {
+    case AttributeEntityTypeEnum.PAGE:
+      return (
+        <AssignContainerDialog
+          containers={pages.map(page => ({ id: page.id, name: page.title }))}
+          labels={{
+            confirmBtn: intl.formatMessage(pagesMessages.confirmBtn),
+            label: intl.formatMessage(pagesMessages.searchLabel),
+            placeholder: intl.formatMessage(pagesMessages.searchPlaceholder),
+            title: intl.formatMessage(pagesMessages.header),
+          }}
+          {...rest}
+        />
+      );
+    case AttributeEntityTypeEnum.PRODUCT:
+      return <AssignProductDialog products={products} {...rest} />;
+    case AttributeEntityTypeEnum.PRODUCT_VARIANT:
+      return <AssignVariantDialog products={products} {...rest} />;
+  }
 };
-
 AssignAttributeValueDialog.displayName = "AssignAttributeValueDialog";
 export default AssignAttributeValueDialog;

--- a/src/components/AssignProductDialog/messages.ts
+++ b/src/components/AssignProductDialog/messages.ts
@@ -2,8 +2,8 @@ import { defineMessages } from "react-intl";
 
 export const messages = defineMessages({
   assignVariantDialogHeader: {
-    id: "dTCDMn",
-    defaultMessage: "Assign Product",
+    id: "juxCV3",
+    defaultMessage: "Assign product",
     description: "dialog header",
   },
   assignProductDialogButton: {
@@ -12,8 +12,8 @@ export const messages = defineMessages({
     description: "button",
   },
   assignProductDialogContent: {
-    id: "/TF6BZ",
-    defaultMessage: "Search Products",
+    id: "un+VWt",
+    defaultMessage: "Search products",
   },
   assignProductDialogSearch: {
     id: "SHm7ee",

--- a/src/components/AssignVariantDialog/AssignVariantDialog.tsx
+++ b/src/components/AssignVariantDialog/AssignVariantDialog.tsx
@@ -45,7 +45,7 @@ export interface AssignVariantDialogProps extends FetchMoreProps, DialogProps {
   products: RelayToFlat<SearchProductsQuery["search"]>;
   loading: boolean;
   onFetch: (value: string) => void;
-  onSubmit: (data: SearchVariant[]) => void;
+  onSubmit: (data: string[]) => void;
 }
 
 const scrollableTargetId = "assignVariantScrollableDialog";
@@ -84,7 +84,7 @@ const AssignVariantDialog: React.FC<AssignVariantDialogProps> = props => {
       )
     : [];
 
-  const handleSubmit = () => onSubmit(variants);
+  const handleSubmit = () => onSubmit(variants.map(variant => variant.id));
 
   return (
     <Dialog

--- a/src/discounts/views/SaleDetails/SaleDetails.tsx
+++ b/src/discounts/views/SaleDetails/SaleDetails.tsx
@@ -390,7 +390,7 @@ export const SaleDetails: React.FC<SaleDetailsProps> = ({ id, params }) => {
               ...paginationState,
               id,
               input: {
-                variants: variants.map(variant => variant.id),
+                variants,
               },
             },
           })

--- a/src/graphql/fragmentTypes.generated.ts
+++ b/src/graphql/fragmentTypes.generated.ts
@@ -25,6 +25,7 @@
       "AttributeValueCreated",
       "AttributeValueDeleted",
       "AttributeValueUpdated",
+      "CalculateTaxes",
       "CategoryCreated",
       "CategoryDeleted",
       "CategoryUpdated",
@@ -236,6 +237,14 @@
       "User",
       "Voucher",
       "Warehouse"
+    ],
+    "TaxSourceLine": [
+      "CheckoutLine",
+      "OrderLine"
+    ],
+    "TaxSourceObject": [
+      "Checkout",
+      "Order"
     ],
     "TranslatableItem": [
       "ProductTranslatableContent",

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -607,6 +607,14 @@ export type BulkStockErrorFieldPolicy = {
 	values?: FieldPolicy<any> | FieldReadFunction<any>,
 	index?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type CalculateTaxesKeySpecifier = ('issuedAt' | 'version' | 'issuingPrincipal' | 'recipient' | 'taxBase' | CalculateTaxesKeySpecifier)[];
+export type CalculateTaxesFieldPolicy = {
+	issuedAt?: FieldPolicy<any> | FieldReadFunction<any>,
+	version?: FieldPolicy<any> | FieldReadFunction<any>,
+	issuingPrincipal?: FieldPolicy<any> | FieldReadFunction<any>,
+	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
+	taxBase?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type CategoryKeySpecifier = ('id' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'metadata' | 'metafield' | 'metafields' | 'seoTitle' | 'seoDescription' | 'name' | 'description' | 'slug' | 'parent' | 'level' | 'descriptionJson' | 'ancestors' | 'products' | 'children' | 'backgroundImage' | 'translation' | CategoryKeySpecifier)[];
 export type CategoryFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -4634,6 +4642,33 @@ export type TaxTypeFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	taxCode?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type TaxableObjectKeySpecifier = ('sourceObject' | 'pricesEnteredWithTax' | 'currency' | 'shippingPrice' | 'address' | 'discounts' | 'lines' | 'channel' | TaxableObjectKeySpecifier)[];
+export type TaxableObjectFieldPolicy = {
+	sourceObject?: FieldPolicy<any> | FieldReadFunction<any>,
+	pricesEnteredWithTax?: FieldPolicy<any> | FieldReadFunction<any>,
+	currency?: FieldPolicy<any> | FieldReadFunction<any>,
+	shippingPrice?: FieldPolicy<any> | FieldReadFunction<any>,
+	address?: FieldPolicy<any> | FieldReadFunction<any>,
+	discounts?: FieldPolicy<any> | FieldReadFunction<any>,
+	lines?: FieldPolicy<any> | FieldReadFunction<any>,
+	channel?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type TaxableObjectDiscountKeySpecifier = ('name' | 'amount' | TaxableObjectDiscountKeySpecifier)[];
+export type TaxableObjectDiscountFieldPolicy = {
+	name?: FieldPolicy<any> | FieldReadFunction<any>,
+	amount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type TaxableObjectLineKeySpecifier = ('sourceLine' | 'quantity' | 'chargeTaxes' | 'productName' | 'variantName' | 'productSku' | 'unitPrice' | 'totalPrice' | TaxableObjectLineKeySpecifier)[];
+export type TaxableObjectLineFieldPolicy = {
+	sourceLine?: FieldPolicy<any> | FieldReadFunction<any>,
+	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
+	chargeTaxes?: FieldPolicy<any> | FieldReadFunction<any>,
+	productName?: FieldPolicy<any> | FieldReadFunction<any>,
+	variantName?: FieldPolicy<any> | FieldReadFunction<any>,
+	productSku?: FieldPolicy<any> | FieldReadFunction<any>,
+	unitPrice?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalPrice?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type TaxedMoneyKeySpecifier = ('currency' | 'gross' | 'net' | 'tax' | TaxedMoneyKeySpecifier)[];
 export type TaxedMoneyFieldPolicy = {
 	currency?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -5497,6 +5532,10 @@ export type StrictTypedTypePolicies = {
 	BulkStockError?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | BulkStockErrorKeySpecifier | (() => undefined | BulkStockErrorKeySpecifier),
 		fields?: BulkStockErrorFieldPolicy,
+	},
+	CalculateTaxes?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | CalculateTaxesKeySpecifier | (() => undefined | CalculateTaxesKeySpecifier),
+		fields?: CalculateTaxesFieldPolicy,
 	},
 	Category?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | CategoryKeySpecifier | (() => undefined | CategoryKeySpecifier),
@@ -7397,6 +7436,18 @@ export type StrictTypedTypePolicies = {
 	TaxType?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | TaxTypeKeySpecifier | (() => undefined | TaxTypeKeySpecifier),
 		fields?: TaxTypeFieldPolicy,
+	},
+	TaxableObject?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | TaxableObjectKeySpecifier | (() => undefined | TaxableObjectKeySpecifier),
+		fields?: TaxableObjectFieldPolicy,
+	},
+	TaxableObjectDiscount?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | TaxableObjectDiscountKeySpecifier | (() => undefined | TaxableObjectDiscountKeySpecifier),
+		fields?: TaxableObjectDiscountFieldPolicy,
+	},
+	TaxableObjectLine?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | TaxableObjectLineKeySpecifier | (() => undefined | TaxableObjectLineKeySpecifier),
+		fields?: TaxableObjectLineFieldPolicy,
 	},
 	TaxedMoney?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | TaxedMoneyKeySpecifier | (() => undefined | TaxedMoneyKeySpecifier),

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -5090,11 +5090,12 @@ export type WarehouseDeletedFieldPolicy = {
 	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type WarehouseErrorKeySpecifier = ('field' | 'message' | 'code' | WarehouseErrorKeySpecifier)[];
+export type WarehouseErrorKeySpecifier = ('field' | 'message' | 'code' | 'shippingZones' | WarehouseErrorKeySpecifier)[];
 export type WarehouseErrorFieldPolicy = {
 	field?: FieldPolicy<any> | FieldReadFunction<any>,
 	message?: FieldPolicy<any> | FieldReadFunction<any>,
-	code?: FieldPolicy<any> | FieldReadFunction<any>
+	code?: FieldPolicy<any> | FieldReadFunction<any>,
+	shippingZones?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type WarehouseShippingZoneAssignKeySpecifier = ('warehouseErrors' | 'errors' | 'warehouse' | WarehouseShippingZoneAssignKeySpecifier)[];
 export type WarehouseShippingZoneAssignFieldPolicy = {

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -335,7 +335,8 @@ export type AttributeCreateInput = {
 /** An enumeration. */
 export enum AttributeEntityTypeEnum {
   PAGE = 'PAGE',
-  PRODUCT = 'PRODUCT'
+  PRODUCT = 'PRODUCT',
+  PRODUCTVARIANT = 'PRODUCTVARIANT'
 }
 
 /** An enumeration. */
@@ -486,7 +487,7 @@ export type AttributeValueFilterInput = {
 
 export type AttributeValueInput = {
   /** ID of the selected attribute. */
-  id?: InputMaybe<Scalars['ID']>;
+  id: Scalars['ID'];
   /** The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created. */
   values?: InputMaybe<Array<Scalars['String']>>;
   /** URL of the file attribute. Every time, a new value is created. */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -159,11 +159,10 @@ export enum AddressTypeEnum {
 /**
  * Determine the allocation strategy for the channel.
  *
- *     PRIORITIZE_SORTING_ORDER - the allocation is prioritized by the warehouses' sort
- *     order within the channel
+ *     PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order
+ *     within the channel
  *
- *     PRIORITIZE_HIGH_STOCK - the allocation is prioritized by the highest available
- *     quantity in stocks
+ *     PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock
  *
  */
 export enum AllocationStrategyEnum {
@@ -4934,7 +4933,11 @@ export type WarehouseCreateInput = {
   name: Scalars['String'];
   /** Address of the warehouse. */
   address: AddressInput;
-  /** Shipping zones supported by the warehouse. */
+  /**
+   * Shipping zones supported by the warehouse.
+   *
+   * DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will raise a ValidationError.
+   */
   shippingZones?: InputMaybe<Array<Scalars['ID']>>;
 };
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -335,7 +335,7 @@ export type AttributeCreateInput = {
 export enum AttributeEntityTypeEnum {
   PAGE = 'PAGE',
   PRODUCT = 'PRODUCT',
-  PRODUCTVARIANT = 'PRODUCTVARIANT'
+  PRODUCT_VARIANT = 'PRODUCT_VARIANT'
 }
 
 /** An enumeration. */

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -1,5 +1,5 @@
 import {
-  getAttributeValuesFromReferences,
+  getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@saleor/attributes/utils/data";
 import AssignAttributeValueDialog from "@saleor/components/AssignAttributeValueDialog";
@@ -264,12 +264,13 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
           />
           {canOpenAssignReferencesAttributeDialog && (
             <AssignAttributeValueDialog
-              attributeValues={getAttributeValuesFromReferences(
+              entityType={getReferenceAttributeEntityTypeFromAttribute(
                 assignReferencesAttributeId,
                 data.attributes,
-                referencePages,
-                referenceProducts,
               )}
+              confirmButtonState={"default"}
+              products={referenceProducts}
+              pages={referencePages}
               hasMore={handlers.fetchMoreReferences?.hasMore}
               open={canOpenAssignReferencesAttributeDialog}
               onFetch={handlers.fetchReferences}

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -1,5 +1,5 @@
 import {
-  getAttributeValuesFromReferences,
+  getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@saleor/attributes/utils/data";
 import CannotDefineChannelsAvailabilityCard from "@saleor/channels/components/CannotDefineChannelsAvailabilityCard/CannotDefineChannelsAvailabilityCard";
@@ -376,12 +376,13 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
             />
             {canOpenAssignReferencesAttributeDialog && (
               <AssignAttributeValueDialog
-                attributeValues={getAttributeValuesFromReferences(
+                entityType={getReferenceAttributeEntityTypeFromAttribute(
                   assignReferencesAttributeId,
                   data.attributes,
-                  referencePages,
-                  referenceProducts,
                 )}
+                confirmButtonState={"default"}
+                products={referenceProducts}
+                pages={referencePages}
                 hasMore={handlers.fetchMoreReferences?.hasMore}
                 open={canOpenAssignReferencesAttributeDialog}
                 onFetch={handlers.fetchReferences}

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -5,7 +5,7 @@ import {
   useExtensions,
 } from "@saleor/apps/useExtensions";
 import {
-  getAttributeValuesFromReferences,
+  getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@saleor/attributes/utils/data";
 import { ChannelData } from "@saleor/channels/utils";
@@ -525,12 +525,13 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               />
               {canOpenAssignReferencesAttributeDialog && (
                 <AssignAttributeValueDialog
-                  attributeValues={getAttributeValuesFromReferences(
+                  entityType={getReferenceAttributeEntityTypeFromAttribute(
                     assignReferencesAttributeId,
                     data.attributes,
-                    referencePages,
-                    referenceProducts,
                   )}
+                  confirmButtonState={"default"}
+                  products={referenceProducts}
+                  pages={referencePages}
                   hasMore={handlers.fetchMoreReferences?.hasMore}
                   open={canOpenAssignReferencesAttributeDialog}
                   onFetch={handlers.fetchReferences}

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -1,5 +1,5 @@
 import {
-  getAttributeValuesFromReferences,
+  getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@saleor/attributes/utils/data";
 import AssignAttributeValueDialog from "@saleor/components/AssignAttributeValueDialog";
@@ -281,12 +281,13 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
           />
           {canOpenAssignReferencesAttributeDialog && (
             <AssignAttributeValueDialog
-              attributeValues={getAttributeValuesFromReferences(
+              entityType={getReferenceAttributeEntityTypeFromAttribute(
                 assignReferencesAttributeId,
                 data.attributes,
-                referencePages,
-                referenceProducts,
               )}
+              confirmButtonState={"default"}
+              products={referenceProducts}
+              pages={referencePages}
               hasMore={handlers.fetchMoreReferences?.hasMore}
               open={canOpenAssignReferencesAttributeDialog}
               onFetch={handlers.fetchReferences}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -1,5 +1,5 @@
 import {
-  getAttributeValuesFromReferences,
+  getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@saleor/attributes/utils/data";
 import { ChannelPriceData } from "@saleor/channels/utils";
@@ -381,12 +381,13 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                 />
                 {canOpenAssignReferencesAttributeDialog && (
                   <AssignAttributeValueDialog
-                    attributeValues={getAttributeValuesFromReferences(
+                    entityType={getReferenceAttributeEntityTypeFromAttribute(
                       assignReferencesAttributeId,
                       data.attributes,
-                      referencePages,
-                      referenceProducts,
                     )}
+                    confirmButtonState={"default"}
+                    products={referenceProducts}
+                    pages={referencePages}
                     hasMore={handlers.fetchMoreReferences?.hasMore}
                     open={canOpenAssignReferencesAttributeDialog}
                     onFetch={handlers.fetchReferences}


### PR DESCRIPTION
I want to merge this change because it
- adds product variant reference attribute
- reworks modals for reference attribute values
    - modals for products now have thumbnails
    - modals for product variants now have thumbnails & prices

Impact:
- Product variant view
- Product create view
- Product update view
- Page create view
- Page update view
 
Code was also touched in Sales details view. Assigning variants to sales should be tested.

**PR intended to be tested with API branch:** https://github.com/saleor/saleor/pull/10468
## Screenshots

<img width="850" alt="image" src="https://user-images.githubusercontent.com/41952692/188172261-3685ff44-824c-4e25-8ea4-ca2aa944ca2b.png">
<img width="602" alt="image" src="https://user-images.githubusercontent.com/41952692/188172395-00039ccc-7751-4cd8-80bc-6d4ef7d18c6e.png">
<img width="602" alt="image" src="https://user-images.githubusercontent.com/41952692/188172544-e4dd0c79-a202-4f83-b6ed-898a9143042e.png">



### Pull Request Checklist

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

API_URI=https://saleor-7922-reference-attribute-linkining-to-product-variant.api.saleor.rocks/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
