### PR TITLE
Fix account settings page when logged in with external auth

### DIFF
--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -24,6 +24,7 @@ import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { getUserName } from "@saleor/misc";
 import UserStatus from "@saleor/staff/components/UserStatus";
 import { staffListUrl } from "@saleor/staff/urls";
+import { getMemberPermissionGroups, isMemberActive } from "@saleor/staff/utils";
 import { FetchMoreProps, RelayToFlat, SearchPageProps } from "@saleor/types";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
 import React from "react";
@@ -86,16 +87,8 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
 
   const { locale, setLocale } = useLocale();
 
-  const isActive = !!(
-    staffMember &&
-    "isActive" in staffMember &&
-    staffMember.isActive
-  );
-  const permissionGroups =
-    (staffMember &&
-      "permissionGroups" in staffMember &&
-      staffMember.permissionGroups) ||
-    [];
+  const isActive = isMemberActive(staffMember);
+  const permissionGroups = getMemberPermissionGroups(staffMember);
 
   const [
     permissionGroupsDisplayValues,

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -12,7 +12,6 @@ import Savebar from "@saleor/components/Savebar";
 import {
   SearchPermissionGroupsQuery,
   StaffErrorFragment,
-  StaffMemberDetailsFragment,
 } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useLocale from "@saleor/hooks/useLocale";
@@ -22,6 +21,7 @@ import { sectionNames } from "@saleor/intl";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { getUserName } from "@saleor/misc";
 import UserStatus from "@saleor/staff/components/UserStatus";
+import { StaffMemberDetails } from "@saleor/staff/types";
 import { staffListUrl } from "@saleor/staff/urls";
 import { FetchMoreProps, RelayToFlat, SearchPageProps } from "@saleor/types";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
@@ -51,7 +51,7 @@ export interface StaffDetailsPageProps extends SearchPageProps {
   disabled: boolean;
   fetchMorePermissionGroups: FetchMoreProps;
   saveButtonBarState: ConfirmButtonTransitionState;
-  staffMember: StaffMemberDetailsFragment;
+  staffMember: StaffMemberDetails;
   errors: StaffErrorFragment[];
   onChangePassword: () => void;
   onDelete: () => void;
@@ -101,7 +101,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
     firstName: staffMember?.firstName || "",
     isActive: !!staffMember?.isActive,
     lastName: staffMember?.lastName || "",
-    permissionGroups: staffMember?.permissionGroups.map(pg => pg.id) || [],
+    permissionGroups: staffMember?.permissionGroups?.map(pg => pg.id) || [],
   };
 
   return (

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -12,6 +12,8 @@ import Savebar from "@saleor/components/Savebar";
 import {
   SearchPermissionGroupsQuery,
   StaffErrorFragment,
+  StaffMemberDetailsFragment,
+  UserFragment,
 } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useLocale from "@saleor/hooks/useLocale";
@@ -21,7 +23,6 @@ import { sectionNames } from "@saleor/intl";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { getUserName } from "@saleor/misc";
 import UserStatus from "@saleor/staff/components/UserStatus";
-import { StaffMemberDetails } from "@saleor/staff/types";
 import { staffListUrl } from "@saleor/staff/urls";
 import { FetchMoreProps, RelayToFlat, SearchPageProps } from "@saleor/types";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
@@ -51,7 +52,7 @@ export interface StaffDetailsPageProps extends SearchPageProps {
   disabled: boolean;
   fetchMorePermissionGroups: FetchMoreProps;
   saveButtonBarState: ConfirmButtonTransitionState;
-  staffMember: StaffMemberDetails;
+  staffMember: StaffMemberDetailsFragment | UserFragment;
   errors: StaffErrorFragment[];
   onChangePassword: () => void;
   onDelete: () => void;
@@ -85,11 +86,22 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
 
   const { locale, setLocale } = useLocale();
 
+  const isActive = !!(
+    staffMember &&
+    "isActive" in staffMember &&
+    staffMember.isActive
+  );
+  const permissionGroups =
+    (staffMember &&
+      "permissionGroups" in staffMember &&
+      staffMember.permissionGroups) ||
+    [];
+
   const [
     permissionGroupsDisplayValues,
     setPermissionGroupsDisplayValues,
   ] = useStateFromProps<MultiAutocompleteChoiceType[]>(
-    (staffMember?.permissionGroups || []).map(group => ({
+    permissionGroups.map(group => ({
       disabled: !group.userCanManage,
       label: group.name,
       value: group.id,
@@ -99,9 +111,9 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
   const initialForm: StaffDetailsFormData = {
     email: staffMember?.email || "",
     firstName: staffMember?.firstName || "",
-    isActive: !!staffMember?.isActive,
+    isActive,
     lastName: staffMember?.lastName || "",
-    permissionGroups: staffMember?.permissionGroups?.map(pg => pg.id) || [],
+    permissionGroups: permissionGroups.map(pg => pg.id),
   };
 
   return (

--- a/src/staff/components/StaffProperties/StaffProperties.tsx
+++ b/src/staff/components/StaffProperties/StaffProperties.tsx
@@ -1,12 +1,10 @@
 import photoIcon from "@assets/images/photo-icon.svg";
 import { Card, CardContent, TextField, Typography } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
-import {
-  StaffErrorFragment,
-  StaffMemberDetailsFragment,
-} from "@saleor/graphql";
+import { StaffErrorFragment } from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/macaw-ui";
+import { StaffMemberDetails } from "@saleor/staff/types";
 import { getFormErrors } from "@saleor/utils/errors";
 import getStaffErrorMessage from "@saleor/utils/errors/staff";
 import React from "react";
@@ -105,7 +103,7 @@ interface StaffPropertiesProps {
   };
   errors: StaffErrorFragment[];
   disabled: boolean;
-  staffMember: StaffMemberDetailsFragment;
+  staffMember: StaffMemberDetails;
   onChange: (event: React.ChangeEvent<any>) => void;
   onImageDelete: () => void;
   onImageUpload: (file: File) => void;

--- a/src/staff/components/StaffProperties/StaffProperties.tsx
+++ b/src/staff/components/StaffProperties/StaffProperties.tsx
@@ -1,10 +1,13 @@
 import photoIcon from "@assets/images/photo-icon.svg";
 import { Card, CardContent, TextField, Typography } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
-import { StaffErrorFragment } from "@saleor/graphql";
+import {
+  StaffErrorFragment,
+  StaffMemberDetailsFragment,
+  UserFragment,
+} from "@saleor/graphql";
 import { commonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/macaw-ui";
-import { StaffMemberDetails } from "@saleor/staff/types";
 import { getFormErrors } from "@saleor/utils/errors";
 import getStaffErrorMessage from "@saleor/utils/errors/staff";
 import React from "react";
@@ -103,7 +106,7 @@ interface StaffPropertiesProps {
   };
   errors: StaffErrorFragment[];
   disabled: boolean;
-  staffMember: StaffMemberDetails;
+  staffMember: StaffMemberDetailsFragment | UserFragment;
   onChange: (event: React.ChangeEvent<any>) => void;
   onImageDelete: () => void;
   onImageUpload: (file: File) => void;

--- a/src/staff/types.ts
+++ b/src/staff/types.ts
@@ -1,8 +1,0 @@
-import { StaffMemberDetailsFragment } from "@saleor/graphql";
-
-type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
-export type StaffMemberDetails = WithOptional<
-  StaffMemberDetailsFragment,
-  "isActive" | "permissionGroups"
->;

--- a/src/staff/types.ts
+++ b/src/staff/types.ts
@@ -1,0 +1,8 @@
+import { StaffMemberDetailsFragment } from "@saleor/graphql";
+
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type StaffMemberDetails = WithOptional<
+  StaffMemberDetailsFragment,
+  "isActive" | "permissionGroups"
+>;

--- a/src/staff/utils.ts
+++ b/src/staff/utils.ts
@@ -1,4 +1,4 @@
-import { StaffMemberDetailsFragment } from "@saleor/graphql";
+import { StaffMemberDetailsFragment, UserFragment } from "@saleor/graphql";
 import difference from "lodash/difference";
 
 import { StaffDetailsFormData } from "./components/StaffDetailsPage";
@@ -17,4 +17,24 @@ export const groupsDiff = (
     addGroups: difference(newGroups, oldGroups),
     removeGroups: difference(oldGroups, newGroups),
   };
+};
+
+export const isMemberActive = (
+  staffMember: StaffMemberDetailsFragment | UserFragment,
+) => {
+  if (staffMember && "isActive" in staffMember) {
+    return staffMember.isActive;
+  }
+
+  return false;
+};
+
+export const getMemberPermissionGroups = (
+  staffMember: StaffMemberDetailsFragment | UserFragment,
+) => {
+  if (staffMember && "permissionGroups" in staffMember) {
+    return staffMember.permissionGroups;
+  }
+
+  return [];
 };

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -55,12 +55,15 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
       }),
     );
 
+  const isUserSameAsViewer = user.user?.id === id;
+
   const { data, loading, refetch } = useStaffMemberDetailsQuery({
     displayLoader: true,
     variables: { id },
+    skip: isUserSameAsViewer,
   });
 
-  const staffMember = data?.user;
+  const staffMember = isUserSameAsViewer ? user.user : data?.user;
 
   const [changePassword, changePasswordOpts] = useChangeStaffPasswordMutation({
     onCompleted: data => {
@@ -158,8 +161,6 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
         },
       }),
     );
-
-  const isUserSameAsViewer = user.user?.id === data?.user?.id;
 
   return (
     <>


### PR DESCRIPTION
I want to merge this change because it fixes the 404 crash that occurs on user account page mentioned in https://github.com/saleor/saleor-dashboard/issues/2471 (the issue with not separated `Query.me` cache from `Query.user` cache still needs to be solved).

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1