### PR TITLE
Firefox checkbox overlap workaround

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -23,6 +23,11 @@ export type CheckboxProps = Omit<
   error?: boolean;
 };
 
+const firefoxHandler = (event, onChange, checked) => {
+  event.preventDefault();
+  onChange(event, checked);
+};
+
 const Checkbox: React.FC<CheckboxProps> = ({ helperText, error, ...props }) => {
   const { disableClickPropagation, ...rest } = props;
   const classes = useStyles();
@@ -32,7 +37,17 @@ const Checkbox: React.FC<CheckboxProps> = ({ helperText, error, ...props }) => {
       <MuiCheckbox
         {...rest}
         onClick={
-          disableClickPropagation ? event => event.stopPropagation() : undefined
+          disableClickPropagation
+            ? event => {
+                event.stopPropagation();
+
+                /*
+              Workaround for firefox
+              ref: https://bugzilla.mozilla.org/show_bug.cgi?id=62151
+            */
+                firefoxHandler(event, rest.onChange, rest.checked);
+              }
+            : undefined
         }
       />
       {helperText && (


### PR DESCRIPTION
Adding preventDefault to prevent link following on firefox.

### Pull Request Checklist

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations

CONTAINERS=1