### PR TITLE
Edit variant name on variant edit/create

### DIFF
--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -98,13 +98,13 @@ describe("As an admin I should be able to create variant", () => {
           getProductVariants(createdProduct.id, defaultChannel.slug);
         })
         .then(([variant]) => {
-          expect(variant).to.have.property("name", name);
+          expect(variant).to.have.property("name", attributeValues[0]);
           expect(variant).to.have.property("price", price);
           expect(variant).to.have.property("currency", "USD");
           getProductVariants(createdProduct.id, newChannel.slug);
         })
         .then(([variant]) => {
-          expect(variant).to.have.property("name", name);
+          expect(variant).to.have.property("name", attributeValues[0]);
           expect(variant).to.have.property("price", price);
           expect(variant).to.have.property("currency", "PLN");
         });

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -11509,7 +11509,7 @@ export type VariantDatagridChannelListingUpdateMutationHookResult = ReturnType<t
 export type VariantDatagridChannelListingUpdateMutationResult = Apollo.MutationResult<Types.VariantDatagridChannelListingUpdateMutation>;
 export type VariantDatagridChannelListingUpdateMutationOptions = Apollo.BaseMutationOptions<Types.VariantDatagridChannelListingUpdateMutation, Types.VariantDatagridChannelListingUpdateMutationVariables>;
 export const VariantUpdateDocument = gql`
-    mutation VariantUpdate($addStocks: [StockInput!]!, $removeStocks: [ID!]!, $id: ID!, $attributes: [AttributeValueInput!], $sku: String, $quantityLimitPerCustomer: Int, $trackInventory: Boolean!, $stocks: [StockInput!]!, $preorder: PreorderSettingsInput, $weight: WeightScalar, $firstValues: Int, $afterValues: String, $lastValues: Int, $beforeValues: String) {
+    mutation VariantUpdate($addStocks: [StockInput!]!, $removeStocks: [ID!]!, $id: ID!, $attributes: [AttributeValueInput!], $sku: String, $quantityLimitPerCustomer: Int, $trackInventory: Boolean!, $stocks: [StockInput!]!, $preorder: PreorderSettingsInput, $weight: WeightScalar, $firstValues: Int, $afterValues: String, $lastValues: Int, $beforeValues: String, $name: String!) {
   productVariantStocksDelete(warehouseIds: $removeStocks, variantId: $id) {
     errors {
       ...ProductVariantStocksDeleteError
@@ -11542,7 +11542,7 @@ export const VariantUpdateDocument = gql`
   }
   productVariantUpdate(
     id: $id
-    input: {attributes: $attributes, sku: $sku, trackInventory: $trackInventory, preorder: $preorder, weight: $weight, quantityLimitPerCustomer: $quantityLimitPerCustomer}
+    input: {attributes: $attributes, sku: $sku, trackInventory: $trackInventory, preorder: $preorder, weight: $weight, quantityLimitPerCustomer: $quantityLimitPerCustomer, name: $name}
   ) {
     errors {
       ...ProductErrorWithAttributes
@@ -11586,6 +11586,7 @@ export type VariantUpdateMutationFn = Apollo.MutationFunction<Types.VariantUpdat
  *      afterValues: // value for 'afterValues'
  *      lastValues: // value for 'lastValues'
  *      beforeValues: // value for 'beforeValues'
+ *      name: // value for 'name'
  *   },
  * });
  */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -7784,6 +7784,7 @@ export type VariantUpdateMutationVariables = Exact<{
   afterValues?: InputMaybe<Scalars['String']>;
   lastValues?: InputMaybe<Scalars['Int']>;
   beforeValues?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
 }>;
 
 

--- a/src/products/components/ProductDetailsForm/ProductDetailsForm.tsx
+++ b/src/products/components/ProductDetailsForm/ProductDetailsForm.tsx
@@ -40,6 +40,7 @@ export const ProductDetailsForm: React.FC<ProductDetailsFormProps> = ({
   } = useRichTextContext();
 
   const formErrors = getFormErrors(["name", "description", "rating"], errors);
+
   return (
     <Card>
       <CardTitle

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -22,6 +22,7 @@ import {
   SearchProductsQuery,
   SearchWarehousesQuery,
 } from "@saleor/graphql";
+import { SubmitPromise } from "@saleor/hooks/useForm";
 import useNavigator from "@saleor/hooks/useNavigator";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { ProductDetailsChannelsAvailabilityCard } from "@saleor/products/components/ProductVariantChannels/ChannelsAvailabilityCard";
@@ -87,7 +88,7 @@ interface ProductVariantCreatePageProps {
   attributeValues: RelayToFlat<
     SearchAttributeValuesQuery["attribute"]["choices"]
   >;
-  onSubmit: (data: ProductVariantCreateData) => void;
+  onSubmit: (data: ProductVariantCreateData) => SubmitPromise;
   onVariantClick: (variantId: string) => void;
   onVariantReorder: ReorderAction;
   onWarehouseConfigure: () => void;
@@ -107,7 +108,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   productId,
   defaultVariantId,
   disabled,
-  errors,
+  errors: apiErrors,
   header,
   product,
   saveButtonBarState,
@@ -172,170 +173,179 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
         change,
         data,
         formErrors,
+        validationErrors,
         handlers,
         submit,
         isSaveDisabled,
         attributeRichTextGetters,
-      }) => (
-        <Container>
-          <Backlink href={productUrl(productId)}>{product?.name}</Backlink>
-          <PageHeader title={header} />
-          <Grid variant="inverted">
-            <div>
-              <ProductVariantNavigation
-                fallbackThumbnail={product?.thumbnail?.url}
-                variants={product?.variants}
-                productId={productId}
-                defaultVariantId={defaultVariantId}
-                onReorder={onVariantReorder}
-                isCreate={true}
-              />
-            </div>
-            <div>
-              <ProductVariantName
-                value={data.name}
-                onChange={change}
-                errors={errors}
-              />
-              <CardSpacer />
-              <ProductDetailsChannelsAvailabilityCard
-                product={product}
-                onManageClick={toggleManageChannels}
-              />
-              <Attributes
-                title={intl.formatMessage(messages.attributesHeader)}
-                attributes={data.attributes.filter(
-                  attribute =>
-                    attribute.data.variantAttributeScope ===
-                    VariantAttributeScope.NOT_VARIANT_SELECTION,
-                )}
-                attributeValues={attributeValues}
-                loading={disabled}
-                disabled={disabled}
-                errors={errors}
-                onChange={handlers.selectAttribute}
-                onMultiChange={handlers.selectAttributeMultiple}
-                onFileChange={handlers.selectAttributeFile}
-                onReferencesRemove={handlers.selectAttributeReference}
-                onReferencesAddClick={onAssignReferencesClick}
-                onReferencesReorder={handlers.reorderAttributeValue}
-                fetchAttributeValues={fetchAttributeValues}
-                fetchMoreAttributeValues={fetchMoreAttributeValues}
-                onAttributeSelectBlur={onAttributeSelectBlur}
-                richTextGetters={attributeRichTextGetters}
-              />
-              <CardSpacer />
-              <Attributes
-                title={intl.formatMessage(messages.attributesSelectionHeader)}
-                attributes={data.attributes.filter(
-                  attribute =>
-                    attribute.data.variantAttributeScope ===
-                    VariantAttributeScope.VARIANT_SELECTION,
-                )}
-                attributeValues={attributeValues}
-                loading={disabled}
-                disabled={disabled}
-                errors={errors}
-                onChange={handlers.selectAttribute}
-                onMultiChange={handlers.selectAttributeMultiple}
-                onFileChange={handlers.selectAttributeFile}
-                onReferencesRemove={handlers.selectAttributeReference}
-                onReferencesAddClick={onAssignReferencesClick}
-                onReferencesReorder={handlers.reorderAttributeValue}
-                fetchAttributeValues={fetchAttributeValues}
-                fetchMoreAttributeValues={fetchMoreAttributeValues}
-                onAttributeSelectBlur={onAttributeSelectBlur}
-                richTextGetters={attributeRichTextGetters}
-              />
-              <CardSpacer />
-              <ProductVariantCheckoutSettings
-                data={data}
-                disabled={disabled}
-                errors={errors}
-                onChange={change}
-              />
-              <CardSpacer />
-              <ProductShipping
-                data={data}
-                disabled={disabled}
-                errors={errors}
-                weightUnit={weightUnit}
-                onChange={change}
-              />
-              <CardSpacer />
-              <ProductVariantPrice
-                disabled={!product}
-                ProductVariantChannelListings={data.channelListings.map(
-                  channel => ({
-                    ...channel.data,
-                    ...channel.value,
-                  }),
-                )}
-                errors={[]}
-                loading={!product}
-                onChange={handlers.changeChannels}
-              />
-              <CardSpacer />
-              <ProductStocks
-                data={data}
-                disabled={disabled}
-                hasVariants={true}
-                onFormDataChange={change}
-                formErrors={formErrors}
-                errors={errors}
-                stocks={data.stocks}
-                warehouses={warehouses}
-                onChange={handlers.changeStock}
-                onChangePreorderEndDate={handlers.changePreorderEndDate}
-                onWarehouseStockAdd={handlers.addStock}
-                onWarehouseStockDelete={handlers.deleteStock}
-                onWarehouseConfigure={onWarehouseConfigure}
-              />
-              <CardSpacer />
-              <Metadata data={data} onChange={handlers.changeMetadata} />
-            </div>
-          </Grid>
-          <Savebar
-            disabled={isSaveDisabled}
-            labels={{
-              confirm: intl.formatMessage(messages.saveVariant),
-              delete: intl.formatMessage(messages.deleteVariant),
-            }}
-            state={saveButtonBarState}
-            onCancel={() => navigate(productUrl(productId))}
-            onSubmit={submit}
-          />
-          {canOpenAssignReferencesAttributeDialog && (
-            <AssignAttributeValueDialog
-              entityType={getReferenceAttributeEntityTypeFromAttribute(
-                assignReferencesAttributeId,
-                data.attributes,
-              )}
-              confirmButtonState={"default"}
-              products={referenceProducts}
-              pages={referencePages}
-              hasMore={handlers.fetchMoreReferences?.hasMore}
-              open={canOpenAssignReferencesAttributeDialog}
-              onFetch={handlers.fetchReferences}
-              onFetchMore={handlers.fetchMoreReferences?.onFetchMore}
-              loading={handlers.fetchMoreReferences?.loading}
-              onClose={onCloseDialog}
-              onSubmit={attributeValues =>
-                handleAssignReferenceAttribute(attributeValues, data, handlers)
-              }
+      }) => {
+        const errors = [...apiErrors, ...validationErrors];
+
+        return (
+          <Container>
+            <Backlink href={productUrl(productId)}>{product?.name}</Backlink>
+            <PageHeader title={header} />
+            <Grid variant="inverted">
+              <div>
+                <ProductVariantNavigation
+                  fallbackThumbnail={product?.thumbnail?.url}
+                  variants={product?.variants}
+                  productId={productId}
+                  defaultVariantId={defaultVariantId}
+                  onReorder={onVariantReorder}
+                  isCreate={true}
+                />
+              </div>
+              <div>
+                <ProductVariantName
+                  value={data.name}
+                  onChange={change}
+                  errors={errors}
+                />
+                <CardSpacer />
+                <ProductDetailsChannelsAvailabilityCard
+                  product={product}
+                  onManageClick={toggleManageChannels}
+                />
+                <Attributes
+                  title={intl.formatMessage(messages.attributesHeader)}
+                  attributes={data.attributes.filter(
+                    attribute =>
+                      attribute.data.variantAttributeScope ===
+                      VariantAttributeScope.NOT_VARIANT_SELECTION,
+                  )}
+                  attributeValues={attributeValues}
+                  loading={disabled}
+                  disabled={disabled}
+                  errors={errors}
+                  onChange={handlers.selectAttribute}
+                  onMultiChange={handlers.selectAttributeMultiple}
+                  onFileChange={handlers.selectAttributeFile}
+                  onReferencesRemove={handlers.selectAttributeReference}
+                  onReferencesAddClick={onAssignReferencesClick}
+                  onReferencesReorder={handlers.reorderAttributeValue}
+                  fetchAttributeValues={fetchAttributeValues}
+                  fetchMoreAttributeValues={fetchMoreAttributeValues}
+                  onAttributeSelectBlur={onAttributeSelectBlur}
+                  richTextGetters={attributeRichTextGetters}
+                />
+                <CardSpacer />
+                <Attributes
+                  title={intl.formatMessage(messages.attributesSelectionHeader)}
+                  attributes={data.attributes.filter(
+                    attribute =>
+                      attribute.data.variantAttributeScope ===
+                      VariantAttributeScope.VARIANT_SELECTION,
+                  )}
+                  attributeValues={attributeValues}
+                  loading={disabled}
+                  disabled={disabled}
+                  errors={errors}
+                  onChange={handlers.selectAttribute}
+                  onMultiChange={handlers.selectAttributeMultiple}
+                  onFileChange={handlers.selectAttributeFile}
+                  onReferencesRemove={handlers.selectAttributeReference}
+                  onReferencesAddClick={onAssignReferencesClick}
+                  onReferencesReorder={handlers.reorderAttributeValue}
+                  fetchAttributeValues={fetchAttributeValues}
+                  fetchMoreAttributeValues={fetchMoreAttributeValues}
+                  onAttributeSelectBlur={onAttributeSelectBlur}
+                  richTextGetters={attributeRichTextGetters}
+                />
+                <CardSpacer />
+                <ProductVariantCheckoutSettings
+                  data={data}
+                  disabled={disabled}
+                  errors={errors}
+                  onChange={change}
+                />
+                <CardSpacer />
+                <ProductShipping
+                  data={data}
+                  disabled={disabled}
+                  errors={errors}
+                  weightUnit={weightUnit}
+                  onChange={change}
+                />
+                <CardSpacer />
+                <ProductVariantPrice
+                  disabled={!product}
+                  ProductVariantChannelListings={data.channelListings.map(
+                    channel => ({
+                      ...channel.data,
+                      ...channel.value,
+                    }),
+                  )}
+                  errors={[]}
+                  loading={!product}
+                  onChange={handlers.changeChannels}
+                />
+                <CardSpacer />
+                <ProductStocks
+                  data={data}
+                  disabled={disabled}
+                  hasVariants={true}
+                  onFormDataChange={change}
+                  formErrors={formErrors}
+                  errors={errors}
+                  stocks={data.stocks}
+                  warehouses={warehouses}
+                  onChange={handlers.changeStock}
+                  onChangePreorderEndDate={handlers.changePreorderEndDate}
+                  onWarehouseStockAdd={handlers.addStock}
+                  onWarehouseStockDelete={handlers.deleteStock}
+                  onWarehouseConfigure={onWarehouseConfigure}
+                />
+                <CardSpacer />
+                <Metadata data={data} onChange={handlers.changeMetadata} />
+              </div>
+            </Grid>
+            <Savebar
+              disabled={isSaveDisabled}
+              labels={{
+                confirm: intl.formatMessage(messages.saveVariant),
+                delete: intl.formatMessage(messages.deleteVariant),
+              }}
+              state={saveButtonBarState}
+              onCancel={() => navigate(productUrl(productId))}
+              onSubmit={submit}
             />
-          )}
-          {product && (
-            <VariantChannelsDialog
-              channelListings={product.channelListings}
-              selectedChannelListings={data.channelListings}
-              open={isManageChannelsModalOpen}
-              onClose={toggleManageChannels}
-              onConfirm={handlers.updateChannels}
-            />
-          )}
-        </Container>
-      )}
+            {canOpenAssignReferencesAttributeDialog && (
+              <AssignAttributeValueDialog
+                entityType={getReferenceAttributeEntityTypeFromAttribute(
+                  assignReferencesAttributeId,
+                  data.attributes,
+                )}
+                confirmButtonState={"default"}
+                products={referenceProducts}
+                pages={referencePages}
+                hasMore={handlers.fetchMoreReferences?.hasMore}
+                open={canOpenAssignReferencesAttributeDialog}
+                onFetch={handlers.fetchReferences}
+                onFetchMore={handlers.fetchMoreReferences?.onFetchMore}
+                loading={handlers.fetchMoreReferences?.loading}
+                onClose={onCloseDialog}
+                onSubmit={attributeValues =>
+                  handleAssignReferenceAttribute(
+                    attributeValues,
+                    data,
+                    handlers,
+                  )
+                }
+              />
+            )}
+            {product && (
+              <VariantChannelsDialog
+                channelListings={product.channelListings}
+                selectedChannelListings={data.channelListings}
+                open={isManageChannelsModalOpen}
+                onClose={toggleManageChannels}
+                onConfirm={handlers.updateChannels}
+              />
+            )}
+          </Container>
+        );
+      }}
     </ProductVariantCreateForm>
   );
 };

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -35,6 +35,7 @@ import ProductStocks from "../ProductStocks";
 import { useManageChannels } from "../ProductVariantChannels/useManageChannels";
 import { VariantChannelsDialog } from "../ProductVariantChannels/VariantChannelsDialog";
 import ProductVariantCheckoutSettings from "../ProductVariantCheckoutSettings/ProductVariantCheckoutSettings";
+import ProductVariantName from "../ProductVariantName";
 import ProductVariantNavigation from "../ProductVariantNavigation";
 import ProductVariantPrice from "../ProductVariantPrice";
 import ProductVariantCreateForm, {
@@ -191,6 +192,12 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
               />
             </div>
             <div>
+              <ProductVariantName
+                value={data.name}
+                onChange={change}
+                errors={errors}
+              />
+              <CardSpacer />
               <ProductDetailsChannelsAvailabilityCard
                 product={product}
                 onManageClick={toggleManageChannels}

--- a/src/products/components/ProductVariantCreatePage/form.tsx
+++ b/src/products/components/ProductVariantCreatePage/form.tsx
@@ -6,7 +6,6 @@ import {
   RichTextProps,
 } from "@saleor/attributes/utils/data";
 import {
-  createAttributeChangeHandler,
   createAttributeFileChangeHandler,
   createAttributeMultiChangeHandler,
   createAttributeReferenceChangeHandler,
@@ -66,6 +65,7 @@ export interface ProductVariantCreateFormData extends MetadataFormData {
   hasPreorderEndDate: boolean;
   quantityLimitPerCustomer: number | null;
   preorderEndDateTime?: string;
+  name: string;
 }
 export interface ProductVariantCreateData extends ProductVariantCreateFormData {
   attributes: AttributeInput[];
@@ -137,6 +137,7 @@ const initial: ProductVariantCreateFormData = {
   hasPreorderEndDate: false,
   preorderEndDateTime: "",
   quantityLimitPerCustomer: null,
+  name: "",
 };
 
 function useProductVariantCreateForm(
@@ -185,10 +186,13 @@ function useProductVariantCreateForm(
   } = useMetadataChangeTrigger();
 
   const changeMetadata = makeMetadataChangeHandler(handleChange);
-  const handleAttributeChange = createAttributeChangeHandler(
-    attributes.change,
-    triggerChange,
-  );
+
+  const handleAttributeChangeWithName = (id: string, value: string) => {
+    triggerChange();
+    attributes.change(id, value === "" ? [] : [value]);
+    handleChange({ target: { value, name: "name" } });
+  };
+
   const handleAttributeMultiChange = createAttributeMultiChangeHandler(
     attributes.change,
     attributes.data,
@@ -303,8 +307,9 @@ function useProductVariantCreateForm(
     data.isPreorder &&
     data.hasPreorderEndDate &&
     !!form.errors.preorderEndDateTime;
+  const emptyName = !data.name;
 
-  const formDisabled = invalidPreorder || invalidChannels;
+  const formDisabled = invalidPreorder || invalidChannels || emptyName;
   const isSaveDisabled = disabled || formDisabled || !onSubmit;
 
   setIsSubmitDisabled(isSaveDisabled);
@@ -325,7 +330,7 @@ function useProductVariantCreateForm(
       fetchMoreReferences: handleFetchMoreReferences,
       fetchReferences: handleFetchReferences,
       reorderAttributeValue: handleAttributeValueReorder,
-      selectAttribute: handleAttributeChange,
+      selectAttribute: handleAttributeChangeWithName,
       selectAttributeFile: handleAttributeFileChange,
       selectAttributeMultiple: handleAttributeMultiChange,
       selectAttributeReference: handleAttributeReferenceChange,

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -36,8 +36,8 @@ const ProductVariantName = ({ value, onChange, disabled, errors }: Props) => {
           fullWidth
           disabled={disabled}
           helperText={getProductErrorMessage(formErrors.name, intl)}
-          required
           data-test-id="variant-name"
+          required
         />
       </CardContent>
     </Card>

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -7,7 +7,7 @@ import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
 import React from "react";
 import { useIntl } from "react-intl";
 
-interface Props {
+interface ProductVariantNameProps {
   value: string;
   onChange: FormChange<any>;
   disabled?: boolean;

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -14,7 +14,12 @@ interface Props {
   errors: ProductErrorFragment[];
 }
 
-const ProductVariantName = ({ value, onChange, disabled, errors }: Props) => {
+const ProductVariantName: React.FC<Props> = ({
+  value,
+  onChange,
+  disabled,
+  errors,
+}) => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name"], errors);
 

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, TextField } from "@material-ui/core";
+import CardTitle from "@saleor/components/CardTitle";
+import { ProductErrorFragment } from "@saleor/graphql";
+import { FormChange } from "@saleor/hooks/useForm";
+import { commonMessages } from "@saleor/intl";
+import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { ProductVariantUpdateData } from "../ProductVariantPage/form";
+
+interface Props {
+  data: ProductVariantUpdateData;
+  onChange: FormChange<any>;
+  disabled: boolean;
+  errors: ProductErrorFragment[];
+}
+
+const ProductVariantName = ({ data, onChange, disabled, errors }: Props) => {
+  const intl = useIntl();
+  const formErrors = getFormErrors(["name"], errors);
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          id: "T1f2Yl",
+          defaultMessage: "Variant Name",
+        })}
+      />
+      <CardContent>
+        <TextField
+          name="name"
+          value={data.name}
+          label={intl.formatMessage(commonMessages.name)}
+          onChange={onChange}
+          error={!!formErrors.name}
+          fullWidth
+          disabled={disabled}
+          helperText={getProductErrorMessage(formErrors.name, intl)}
+          required
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+ProductVariantName.displayName = "ProductVariantName";
+export default ProductVariantName;

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -14,7 +14,7 @@ interface ProductVariantNameProps {
   errors: ProductErrorFragment[];
 }
 
-const ProductVariantName: React.FC<Props> = ({
+const ProductVariantName: React.FC<ProductVariantNameProps> = ({
   value,
   onChange,
   disabled,

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -42,7 +42,6 @@ const ProductVariantName: React.FC<Props> = ({
           disabled={disabled}
           helperText={getProductErrorMessage(formErrors.name, intl)}
           data-test-id="variant-name"
-          required
         />
       </CardContent>
     </Card>

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -7,16 +7,14 @@ import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { ProductVariantUpdateData } from "../ProductVariantPage/form";
-
 interface Props {
-  data: ProductVariantUpdateData;
+  value: string;
   onChange: FormChange<any>;
-  disabled: boolean;
+  disabled?: boolean;
   errors: ProductErrorFragment[];
 }
 
-const ProductVariantName = ({ data, onChange, disabled, errors }: Props) => {
+const ProductVariantName = ({ value, onChange, disabled, errors }: Props) => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name"], errors);
 
@@ -31,7 +29,7 @@ const ProductVariantName = ({ data, onChange, disabled, errors }: Props) => {
       <CardContent>
         <TextField
           name="name"
-          value={data.name}
+          value={value}
           label={intl.formatMessage(commonMessages.name)}
           onChange={onChange}
           error={!!formErrors.name}

--- a/src/products/components/ProductVariantName/ProductVariantName.tsx
+++ b/src/products/components/ProductVariantName/ProductVariantName.tsx
@@ -37,6 +37,7 @@ const ProductVariantName = ({ value, onChange, disabled, errors }: Props) => {
           disabled={disabled}
           helperText={getProductErrorMessage(formErrors.name, intl)}
           required
+          data-test-id="variant-name"
         />
       </CardContent>
     </Card>

--- a/src/products/components/ProductVariantName/index.ts
+++ b/src/products/components/ProductVariantName/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProductVariantName";

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -261,7 +261,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   </div>
                   <div>
                     <ProductVariantName
-                      data={data}
+                      value={data.name}
                       onChange={change}
                       disabled={loading}
                       errors={errors}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -41,6 +41,7 @@ import ProductVariantCheckoutSettings from "../ProductVariantCheckoutSettings/Pr
 import ProductVariantEndPreorderDialog from "../ProductVariantEndPreorderDialog";
 import ProductVariantMediaSelectDialog from "../ProductVariantImageSelectDialog";
 import ProductVariantMedia from "../ProductVariantMedia";
+import ProductVariantName from "../ProductVariantName";
 import ProductVariantNavigation from "../ProductVariantNavigation";
 import ProductVariantPrice from "../ProductVariantPrice";
 import ProductVariantSetDefault from "../ProductVariantSetDefault";
@@ -259,6 +260,13 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                     />
                   </div>
                   <div>
+                    <ProductVariantName
+                      data={data}
+                      onChange={change}
+                      disabled={loading}
+                      errors={errors}
+                    />
+                    <CardSpacer />
                     <VariantDetailsChannelsAvailabilityCard
                       variant={variant}
                       onManageClick={toggleManageChannels}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -129,7 +129,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
   channelErrors,
   defaultVariantId,
   defaultWeightUnit,
-  errors,
+  errors: apiErrors,
   header,
   loading,
   placeholderImage,
@@ -234,6 +234,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
             change,
             data,
             formErrors,
+            validationErrors,
             isSaveDisabled,
             handlers,
             submit,
@@ -245,6 +246,8 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
             const selectionAttributes = data.attributes.filter(
               byAttributeScope(VariantAttributeScope.VARIANT_SELECTION),
             );
+
+            const errors = [...apiErrors, ...validationErrors];
 
             return (
               <>

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -190,7 +190,7 @@ function useProductVariantUpdateForm(
     preorderEndDateTime: variant?.preorder?.endDate,
     weight: variant?.weight?.value.toString() || "",
     quantityLimitPerCustomer: variant?.quantityLimitPerCustomer || null,
-    name: variant?.name || "",
+    name: variant?.name ?? "",
   };
 
   const form = useForm(initial, undefined, {

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -175,6 +175,7 @@ export const variantUpdateMutation = gql`
     $afterValues: String
     $lastValues: Int
     $beforeValues: String
+    $name: String!
   ) {
     productVariantStocksDelete(warehouseIds: $removeStocks, variantId: $id) {
       errors {
@@ -215,6 +216,7 @@ export const variantUpdateMutation = gql`
         preorder: $preorder
         weight: $weight
         quantityLimitPerCustomer: $quantityLimitPerCustomer
+        name: $name
       }
     ) {
       errors {

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -39,6 +39,5 @@ export const validateProductCreateData = (data: ProductCreateData) => {
 
 export const validateVariantData = (
   data: ProductVariantCreateData | ProductVariantUpdateSubmitData,
-): ProductErrorWithAttributesFragment[] => (
+): ProductErrorWithAttributesFragment[] =>
   !data.name ? [createEmptyRequiredError("name")] : [];
-);

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -4,6 +4,8 @@ import {
 } from "@saleor/graphql";
 
 import { ProductCreateData } from "../components/ProductCreatePage";
+import { ProductVariantCreateData } from "../components/ProductVariantCreatePage/form";
+import { ProductVariantUpdateSubmitData } from "../components/ProductVariantPage/form";
 
 export const validatePrice = (price: string) =>
   price === "" || parseInt(price, 10) < 0;
@@ -32,5 +34,16 @@ export const validateProductCreateData = (data: ProductCreateData) => {
     errors = [...errors, createEmptyRequiredError("name")];
   }
 
+  return errors;
+};
+
+export const validateVariantData = (
+  data: ProductVariantCreateData | ProductVariantUpdateSubmitData,
+) => {
+  let errors: ProductErrorWithAttributesFragment[] = [];
+
+  if (!data.name) {
+    errors = [...errors, createEmptyRequiredError("name")];
+  }
   return errors;
 };

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -39,11 +39,6 @@ export const validateProductCreateData = (data: ProductCreateData) => {
 
 export const validateVariantData = (
   data: ProductVariantCreateData | ProductVariantUpdateSubmitData,
-) => {
-  let errors: ProductErrorWithAttributesFragment[] = [];
-
-  if (!data.name) {
-    errors = [...errors, createEmptyRequiredError("name")];
-  }
-  return errors;
-};
+): ProductErrorWithAttributesFragment[] => (
+  !data.name ? [createEmptyRequiredError("name")] : [];
+);

--- a/src/products/views/ProductVariant/ProductVariant.tsx
+++ b/src/products/views/ProductVariant/ProductVariant.tsx
@@ -242,6 +242,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
           : null,
         weight: weight(data.weight),
         firstValues: 10,
+        name: data.name,
       },
     });
 

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -124,6 +124,7 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
           }),
           product: productId,
           sku: formData.sku,
+          name: formData.name,
           stocks: formData.stocks.map(stock => ({
             quantity: parseInt(stock.value, 10) || 0,
             warehouse: stock.id,


### PR DESCRIPTION
I want to merge this change to fix #2000. I've added:
* required text input to change the name for both edit & create variant forms
* logic to change `Variant Name` based on `Variant Selection Attributes`
* validation logic on frontend side (the same pattern as in product create)

<!-- Please mention all relevant issue numbers. -->

## Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

Before
---
![CleanShot 2022-10-17 at 14 07 50@2x](https://user-images.githubusercontent.com/9116238/196173194-087117c9-f7b0-4b20-af4e-a7588addea2e.jpg)
![CleanShot 2022-10-17 at 14 08 15@2x](https://user-images.githubusercontent.com/9116238/196173254-f5613a30-6168-4415-8fa4-2181c9be6f53.jpg)


After
---
<img width="1669" alt="image" src="https://user-images.githubusercontent.com/9116238/196173058-4bc544fe-5a6f-4557-b8c9-6737b47c3290.png">
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/9116238/196173106-235296bb-4ce2-4a10-8061-a5c8dc19a16a.png">
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/9116238/196367377-23815357-d47a-4937-875a-9001a4d3f5f5.png">



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1
