### PR TITLE
Allow view taxes with product manage permission

### DIFF
--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -1,32 +1,18 @@
 import { Typography } from "@material-ui/core";
-import { IconProps } from "@material-ui/core/Icon";
 import { useTheme } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { PermissionEnum, UserFragment } from "@saleor/graphql";
+import { UserFragment } from "@saleor/graphql";
 import { sectionNames } from "@saleor/intl";
 import { makeStyles, NavigationCard } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
-import { hasAnyPermissions } from "../auth/misc";
 import Container from "../components/Container";
 import PageHeader from "../components/PageHeader";
 import VersionInfo from "../components/VersionInfo";
-
-export interface MenuItem {
-  description: string;
-  icon: React.ReactElement<IconProps>;
-  permissions: PermissionEnum[];
-  title: string;
-  url?: string;
-  testId?: string;
-}
-
-export interface MenuSection {
-  label: string;
-  menuItems: MenuItem[];
-}
+import { MenuSection } from "./types";
+import { hasUserMenuItemPermissions } from "./utils";
 
 interface VersionInfo {
   dashboardVersion: string;
@@ -115,7 +101,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
       {menus
         .filter(menu =>
           menu.menuItems.some(menuItem =>
-            hasAnyPermissions(menuItem.permissions, user),
+            hasUserMenuItemPermissions(menuItem, user),
           ),
         )
         .map((menu, menuIndex) => (
@@ -125,9 +111,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
             </div>
             <div className={classes.configurationItem}>
               {menu.menuItems
-                .filter(menuItem =>
-                  hasAnyPermissions(menuItem.permissions, user),
-                )
+                .filter(menuItem => hasUserMenuItemPermissions(menuItem, user))
                 .map((item, itemIndex) => (
                   <Link className={classes.link} to={item.url}>
                     <NavigationCard

--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -32,7 +32,8 @@ import { warehouseSection } from "@saleor/warehouses/urls";
 import React from "react";
 import { IntlShape, useIntl } from "react-intl";
 
-import ConfigurationPage, { MenuSection } from "./ConfigurationPage";
+import ConfigurationPage from "./ConfigurationPage";
+import { MenuSection } from "./types";
 
 export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
   return [
@@ -81,7 +82,6 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             defaultMessage: "Manage how your store charges tax",
           }),
           icon: <Taxes />,
-          permissions: [PermissionEnum.MANAGE_SETTINGS],
           title: intl.formatMessage(sectionNames.taxes),
           url: taxConfigurationListUrl(),
           testId: "configuration-menu-taxes",

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -1,0 +1,16 @@
+import { IconProps } from "@material-ui/core";
+import { PermissionEnum } from "@saleor/graphql";
+
+export interface MenuItem {
+  description: string;
+  icon: React.ReactElement<IconProps>;
+  permissions?: PermissionEnum[];
+  title: string;
+  url?: string;
+  testId?: string;
+}
+
+export interface MenuSection {
+  label: string;
+  menuItems: MenuItem[];
+}

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -1,7 +1,9 @@
-import { PermissionEnum } from "@saleor/graphql";
+import { hasAnyPermissions } from "@saleor/auth/misc";
+import { PermissionEnum, UserFragment } from "@saleor/graphql";
 import { IntlShape } from "react-intl";
 
 import { createConfigurationMenu } from ".";
+import { MenuItem } from "./types";
 
 export const getConfigMenuItemsPermissions = (
   intl: IntlShape,
@@ -15,3 +17,9 @@ export const getConfigMenuItemsPermissions = (
       [],
     )
     .flat();
+
+export const hasUserMenuItemPermissions = (
+  menuItem: MenuItem,
+  user: UserFragment,
+): boolean =>
+  menuItem.permissions ? hasAnyPermissions(menuItem.permissions, user) : true;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -229,11 +229,7 @@ const Routes: React.FC = () => {
                 path="/site-settings"
                 component={SiteSettingsSection}
               />
-              <SectionRoute
-                permissions={[PermissionEnum.MANAGE_SETTINGS]}
-                path="/taxes"
-                component={TaxesSection}
-              />
+              <SectionRoute path="/taxes" component={TaxesSection} />
               <SectionRoute
                 permissions={[PermissionEnum.MANAGE_SHIPPING]}
                 path="/shipping"


### PR DESCRIPTION
It makes subpages under `/taxes` path available to read by any staff user (backend requires one of the following permissions in taxes queries: `AuthorizationFilters.AUTHENTICATED_STAFF_USER`, `AuthorizationFilters.AUTHENTICATED_APP`, what means that any staff user should be able to access taxes views)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> https://github.com/saleor/saleor/pull/9784

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-6391-simple-taxes.api.saleor.rocks/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1