### PR TITLE
Use single price value instead of range in product list

### DIFF
--- a/src/components/MoneyRange/MoneyRange.tsx
+++ b/src/components/MoneyRange/MoneyRange.tsx
@@ -14,43 +14,48 @@ export const MoneyRange: React.FC<MoneyRangeProps> = ({ from, to }) => {
 
   return (
     <LocaleConsumer>
-      {({ locale }) =>
-        from && to
-          ? intl.formatMessage(
-              {
-                id: "zTdwWM",
-                defaultMessage: "{fromMoney} - {toMoney}",
-                description: "money",
-              },
-              {
-                fromMoney: formatMoney(from, locale),
-                toMoney: formatMoney(to, locale),
-              },
-            )
-          : from && !to
-          ? intl.formatMessage(
-              {
-                id: "lW5uJO",
-                defaultMessage: "from {money}",
-                description: "money",
-              },
-              {
-                money: formatMoney(from, locale),
-              },
-            )
-          : !from && to
-          ? intl.formatMessage(
-              {
-                id: "hptDxW",
-                defaultMessage: "to {money}",
-                description: "money",
-              },
-              {
-                money: formatMoney(to, locale),
-              },
-            )
-          : "-"
-      }
+      {({ locale }) => {
+        if (from && to) {
+          return from.amount === to.amount
+            ? formatMoney(from, locale)
+            : intl.formatMessage(
+                {
+                  id: "zTdwWM",
+                  defaultMessage: "{fromMoney} - {toMoney}",
+                  description: "money",
+                },
+                {
+                  fromMoney: formatMoney(from, locale),
+                  toMoney: formatMoney(to, locale),
+                },
+              );
+        }
+        if (from && !to) {
+          return intl.formatMessage(
+            {
+              id: "lW5uJO",
+              defaultMessage: "from {money}",
+              description: "money",
+            },
+            {
+              money: formatMoney(from, locale),
+            },
+          );
+        }
+        if (!from && to) {
+          return intl.formatMessage(
+            {
+              id: "hptDxW",
+              defaultMessage: "to {money}",
+              description: "money",
+            },
+            {
+              money: formatMoney(to, locale),
+            },
+          );
+        }
+        return "-";
+      }}
     </LocaleConsumer>
   );
 };


### PR DESCRIPTION
I want to merge this change because it improves product list view. With channel filter selected, we often see price ranges for single-variant products even though the price is constant. This change improves the readability by rendering single price whenever the range is not actually a range.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> main

### Screenshots

**Before**
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/41952692/196132516-e6dedef2-f704-45c5-bc18-b9c5fc3289b5.png">

**After**
<img width="1570" alt="image" src="https://user-images.githubusercontent.com/41952692/196132115-fb0b5c47-a2d6-4b33-b9f9-fca630a7c855.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1