### PR TITLE
Provide full API URL of Saleor to app iframe, add test

### DIFF
--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -1,7 +1,7 @@
 import {
   AppDetailsUrlQueryParams,
-  appIframeUrl,
   getAppDeepPathFromDashboardUrl,
+  resolveAppIframeUrl,
 } from "@saleor/apps/urls";
 import useLocale from "@saleor/hooks/useLocale";
 import useShop from "@saleor/hooks/useShop";
@@ -102,7 +102,7 @@ export const AppFrame: React.FC<Props> = ({
   return (
     <iframe
       ref={frameRef}
-      src={appIframeUrl(appId, src, shop.domain.host, params)}
+      src={resolveAppIframeUrl(appId, src, shop.domain.host, params)}
       onError={onError}
       onLoad={handleLoad}
       className={clsx(classes.iframe, className)}

--- a/src/apps/urls.test.ts
+++ b/src/apps/urls.test.ts
@@ -1,0 +1,36 @@
+import { resolveAppIframeUrl } from "@saleor/apps/urls";
+
+jest.mock("@saleor/config", () => ({
+  ...jest.requireActual("@saleor/config"),
+  API_URI: "https://shop.saleor.cloud/graphql/",
+}));
+
+describe("resolveAppIframeUrl", () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[string, string, string, Record<string, unknown>, string]>([
+    [
+      "XyZ123",
+      "https://my-app.vercel.app",
+      "shop.saleor.cloud",
+      { param1: "param1" },
+      "https://my-app.vercel.app?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=XyZ123&param1=param1",
+    ],
+    [
+      "AbC987",
+      "https://my-app.vercel.app/configuration",
+      "shop.saleor.cloud",
+      { param1: "param1", param2: "param2" },
+      "https://my-app.vercel.app/configuration?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=AbC987&param1=param1&param2=param2",
+    ],
+  ])(
+    "Generates valid URL from segments",
+    (id, appUrl, shopHostname, params, expectedUrl) => {
+      const result = resolveAppIframeUrl(id, appUrl, shopHostname, params);
+
+      expect(result).toEqual(expectedUrl);
+    },
+  );
+});

--- a/src/apps/urls.test.ts
+++ b/src/apps/urls.test.ts
@@ -2,7 +2,7 @@ import { resolveAppIframeUrl } from "@saleor/apps/urls";
 
 jest.mock("@saleor/config", () => ({
   ...jest.requireActual("@saleor/config"),
-  API_URI: "https://shop.saleor.cloud/graphql/",
+  getApiUrl: () => "https://shop.saleor.cloud/graphql/",
 }));
 
 describe("resolveAppIframeUrl", () => {

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -1,3 +1,4 @@
+import { API_URI } from "@saleor/config";
 import { stringifyQs } from "@saleor/utils/urls";
 import urlJoin from "url-join";
 
@@ -117,15 +118,28 @@ export const customAppAddUrl = customAppAddPath;
 export const appsListUrl = (params?: AppListUrlQueryParams) =>
   appsListPath + "?" + stringifyQs(params);
 
-export const appIframeUrl = (
+export const resolveAppIframeUrl = (
   appId: string,
   appUrl: string,
   shopDomainHost: string,
   params: AppDetailsUrlQueryParams,
 ) => {
   const iframeContextQueryString = `?${stringifyQs(
-    { domain: shopDomainHost, id: appId, ...params },
+    {
+      /**
+       * @deprecated - domain will be removed in favor of saleorApiUrl.
+       * Current hostname (used as domain) can be extracted from full URL
+       *
+       * Difference will be:
+       * shop.saleor.cloud -> https://shop.saleor.cloud/graphql/
+       */
+      domain: shopDomainHost,
+      saleorApiUrl: API_URI,
+      id: appId,
+      ...params,
+    },
     "comma",
   )}`;
+
   return urlJoin(appUrl, window.location.search, iframeContextQueryString);
 };

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -1,4 +1,4 @@
-import { API_URI } from "@saleor/config";
+import { getApiUrl } from "@saleor/config";
 import { stringifyQs } from "@saleor/utils/urls";
 import urlJoin from "url-join";
 
@@ -134,7 +134,7 @@ export const resolveAppIframeUrl = (
        * shop.saleor.cloud -> https://shop.saleor.cloud/graphql/
        */
       domain: shopDomainHost,
-      saleorApiUrl: API_URI,
+      saleorApiUrl: getApiUrl(),
       id: appId,
       ...params,
     },


### PR DESCRIPTION
I want to merge this change because...

https://github.com/saleor/saleor-dashboard/issues/2387

tldr - apps should receive full URL of API, so they don't need to guess where the API is

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1