### PR TITLE
fix for flaky change user email tests and refactor of plugins tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,5 +48,6 @@ Tests will be re-run only when the "run e2e" label is added.
 16. [ ] orders
 17. [ ] products
 18. [ ] app
+19. [ ] plugins
 
 CONTAINERS=1

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -5,7 +5,7 @@ export function inviteStaffMemberWithFirstPermission({
   email,
   isActive = true,
   firstName = "",
-  lastName = ""
+  lastName = "",
 }) {
   return getPermissionsArray(1).then(permissions => {
     inviteStaffMember({
@@ -13,7 +13,7 @@ export function inviteStaffMemberWithFirstPermission({
       lastName,
       email,
       isActive,
-      permissionId: permissions[0].node.id
+      permissionId: permissions[0].node.id,
     });
   });
 }
@@ -68,7 +68,7 @@ export function getMailActivationLinkForUserAndSubject(email, subject, i = 0) {
                 const urlRegex = /\[([^\]]*)\]/;
                 const bodyWithoutWhiteSpaces = body.replace(
                   /(\r\n|\n|\r|\s)/gm,
-                  ""
+                  "",
                 );
                 return urlRegex.exec(bodyWithoutWhiteSpaces)[1];
               });
@@ -78,13 +78,28 @@ export function getMailActivationLinkForUserAndSubject(email, subject, i = 0) {
   });
 }
 
+export function getMailWithResetPasswordLink(email, subject, i = 0) {
+  if (i > 5) {
+    throw new Error(`There is no email with reset password for user ${email}`);
+  }
+  return cy.mhGetMailsByRecipient(email).should(mails => {
+    if (!mails.length) {
+      cy.wait(3000);
+      getMailWithResetPasswordLink(email, subject, i + 1);
+    } else {
+      cy.mhGetMailsBySubject(subject);
+      return mails;
+    }
+  });
+}
+
 export function getMailsForUser(email, i = 0) {
-  if (i > 3) {
+  if (i > 5) {
     throw new Error(`There is no email invitation for user ${email}`);
   }
   return cy.mhGetMailsByRecipient(email).should(mails => {
     if (!mails.length) {
-      cy.wait(10000);
+      cy.wait(3000);
       getMailsForUser(email, i + 1);
     } else {
       return mails;


### PR DESCRIPTION
I want to merge this change because:
- fixes flaky `should change user email` - needed to wait until progress bar disappear,
- adding function `getMailWithResetPasswordLink` - for update admin email plugin - to check if email with proper subject is available

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app

CONTAINERS=1