### PR TITLE
remove adding sku to simple product (#2467)

### DIFF
--- a/cypress/e2e/products/productsWithoutSku/updatingProductsWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/updatingProductsWithoutSku.js
@@ -3,14 +3,10 @@
 
 import faker from "faker";
 
-import { PRODUCT_DETAILS } from "../../../elements/catalog/products/product-details";
 import { VARIANTS_SELECTORS } from "../../../elements/catalog/products/variants-selectors";
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import { SHARED_ELEMENTS } from "../../../elements/shared/sharedElements";
-import {
-  productDetailsUrl,
-  productVariantDetailUrl,
-} from "../../../fixtures/urlList";
+import { productVariantDetailUrl } from "../../../fixtures/urlList";
 import {
   createVariant,
   getVariant,
@@ -115,49 +111,6 @@ describe("Updating products without sku", () => {
   });
 
   it(
-    "should add sku to simple product",
-    { tags: ["@products", "@allEnv", "@stable"] },
-    () => {
-      const sku = "NewSkuSimpleProd";
-      const simpleProductName = `${startsWith}${faker.datatype.number()}`;
-      let simpleProduct;
-      createProductInChannelWithoutVariants({
-        name: simpleProductName,
-        attributeId: attribute.id,
-        categoryId: category.id,
-        channelId: defaultChannel.id,
-        productTypeId: productTypeWithoutVariants.id,
-      })
-        .then(productResp => {
-          simpleProduct = productResp;
-          createVariant({
-            productId: simpleProduct.id,
-            channelId: defaultChannel.id,
-            warehouseId: warehouse.id,
-            quantityInWarehouse: 10,
-          });
-        })
-        .then(variantsList => {
-          cy.visitAndWaitForProgressBarToDisappear(
-            productDetailsUrl(simpleProduct.id),
-          )
-            .get(SHARED_ELEMENTS.skeleton)
-            .should("not.exist")
-            .get(PRODUCT_DETAILS.skuInput)
-            .type(sku)
-            .addAliasToGraphRequest("SimpleProductUpdate")
-            .get(BUTTON_SELECTORS.confirm)
-            .click()
-            .waitForRequestAndCheckIfNoErrors("@SimpleProductUpdate");
-          getVariant(variantsList[0].id, defaultChannel.slug);
-        })
-        .then(variantResp => {
-          expect(variantResp.sku).to.eq(sku);
-        });
-    },
-  );
-
-  it(
     "should add sku to variant",
     { tags: ["@products", "@allEnv", "@stable"] },
     () => {
@@ -220,50 +173,6 @@ describe("Updating products without sku", () => {
             .click()
             .waitForRequestAndCheckIfNoErrors("@VariantUpdate");
           getVariant(variant.id, defaultChannel.slug);
-        })
-        .then(variantResp => {
-          expect(variantResp.sku).to.be.null;
-          checkIfCheckoutForVariantCanBeCompleted(variantResp);
-        });
-    },
-  );
-
-  it(
-    "should remove sku from simple product",
-    { tags: ["@products", "@allEnv", "@stable"] },
-    () => {
-      const simpleProductName = `${startsWith}${faker.datatype.number()}`;
-      let simpleProduct;
-      createProductInChannelWithoutVariants({
-        name: simpleProductName,
-        attributeId: attribute.id,
-        categoryId: category.id,
-        channelId: defaultChannel.id,
-        productTypeId: productTypeWithoutVariants.id,
-      })
-        .then(productResp => {
-          simpleProduct = productResp;
-          createVariant({
-            productId: simpleProduct.id,
-            channelId: defaultChannel.id,
-            sku: simpleProductName,
-            quantityInWarehouse: 10,
-            warehouseId: warehouse.id,
-          });
-        })
-        .then(variantsList => {
-          cy.visitAndWaitForProgressBarToDisappear(
-            productDetailsUrl(simpleProduct.id),
-          )
-            .get(SHARED_ELEMENTS.skeleton)
-            .should("not.exist")
-            .get(PRODUCT_DETAILS.skuInput)
-            .clear()
-            .addAliasToGraphRequest("SimpleProductUpdate")
-            .get(BUTTON_SELECTORS.confirm)
-            .click()
-            .waitForRequestAndCheckIfNoErrors("@SimpleProductUpdate");
-          getVariant(variantsList[0].id, defaultChannel.slug);
         })
         .then(variantResp => {
           expect(variantResp.sku).to.be.null;


### PR DESCRIPTION
I want to merge this change because it removed tests nod needed any more. It's cherry-picked from - https://github.com/saleor/saleor-dashboard/pull/2467

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1