### PR TITLE
Activate plugins before tests

### DIFF
--- a/cypress/e2e/configuration/plugins/plugins.js
+++ b/cypress/e2e/configuration/plugins/plugins.js
@@ -12,6 +12,7 @@ import {
   deleteCustomersStartsWith,
   requestPasswordReset,
 } from "../../../support/api/requests/Customer";
+import { activatePlugin } from "../../../support/api/requests/Plugins";
 import {
   deleteChannelsStartsWith,
   getDefaultChannel,
@@ -31,7 +32,14 @@ describe("As an admin I want to manage plugins", () => {
     cy.clearSessionData().loginUserViaRequest();
     deleteCustomersStartsWith(startsWith);
     deleteChannelsStartsWith(startsWith);
-    getDefaultChannel().then(channel => (defaultChannel = channel));
+    getDefaultChannel().then(channel => {
+      defaultChannel = channel;
+      activatePlugin({ id: "mirumee.notifications.admin_email" });
+      activatePlugin({
+        id: "mirumee.notifications.user_email",
+        channel: channel.id,
+      });
+    });
   });
 
   beforeEach(() => {

--- a/cypress/support/api/requests/Plugins.js
+++ b/cypress/support/api/requests/Plugins.js
@@ -14,3 +14,19 @@ export function updatePlugin(id, name, value) {
   }`;
   return cy.sendRequestWithQuery(mutation);
 }
+
+export function activatePlugin({ id, channel, active = true }) {
+  const channelLine = channel ? `channelId: "${channel}"` : "";
+
+  const mutation = `mutation{
+    pluginUpdate(id: "${id}" ${channelLine} input:{
+      active:${active}
+    }){
+      errors{
+        field
+        message
+      }
+    } 
+  }`;
+  return cy.sendRequestWithQuery(mutation);
+}


### PR DESCRIPTION
I want to merge this change because I want to make sure that plugins are active before testing them

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [x] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1