### PR TITLE
Remove multiselect from use attributes in variant selection tests

### DIFF
--- a/cypress/e2e/configuration/attributes/attributeVariantSelection.js
+++ b/cypress/e2e/configuration/attributes/attributeVariantSelection.js
@@ -19,7 +19,6 @@ describe("As an admin I want to use attributes in variant selection", () => {
 
   const attributesTypes = [
     { key: "DROPDOWN", TC: "SALEOR_0534" },
-    { key: "MULTISELECT", TC: "SALEOR_0535" },
     { key: "BOOLEAN", TC: "SALEOR_0536" },
     { key: "NUMERIC", TC: "SALEOR_0537" },
     { key: "SWATCH", TC: "SALEOR_0538" },


### PR DESCRIPTION
I want to merge this change because it looks like Multiselect isn't a valid choice for Variant Selection:
<img width="1135" alt="Zrzut ekranu 2022-10-27 o 09 46 38" src="https://user-images.githubusercontent.com/30683248/198227496-ef2c1861-ba16-4d7c-b7c3-50701fce6d5a.png">
<img width="923" alt="Zrzut ekranu 2022-10-27 o 09 41 50" src="https://user-images.githubusercontent.com/30683248/198227545-0569eaac-b112-48c7-bd34-bed1da9c647a.png">




<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1