### PR TITLE
[WIP] Display not installed Saleor Apps

### DIFF
--- a/src/apps/components/AppsListPage/AppsListPage.tsx
+++ b/src/apps/components/AppsListPage/AppsListPage.tsx
@@ -2,6 +2,7 @@ import {
   AppPageTabs,
   AppPageTabValue,
 } from "@saleor/apps/components/AppPageTabs/AppPageTabs";
+import SaleorAppsList from "@saleor/apps/components/SaleorAppsList";
 import { useSaleorApps } from "@saleor/apps/hooks/useSaleorApps";
 import CardSpacer from "@saleor/components/CardSpacer";
 import Container from "@saleor/components/Container";
@@ -73,21 +74,9 @@ const AppsListPage: React.FC<AppsListPageProps> = ({
       installedAppsList?.filter(
         app =>
           !(fetchedSaleorApps ?? []).find(fetchedApp =>
-            app.node.manifestUrl?.includes(fetchedApp.hostname),
+            app.node.manifestUrl?.includes(fetchedApp.manifestUrl),
           ),
       ),
-    [installedAppsList, fetchedSaleorApps],
-  );
-
-  const saleorApps = useMemo(
-    () =>
-      fetchedSaleorApps
-        ?.map(app =>
-          installedAppsList?.find(installedApp =>
-            installedApp.node.manifestUrl?.includes(app.hostname),
-          ),
-        )
-        .filter(Boolean),
     [installedAppsList, fetchedSaleorApps],
   );
 
@@ -157,13 +146,14 @@ const AppsListPage: React.FC<AppsListPageProps> = ({
                 id="FLtdaw"
               />
             </p>
-            <InstalledApps
+            <SaleorAppsList
               title={intl.formatMessage({
                 id: "PbQJY5",
                 defaultMessage: "Saleor Apps",
                 description: "section header",
               })}
-              appsList={saleorApps}
+              availableApps={fetchedSaleorApps}
+              installedApps={installedAppsList}
               onRemove={onInstalledAppRemove}
               {...listProps}
             />

--- a/src/apps/components/SaleorAppsList/SaleorAppsList.tsx
+++ b/src/apps/components/SaleorAppsList/SaleorAppsList.tsx
@@ -1,0 +1,187 @@
+import {
+  Card,
+  Switch,
+  TableBody,
+  TableCell,
+  Typography,
+} from "@material-ui/core";
+import { useAppListContext } from "@saleor/apps/context";
+import { SaleorApp } from "@saleor/apps/hooks/useSaleorApps";
+import { appUrl, createAppInstallUrl } from "@saleor/apps/urls";
+import CardTitle from "@saleor/components/CardTitle";
+import { IconButton } from "@saleor/components/IconButton";
+import { TableButtonWrapper } from "@saleor/components/TableButtonWrapper/TableButtonWrapper";
+import TableRowLink from "@saleor/components/TableRowLink";
+import { AppListItemFragment, AppsListQuery } from "@saleor/graphql";
+import useNavigator from "@saleor/hooks/useNavigator";
+import { DeleteIcon, ResponsiveTable } from "@saleor/macaw-ui";
+import { renderCollection } from "@saleor/misc";
+import { ListProps } from "@saleor/types";
+import React, { useCallback, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
+
+import { useStyles } from "../../styles";
+import { AppPermissions } from "../AppPermissions/AppPermissions";
+import AppsSkeleton from "../AppsSkeleton";
+
+export interface InstalledAppsProps extends ListProps {
+  installedApps: AppsListQuery["apps"]["edges"];
+  availableApps: SaleorApp[];
+  onRemove: (id: string) => void;
+  title: string;
+}
+
+const SaleorAppsList: React.FC<InstalledAppsProps> = ({
+  installedApps,
+  onRemove,
+  title,
+  availableApps,
+  ...props
+}) => {
+  const classes = useStyles(props);
+  const { activateApp, deactivateApp } = useAppListContext();
+  const navigate = useNavigator();
+
+  const navigateToAppInstallPage = useCallback(
+    (url: string) => {
+      navigate(createAppInstallUrl(url));
+    },
+    [navigate],
+  );
+
+  const getHandleToggle = (app: AppListItemFragment) => () => {
+    if (app.isActive) {
+      deactivateApp(app.id);
+    } else {
+      activateApp(app.id);
+    }
+  };
+
+  const installedSaleorApps = useMemo(
+    () =>
+      installedApps.filter(app =>
+        availableApps.find(
+          saleorApp => app.node?.manifestUrl === saleorApp.manifestUrl,
+        ),
+      ),
+    [availableApps, installedApps],
+  );
+
+  const notInstalledSaleorApps = useMemo(
+    () =>
+      availableApps.filter(
+        availableApp =>
+          !installedApps.find(
+            installedApp =>
+              installedApp.node.manifestUrl === availableApp.manifestUrl,
+          ),
+      ),
+    [availableApps, installedApps],
+  );
+
+  return (
+    <>
+      <Card className={classes.apps}>
+        <CardTitle title={title} />
+        <ResponsiveTable>
+          <TableBody>
+            {renderCollection(
+              installedSaleorApps,
+              (app, index) =>
+                app ? (
+                  <TableRowLink
+                    key={app.node.id}
+                    className={classes.tableRow}
+                    href={appUrl(app.node.id)}
+                  >
+                    <TableCell className={classes.colName}>
+                      <span data-tc="name" className={classes.appName}>
+                        {app.node.name}
+                      </span>
+                    </TableCell>
+
+                    <TableCell className={classes.colAction}>
+                      <TableButtonWrapper>
+                        <Switch
+                          checked={app.node.isActive}
+                          onChange={getHandleToggle(app.node)}
+                        />
+                      </TableButtonWrapper>
+                      <AppPermissions permissions={app.node.permissions} />
+                      <TableButtonWrapper>
+                        <IconButton
+                          variant="secondary"
+                          color="primary"
+                          onClick={() => onRemove(app.node.id)}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </TableButtonWrapper>
+                    </TableCell>
+                  </TableRowLink>
+                ) : (
+                  <AppsSkeleton key={index} />
+                ),
+              () => (
+                <TableRowLink className={classes.tableRow}>
+                  <TableCell className={classes.colName}>
+                    <Typography className={classes.text} variant="body2">
+                      <FormattedMessage
+                        id="9tgY4G"
+                        defaultMessage="You don’t have any installed apps in your dashboard"
+                        description="apps content"
+                      />
+                    </Typography>
+                  </TableCell>
+                </TableRowLink>
+              ),
+            )}
+          </TableBody>
+        </ResponsiveTable>
+      </Card>
+
+      <Card className={classes.apps}>
+        <CardTitle title="Available Saleor Apps" />
+        <ResponsiveTable>
+          <TableBody>
+            {renderCollection(
+              notInstalledSaleorApps,
+              (app, index) =>
+                app ? (
+                  <TableRowLink
+                    key={app.manifestUrl}
+                    className={classes.tableRow}
+                    onClick={() => navigateToAppInstallPage(app.manifestUrl)}
+                  >
+                    <TableCell className={classes.colName}>
+                      <span data-tc="name" className={classes.appName}>
+                        {app.name}
+                      </span>
+                    </TableCell>
+                  </TableRowLink>
+                ) : (
+                  <AppsSkeleton key={index} />
+                ),
+              () => (
+                <TableRowLink className={classes.tableRow}>
+                  <TableCell className={classes.colName}>
+                    <Typography className={classes.text} variant="body2">
+                      <FormattedMessage
+                        id="9tgY4G"
+                        defaultMessage="You don’t have any installed apps in your dashboard"
+                        description="apps content"
+                      />
+                    </Typography>
+                  </TableCell>
+                </TableRowLink>
+              ),
+            )}
+          </TableBody>
+        </ResponsiveTable>
+      </Card>
+    </>
+  );
+};
+
+SaleorAppsList.displayName = "InstalledApps";
+export default SaleorAppsList;

--- a/src/apps/components/SaleorAppsList/index.ts
+++ b/src/apps/components/SaleorAppsList/index.ts
@@ -1,0 +1,2 @@
+export * from "./SaleorAppsList";
+export { default } from "./SaleorAppsList";

--- a/src/apps/hooks/useSaleorApps.ts
+++ b/src/apps/hooks/useSaleorApps.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 
 export interface SaleorApp {
   name: string;
-  hostname: string;
+  manifestUrl: string;
 }
 
 const saleorAppsEnabled = Boolean(SALEOR_APPS_ENDPOINT);
@@ -22,7 +22,7 @@ export const useSaleorApps = () => {
         if (
           !data.every(
             item =>
-              typeof item.hostname === "string" ||
+              typeof item.manifestUrl === "string" ||
               typeof item.name === "string",
           )
         ) {


### PR DESCRIPTION
I want to merge this change because...

This is a foundation of the current Marketplace. Dashboard fetches available catalog of apps and displays them. If the app is installed it will render a row with the installed app. If the app is not installed it will display it for user, to install it quickly

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="1324" alt="Zrzut ekranu 2022-11-2 o 18 09 56" src="https://user-images.githubusercontent.com/9268745/199555744-31001f66-6015-4c7b-b311-72d7eb718e96.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1