### PR TITLE
Fix broken preorders on order fulfill page

### DIFF
--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
@@ -164,22 +164,26 @@ export const OrderFulfillLine: React.FC<OrderFulfillLineProps> = props => {
           : "-"}
       </TableCell>
       <TableCell className={classes.colWarehouse}>
-        <IconButton
-          onClick={onWarehouseChange}
-          className={classNames(
-            classes.warehouseButton,
-            "MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd",
-          )}
-          data-test-id="select-warehouse-button"
-        >
-          <div className={classes.warehouseButtonContent}>
-            <Typography className={classes.warehouseButtonContentText}>
-              {lineFormWarehouse?.name ??
-                intl.formatMessage(messages.selectWarehouse)}
-            </Typography>
-            <ChevronIcon />
-          </div>
-        </IconButton>
+        {isPreorder ? (
+          "-"
+        ) : (
+          <IconButton
+            onClick={onWarehouseChange}
+            className={classNames(
+              classes.warehouseButton,
+              "MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd",
+            )}
+            data-test-id="select-warehouse-button"
+          >
+            <div className={classes.warehouseButtonContent}>
+              <Typography className={classes.warehouseButtonContentText}>
+                {lineFormWarehouse?.name ??
+                  intl.formatMessage(messages.selectWarehouse)}
+              </Typography>
+              <ChevronIcon />
+            </div>
+          </IconButton>
+        )}
       </TableCell>
     </TableRowLink>
   );

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -163,9 +163,9 @@ const OrderFulfillPage: React.FC<OrderFulfillPageProps> = props => {
     !shopSettings?.fulfillmentAllowUnpaid &&
     !order?.isPaid;
 
-  const areWarehousesSet = formsetData.every(line =>
-    line.value.every(v => v.warehouse),
-  );
+  const areWarehousesSet = formsetData
+    .filter(item => !!item?.value) // preorder case
+    .every(line => line.value.every(v => v.warehouse));
 
   const shouldEnableSave = () => {
     if (!order || loading) {


### PR DESCRIPTION
I want to merge this change because it fixes broken preorders on order fulfill page. Fixes #2438.
- Fixes crash when preorder variant present on order fulfill page
- Removes warehouse selection button from preorder lines - we don't fulfill them anyway.



<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> main

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1