### PR TITLE
Fix fulfillment page if not tracking stock

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3810,6 +3810,10 @@
     "context": "unassign attribute from product type, button",
     "string": "Unassign"
   },
+  "SBb6Ej": {
+    "context": "select a warehouse to fulfill product from",
+    "string": "Select warehouse..."
+  },
   "SHm7ee": {
     "string": "Search by product name, attribute, product type etc..."
   },

--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
@@ -174,11 +174,7 @@ export const OrderFulfillLine: React.FC<OrderFulfillLineProps> = props => {
               className={classes.warehouseButtonContentText}
             >
               {lineFormWarehouse?.name ??
-                intl.formatMessage({
-                  defaultMessage: "Select warehouse...",
-                  id: "SBb6Ej",
-                  description: "select a warehouse to fulfill product from",
-                })}
+                intl.formatMessage(messages.selectWarehouse)}
             </Typography>
             <ChevronIcon />
           </div>

--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
@@ -58,7 +58,7 @@ export const OrderFulfillLine: React.FC<OrderFulfillLineProps> = props => {
 
   const isStockExceeded = lineFormQuantity > availableQuantity;
 
-  if (!line || !lineFormWarehouse) {
+  if (!line) {
     return (
       <TableRow key={lineIndex}>
         <TableCellAvatar className={classes.colName}>
@@ -156,7 +156,11 @@ export const OrderFulfillLine: React.FC<OrderFulfillLineProps> = props => {
         </TableCell>
       )}
       <TableCell className={classes.colStock} key="total">
-        {isPreorder || isDeletedVariant ? undefined : availableQuantity}
+        {lineFormWarehouse
+          ? isPreorder || isDeletedVariant
+            ? undefined
+            : availableQuantity
+          : "-"}
       </TableCell>
       <TableCell className={classes.colWarehouse}>
         <IconButton
@@ -165,9 +169,17 @@ export const OrderFulfillLine: React.FC<OrderFulfillLineProps> = props => {
           data-test-id="select-warehouse-button"
         >
           <div className={classes.warehouseButtonContent}>
-            <div className={classes.warehouseButtonContentText}>
-              {lineFormWarehouse?.name ?? <Skeleton />}
-            </div>
+            <Typography
+              color={lineFormWarehouse ? "textPrimary" : "textSecondary"}
+              className={classes.warehouseButtonContentText}
+            >
+              {lineFormWarehouse?.name ??
+                intl.formatMessage({
+                  defaultMessage: "Select warehouse...",
+                  id: "SBb6Ej",
+                  description: "select a warehouse to fulfill product from",
+                })}
+            </Typography>
             <ChevronIcon />
           </div>
         </IconButton>

--- a/src/orders/components/OrderFulfillLine/messages.ts
+++ b/src/orders/components/OrderFulfillLine/messages.ts
@@ -17,4 +17,9 @@ export const messages = defineMessages({
     id: "W5hb5H",
     description: "warehouse input",
   },
+  selectWarehouse: {
+    defaultMessage: "Select warehouse...",
+    id: "SBb6Ej",
+    description: "select a warehouse to fulfill product from",
+  },
 });

--- a/src/orders/components/OrderFulfillLine/styles.ts
+++ b/src/orders/components/OrderFulfillLine/styles.ts
@@ -62,6 +62,7 @@ export const useStyles = makeStyles(
     warehouseButtonContentText: {
       overflow: "hidden",
       textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
     },
   }),
   { name: "OrderFulfillLine" },

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -163,6 +163,10 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
     !shopSettings?.fulfillmentAllowUnpaid &&
     !order?.isPaid;
 
+  const areWarehousesSet = formsetData.every(line =>
+    line.value.every(v => v.warehouse),
+  );
+
   const shouldEnableSave = () => {
     if (!order || loading) {
       return false;
@@ -186,7 +190,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
         return formQuantityFulfilled > quantityToFulfill;
       });
 
-    return !overfulfill && isAtLeastOneFulfilled;
+    return !overfulfill && isAtLeastOneFulfilled && areWarehousesSet;
   };
 
   return (
@@ -261,7 +265,7 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
                                 lineId: line.id,
                                 warehouseId:
                                   formsetData[lineIndex]?.value?.[0]?.warehouse
-                                    .id,
+                                    ?.id,
                               })
                             }
                           />


### PR DESCRIPTION
I want to merge this change because it fixes bug that caused fulfillment page to load endlessly if any variant had "track inventory" disabled.

**PR intended to be tested with API branch:** main

### Screenshots
<img width="1287" alt="Zrzut ekranu 2022-09-6 o 15 47 12" src="https://user-images.githubusercontent.com/6833443/188665905-73c3f519-2d80-4b4d-990a-3192f321add0.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/
