### PR TITLE
Fix variants tests in datagrid

### DIFF
--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -42,7 +42,7 @@ describe("As an admin I should be able to create variant", () => {
         defaultChannel = resp.defaultChannel;
         warehouse = resp.warehouse;
 
-        createChannel({ isActive: true, name, currencyCode: "PL" });
+        createChannel({ isActive: true, name, currencyCode: "PLN" });
       })
       .then(resp => (newChannel = resp));
   });
@@ -96,6 +96,7 @@ describe("As an admin I should be able to create variant", () => {
             .waitForProgressBarToNotBeVisible()
             .get(PRODUCT_DETAILS.dataGridTable)
             .should("be.visible")
+            .wait(1000)
             .get(BUTTON_SELECTORS.showMoreButton)
             .click()
             .get(PRODUCT_DETAILS.editVariant)
@@ -123,7 +124,7 @@ describe("As an admin I should be able to create variant", () => {
         .then(([variant]) => {
           expect(variant).to.have.property("name", name);
           expect(variant).to.have.property("price", price);
-          expect(variant).to.have.property("currency", "PL");
+          expect(variant).to.have.property("currency", "PLN");
         });
     },
   );
@@ -156,22 +157,27 @@ describe("As an admin I should be able to create variant", () => {
             .get(PRODUCT_DETAILS.editVariant)
             .click()
             .get(PRODUCT_DETAILS.addVariantButton)
-            .click();
-          createVariant({
-            sku: secondVariantSku,
-            attributeName: variants[1].name,
-            price: variants[1].price,
-            channelName: defaultChannel.name,
-          });
-          getProductVariants(createdProduct.id, defaultChannel.slug);
-        })
-        .then(([firstVariant, secondVariant]) => {
-          expect(firstVariant).to.have.property("price", variants[0].price);
-          expect(firstVariant).to.have.property("name", "value");
-          expect(firstVariant).to.have.property("currency", "USD");
-          expect(secondVariant).to.have.property("name", "value2");
-          expect(secondVariant).to.have.property("price", variants[1].price);
-          expect(secondVariant).to.have.property("currency", "USD");
+            .click()
+            .then(() => {
+              createVariant({
+                sku: secondVariantSku,
+                attributeName: variants[1].name,
+                price: variants[1].price,
+                channelName: defaultChannel.name,
+              });
+              getProductVariants(createdProduct.id, defaultChannel.slug);
+            })
+            .then(([firstVariant, secondVariant]) => {
+              expect(firstVariant).to.have.property("price", variants[0].price);
+              expect(firstVariant).to.have.property("name", "value");
+              expect(firstVariant).to.have.property("currency", "USD");
+              expect(secondVariant).to.have.property("name", "value2");
+              expect(secondVariant).to.have.property(
+                "price",
+                variants[1].price,
+              );
+              expect(secondVariant).to.have.property("currency", "USD");
+            });
         });
     },
   );

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -3,6 +3,9 @@
 
 import faker from "faker";
 
+import { PRODUCT_DETAILS } from "../../elements/catalog/products/product-details";
+import { VARIANTS_SELECTORS } from "../../elements/catalog/products/variants-selectors";
+import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
 import { urlList } from "../../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../../fixtures/users";
 import { createChannel } from "../../support/api/requests/Channels";
@@ -12,11 +15,7 @@ import {
 } from "../../support/api/requests/Product";
 import * as productUtils from "../../support/api/utils/products/productsUtils";
 import { getProductVariants } from "../../support/api/utils/storeFront/storeFrontProductUtils";
-import {
-  createVariant,
-  variantsShouldBeVisible,
-} from "../../support/pages/catalog/products/VariantsPage";
-import { selectChannelInHeader } from "../../support/pages/channelsPage";
+import { createVariant } from "../../support/pages/catalog/products/VariantsPage";
 
 describe("As an admin I should be able to create variant", () => {
   const startsWith = "CyCreateVariants-";
@@ -43,7 +42,7 @@ describe("As an admin I should be able to create variant", () => {
         defaultChannel = resp.defaultChannel;
         warehouse = resp.warehouse;
 
-        createChannel({ isActive: true, name, currencyCode: "USD" });
+        createChannel({ isActive: true, name, currencyCode: "PL" });
       })
       .then(resp => (newChannel = resp));
   });
@@ -71,6 +70,7 @@ describe("As an admin I should be able to create variant", () => {
       })
         .then(resp => {
           createdProduct = resp;
+
           updateChannelInProduct({
             productId: createdProduct.id,
             channelId: defaultChannel.id,
@@ -79,32 +79,47 @@ describe("As an admin I should be able to create variant", () => {
             productId: createdProduct.id,
             channelId: newChannel.id,
           });
-          cy.visit(`${urlList.products}${createdProduct.id}`);
+          cy.visit(`${urlList.products}${createdProduct.id}`)
+            .waitForProgressBarToNotBeVisible()
+            .get(PRODUCT_DETAILS.addVariantButton)
+            .should("exist")
+            .click()
+            .get(PRODUCT_DETAILS.firstRowDataGrid)
+            .click({ force: true })
+            .type(name)
+            .get(BUTTON_SELECTORS.confirm)
+            .click()
+            .confirmationMessageShouldAppear()
+            .reload()
+            .waitForProgressBarToNotBeVisible()
+            .get(BUTTON_SELECTORS.showMoreButton)
+            .click()
+            .get(PRODUCT_DETAILS.editVariant)
+            .click()
+            .get(VARIANTS_SELECTORS.manageChannels)
+            .click()
+            .get(VARIANTS_SELECTORS.allChannels)
+            .check()
+            .get(BUTTON_SELECTORS.submit)
+            .click();
           createVariant({
             channelName: [defaultChannel.name, newChannel.name],
             sku: name,
             price,
             attributeName: attributeValues[0],
           });
-          selectChannelInHeader(defaultChannel.name);
-          variantsShouldBeVisible({ name, price });
           getProductVariants(createdProduct.id, defaultChannel.slug);
         })
         .then(([variant]) => {
-          expect(variant).to.have.property("name", attributeValues[0]);
+          expect(variant).to.have.property("name", name);
           expect(variant).to.have.property("price", price);
-          selectChannelInHeader(newChannel.name);
-          variantsShouldBeVisible({ name, price });
-          getProductVariants(createdProduct.id, defaultChannel.slug);
-        })
-        .then(([variant]) => {
-          expect(variant).to.have.property("name", attributeValues[0]);
-          expect(variant).to.have.property("price", price);
+          expect(variant).to.have.property("currency", "USD");
           getProductVariants(createdProduct.id, newChannel.slug);
         })
         .then(([variant]) => {
-          expect(variant).to.have.property("name", attributeValues[0]);
+          expect(variant).to.have.property("name", name);
           expect(variant).to.have.property("price", price);
+          expect(variant).to.have.property("currency", "PL");
         });
     },
   );
@@ -130,26 +145,29 @@ describe("As an admin I should be able to create variant", () => {
         })
         .then(({ product: productResp }) => {
           createdProduct = productResp;
-          cy.visit(`${urlList.products}${createdProduct.id}`);
+
+          cy.visit(`${urlList.products}${createdProduct.id}`)
+            .get(BUTTON_SELECTORS.showMoreButton)
+            .click()
+            .get(PRODUCT_DETAILS.editVariant)
+            .click()
+            .get(PRODUCT_DETAILS.addVariantButton)
+            .click();
           createVariant({
             sku: secondVariantSku,
             attributeName: variants[1].name,
             price: variants[1].price,
             channelName: defaultChannel.name,
           });
-        })
-        .then(() => {
-          selectChannelInHeader(defaultChannel.name);
-          variantsShouldBeVisible({
-            name: variants[1].name,
-            price: variants[1].price,
-          });
           getProductVariants(createdProduct.id, defaultChannel.slug);
         })
         .then(([firstVariant, secondVariant]) => {
           expect(firstVariant).to.have.property("price", variants[0].price);
-          expect(secondVariant).to.have.property("name", variants[1].name);
+          expect(firstVariant).to.have.property("name", "value");
+          expect(firstVariant).to.have.property("currency", "USD");
+          expect(secondVariant).to.have.property("name", "value2");
           expect(secondVariant).to.have.property("price", variants[1].price);
+          expect(secondVariant).to.have.property("currency", "USD");
         });
     },
   );

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -171,11 +171,11 @@ describe("As an admin I should be able to create variant", () => {
               expect(firstVariant).to.have.property("price", variants[0].price);
               expect(firstVariant).to.have.property("name", "value");
               expect(firstVariant).to.have.property("currency", "USD");
-              expect(secondVariant).to.have.property("name", "value2");
               expect(secondVariant).to.have.property(
                 "price",
                 variants[1].price,
               );
+              expect(secondVariant).to.have.property("name", "value2");
               expect(secondVariant).to.have.property("currency", "USD");
             });
         });

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -94,6 +94,8 @@ describe("As an admin I should be able to create variant", () => {
             .confirmationMessageShouldAppear()
             .reload()
             .waitForProgressBarToNotBeVisible()
+            .get(PRODUCT_DETAILS.dataGridTable)
+            .should("be.visible")
             .get(BUTTON_SELECTORS.showMoreButton)
             .click()
             .get(PRODUCT_DETAILS.editVariant)

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -84,6 +84,8 @@ describe("As an admin I should be able to create variant", () => {
             .get(PRODUCT_DETAILS.addVariantButton)
             .should("exist")
             .click()
+            .get(PRODUCT_DETAILS.dataGridTable)
+            .should("be.visible")
             .get(PRODUCT_DETAILS.firstRowDataGrid)
             .click({ force: true })
             .type(name)

--- a/cypress/elements/catalog/products/product-details.js
+++ b/cypress/elements/catalog/products/product-details.js
@@ -27,4 +27,5 @@ export const PRODUCT_DETAILS = {
   saveUploadUrlButton: '[data-test-id="upload-url-button"]',
   editVariant: '[id="menu-list-grow"]',
   firstRowDataGrid: "[data-testid='glide-cell-1-0']",
+  dataGridTable: "[data-testid='data-grid-canvas']",
 };

--- a/cypress/elements/catalog/products/product-details.js
+++ b/cypress/elements/catalog/products/product-details.js
@@ -25,4 +25,6 @@ export const PRODUCT_DETAILS = {
   uploadSavedImagesButton: '[data-test-id="upload-images"]',
   uploadMediaUrlButton: '[data-test-id="upload-media-url"]',
   saveUploadUrlButton: '[data-test-id="upload-url-button"]',
+  editVariant: '[id="menu-list-grow"]',
+  firstRowDataGrid: "[data-testid='glide-cell-1-0']",
 };

--- a/cypress/elements/catalog/products/variants-selectors.js
+++ b/cypress/elements/catalog/products/variants-selectors.js
@@ -17,4 +17,6 @@ export const VARIANTS_SELECTORS = {
   globalThresholdInput: "[name='globalThreshold']",
   stockInput: "[data-test-id='stock-input']",
   selectOption: "[data-test-id='multi-autocomplete-select-option']",
+  manageChannels: "[data-testid='manage-channels-button']",
+  allChannels: "[name='allChannels']",
 };

--- a/cypress/support/api/utils/storeFront/storeFrontProductUtils.js
+++ b/cypress/support/api/utils/storeFront/storeFrontProductUtils.js
@@ -25,6 +25,7 @@ export const getProductVariants = (productId, channelSlug) => {
       id: element.id,
       name: element.name,
       price: element.pricing.price.gross.amount,
+      currency: element.pricing.price.gross.currency,
     }));
   });
 };

--- a/cypress/support/pages/catalog/products/VariantsPage.js
+++ b/cypress/support/pages/catalog/products/VariantsPage.js
@@ -19,7 +19,6 @@ export function createVariant({
   costPrice = price,
   quantity = 10,
 }) {
-  cy.get(PRODUCT_DETAILS.addVariantButton).click();
   fillUpVariantDetails({
     attributeName,
     sku,

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -198,6 +198,7 @@ export const Datagrid: React.FC<DatagridProps> = ({
         toolbar={
           <div className={classes.btnContainer}>
             <Button
+              data-test-id="button-add-variant"
               className={classes.addBtn}
               variant="tertiary"
               onClick={onRowAdded}

--- a/src/products/components/ProductVariantChannels/ChannelsAvailabilityCard/CreateVariantTitle.tsx
+++ b/src/products/components/ProductVariantChannels/ChannelsAvailabilityCard/CreateVariantTitle.tsx
@@ -18,7 +18,12 @@ export const CreateVariantTitle: React.FC<CreateVariantTitleProps> = ({
     <CardTitle
       title={intl.formatMessage(messages.title)}
       toolbar={
-        <Button variant="tertiary" disabled={false} onClick={onManageClick}>
+        <Button
+          variant="tertiary"
+          data-testid="manage-channels-button"
+          disabled={false}
+          onClick={onManageClick}
+        >
           {intl.formatMessage(messages.manageButtonText)}
         </Button>
       }


### PR DESCRIPTION
I want to merge this change because it fixes tests for variants. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1