### PR TITLE
Fix product channels update error

### DIFF
--- a/src/products/views/ProductUpdate/handlers/utils.test.ts
+++ b/src/products/views/ProductUpdate/handlers/utils.test.ts
@@ -1,0 +1,76 @@
+import { ProductFragment } from "@saleor/graphql";
+import { ProductUpdateSubmitData } from "@saleor/products/components/ProductUpdatePage/types";
+
+import { inferProductChannelsAfterUpdate } from "./utils";
+
+describe("Product update utils", () => {
+  it("should infer product channels after update with data", () => {
+    const product = {
+      channelListings: [
+        {
+          channel: {
+            id: "1",
+          },
+        },
+        {
+          channel: {
+            id: "2",
+          },
+        },
+        {
+          channel: {
+            id: "3",
+          },
+        },
+      ],
+    } as ProductFragment;
+
+    const submitData = {
+      channels: {
+        updateChannels: [
+          {
+            channelId: "1",
+          },
+          {
+            channelId: "4",
+          },
+        ],
+        removeChannels: ["2"],
+      },
+    } as ProductUpdateSubmitData;
+
+    const result = inferProductChannelsAfterUpdate(product, submitData);
+
+    expect(result).toEqual(["1", "3", "4"]);
+  });
+
+  it("should infer product channels after update without data", () => {
+    const product = {
+      channelListings: [
+        {
+          channel: {
+            id: "1",
+          },
+        },
+        {
+          channel: {
+            id: "2",
+          },
+        },
+        {
+          channel: {
+            id: "3",
+          },
+        },
+      ],
+    } as ProductFragment;
+
+    const submitData = {
+      channels: {},
+    } as ProductUpdateSubmitData;
+
+    const result = inferProductChannelsAfterUpdate(product, submitData);
+
+    expect(result).toEqual(["1", "2", "3"]);
+  });
+});

--- a/src/products/views/ProductUpdate/handlers/utils.ts
+++ b/src/products/views/ProductUpdate/handlers/utils.ts
@@ -61,14 +61,31 @@ const hasChannel = (
   return variant.channelListings.some(c => c.channel.id === channelId);
 };
 
+function inferProductChannelsAfterUpdate(
+  product: ProductFragment,
+  data: ProductUpdateSubmitData,
+) {
+  const productChannelsIds = product.channelListings.map(
+    listing => listing.channel.id,
+  );
+  const updatedChannelsIds = data.channels.updateChannels.map(
+    listing => listing.channelId,
+  );
+  const removedChannelsIds = data.channels.removeChannels;
+
+  return uniq([
+    ...productChannelsIds.filter(
+      channelId => !removedChannelsIds.includes(channelId),
+    ),
+    ...updatedChannelsIds,
+  ]);
+}
+
 export function getProductChannelsUpdateVariables(
   product: ProductFragment,
   data: ProductUpdateSubmitData,
 ): ProductChannelListingUpdateMutationVariables {
-  const channels = uniq([
-    ...product.channelListings.map(listing => listing.channel.id),
-    ...data.channels.updateChannels.map(listing => listing.channelId),
-  ]);
+  const channels = inferProductChannelsAfterUpdate(product, data);
 
   const dataUpdated = new Map<string, ProductChannelListingAddInput>();
   data.channels.updateChannels

--- a/src/products/views/ProductUpdate/handlers/utils.ts
+++ b/src/products/views/ProductUpdate/handlers/utils.ts
@@ -61,17 +61,16 @@ const hasChannel = (
   return variant.channelListings.some(c => c.channel.id === channelId);
 };
 
-function inferProductChannelsAfterUpdate(
+export function inferProductChannelsAfterUpdate(
   product: ProductFragment,
   data: ProductUpdateSubmitData,
 ) {
   const productChannelsIds = product.channelListings.map(
     listing => listing.channel.id,
   );
-  const updatedChannelsIds = data.channels.updateChannels.map(
-    listing => listing.channelId,
-  );
-  const removedChannelsIds = data.channels.removeChannels;
+  const updatedChannelsIds =
+    data.channels.updateChannels?.map(listing => listing.channelId) || [];
+  const removedChannelsIds = data.channels.removeChannels || [];
 
   return uniq([
     ...productChannelsIds.filter(


### PR DESCRIPTION
Fixed error occured after trying to update availability of variant channel in datagrid, which (channel) was later on removed from being available on product. Now variant channel availability shouldn't be appended to channel listing update input when channel has been disabled on product. Fixes https://github.com/saleor/saleor-dashboard/issues/2514.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [x] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [x] variants

CONTAINERS=1