### PR TITLE
Fix Heroku deployment error related to it's stack version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "name": "saleor-dashboard",
+  "stack": "heroku-20",
   "description": "A GraphQL-powered, single-page dashboard application for Saleor",
   "repository": "https://github.com/mirumee/saleor-dashboard",
   "website": "http://getsaleor.com/",


### PR DESCRIPTION
Add a "stack" option, because the default heroku-22 throws an error.
