### PR TITLE
Add format tip for text attribute rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Enable save button on discount pages - #2319 by @orzechdev
 - Enable save button on page pages - #2325 by @orzechdev
 - Fix pagination errors on voucher and sale pages - #2317 by @orzechdev
-
+- Add format tip for text attribute rows - #2340 by @orzechdev
 
 ## 3.4
 

--- a/src/channels/components/ChannelAllocationStrategy/styles.ts
+++ b/src/channels/components/ChannelAllocationStrategy/styles.ts
@@ -7,7 +7,7 @@ export const useStyles = makeStyles(
       marginBottom: theme.spacing(),
     },
     tooltipIcon: {
-      fill: "#28234A",
+      fill: theme.palette.type === "dark" ? "#FAFAFA" : "#28234A",
       fillOpacity: 0.6,
       "&:hover": {
         fillOpacity: 1,

--- a/src/components/Attributes/AttributeRow.tsx
+++ b/src/components/Attributes/AttributeRow.tsx
@@ -1,4 +1,5 @@
 import { InputAdornment, TextField } from "@material-ui/core";
+import { inputTypeMessages } from "@saleor/attributes/components/AttributeDetails/messages";
 import { getMeasurementUnitMessage } from "@saleor/attributes/components/AttributeDetails/utils";
 import BasicAttributeRow from "@saleor/components/Attributes/BasicAttributeRow";
 import ExtendedAttributeRow from "@saleor/components/Attributes/ExtendedAttributeRow";
@@ -126,7 +127,10 @@ const AttributeRow: React.FC<AttributeRowProps> = ({
       );
     case AttributeInputTypeEnum.PLAIN_TEXT:
       return (
-        <BasicAttributeRow label={attribute.label}>
+        <BasicAttributeRow
+          label={attribute.label}
+          description={intl.formatMessage(inputTypeMessages.plainText)}
+        >
           <TextField
             fullWidth
             disabled={disabled}
@@ -149,7 +153,10 @@ const AttributeRow: React.FC<AttributeRowProps> = ({
       } = richTextGetters;
       const defaultValue = getDefaultValue(attribute.id);
       return (
-        <BasicAttributeRow label={attribute.label}>
+        <BasicAttributeRow
+          label={attribute.label}
+          description={intl.formatMessage(inputTypeMessages.richText)}
+        >
           {getShouldMount(attribute.id) && (
             <RichTextEditor
               defaultValue={defaultValue}

--- a/src/components/Attributes/BasicAttributeRow.tsx
+++ b/src/components/Attributes/BasicAttributeRow.tsx
@@ -1,51 +1,25 @@
 import { Typography } from "@material-ui/core";
+import HelpOutline from "@material-ui/icons/HelpOutline";
 import Grid from "@saleor/components/Grid";
-import { makeStyles } from "@saleor/macaw-ui";
+import { Tooltip } from "@saleor/macaw-ui";
 import classNames from "classnames";
 import React from "react";
 
-const useStyles = makeStyles(
-  theme => ({
-    attributeSection: {
-      "&:last-of-type": {
-        paddingBottom: 0,
-      },
-      padding: theme.spacing(2, 0),
-      wordBreak: "break-word",
-    },
-    attributeSectionLabel: {
-      alignItems: "center",
-      display: "flex",
-    },
-    flex: {
-      columnGap: theme.spacing(2) + "px",
-      display: "flex",
-      flexDirection: "row",
-      [theme.breakpoints.down("md")]: {
-        flexDirection: "column",
-        rowGap: theme.spacing(2) + "px",
-      },
-    },
-    value: {
-      "&&": {
-        overflow: "visible",
-      },
-    },
-  }),
-  { name: "BasicAttributeRow" },
-);
+import { useBasicAttributeStyles } from "./styles";
 
 interface BasicAttributeRowProps {
   label: string | React.ReactNode;
+  description?: string | React.ReactNode;
   flexValueContainer?: boolean;
 }
 
 const BasicAttributeRow: React.FC<BasicAttributeRowProps> = ({
   label,
+  description,
   children,
   flexValueContainer,
 }) => {
-  const classes = useStyles();
+  const classes = useBasicAttributeStyles();
 
   return (
     <Grid className={classes.attributeSection} variant="uniform">
@@ -53,7 +27,14 @@ const BasicAttributeRow: React.FC<BasicAttributeRowProps> = ({
         className={classes.attributeSectionLabel}
         data-test-id="attribute-label"
       >
-        <Typography>{label}</Typography>
+        <Typography>
+          {label}
+          {description && (
+            <Tooltip title={description}>
+              <HelpOutline className={classes.tooltipIcon} />
+            </Tooltip>
+          )}
+        </Typography>
       </div>
       <div
         data-test-id="attribute-value"

--- a/src/components/Attributes/ExtendedAttributeRow.tsx
+++ b/src/components/Attributes/ExtendedAttributeRow.tsx
@@ -1,27 +1,9 @@
 import { Typography } from "@material-ui/core";
 import { Button } from "@saleor/components/Button";
 import Grid from "@saleor/components/Grid";
-import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 
-const useStyles = makeStyles(
-  theme => ({
-    attributeSection: {
-      "&:last-of-type": {
-        paddingBottom: 0,
-      },
-      padding: theme.spacing(2, 0),
-    },
-    attributeSectionButton: {
-      float: "right",
-    },
-    attributeSectionLabel: {
-      alignItems: "center",
-      display: "flex",
-    },
-  }),
-  { name: "ExtendedAttributeRow" },
-);
+import { useExtendedAttributeStyles } from "./styles";
 
 interface ExtendedAttributeRowProps {
   label: string;
@@ -32,7 +14,7 @@ interface ExtendedAttributeRowProps {
 
 const ExtendedAttributeRow: React.FC<ExtendedAttributeRowProps> = props => {
   const { label, selectLabel, disabled, onSelect, children } = props;
-  const classes = useStyles(props);
+  const classes = useExtendedAttributeStyles(props);
 
   return (
     <>

--- a/src/components/Attributes/styles.ts
+++ b/src/components/Attributes/styles.ts
@@ -23,3 +23,63 @@ export const useStyles = makeStyles(
   }),
   { name: "AttributeRow" },
 );
+
+export const useBasicAttributeStyles = makeStyles(
+  theme => ({
+    attributeSection: {
+      "&:last-of-type": {
+        paddingBottom: 0,
+      },
+      padding: theme.spacing(2, 0),
+      wordBreak: "break-word",
+    },
+    attributeSectionLabel: {
+      alignItems: "center",
+      display: "flex",
+    },
+    flex: {
+      columnGap: theme.spacing(2) + "px",
+      display: "flex",
+      flexDirection: "row",
+      [theme.breakpoints.down("md")]: {
+        flexDirection: "column",
+        rowGap: theme.spacing(2) + "px",
+      },
+    },
+    value: {
+      "&&": {
+        overflow: "visible",
+      },
+    },
+    tooltipIcon: {
+      fill: "#28234A",
+      fillOpacity: 0.6,
+      "&:hover": {
+        fillOpacity: 1,
+      },
+      position: "absolute",
+      padding: theme.spacing(0.25),
+      marginLeft: theme.spacing(0.75),
+    },
+  }),
+  { name: "BasicAttributeRow" },
+);
+
+export const useExtendedAttributeStyles = makeStyles(
+  theme => ({
+    attributeSection: {
+      "&:last-of-type": {
+        paddingBottom: 0,
+      },
+      padding: theme.spacing(2, 0),
+    },
+    attributeSectionButton: {
+      float: "right",
+    },
+    attributeSectionLabel: {
+      alignItems: "center",
+      display: "flex",
+    },
+  }),
+  { name: "ExtendedAttributeRow" },
+);

--- a/src/components/Attributes/styles.ts
+++ b/src/components/Attributes/styles.ts
@@ -52,7 +52,7 @@ export const useBasicAttributeStyles = makeStyles(
       },
     },
     tooltipIcon: {
-      fill: "#28234A",
+      fill: theme.palette.type === "dark" ? "#FAFAFA" : "#28234A",
       fillOpacity: 0.6,
       "&:hover": {
         fillOpacity: 1,


### PR DESCRIPTION
It adds tooltip with format tip for text attribute rows to indicate if it is a `simple text` or a `rich text` attribute.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="607" alt="Screenshot 2022-09-27 at 17 21 57" src="https://user-images.githubusercontent.com/9825562/192567710-7d4d25bc-7f64-42c1-9b83-92391a4eb46b.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [x] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [x] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1