### PR TITLE
Fix test should create simple product without sku SALEOR_2806

### DIFF
--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -356,3 +356,22 @@ export function updateVariantPrice({ variantId, channelId, price }) {
     .sendRequestWithQuery(mutation)
     .its("body.data.productVariantChannelListingUpdate");
 }
+
+export function updateVariantWarehouse({ variantId, warehouseId }) {
+  const mutation = `mutation{
+    productVariantStocksCreate(variantId: "${variantId}", 
+      stocks: 
+      {
+        quantity: 0,
+        warehouse: "${warehouseId}"
+      }
+      ){
+      errors{
+        field
+        message
+      }
+    }
+  }
+  `;
+  return cy.sendRequestWithQuery(mutation);
+}

--- a/cypress/support/customCommands/sharedElementsOperations/selects.js
+++ b/cypress/support/customCommands/sharedElementsOperations/selects.js
@@ -48,7 +48,9 @@ Cypress.Commands.add("fillAutocompleteSelect", (selectSelector, option) => {
         cy.wrap(detachedOption).should(det => {
           Cypress.dom.isDetached(det);
         });
-        cy.contains(BUTTON_SELECTORS.selectOption, option).click();
+        cy.contains(BUTTON_SELECTORS.selectOption, option)
+          .should("be.visible")
+          .click();
         cy.wrap(option).as("option");
       });
   } else {


### PR DESCRIPTION
I want to merge this change because it fixes the test and adds mutation to create variant stock

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1