### PR TITLE
Fix empty slug in attributes (3.1 backport)

### DIFF
--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -32,6 +32,25 @@ export const apolloClient = new ApolloClient({
       },
       Shop: {
         keyFields: []
+      },
+      AttributeValue: {
+        fields: {
+          /**
+           * Since, API sometimes creates an empty slug,
+           * We need to handle that case also on front-end,
+           * so after fix that problem in the API, the UI will ablle
+           * to handle it.
+           *
+           * If the slug is empty, use the name
+           */
+          slug: (givenSlug, { readField }) => {
+            if (!givenSlug) {
+              return readField("name");
+            }
+
+            return givenSlug;
+          }
+        }
       }
     } as TypedTypePolicies
   }),


### PR DESCRIPTION
closes: #2397


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1