### PR TITLE
Wait for requests on add menu item page

### DIFF
--- a/cypress/e2e/configuration/navigation.js
+++ b/cypress/e2e/configuration/navigation.js
@@ -58,6 +58,9 @@ describe("Tests for menu navigation", () => {
         const itemName = `${startsWith}${faker.datatype.number()}`;
         let selectedItem;
 
+        cy.addAliasToGraphRequest("SearchCategories")
+          .addAliasToGraphRequest("SearchPages")
+          .addAliasToGraphRequest("SearchCollections");
         createNewMenuItem({
           menuId: menu.id,
           name: itemName,

--- a/cypress/support/pages/navigationPage.js
+++ b/cypress/support/pages/navigationPage.js
@@ -24,6 +24,9 @@ export function createNewMenuItem({ menuId, name, menuItemType }) {
 
   return cy
     .visit(menuDetailsUrl(menuId))
+    .wait("@SearchCollections")
+    .wait("@SearchPages")
+    .wait("@SearchCategories")
     .get(MENU_DETAILS.createNewMenuItemButton)
     .click()
     .get(SHARED_ELEMENTS.dialog)
@@ -52,5 +55,5 @@ export function createNewMenuItem({ menuId, name, menuItemType }) {
 export const MENU_ITEM_TYPES = {
   category: "categoryItem",
   collection: "collectionItem",
-  page: "pageItem"
+  page: "pageItem",
 };


### PR DESCRIPTION
I want to merge this change because... it fixes tests that are randomly failing on releases

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants

CONTAINERS=1