### PR TITLE
SALEOR-7976 add test for create order from checkout as app

### DIFF
--- a/cypress/e2e/apps.js
+++ b/cypress/e2e/apps.js
@@ -10,10 +10,25 @@ import { BUTTON_SELECTORS } from "../elements/shared/button-selectors";
 import { appDetailsUrl, urlList } from "../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../fixtures/users";
 import { createApp, getApp, updateApp } from "../support/api/requests/Apps";
+import {
+  addShippingMethod,
+  createCheckout,
+  orderCreateFromCheckout,
+} from "../support/api/requests/Checkout";
 import { createVoucher } from "../support/api/requests/Discounts/Vouchers";
 import { createGiftCard } from "../support/api/requests/GiftCard";
 import { deleteAppsStartsWith } from "../support/api/utils/appUtils";
 import { getDefaultChannel } from "../support/api/utils/channelsUtils";
+import { getShippingMethodIdFromCheckout } from "../support/api/utils/ordersUtils";
+import {
+  createProductInChannel,
+  createTypeAttributeAndCategoryForProduct,
+  deleteProductsStartsWith,
+} from "../support/api/utils/products/productsUtils";
+import {
+  createShipping,
+  deleteShippingStartsWith,
+} from "../support/api/utils/shippingUtils";
 import { discountOptions } from "../support/pages/discounts/vouchersPage";
 
 describe("As a staff user I want to manage apps", () => {
@@ -22,16 +37,58 @@ describe("As a staff user I want to manage apps", () => {
 
   let createdApp;
   let defaultChannel;
+  let address;
+  let warehouse;
+  let shippingMethod;
+  let variantsList;
+  let checkout;
+  const email = `example@example.com`;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
     deleteAppsStartsWith(startsWith);
+    deleteProductsStartsWith(startsWith);
+    deleteShippingStartsWith(startsWith);
+
     createApp(name, "MANAGE_APPS").then(app => {
       createdApp = app;
     });
-    getDefaultChannel().then(channel => {
-      defaultChannel = channel;
-    });
+    cy.fixture("addresses")
+      .then(addresses => {
+        address = addresses.usAddress;
+        getDefaultChannel();
+      })
+      .then(channelResp => {
+        defaultChannel = channelResp;
+        createShipping({
+          channelId: defaultChannel.id,
+          name,
+          address,
+          price: 10,
+        });
+      })
+      .then(
+        ({
+          warehouse: warehouseResp,
+          shippingZone: shippingZoneResp,
+          shippingMethod: shippingMethodResp,
+        }) => {
+          warehouse = warehouseResp;
+          shippingMethod = shippingMethodResp;
+        },
+      );
+    createTypeAttributeAndCategoryForProduct({ name })
+      .then(({ productType, attribute, category }) => {
+        createProductInChannel({
+          name,
+          channelId: defaultChannel.id,
+          warehouseId: warehouse.id,
+          productTypeId: productType.id,
+          attributeId: attribute.id,
+          categoryId: category.id,
+        });
+      })
+      .then(({ variantsList: variants }) => (variantsList = variants));
   });
 
   beforeEach(() => {
@@ -154,6 +211,39 @@ describe("As a staff user I want to manage apps", () => {
       createGiftCard(giftCardData, token).then(resp => {
         expect(resp.code).to.be.not.empty;
         expect(resp.isActive).to.eq(true);
+      });
+    },
+  );
+
+  it(
+    "should be able to use app to create order from checkout. TC: SALEOR_3005",
+    { tags: ["@app", "@allEnv"] },
+    () => {
+      const startsWith = "HandleCheckouts";
+      const token = createdApp.authToken;
+
+      cy.clearSessionData().loginUserViaRequest();
+      updateApp(createdApp.app.id, "HANDLE_CHECKOUTS");
+
+      cy.clearSessionData();
+
+      createCheckout({
+        channelSlug: defaultChannel.slug,
+        email,
+        variantsList,
+        address,
+        billingAddress: address,
+        auth: "token",
+      }).then(({ checkout: checkoutResp }) => {
+        const shippingMethodId = getShippingMethodIdFromCheckout(
+          checkoutResp,
+          shippingMethod.name,
+        );
+        checkout = checkoutResp;
+        addShippingMethod(checkout.id, shippingMethodId);
+        orderCreateFromCheckout(checkout.id, true, token).then(resp => {
+          expect(resp.id).to.be.not.empty;
+        });
       });
     },
   );

--- a/cypress/e2e/apps.js
+++ b/cypress/e2e/apps.js
@@ -68,11 +68,7 @@ describe("As a staff user I want to manage apps", () => {
         });
       })
       .then(
-        ({
-          warehouse: warehouseResp,
-          shippingZone: shippingZoneResp,
-          shippingMethod: shippingMethodResp,
-        }) => {
+        ({ warehouse: warehouseResp, shippingMethod: shippingMethodResp }) => {
           warehouse = warehouseResp;
           shippingMethod = shippingMethodResp;
         },
@@ -217,9 +213,8 @@ describe("As a staff user I want to manage apps", () => {
 
   it(
     "should be able to use app to create order from checkout. TC: SALEOR_3005",
-    { tags: ["@app", "@allEnv"] },
+    { tags: ["@app", "@allEnv", "@stable"] },
     () => {
-      const startsWith = "HandleCheckouts";
       const token = createdApp.authToken;
 
       cy.clearSessionData().loginUserViaRequest();
@@ -241,7 +236,7 @@ describe("As a staff user I want to manage apps", () => {
         );
         checkout = checkoutResp;
         addShippingMethod(checkout.id, shippingMethodId);
-        orderCreateFromCheckout(checkout.id, true, token).then(resp => {
+        orderCreateFromCheckout(checkout.id, token).then(resp => {
           expect(resp.id).to.be.not.empty;
         });
       });

--- a/cypress/support/api/requests/Checkout.js
+++ b/cypress/support/api/requests/Checkout.js
@@ -283,8 +283,8 @@ export function getCheckout(token) {
 
 export function orderCreateFromCheckout(
   checkoutId,
-  removeCheckoutFlag = true,
   token,
+  removeCheckoutFlag = true,
 ) {
   const mutation = `mutation {
     orderCreateFromCheckout(id: "${checkoutId}", removeCheckout: ${removeCheckoutFlag})

--- a/cypress/support/api/requests/Checkout.js
+++ b/cypress/support/api/requests/Checkout.js
@@ -280,3 +280,25 @@ export function getCheckout(token) {
   }`;
   return cy.sendRequestWithQuery(query).its("body.data.checkout");
 }
+
+export function orderCreateFromCheckout(
+  checkoutId,
+  removeCheckoutFlag = true,
+  token,
+) {
+  const mutation = `mutation {
+    orderCreateFromCheckout(id: "${checkoutId}", removeCheckout: ${removeCheckoutFlag})
+    {
+          order{
+              id
+          }
+          errors{
+              field
+              message
+          }
+      }
+  }`;
+  return cy
+    .sendRequestWithQuery(mutation, token)
+    .its("body.data.orderCreateFromCheckout.order");
+}


### PR DESCRIPTION
I want to merge this change because I add a test for creating order from checkout as app with Handle Checkouts permission

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
