### PR TITLE
Adjust breakpoints

### DIFF
--- a/src/themeOverrides.ts
+++ b/src/themeOverrides.ts
@@ -1,6 +1,12 @@
 import { Theme } from "@material-ui/core/styles";
 
+const breakpoints = ({
+  keys: ["xs", "sm", "md", "lg", "xl"],
+  values: { lg: 1680, md: 1280, sm: 600, xl: 1920, xs: 0 },
+} as unknown) as Theme["breakpoints"];
+
 const themeOverrides: Partial<Theme> = {
+  breakpoints,
   overrides: {
     MuiTableCell: {
       body: {
@@ -15,4 +21,5 @@ const themeOverrides: Partial<Theme> = {
     },
   },
 };
+
 export default themeOverrides;


### PR DESCRIPTION
This PR affects two breakpoints:

• Largest breakpoint became 400px wider, allowing more information to be displayed in tables
• Medium breakpoint is more narrow, meaning that mobile (one column layout) would appear sooner to avoid cramped views


Before: 
```{lg: 1280, md: 960, sm: 600, xl: 1920, xs: 0}```

After:
```lg: 1680, md: 1280, sm: 600, xl: 1920, xs: 0```