### PR TITLE
Update docker copy syntax & readme runtime API URL change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ COPY nginx/ nginx/
 COPY assets/ assets/
 COPY locale/ locale/
 COPY testUtils testUtils/
-COPY codegen.yml .
-COPY webpack.config.js .
-COPY tsconfig.json .
-COPY *.d.ts .
-COPY schema.graphql .
-COPY introspection.json .
+COPY codegen.yml ./
+COPY webpack.config.js ./
+COPY tsconfig.json ./
+COPY *.d.ts ./
+COPY schema.graphql ./
+COPY introspection.json ./
 COPY src/ src/
 
 ARG API_URI

--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ docker run --publish 8080:80 --env "API_URL=<YOUR_API_URL>" saleor-dashboard
 
 Enter `http://localhost:8080/` to use dashboard.
 
-##### Usage with Sentry adapter:
+If you want to dynamically change `API_URL` in runtime you can use (assuming you have running container named `saleor-dashboard`):
+
+```shell
+docker exec -it -e API_URL=NEW_URL saleor-dashboard /docker-entrypoint.d/50-replace-api-url.sh
+```
+
+### Usage with Sentry adapter
 
 Sentry is used as the default tracker so no changes in code are necessary and the configuration is done via environment variables.
 


### PR DESCRIPTION
What was done:
- fix: add copy syntax for backward compatibility
- docs: add info about runtime API URL change

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1