### PR TITLE
Fix invisible popup in darkmode

### DIFF
--- a/src/plugins/components/PluginSettings/PluginSettings.tsx
+++ b/src/plugins/components/PluginSettings/PluginSettings.tsx
@@ -49,6 +49,9 @@ const useStyles = makeStyles(
     spacer: {
       flex: 1,
     },
+    tooltip: {
+      color: theme.palette.saleor.active[5],
+    },
   }),
   { name: "PluginSettings" },
 );
@@ -96,7 +99,7 @@ const PluginSettings: React.FC<PluginSettingsProps> = ({
                   {fieldData.helpText && (
                     <Tooltip
                       title={
-                        <Typography variant="body2">
+                        <Typography variant="body2" className={classes.tooltip}>
                           {fieldData.helpText}
                         </Typography>
                       }

--- a/src/plugins/components/PluginSettings/PluginSettings.tsx
+++ b/src/plugins/components/PluginSettings/PluginSettings.tsx
@@ -12,13 +12,13 @@ import {
   ConfigurationItemFragment,
   ConfigurationTypeFieldEnum,
 } from "@saleor/graphql";
-import { makeStyles } from "@saleor/macaw-ui";
 import { UserError } from "@saleor/types";
 import { getFieldError } from "@saleor/utils/errors";
 import React from "react";
 import { useIntl } from "react-intl";
 
 import { PluginDetailsPageFormData } from "../PluginsDetailsPage";
+import { useStyles } from "./styles";
 
 interface PluginSettingsProps {
   data: PluginDetailsPageFormData;
@@ -27,34 +27,6 @@ interface PluginSettingsProps {
   onChange: (event: React.ChangeEvent<any>) => void;
   fields: ConfigurationItemFragment[];
 }
-
-const useStyles = makeStyles(
-  theme => ({
-    authItem: {
-      display: "flex",
-    },
-    button: {
-      marginRight: theme.spacing(),
-    },
-    item: {
-      "&:not(:last-child)": {
-        marginBottom: theme.spacing(3),
-      },
-      alignItems: "center",
-      display: "flex",
-    },
-    itemLabel: {
-      fontWeight: 500,
-    },
-    spacer: {
-      flex: 1,
-    },
-    tooltip: {
-      color: theme.palette.saleor.active[5],
-    },
-  }),
-  { name: "PluginSettings" },
-);
 
 const PluginSettings: React.FC<PluginSettingsProps> = ({
   data,

--- a/src/plugins/components/PluginSettings/styles.ts
+++ b/src/plugins/components/PluginSettings/styles.ts
@@ -1,0 +1,29 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    authItem: {
+      display: "flex",
+    },
+    button: {
+      marginRight: theme.spacing(),
+    },
+    item: {
+      "&:not(:last-child)": {
+        marginBottom: theme.spacing(3),
+      },
+      alignItems: "center",
+      display: "flex",
+    },
+    itemLabel: {
+      fontWeight: 500,
+    },
+    spacer: {
+      flex: 1,
+    },
+    tooltip: {
+      color: theme.palette.saleor.active[5],
+    },
+  }),
+  { name: "PluginSettings" },
+);


### PR DESCRIPTION
I want to merge this change because it fixes an issue with an info tooltip in the plugin details view - popup was invisible in the dark mode.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> main

### Screenshots
<img width="691" alt="image" src="https://user-images.githubusercontent.com/41952692/187924991-9818b145-825b-4d0a-99e2-8a319dc1bde9.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
