### PR TITLE
Refactor of tests in navigation.js

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,5 +50,6 @@ Tests will be re-run only when the "run e2e" label is added.
 18. [ ] app
 19. [ ] plugins
 20. [ ] translations
+21. [ ] navigation
 
 CONTAINERS=1

--- a/cypress/e2e/navigation.js
+++ b/cypress/e2e/navigation.js
@@ -47,44 +47,37 @@ describe("As a staff user I want to navigate through shop using different permis
     if (key !== "all") {
       it(
         `should be able to navigate through shop as a staff member using ${key} permission. ${permissionsOptions[key].testCase}`,
-        { tags: ["@allEnv", "@navigation"] },
+        { tags: ["@allEnv", "@navigation", "@stable"] },
         () => {
           const permissionOption = permissionsOptions[key];
           const permissions = permissionOption.permissions;
+
           cy.clearSessionData();
           permissionsSteps.navigateToAllAvailablePageAndCheckIfDisplayed(
             permissionOption,
           );
-          permissionsSteps
-            .getDisplayedSelectors()
-            .then(selectors => {
-              permissionsSteps.expectAllSelectorsPermitted(
-                permissions,
-                selectors,
-              );
-            })
-            .then(() => {
-              if (!permissions) {
-                return;
-              }
-              permissions.forEach(permission => {
-                if (permission.parent) {
-                  cy.get(permission.parent.parentMenuSelector)
-                    .click()
-                    .then(() => {
-                      permissionsSteps.getDisplayedSelectors(
-                        permission.parent.parentSelectors,
-                      );
-                    })
-                    .then(parentSelectors => {
-                      permissionsSteps.expectAllSelectorsPermitted(
-                        permissions,
-                        parentSelectors,
-                      );
-                    });
-                }
-              });
-            });
+          permissionsSteps.getDisplayedSelectors().then(selectors => {
+            permissionsSteps.expectAllSelectorsPermitted(
+              permissions,
+              selectors,
+            );
+          });
+          if (!permissions) {
+            return;
+          }
+          permissions.forEach(permission => {
+            if (permission.parent) {
+              cy.get(permission.parent.parentMenuSelector).click();
+              permissionsSteps
+                .getDisplayedSelectors(permission.parent.parentSelectors)
+                .then(parentSelectors => {
+                  permissionsSteps.expectAllSelectorsPermitted(
+                    permissions,
+                    parentSelectors,
+                  );
+                });
+            }
+          });
         },
       );
     }
@@ -95,6 +88,7 @@ describe("As a staff user I want to navigate through shop using different permis
     { tags: ["@critical", "@allEnv", "@navigation", "@stable"] },
     () => {
       const permissionOption = permissionsOptions.all;
+
       cy.clearSessionData();
       permissionsSteps.navigateToAllAvailablePageAndCheckIfDisplayed(
         permissionOption,

--- a/cypress/fixtures/permissionsUsers.js
+++ b/cypress/fixtures/permissionsUsers.js
@@ -5,81 +5,80 @@ export const PERMISSIONS_OPTIONS = {
   all: {
     user: TEST_ADMIN_USER,
     permissions: Object.values(PERMISSIONS),
-    testCase: "TC: SALEOR_3401"
+    testCase: "TC: SALEOR_3401",
   },
   app: {
     user: ONE_PERMISSION_USERS.app,
     permissions: [],
-    testCase: "TC: SALEOR_3402"
+    testCase: "TC: SALEOR_3402",
   },
   channel: {
     user: ONE_PERMISSION_USERS.channel,
     permissions: [PERMISSIONS.channel],
-    testCase: "TC: SALEOR_3403"
+    testCase: "TC: SALEOR_3403",
   },
   customer: {
     user: ONE_PERMISSION_USERS.user,
     permissions: [PERMISSIONS.customer],
-    testCase: "TC: SALEOR_3404"
+    testCase: "TC: SALEOR_3404",
   },
   discount: {
     user: ONE_PERMISSION_USERS.discount,
     permissions: [PERMISSIONS.discounts],
-    testCase: "TC: SALEOR_3405"
+    testCase: "TC: SALEOR_3405",
   },
   giftCard: {
     user: ONE_PERMISSION_USERS.giftCard,
-    testCase: "TC: SALEOR_3406"
+    testCase: "TC: SALEOR_3406",
   },
   order: {
     user: ONE_PERMISSION_USERS.order,
     permissions: [PERMISSIONS.order],
-    testCase: "TC: SALEOR_3407"
+    testCase: "TC: SALEOR_3407",
   },
   page: {
     user: ONE_PERMISSION_USERS.page,
     permissions: [PERMISSIONS.page],
-    testCase: "TC: SALEOR_3408"
+    testCase: "TC: SALEOR_3408",
   },
   plugin: {
     user: ONE_PERMISSION_USERS.plugin,
     permissions: [PERMISSIONS.plugin],
-    testCase: "TC: SALEOR_3409"
+    testCase: "TC: SALEOR_3409",
   },
   product: {
     user: ONE_PERMISSION_USERS.product,
     permissions: [PERMISSIONS.product, PERMISSIONS.warehouse],
-    testCase: "TC: SALEOR_3410"
+    testCase: "TC: SALEOR_3410",
   },
   productTypeAndAttribute: {
     user: ONE_PERMISSION_USERS.productTypeAndAttribute,
     permissions: [PERMISSIONS.productTypeAndAttribute],
-    testCase: "TC: SALEOR_3411"
+    testCase: "TC: SALEOR_3411",
   },
   pageTypeAndAttribute: {
     user: ONE_PERMISSION_USERS.pageTypeAndAttribute,
     permissions: [PERMISSIONS.pageTypeAndAttribute],
-    testCase: "TC: SALEOR_3412"
+    testCase: "TC: SALEOR_3412",
   },
   settings: {
     user: ONE_PERMISSION_USERS.settings,
     permissions: [PERMISSIONS.settings],
-    testCase: "TC: SALEOR_3413"
-  },
-  shipping: {
-    user: ONE_PERMISSION_USERS.shipping,
-    permissions: [PERMISSIONS.shipping],
-    testCase: "TC: SALEOR_3415"
+    testCase: "TC: SALEOR_3413",
   },
   staff: {
     user: ONE_PERMISSION_USERS.staff,
     permissions: [PERMISSIONS.staff],
-    testCase: "TC: SALEOR_3414"
-  }
-  // },
-  // translations: {
-  //   user: ONE_PERMISSION_USERS.translations,
-  //   permissions: [PERMISSIONS.translations],
-  //   testCase: "TC: SALEOR_3416"
-  // } // commented as part of  SALEOR-6705 task. Need to be fixed in future. Klaudia Jaroszewicz
+    testCase: "TC: SALEOR_3414",
+  },
+  shipping: {
+    user: ONE_PERMISSION_USERS.shipping,
+    permissions: [PERMISSIONS.shipping],
+    testCase: "TC: SALEOR_3415",
+  },
+  translations: {
+    user: ONE_PERMISSION_USERS.translations,
+    permissions: [PERMISSIONS.translations],
+    testCase: "TC: SALEOR_3416",
+  },
 };

--- a/cypress/support/pages/permissionsPage.js
+++ b/cypress/support/pages/permissionsPage.js
@@ -4,72 +4,68 @@ import { urlList } from "../../fixtures/urlList";
 
 export function navigateToAllAvailablePageAndCheckIfDisplayed({
   user,
-  permissions
+  permissions,
 }) {
-  cy.loginUserViaRequest("auth", user);
-  cy.visit(urlList.homePage);
+  cy.loginUserViaRequest("auth", user).visit(urlList.homePage);
   if (!permissions) {
     return;
   }
   return permissions.forEach(permission =>
     permission.permissionSelectors.forEach(permissionSelector => {
-      navigateToAvailablePageAndCheckIfDisplayed(
-        permission.parent,
-        permissionSelector
-      );
-    })
+      if (permission.parent) {
+        cy.get(permission.parent.parentMenuSelector).click();
+      }
+      return cy
+        .get(permissionSelector)
+        .click()
+        .then(() => {
+          isElementDisplayed().should("be.true");
+        });
+    }),
   );
 }
-function navigateToAvailablePageAndCheckIfDisplayed(
-  parent,
-  permissionSelector
-) {
-  if (parent) {
-    cy.get(parent.parentMenuSelector).click();
-  }
-  return cy
-    .get(permissionSelector)
-    .click()
-    .then(() => {
-      isElementDisplayed();
-    })
-    .then(isDisplayed => {
-      expect(isDisplayed).to.be.true;
-    });
-}
+
 export function isElementDisplayed(element = SHARED_ELEMENTS.header) {
   return cy.get("body").then(body => body.find(element).length > 0);
 }
+
 export function getDisplayedSelectors(selectors = LEFT_MENU_SELECTORS) {
   const displayedSelectors = {};
+
   cy.wrap(displayedSelectors).as("displayedSelectors");
 
   Object.values(selectors).forEach((value, i) =>
     isElementDisplayed(value).then(isDisplayed => {
       if (isDisplayed) {
         cy.wrap(value);
+
         displayedSelectors["link" + i] = value;
+
         cy.wrap(displayedSelectors).as("displayedSelectors");
       }
-    })
+    }),
   );
   return cy.get("@displayedSelectors");
 }
+
 export function expectAllSelectorsPermitted(permissions, selectors) {
   Object.values(selectors).forEach(selector => {
     const isSelectorPermitted = isPermitted(permissions, selector);
+
     expect(isSelectorPermitted, `${selector} selector should be in permitted`)
       .to.be.true;
   });
 }
+
 function isPermitted(permissions, selector) {
   let permittedSelectors = [LEFT_MENU_SELECTORS.home];
+
   permissions.forEach(permission => {
     if (permission.parent) {
       permittedSelectors.push(permission.parent.parentMenuSelector);
     }
     permittedSelectors = permittedSelectors.concat(
-      permission.permissionSelectors
+      permission.permissionSelectors,
     );
   });
   return permittedSelectors.includes(selector);


### PR DESCRIPTION
I want to merge this change because it contains refactor of navigation.js tests. 
Adding an option to run navigation tests.
<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations

CONTAINERS=1