### PR TITLE
Allow to send 0 as price

### DIFF
--- a/src/shipping/handlers.ts
+++ b/src/shipping/handlers.ts
@@ -192,7 +192,7 @@ export function getShippingMethodChannelVariables(
             channel.maxValue && orderValueRestricted ? channel.maxValue : null,
           minimumOrderPrice:
             channel.minValue && orderValueRestricted ? channel.minValue : null,
-          price: channel.price || null,
+          price: channel.price,
         })) || [],
       removeChannels,
     },


### PR DESCRIPTION
I want to merge this change because it allows sending 0 as the price. Previously we fallback to `null` which is not needed as the price is required inside the form.

Fixes #2617 & #2546


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://v38.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1