### PR TITLE
Set different version of macaw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5248,9 +5248,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.6.7.tgz",
-      "integrity": "sha512-HRa8c4M+siOltopPLDusRh/03P7G2FlboFszal5sd2X8HUNZJ4c2BS83gnBMmVgp37kxeZiBVe95Fhjm0PRzbA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.6.5.tgz",
+      "integrity": "sha512-lAhSjSKgLuILoiMRRITZn3dFMMQPYGjHZClSDvsmvOCZSJ1X3dqWFw7PLNp+r3IapZ9R6CT9ZBe7uYZ6l5aDMA==",
       "requires": {
         "@floating-ui/react-dom-interactions": "^0.5.0",
         "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
     "@reach/auto-id": "^0.16.0",
-    "@saleor/macaw-ui": "~0.6.7",
+    "@saleor/macaw-ui": "0.6.5",
     "@saleor/sdk": "^0.4.4",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",


### PR DESCRIPTION
Setting previous version of macawui

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1