### PR TITLE
remove test for variant creator

### DIFF
--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -9,10 +9,6 @@ import { AVAILABLE_CHANNELS_FORM } from "../../../elements/channels/available-ch
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import { urlList } from "../../../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../../../fixtures/users";
-import {
-  createProduct,
-  updateChannelInProduct,
-} from "../../../support/api/requests/Product";
 import { createTypeProduct } from "../../../support/api/requests/ProductType";
 import {
   deleteChannelsStartsWith,
@@ -22,10 +18,7 @@ import { createWaitingForCaptureOrder } from "../../../support/api/utils/ordersU
 import * as productUtils from "../../../support/api/utils/products/productsUtils";
 import * as shippingUtils from "../../../support/api/utils/shippingUtils";
 import { getProductVariants } from "../../../support/api/utils/storeFront/storeFrontProductUtils";
-import {
-  createFirstVariant,
-  createVariant,
-} from "../../../support/pages/catalog/products/VariantsPage";
+import { createVariant } from "../../../support/pages/catalog/products/VariantsPage";
 import { selectChannelInDetailsPages } from "../../../support/pages/channelsPage";
 
 describe("Creating variants", () => {
@@ -97,51 +90,6 @@ describe("Creating variants", () => {
       ONE_PERMISSION_USERS.product,
     );
   });
-
-  xit(
-    "should create variant without sku by variant creator",
-    { tags: ["@products", "@allEnv"] },
-    () => {
-      const name = `${startsWith}${faker.datatype.number()}`;
-      const price = 10;
-      let createdProduct;
-
-      createProduct({
-        attributeId: attribute.id,
-        name,
-        productTypeId: productType.id,
-        categoryId: category.id,
-      })
-        .then(resp => {
-          createdProduct = resp;
-          updateChannelInProduct({
-            productId: createdProduct.id,
-            channelId: defaultChannel.id,
-          });
-          cy.visit(`${urlList.products}${createdProduct.id}`);
-          cy.waitForProgressBarToNotBeVisible();
-          createVariant({
-            price,
-            attributeName: attributeValues[0],
-          });
-          getProductVariants(createdProduct.id, defaultChannel.slug);
-        })
-        .then(([variant]) => {
-          expect(variant).to.have.property("name", attributeValues[0]);
-          expect(variant).to.have.property("price", price);
-          createWaitingForCaptureOrder({
-            channelSlug: defaultChannel.slug,
-            email: "example@example.com",
-            variantsList: [variant],
-            shippingMethodName: shippingMethod.name,
-            address,
-          });
-        })
-        .then(({ order }) => {
-          expect(order.id).to.be.ok;
-        });
-    },
-  );
 
   xit(
     "should create variant without sku",


### PR DESCRIPTION
I want to merge this change because test for variant creator is no longer needed - [variant creator was removed](https://app.clickup.com/t/2549495/SALEOR-7479).

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [x] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation

CONTAINERS=1