### PR TITLE
Add quick app install from manifest

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3627,6 +3627,9 @@
     "context": "product field",
     "string": "Charge Taxes"
   },
+  "QVraQY": {
+    "string": "App manifest URL"
+  },
   "QY7FSs": {
     "context": "button",
     "string": "create product type"
@@ -6007,6 +6010,10 @@
     "context": "set balance dialog subtitle",
     "string": "What would you like to set cards balance to. When you change the balance both values will be changed"
   },
+  "kIXV5V": {
+    "context": "install with app manifest button",
+    "string": "Install with App Manifest"
+  },
   "kIvvax": {
     "string": "Search Products..."
   },
@@ -6460,6 +6467,9 @@
   "ny4zrH": {
     "context": "dialog title",
     "string": "Delete Warehouse"
+  },
+  "o/q4fc": {
+    "string": "Usually ends with /api/manifest"
   },
   "o5KXAN": {
     "context": "delete webhook",
@@ -7246,6 +7256,9 @@
   "ubasgL": {
     "context": "order history message",
     "string": "Order was confirmed"
+  },
+  "ubmFc8": {
+    "string": "Install"
   },
   "ud0w8h": {
     "context": "number of postal code ranges",

--- a/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
+++ b/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
@@ -2,7 +2,7 @@ import { TextField } from "@material-ui/core";
 import { Button } from "@saleor/components/Button";
 import { makeStyles } from "@saleor/macaw-ui";
 import React, { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 type AvailableStates = "initial" | "input-open";
 
@@ -24,6 +24,7 @@ interface Props {
 
 export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
   const styles = useStyles();
+  const intl = useIntl();
 
   const [state, setState] = useState<AvailableStates>("initial");
 
@@ -62,11 +63,18 @@ export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
       return (
         <form onSubmit={handleFormSubmit}>
           <TextField
+            required
             type="url"
             name="manifest-url"
-            label="App manifest url"
+            label={intl.formatMessage({
+              id: "QVraQY",
+              defaultMessage: "App manifest URL",
+            })}
             defaultValue=""
-            helperText="Usually ends with /api/manifest"
+            helperText={intl.formatMessage({
+              id: "o/q4fc",
+              defaultMessage: "Usually ends with /api/manifest",
+            })}
           />
           <Button
             size="medium"
@@ -74,7 +82,10 @@ export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
             className={styles.installButton}
             variant="primary"
           >
-            Install
+            {intl.formatMessage({
+              id: "ubmFc8",
+              defaultMessage: "Install",
+            })}
           </Button>
         </form>
       );

--- a/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
+++ b/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
@@ -4,7 +4,10 @@ import { makeStyles } from "@saleor/macaw-ui";
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-type AvailableStates = "initial" | "input-open";
+enum AvailableStates {
+  Initial,
+  InputOpen,
+}
 
 const useStyles = makeStyles(
   theme => ({
@@ -26,7 +29,7 @@ export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
   const styles = useStyles();
   const intl = useIntl();
 
-  const [state, setState] = useState<AvailableStates>("initial");
+  const [state, setState] = useState<AvailableStates>(AvailableStates.Initial);
 
   const handleFormSubmit: React.FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
@@ -44,12 +47,12 @@ export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
   };
 
   switch (state) {
-    case "initial": {
+    case AvailableStates.Initial: {
       return (
         <Button
           variant="secondary"
           data-test-id="add-app-from-manifest"
-          onClick={() => setState("input-open")}
+          onClick={() => setState(AvailableStates.InputOpen)}
         >
           <FormattedMessage
             id="kIXV5V"
@@ -59,7 +62,7 @@ export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
         </Button>
       );
     }
-    case "input-open": {
+    case AvailableStates.InputOpen: {
       return (
         <form onSubmit={handleFormSubmit}>
           <TextField

--- a/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
+++ b/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
@@ -1,0 +1,83 @@
+import { TextField } from "@material-ui/core";
+import { Button } from "@saleor/components/Button";
+import { makeStyles } from "@saleor/macaw-ui";
+import React, { useState } from "react";
+import { FormattedMessage } from "react-intl";
+
+type AvailableStates = "initial" | "input-open";
+
+const useStyles = makeStyles(
+  theme => ({
+    installButton: {
+      marginLeft: theme.spacing(2),
+      height: 52,
+    },
+  }),
+  {
+    name: "InstallWithManifestFormButton",
+  },
+);
+
+interface Props {
+  onSubmitted(manifestUrl: string): void;
+}
+
+export const InstallWithManifestFormButton = ({ onSubmitted }: Props) => {
+  const styles = useStyles();
+
+  const [state, setState] = useState<AvailableStates>("initial");
+
+  const handleFormSubmit: React.FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+
+    const form = new FormData(e.currentTarget);
+    const inputValue = form.get("manifest-url") as string;
+
+    try {
+      new URL(inputValue);
+
+      onSubmitted(inputValue);
+    } catch (e) {
+      console.error("Invalid URL from input. Should be validated by browser");
+    }
+  };
+
+  switch (state) {
+    case "initial": {
+      return (
+        <Button
+          variant="secondary"
+          data-test-id="add-app-from-manifest"
+          onClick={() => setState("input-open")}
+        >
+          <FormattedMessage
+            id="kIXV5V"
+            defaultMessage="Install with App Manifest"
+            description="install with app manifest button"
+          />
+        </Button>
+      );
+    }
+    case "input-open": {
+      return (
+        <form onSubmit={handleFormSubmit}>
+          <TextField
+            type="url"
+            name="manifest-url"
+            label="App manifest url"
+            defaultValue=""
+            helperText="Usually ends with /api/manifest"
+          />
+          <Button
+            size="medium"
+            type="submit"
+            className={styles.installButton}
+            variant="primary"
+          >
+            Install
+          </Button>
+        </form>
+      );
+    }
+  }
+};

--- a/src/apps/components/InstallWithManifestFormButton/index.ts
+++ b/src/apps/components/InstallWithManifestFormButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./InstallWithManifestFormButton";

--- a/src/apps/components/InstalledApps/InstalledApps.tsx
+++ b/src/apps/components/InstalledApps/InstalledApps.tsx
@@ -6,18 +6,20 @@ import {
   TableRow,
   Typography,
 } from "@material-ui/core";
+import { InstallWithManifestFormButton } from "@saleor/apps/components/InstallWithManifestFormButton";
 import { useAppListContext } from "@saleor/apps/context";
-import { appUrl } from "@saleor/apps/urls";
+import { appUrl, createAppInstallUrl } from "@saleor/apps/urls";
 import CardTitle from "@saleor/components/CardTitle";
 import { IconButton } from "@saleor/components/IconButton";
 import { TableButtonWrapper } from "@saleor/components/TableButtonWrapper/TableButtonWrapper";
 import TableRowLink from "@saleor/components/TableRowLink";
 import { AppListItemFragment, AppsListQuery } from "@saleor/graphql";
+import useNavigator from "@saleor/hooks/useNavigator";
 import { DeleteIcon, ResponsiveTable } from "@saleor/macaw-ui";
 import { renderCollection } from "@saleor/misc";
 import { ListProps } from "@saleor/types";
 import clsx from "clsx";
-import React from "react";
+import React, { useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useStyles } from "../../styles";
@@ -37,6 +39,14 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({
   const intl = useIntl();
   const classes = useStyles(props);
   const { activateApp, deactivateApp } = useAppListContext();
+  const navigate = useNavigator();
+
+  const navigateToAppInstallPage = useCallback(
+    (url: string) => {
+      navigate(createAppInstallUrl(url));
+    },
+    [navigate],
+  );
 
   const getHandleToggle = (app: AppListItemFragment) => () => {
     if (app.isActive) {
@@ -54,6 +64,11 @@ const InstalledApps: React.FC<InstalledAppsProps> = ({
           defaultMessage: "Third Party Apps",
           description: "section header",
         })}
+        toolbar={
+          <InstallWithManifestFormButton
+            onSubmitted={navigateToAppInstallPage}
+          />
+        }
       />
       <ResponsiveTable>
         <TableBody>

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -54,7 +54,8 @@ export const appDeepPath = (id: string, subPath: string) =>
   urlJoin(appPath(id), subPath);
 export const customAppPath = (id: string) => urlJoin(customAppListPath, id);
 export const appInstallPath = urlJoin(appsSection, "install");
-export const appInstallUrl = appInstallPath;
+export const createAppInstallUrl = (manifestUrl: string) =>
+  `${appInstallPath}?manifestUrl=${manifestUrl}`;
 
 export const appDetailsUrl = (id: string, params?: AppDetailsUrlQueryParams) =>
   appDetailsPath(encodeURIComponent(id)) + "?" + stringifyQs(params);


### PR DESCRIPTION
I want to merge this change because...

I want to improve app experience. Developing apps, we often have apps URL with manifest. We can install app by manually concatenating the proper URL, which is not too handy. This PR adds a button that improves it

### Screenshots
![Zrzut ekranu 2022-10-12 o 17 03 03](https://user-images.githubusercontent.com/9268745/195378994-03ba2919-6226-4f41-b3d1-adf02e97376e.png)


![Zrzut ekranu 2022-10-12 o 17 03 05](https://user-images.githubusercontent.com/9268745/195379011-5bcd65d4-11de-4482-869a-67d77377f750.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1