### PR TITLE
Display all error messages on new-password page

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -325,6 +325,9 @@
     "context": "message title",
     "string": "App installed"
   },
+  "0fMNz8": {
+    "string": "User doesn't exist"
+  },
   "0iMYc+": {
     "context": "field is optional",
     "string": "(Optional)"
@@ -2571,6 +2574,9 @@
   "INNPVX": {
     "context": "payment status",
     "string": "Partially paid"
+  },
+  "INfaIc": {
+    "string": "Invalid or expired token"
   },
   "IOshTA": {
     "context": "header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -325,9 +325,6 @@
     "context": "message title",
     "string": "App installed"
   },
-  "0fMNz8": {
-    "string": "User doesn't exist"
-  },
   "0iMYc+": {
     "context": "field is optional",
     "string": "(Optional)"
@@ -1693,6 +1690,9 @@
     "context": "header",
     "string": "Hello there, {userName}"
   },
+  "ByYtFB": {
+    "string": "Invalid or expired token. Please check your token in URL"
+  },
   "C0JLNW": {
     "string": "Provided email address does not exist in our database."
   },
@@ -2574,9 +2574,6 @@
   "INNPVX": {
     "context": "payment status",
     "string": "Partially paid"
-  },
-  "INfaIc": {
-    "string": "Invalid or expired token"
   },
   "IOshTA": {
     "context": "header",
@@ -7113,6 +7110,9 @@
   "tQxBXs": {
     "context": "PageTypeDeleteWarningDialog single assigned items description",
     "string": "You are about to delete page type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{page} other{pages}}. Deleting this page type will also delete those pages. Are you sure you want to do this?"
+  },
+  "tR+UuE": {
+    "string": "User doesn't exist. Please check your email in URL"
   },
   "tTtoKd": {
     "context": "error message",

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
@@ -10,10 +10,10 @@ storiesOf("Views / Authentication / Set up a new password", module)
   .addDecorator(CardDecorator)
   .addDecorator(Decorator)
   .add("default", () => (
-    <NewPasswordPage errors={[]} disabled={false} onSubmit={() => undefined} />
+    <NewPasswordPage errors={[]} loading={false} onSubmit={() => undefined} />
   ))
   .add("loading", () => (
-    <NewPasswordPage errors={[]} disabled={true} onSubmit={() => undefined} />
+    <NewPasswordPage errors={[]} loading={true} onSubmit={() => undefined} />
   ))
   .add("too short error", () => (
     <NewPasswordPage
@@ -24,7 +24,7 @@ storiesOf("Views / Authentication / Set up a new password", module)
         addressType: null,
         message: null,
       }))}
-      disabled={false}
+      loading={false}
       onSubmit={() => undefined}
     />
   ));

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
@@ -15,7 +15,7 @@ export interface NewPasswordPageFormData {
   confirmPassword: string;
 }
 export interface NewPasswordPageProps {
-  disabled: boolean;
+  loading: boolean;
   errors: SetPasswordData["errors"];
   onSubmit: (data: NewPasswordPageFormData) => SubmitPromise;
 }
@@ -26,14 +26,10 @@ const initialForm: NewPasswordPageFormData = {
 };
 
 const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
-  const { disabled, errors, onSubmit } = props;
+  const { loading, errors, onSubmit } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
-  const error = getAccountErrorMessage(
-    errors.find(err => err.field === "password"),
-    intl,
-  );
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
@@ -50,7 +46,14 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
                 description="page title"
               />
             </Typography>
-            {!!error && <div className={classes.panel}>{error}</div>}
+            {errors.map(error => (
+              <div
+                className={classes.panel}
+                key={`${error.code}-${error.field}`}
+              >
+                {getAccountErrorMessage(error, intl)}
+              </div>
+            ))}
             <Typography variant="caption" color="textSecondary">
               <FormattedMessage
                 id="m0Dz+2"
@@ -62,7 +65,7 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
               autoFocus
               fullWidth
               autoComplete="none"
-              disabled={disabled}
+              disabled={loading}
               label={intl.formatMessage({
                 id: "Ev6SEF",
                 defaultMessage: "New Password",
@@ -74,13 +77,14 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
               inputProps={{
                 "data-test-id": "password",
               }}
+              required
             />
             <FormSpacer />
             <TextField
               fullWidth
               error={passwordError}
               autoComplete="none"
-              disabled={disabled}
+              disabled={loading}
               label={intl.formatMessage({
                 id: "vfG+nh",
                 defaultMessage: "Confirm Password",
@@ -99,12 +103,13 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
               inputProps={{
                 "data-test-id": "confirm-password",
               }}
+              required
             />
             <FormSpacer />
             <Button
               data-test="button-bar-confirm"
               className={classes.submit}
-              disabled={(passwordError && data.password.length > 0) || disabled}
+              disabled={loading || data.password.length === 0 || passwordError}
               variant="primary"
               onClick={handleSubmit}
               type="submit"

--- a/src/auth/views/NewPassword.tsx
+++ b/src/auth/views/NewPassword.tsx
@@ -41,7 +41,7 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
   return (
     <NewPasswordPage
       errors={errors}
-      disabled={loading}
+      loading={loading}
       onSubmit={handleSubmit}
     />
   );

--- a/src/utils/errors/account.ts
+++ b/src/utils/errors/account.ts
@@ -38,12 +38,12 @@ const messages = defineMessages({
     defaultMessage: "This needs to be unique",
   },
   invalidToken: {
-    id: "INfaIc",
-    defaultMessage: "Invalid or expired token",
+    id: "ByYtFB",
+    defaultMessage: "Invalid or expired token. Please check your token in URL",
   },
   userNotFound: {
-    id: "0fMNz8",
-    defaultMessage: "User doesn't exist",
+    id: "tR+UuE",
+    defaultMessage: "User doesn't exist. Please check your email in URL",
   },
 });
 

--- a/src/utils/errors/account.ts
+++ b/src/utils/errors/account.ts
@@ -37,6 +37,14 @@ const messages = defineMessages({
     id: "TDhHMi",
     defaultMessage: "This needs to be unique",
   },
+  invalidToken: {
+    id: "INfaIc",
+    defaultMessage: "Invalid or expired token",
+  },
+  userNotFound: {
+    id: "0fMNz8",
+    defaultMessage: "User doesn't exist",
+  },
 });
 
 interface ErrorFragment {
@@ -62,6 +70,10 @@ function getAccountErrorMessage(err: ErrorFragment, intl: IntlShape): string {
         return intl.formatMessage(messages.tooSimilar);
       case AccountErrorCode.UNIQUE:
         return intl.formatMessage(messages.unique);
+      case AccountErrorCode.INVALID:
+        return intl.formatMessage(messages.invalidToken);
+      case AccountErrorCode.NOT_FOUND:
+        return intl.formatMessage(messages.userNotFound);
     }
   }
 


### PR DESCRIPTION
I've added ability to display all error messages when user got errors on `/new-password` page. Previously only errors connected to password were displayed. I also added logic to block submitting new password if inputs are empty. Fixes #2406.

## Screenshots

Before
---

<img width="483" alt="image" src="https://user-images.githubusercontent.com/9116238/196673722-de730499-bc6e-4c76-84ef-c72033d2d4b2.png">

After
---

<img width="461" alt="image" src="https://user-images.githubusercontent.com/9116238/196673756-05ea9fe4-6d67-4bb3-86b3-2db1c38b9fda.png">
<img width="462" alt="image" src="https://user-images.githubusercontent.com/9116238/196673766-1bb8f0f2-5cdd-4563-b14c-96c41e792a2a.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1