### PR TITLE
Fix improper double attempt to get external access token

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1162,6 +1162,10 @@
     "context": "product field",
     "string": "Export Product Weight"
   },
+  "7Jg9ec": {
+    "context": "error message",
+    "string": "You don't have permission to login."
+  },
   "7KRGqz": {
     "context": "Payment card title",
     "string": "Payment balance"
@@ -2215,6 +2219,10 @@
   "Fn3bE0": {
     "string": "Order line updated"
   },
+  "FopBSj": {
+    "context": "error message",
+    "string": "Your username and/or password are incorrect. Please try again."
+  },
   "FpIcp9": {
     "string": "No customers found"
   },
@@ -3050,10 +3058,6 @@
   "M1uijW": {
     "context": "collection",
     "string": "Not Published"
-  },
-  "M4q0Ye": {
-    "context": "error message",
-    "string": "Sorry, login went wrong. Please try again."
   },
   "M6s/9e": {
     "context": "unassign country, dialog header",
@@ -4514,6 +4518,10 @@
   "WnlZMO": {
     "context": "title",
     "string": "There’s a problem with app."
+  },
+  "Wr5UOV": {
+    "context": "error message",
+    "string": "Login went wrong. Please try again."
   },
   "Ww69SE": {
     "context": "search input placeholder",
@@ -7196,10 +7204,6 @@
   },
   "tR+UuE": {
     "string": "User doesn't exist. Please check your email in URL"
-  },
-  "tTtoKd": {
-    "context": "error message",
-    "string": "Sorry, your username and/or password are incorrect. Please try again."
   },
   "tTuCYj": {
     "context": "all gift cards label",

--- a/src/auth/components/LoginPage/LoginPage.stories.tsx
+++ b/src/auth/components/LoginPage/LoginPage.stories.tsx
@@ -15,6 +15,7 @@ const props: Omit<LoginCardProps, "classes"> = {
     },
   ],
   loading: false,
+  errors: [],
   onExternalAuthentication: () => undefined,
   onSubmit: () => undefined,
 };
@@ -23,9 +24,9 @@ storiesOf("Views / Authentication / Log in", module)
   .addDecorator(CardDecorator)
   .addDecorator(Decorator)
   .add("default", () => <LoginPage {...props} />)
-  .add("error login", () => <LoginPage {...props} error={"loginError"} />)
+  .add("error login", () => <LoginPage {...props} errors={["loginError"]} />)
   .add("error external login", () => (
-    <LoginPage {...props} error={"externalLoginError"} />
+    <LoginPage {...props} errors={["externalLoginError"]} />
   ))
   .add("disabled", () => <LoginPage {...props} disabled={true} />)
   .add("loading", () => <LoginPage {...props} loading={true} />);

--- a/src/auth/components/LoginPage/LoginPage.tsx
+++ b/src/auth/components/LoginPage/LoginPage.tsx
@@ -21,7 +21,7 @@ import LoginForm, { LoginFormData } from "./form";
 import { getErrorMessage } from "./messages";
 
 export interface LoginCardProps {
-  error?: UserContextError;
+  errors: UserContextError[];
   disabled: boolean;
   loading: boolean;
   externalAuthentications?: AvailableExternalAuthenticationsQuery["shop"]["availableExternalAuthentications"];
@@ -31,7 +31,7 @@ export interface LoginCardProps {
 
 const LoginCard: React.FC<LoginCardProps> = props => {
   const {
-    error,
+    errors,
     disabled,
     loading,
     externalAuthentications = [],
@@ -62,11 +62,15 @@ const LoginCard: React.FC<LoginCardProps> = props => {
               description="card header"
             />
           </Typography>
-          {error && (
-            <div className={classes.panel} data-test-id="login-error-message">
+          {errors.map(error => (
+            <div
+              className={classes.panel}
+              key={error}
+              data-test-id="login-error-message"
+            >
               {getErrorMessage(error, intl)}
             </div>
-          )}
+          ))}
           <TextField
             autoFocus
             fullWidth

--- a/src/auth/components/LoginPage/messages.ts
+++ b/src/auth/components/LoginPage/messages.ts
@@ -3,20 +3,25 @@ import { defineMessages, IntlShape } from "react-intl";
 
 export const errorMessages = defineMessages({
   loginError: {
-    id: "tTtoKd",
+    id: "FopBSj",
     defaultMessage:
-      "Sorry, your username and/or password are incorrect. Please try again.",
+      "Your username and/or password are incorrect. Please try again.",
     description: "error message",
   },
-  externalLoginError: {
-    id: "M4q0Ye",
-    defaultMessage: "Sorry, login went wrong. Please try again.",
+  unknownLoginError: {
+    id: "Wr5UOV",
+    defaultMessage: "Login went wrong. Please try again.",
     description: "error message",
   },
   serverError: {
     id: "ChGI4V",
     defaultMessage:
       "Saleor is unavailable, please check your network connection and try again.",
+    description: "error message",
+  },
+  noPermissionsError: {
+    id: "7Jg9ec",
+    defaultMessage: "You don't have permission to login.",
     description: "error message",
   },
 });
@@ -29,8 +34,12 @@ export function getErrorMessage(
     case "loginError":
       return intl.formatMessage(errorMessages.loginError);
     case "externalLoginError":
-      return intl.formatMessage(errorMessages.externalLoginError);
+      return intl.formatMessage(errorMessages.unknownLoginError);
+    case "unknownLoginError":
+      return intl.formatMessage(errorMessages.unknownLoginError);
     case "serverError":
       return intl.formatMessage(errorMessages.serverError);
+    case "noPermissionsError":
+      return intl.formatMessage(errorMessages.noPermissionsError);
   }
 }

--- a/src/auth/errors.ts
+++ b/src/auth/errors.ts
@@ -10,6 +10,13 @@ export enum JWTError {
   expired = "ExpiredSignatureError",
 }
 
+export const AuthError = {
+  PermissionDenied: "PermissionDenied",
+  OAuthError: "OAuthError",
+} as const;
+
+export type AuthError = typeof AuthError[keyof typeof AuthError];
+
 export function isJwtError(error: GraphQLError): boolean {
   let jwtError: boolean;
   try {
@@ -26,13 +33,13 @@ export function isTokenExpired(error: GraphQLError): boolean {
 }
 
 export function getAuthErrorType(graphQLError: GraphQLError): UserContextError {
-  switch (graphQLError.extensions?.exception?.code) {
-    case "PermissionDenied":
-      return "noPermissionsError";
-    case "OAuthError":
-      return "externalLoginError";
+  switch (graphQLError.extensions?.exception?.code as AuthError) {
+    case AuthError.PermissionDenied:
+      return UserContextError.noPermissionsError;
+    case AuthError.OAuthError:
+      return UserContextError.externalLoginError;
     default:
-      return "unknownLoginError";
+      return UserContextError.unknownLoginError;
   }
 }
 

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -1,4 +1,4 @@
-import { ApolloClient } from "@apollo/client";
+import { ApolloClient, ApolloError } from "@apollo/client";
 import { IMessageContext } from "@saleor/components/messages";
 import { DEMO_MODE } from "@saleor/config";
 import { useUserDetailsQuery } from "@saleor/graphql";
@@ -21,6 +21,7 @@ import { useEffect, useRef, useState } from "react";
 import { IntlShape } from "react-intl";
 import urlJoin from "url-join";
 
+import { parseAuthError } from "../errors";
 import {
   ExternalLoginInput,
   RequestExternalLoginInput,
@@ -53,12 +54,12 @@ export function useAuthProvider({
     "requestedExternalPluginId",
     null,
   );
-  const [error, setError] = useState<UserContextError>();
+  const [errors, setErrors] = useState<UserContextError[]>([]);
   const permitCredentialsAPI = useRef(true);
 
   useEffect(() => {
-    if (authenticating && error) {
-      setError(undefined);
+    if (authenticating && errors.length) {
+      setErrors([]);
     }
   }, [authenticating]);
 
@@ -87,6 +88,16 @@ export function useAuthProvider({
     // state will cause an error
     fetchPolicy: "cache-and-network",
   });
+
+  const handleLoginError = (error: ApolloError) => {
+    const parsedErrors = parseAuthError(error);
+
+    if (parsedErrors.length) {
+      setErrors(parsedErrors);
+    } else {
+      setErrors(["unknownLoginError"]);
+    }
+  };
 
   const handleLogout = async () => {
     const returnTo = urlJoin(
@@ -139,14 +150,14 @@ export function useAuthProvider({
         }
         saveCredentials(result.data.tokenCreate.user, password);
       } else {
-        setError("loginError");
+        setErrors(["loginError"]);
       }
 
       await logoutNonStaffUser(result.data.tokenCreate);
 
       return result.data.tokenCreate;
     } catch (error) {
-      setError("serverError");
+      handleLoginError(error);
     }
   };
 
@@ -177,14 +188,14 @@ export function useAuthProvider({
           displayDemoMessage(intl, notify);
         }
       } else {
-        setError("externalLoginError");
+        setErrors(["externalLoginError"]);
       }
 
       await logoutNonStaffUser(result.data.externalObtainAccessTokens);
 
       return result?.data?.externalObtainAccessTokens;
     } catch (error) {
-      setError("serverError");
+      handleLoginError(error);
     }
   };
 
@@ -206,9 +217,9 @@ export function useAuthProvider({
     requestLoginByExternalPlugin: handleRequestExternalLogin,
     loginByExternalPlugin: handleExternalLogin,
     logout: handleLogout,
-    authenticating: authenticating && !error,
+    authenticating: authenticating && !errors.length,
     authenticated: authenticated && user?.isStaff,
     user: userDetails.data?.me,
-    error,
+    errors,
   };
 }

--- a/src/auth/index.tsx
+++ b/src/auth/index.tsx
@@ -29,6 +29,7 @@ export const UserContext = React.createContext<Context>({
   requestLoginByExternalPlugin: undefined,
   authenticating: false,
   authenticated: false,
+  errors: [],
 });
 
 const AuthRouter: React.FC = () => (

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -18,12 +18,15 @@ export interface RequestExternalLogoutInput {
   returnTo: string;
 }
 
-export type UserContextError =
-  | "loginError"
-  | "externalLoginError"
-  | "unknownLoginError"
-  | "serverError"
-  | "noPermissionsError";
+export const UserContextError = {
+  loginError: "loginError",
+  serverError: "serverError",
+  noPermissionsError: "noPermissionsError",
+  externalLoginError: "externalLoginError",
+  unknownLoginError: "unknownLoginError",
+} as const;
+
+export type UserContextError = typeof UserContextError[keyof typeof UserContextError];
 
 export interface UserContext {
   login: (username: string, password: string) => Promise<LoginData>;

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -21,7 +21,9 @@ export interface RequestExternalLogoutInput {
 export type UserContextError =
   | "loginError"
   | "externalLoginError"
-  | "serverError";
+  | "unknownLoginError"
+  | "serverError"
+  | "noPermissionsError";
 
 export interface UserContext {
   login: (username: string, password: string) => Promise<LoginData>;
@@ -37,5 +39,5 @@ export interface UserContext {
   user?: UserFragment;
   authenticating: boolean;
   authenticated: boolean;
-  error?: UserContextError;
+  errors: UserContextError[];
 }

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -23,7 +23,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     requestLoginByExternalPlugin,
     loginByExternalPlugin,
     authenticating,
-    error,
+    errors,
   } = useUser();
   const {
     data: externalAuthentications,
@@ -80,7 +80,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     const isCallbackPath = location.pathname.includes(loginCallbackPath);
 
     const externalAuthParamsExist = code && state && isCallbackPath;
-    const externalAuthNotPerformed = !authenticating && !error;
+    const externalAuthNotPerformed = !authenticating && !errors.length;
 
     if (externalAuthParamsExist && externalAuthNotPerformed) {
       handleExternalAuthentication(code, state);
@@ -89,7 +89,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
 
   return (
     <LoginPage
-      error={error}
+      errors={errors}
       disabled={authenticating}
       externalAuthentications={
         externalAuthentications?.shop?.availableExternalAuthentications

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -79,7 +79,10 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     const { code, state } = params;
     const isCallbackPath = location.pathname.includes(loginCallbackPath);
 
-    if (code && state && isCallbackPath) {
+    const externalAuthParamsExist = code && state && isCallbackPath;
+    const externalAuthNotPerformed = !authenticating && !error;
+
+    if (externalAuthParamsExist && externalAuthNotPerformed) {
       handleExternalAuthentication(code, state);
     }
   }, []);

--- a/src/storybook/UserDecorator.tsx
+++ b/src/storybook/UserDecorator.tsx
@@ -12,6 +12,7 @@ export const UserDecorator = (user: UserFragment) => storyFn => (
       user,
       authenticated: false,
       authenticating: false,
+      errors: [],
     }}
   >
     {storyFn()}

--- a/src/storybook/stories/customers/MockedUserProvider.tsx
+++ b/src/storybook/stories/customers/MockedUserProvider.tsx
@@ -24,6 +24,7 @@ export const MockedUserProvider: React.FC<{
         avatar: null,
         __typename: "User",
       },
+      errors: [],
     }}
   >
     {children}


### PR DESCRIPTION
I want to merge this change because... it fixes improper double attempt to get external access token. Fixes https://github.com/saleor/saleor-dashboard/issues/2503.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
Before:
<img width="355" alt="Screenshot 2022-11-02 at 10 50 31" src="https://user-images.githubusercontent.com/9825562/199458688-51834f8e-98d1-4518-a5ed-8cb1ff4ff974.png">
After:
<img width="365" alt="Screenshot 2022-11-02 at 10 50 04" src="https://user-images.githubusercontent.com/9825562/199458724-6eb19a16-455d-4d3e-be97-3021bef83000.png">
<img width="360" alt="Screenshot 2022-11-02 at 10 50 21" src="https://user-images.githubusercontent.com/9825562/199458727-f37fade6-a082-4a17-9d76-f87afe01318f.png">

https://user-images.githubusercontent.com/9825562/199458915-7fc7e5fa-8241-451f-a53f-22caf36c744e.mp4


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1