### PR TITLE
2417 refactor variatns tests 3.7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,5 +51,6 @@ Tests will be re-run only when the "run e2e" label is added.
 19. [ ] plugins
 20. [ ] translations
 21. [ ] navigation
+22. [ ] variants
 
 CONTAINERS=1

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -4,8 +4,6 @@
 import faker from "faker";
 
 import { PRODUCT_DETAILS } from "../../elements/catalog/products/product-details";
-import { VARIANTS_SELECTORS } from "../../elements/catalog/products/variants-selectors";
-import { BUTTON_SELECTORS } from "../../elements/shared/button-selectors";
 import { urlList } from "../../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../../fixtures/users";
 import { createChannel } from "../../support/api/requests/Channels";
@@ -15,8 +13,14 @@ import {
 } from "../../support/api/requests/Product";
 import * as productUtils from "../../support/api/utils/products/productsUtils";
 import { getProductVariants } from "../../support/api/utils/storeFront/storeFrontProductUtils";
-import { createVariant } from "../../support/pages/catalog/products/VariantsPage";
-
+import {
+  addVariantToDataGrid,
+  enterVariantEditPage,
+} from "../../support/pages/catalog/products/productDetailsPage";
+import {
+  createVariant,
+  selectChannelsForVariant,
+} from "../../support/pages/catalog/products/VariantsPage";
 describe("As an admin I should be able to create variant", () => {
   const startsWith = "CyCreateVariants-";
   const attributeValues = ["value1", "value2"];
@@ -79,34 +83,15 @@ describe("As an admin I should be able to create variant", () => {
             productId: createdProduct.id,
             channelId: newChannel.id,
           });
-          cy.visit(`${urlList.products}${createdProduct.id}`)
-            .waitForProgressBarToNotBeVisible()
-            .get(PRODUCT_DETAILS.addVariantButton)
-            .should("exist")
-            .click()
-            .get(PRODUCT_DETAILS.dataGridTable)
+          cy.visit(
+            `${urlList.products}${createdProduct.id}`,
+          ).waitForProgressBarToNotBeVisible();
+          addVariantToDataGrid(name);
+          cy.get(PRODUCT_DETAILS.dataGridTable)
             .should("be.visible")
-            .get(PRODUCT_DETAILS.firstRowDataGrid)
-            .click({ force: true })
-            .type(name)
-            .get(BUTTON_SELECTORS.confirm)
-            .click()
-            .confirmationMessageShouldAppear()
-            .reload()
-            .waitForProgressBarToNotBeVisible()
-            .get(PRODUCT_DETAILS.dataGridTable)
-            .should("be.visible")
-            .wait(1000)
-            .get(BUTTON_SELECTORS.showMoreButton)
-            .click()
-            .get(PRODUCT_DETAILS.editVariant)
-            .click()
-            .get(VARIANTS_SELECTORS.manageChannels)
-            .click()
-            .get(VARIANTS_SELECTORS.allChannels)
-            .check()
-            .get(BUTTON_SELECTORS.submit)
-            .click();
+            .wait(1000);
+          enterVariantEditPage();
+          selectChannelsForVariant();
           createVariant({
             channelName: [defaultChannel.name, newChannel.name],
             sku: name,
@@ -151,12 +136,9 @@ describe("As an admin I should be able to create variant", () => {
         .then(({ product: productResp }) => {
           createdProduct = productResp;
 
-          cy.visit(`${urlList.products}${createdProduct.id}`)
-            .get(BUTTON_SELECTORS.showMoreButton)
-            .click()
-            .get(PRODUCT_DETAILS.editVariant)
-            .click()
-            .get(PRODUCT_DETAILS.addVariantButton)
+          cy.visit(`${urlList.products}${createdProduct.id}`);
+          enterVariantEditPage();
+          cy.get(PRODUCT_DETAILS.addVariantButton)
             .click()
             .then(() => {
               createVariant({

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -87,9 +87,6 @@ describe("As an admin I should be able to create variant", () => {
             `${urlList.products}${createdProduct.id}`,
           ).waitForProgressBarToNotBeVisible();
           addVariantToDataGrid(name);
-          cy.get(PRODUCT_DETAILS.dataGridTable)
-            .should("be.visible")
-            .wait(1000);
           enterVariantEditPage();
           selectChannelsForVariant();
           createVariant({

--- a/cypress/support/pages/catalog/products/VariantsPage.js
+++ b/cypress/support/pages/catalog/products/VariantsPage.js
@@ -200,3 +200,12 @@ export function saveVariant(waitForAlias = "VariantCreate") {
     .click()
     .waitForRequestAndCheckIfNoErrors(`@${waitForAlias}`);
 }
+
+export function selectChannelsForVariant() {
+  cy.get(VARIANTS_SELECTORS.manageChannels)
+    .click()
+    .get(VARIANTS_SELECTORS.allChannels)
+    .check()
+    .get(BUTTON_SELECTORS.submit)
+    .click();
+}

--- a/cypress/support/pages/catalog/products/productDetailsPage.js
+++ b/cypress/support/pages/catalog/products/productDetailsPage.js
@@ -133,3 +133,26 @@ export function fillUpCollectionAndCategory({ category, collection }) {
       return organization;
     });
 }
+
+export function addVariantToDataGrid(variantName) {
+  cy.get(PRODUCT_DETAILS.addVariantButton)
+    .should("exist")
+    .click()
+    .get(PRODUCT_DETAILS.dataGridTable)
+    .should("be.visible")
+    .get(PRODUCT_DETAILS.firstRowDataGrid)
+    .click({ force: true })
+    .type(variantName)
+    .get(BUTTON_SELECTORS.confirm)
+    .click()
+    .confirmationMessageShouldAppear()
+    .reload()
+    .waitForProgressBarToNotBeVisible();
+}
+
+export function enterVariantEditPage() {
+  cy.get(BUTTON_SELECTORS.showMoreButton)
+    .click()
+    .get(PRODUCT_DETAILS.editVariant)
+    .click();
+}

--- a/cypress/support/pages/catalog/products/productDetailsPage.js
+++ b/cypress/support/pages/catalog/products/productDetailsPage.js
@@ -151,7 +151,10 @@ export function addVariantToDataGrid(variantName) {
 }
 
 export function enterVariantEditPage() {
-  cy.get(BUTTON_SELECTORS.showMoreButton)
+  cy.get(PRODUCT_DETAILS.dataGridTable)
+    .should("be.visible")
+    .wait(1000)
+    .get(BUTTON_SELECTORS.showMoreButton)
     .click()
     .get(PRODUCT_DETAILS.editVariant)
     .click();


### PR DESCRIPTION
I want to merge this change because it is a cherry-pick with refactor of productsVariants tests. [PR2417](https://github.com/saleor/saleor-dashboard/pull/2418) and fix for flaky [TC:2902](https://github.com/saleor/saleor-dashboard/pull/2423)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://marketplace-gray.vercel.app/

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1