### PR TITLE
Do not send availableForPurchaseDate if channel is unavailable

### DIFF
--- a/src/products/components/ProductUpdatePage/formChannels.test.ts
+++ b/src/products/components/ProductUpdatePage/formChannels.test.ts
@@ -1,0 +1,98 @@
+import { updateChannelsInput } from "./formChannels";
+
+describe("ProductUpdatePage - fromChannels", () => {
+  describe("updateChannelsInput", () => {
+    const channel = {
+      channelId: "Q2hhbm5lbDox",
+      availableForPurchaseDate: null,
+      __typename: "ProductChannelListing",
+      isPublished: true,
+      publicationDate: "2020-01-01",
+      isAvailableForPurchase: false,
+      availableForPurchase: null,
+      visibleInListings: true,
+      channel: {
+        __typename: "Channel",
+        id: "Q2hhbm5lbDox",
+        name: "Default channel",
+        currencyCode: "USD",
+      },
+    };
+
+    it("should update availableForPurchaseDate if isAvailableForPurchase is set to true", () => {
+      const input = {
+        removeChannels: [],
+        updateChannels: [channel],
+      };
+      const data = {
+        availableForPurchase: "2020-10-01",
+        isAvailableForPurchase: true,
+        isPublished: true,
+        publicationDate: "2020-01-01",
+        visibleInListings: true,
+      };
+
+      const result = updateChannelsInput(input, data, channel.channelId);
+
+      expect(result).toEqual({
+        removeChannels: [],
+        updateChannels: [
+          {
+            ...channel,
+            isAvailableForPurchase: true,
+            availableForPurchaseDate: "2020-10-01",
+            availableForPurchase: "2020-10-01",
+          },
+        ],
+      });
+    });
+
+    it("should set availableForPurchaseDate to null if isAvailableForPurchase is set to false", () => {
+      const oldData = {
+        removeChannels: [],
+        updateChannels: [channel],
+      };
+      const newData = {
+        availableForPurchase: "2020-10-01",
+        isAvailableForPurchase: false,
+        isPublished: true,
+        publicationDate: "2020-01-01",
+        visibleInListings: true,
+      };
+
+      const result = updateChannelsInput(oldData, newData, channel.channelId);
+
+      expect(result).toEqual({
+        removeChannels: [],
+        updateChannels: [
+          {
+            ...channel,
+            availableForPurchaseDate: null,
+            availableForPurchase: "2020-10-01",
+          },
+        ],
+      });
+    });
+
+    it("should not update listing if channel id do not match", () => {
+      const input = {
+        removeChannels: [],
+        updateChannels: [channel],
+      };
+      const data = {
+        availableForPurchase: "2020-10-01",
+        isAvailableForPurchase: true,
+        isPublished: true,
+        publicationDate: "2020-01-01",
+        visibleInListings: true,
+      };
+
+      const result = updateChannelsInput(input, data, "42");
+
+      expect(result).toEqual({
+        removeChannels: [],
+        updateChannels: [channel],
+      });
+    });
+  });
+});

--- a/src/products/components/ProductUpdatePage/formChannels.ts
+++ b/src/products/components/ProductUpdatePage/formChannels.ts
@@ -19,6 +19,29 @@ const emptyListing: Omit<ProductChannelListingAddInput, "channelId"> = {
   visibleInListings: false,
 };
 
+export const updateChannelsInput = (
+  input: ProductChannelListingUpdateInput,
+  data: ChannelOpts,
+  id: string,
+) => {
+  const mergeListings = (listing: ProductChannelListingAddInput) => {
+    if (listing.channelId === id) {
+      return {
+        ...listing,
+        ...data,
+        availableForPurchaseDate: data.isAvailableForPurchase
+          ? data.availableForPurchase
+          : null,
+      };
+    }
+    return listing;
+  };
+  return {
+    ...input,
+    updateChannels: input.updateChannels.map(mergeListings),
+  };
+};
+
 export function useProductChannelListingsForm(
   product: Pick<ProductFragment, "channelListings">,
   triggerChange: () => void,
@@ -42,20 +65,7 @@ export function useProductChannelListingsForm(
 
   const handleChannelChange = useCallback(
     (id: string, data: ChannelOpts) => {
-      setChannels(prevData => ({
-        ...prevData,
-        updateChannels: prevData.updateChannels.map(prevListing =>
-          prevListing.channelId === id
-            ? {
-                ...prevListing,
-                ...data,
-                availableForPurchaseDate: data.isAvailableForPurchase
-                  ? data.availableForPurchase
-                  : null,
-              }
-            : prevListing,
-        ),
-      }));
+      setChannels(input => updateChannelsInput(input, data, id));
       triggerChange();
       touch(id);
     },

--- a/src/products/components/ProductUpdatePage/formChannels.ts
+++ b/src/products/components/ProductUpdatePage/formChannels.ts
@@ -40,18 +40,27 @@ export function useProductChannelListingsForm(
     touched.current = uniq([...touched.current, id]);
   };
 
-  const handleChannelChange = useCallback((id: string, data: ChannelOpts) => {
-    setChannels(prevData => ({
-      ...prevData,
-      updateChannels: prevData.updateChannels.map(prevListing =>
-        prevListing.channelId === id
-          ? { ...prevListing, ...data }
-          : prevListing,
-      ),
-    }));
-    triggerChange();
-    touch(id);
-  }, []);
+  const handleChannelChange = useCallback(
+    (id: string, data: ChannelOpts) => {
+      setChannels(prevData => ({
+        ...prevData,
+        updateChannels: prevData.updateChannels.map(prevListing =>
+          prevListing.channelId === id
+            ? {
+                ...prevListing,
+                ...data,
+                availableForPurchaseDate: data.isAvailableForPurchase
+                  ? data.availableForPurchase
+                  : null,
+              }
+            : prevListing,
+        ),
+      }));
+      triggerChange();
+      touch(id);
+    },
+    [setChannels, triggerChange],
+  );
 
   const handleChannelListUpdate: ProductChannelsListingDialogSubmit = useCallback(
     ({ added, removed }) => {


### PR DESCRIPTION
I want to merge this change because it fixes #2474. Previously we send `availableForPurchaseDate` no matter of availability of the channel. I changed that and currently it will be based on `isAvailableForPurchase` boolean. I also fixed a rules of hooks error.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1