### PR TITLE
Improve saving variant images

### DIFF
--- a/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
+++ b/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
@@ -9,51 +9,11 @@ import ConfirmButton from "@saleor/components/ConfirmButton";
 import { ProductMediaFragment } from "@saleor/graphql";
 import useModalDialogOpen from "@saleor/hooks/useModalDialogOpen";
 import { buttonMessages } from "@saleor/intl";
-import { makeStyles } from "@saleor/macaw-ui";
 import clsx from "clsx";
 import React, { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
-const useStyles = makeStyles(
-  theme => ({
-    image: {
-      height: "100%",
-      objectFit: "contain",
-      userSelect: "none",
-      width: "100%",
-    },
-    imageContainer: {
-      background: "transparent",
-      border: "1px solid #eaeaea",
-      borderRadius: theme.spacing(),
-      cursor: "pointer",
-      height: theme.spacing(21.5),
-      overflow: "hidden",
-      padding: theme.spacing(2),
-      position: "relative",
-      transitionDuration: theme.transitions.duration.standard + "ms",
-    },
-    content: {
-      overflowY: "scroll",
-    },
-    root: {
-      display: "grid",
-      gridColumnGap: theme.spacing(2),
-      gridRowGap: theme.spacing(2),
-      gridTemplateColumns: "repeat(3, 1fr)",
-      maxWidth: "100%",
-      width: theme.breakpoints.values.lg,
-      [theme.breakpoints.down("sm")]: {
-        gridTemplateColumns: "repeat(2, 1fr)",
-      },
-    },
-    selectedImageContainer: {
-      borderColor: theme.palette.primary.main,
-      borderWidth: "2px",
-    },
-  }),
-  { name: "ProductVariantImageSelectDialog" },
-);
+import { useStyles } from "./styles";
 
 interface ProductVariantImageSelectDialogProps {
   media?: ProductMediaFragment[];

--- a/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
+++ b/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
@@ -90,7 +90,7 @@ const ProductVariantMediaSelectDialog: React.FC<ProductVariantImageSelectDialogP
                         selectedMedia.indexOf(mediaObj.id) !== -1,
                     },
                   ])}
-                  onClick={onMediaSelect(mediaObj.id)}
+                  onClick={() => onMediaSelect(mediaObj.id)}
                   key={mediaObj.id}
                 >
                   <img

--- a/src/products/components/ProductVariantImageSelectDialog/styles.ts
+++ b/src/products/components/ProductVariantImageSelectDialog/styles.ts
@@ -1,0 +1,42 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  theme => ({
+    image: {
+      height: "100%",
+      objectFit: "contain",
+      userSelect: "none",
+      width: "100%",
+    },
+    imageContainer: {
+      background: "transparent",
+      border: "1px solid #eaeaea",
+      borderRadius: theme.spacing(),
+      cursor: "pointer",
+      height: theme.spacing(21.5),
+      overflow: "hidden",
+      padding: theme.spacing(2),
+      position: "relative",
+      transitionDuration: theme.transitions.duration.standard + "ms",
+    },
+    content: {
+      overflowY: "scroll",
+    },
+    root: {
+      display: "grid",
+      gridColumnGap: theme.spacing(2),
+      gridRowGap: theme.spacing(2),
+      gridTemplateColumns: "repeat(3, 1fr)",
+      maxWidth: "100%",
+      width: theme.breakpoints.values.lg,
+      [theme.breakpoints.down("sm")]: {
+        gridTemplateColumns: "repeat(2, 1fr)",
+      },
+    },
+    selectedImageContainer: {
+      borderColor: theme.palette.primary.main,
+      borderWidth: "2px",
+    },
+  }),
+  { name: "ProductVariantImageSelectDialog" },
+);

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -118,7 +118,6 @@ interface ProductVariantPageProps {
   onAttributeSelectBlur: () => void;
   onDelete();
   onSubmit(data: ProductVariantUpdateSubmitData);
-  onMediaSelect(id: string);
   onSetDefaultVariant();
   onWarehouseConfigure();
 }
@@ -140,7 +139,6 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
   referenceProducts = [],
   attributeValues,
   onDelete,
-  onMediaSelect,
   onSubmit,
   onVariantPreorderDeactivate,
   variantDeactivatePreoderButtonState,
@@ -172,13 +170,9 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
     setIsEndPreorderModalOpened,
   ] = React.useState(false);
 
-  const variantMedia = variant?.media?.map(image => image.id);
   const productMedia = [
     ...(variant?.product?.media ?? []),
   ]?.sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));
-  const media = productMedia
-    ?.filter(image => variantMedia.indexOf(image.id) !== -1)
-    .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));
 
   const canOpenAssignReferencesAttributeDialog = !!assignReferencesAttributeId;
 
@@ -246,6 +240,9 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
             const selectionAttributes = data.attributes.filter(
               byAttributeScope(VariantAttributeScope.VARIANT_SELECTION),
             );
+            const media = productMedia
+              ?.filter(image => data.media.indexOf(image.id) !== -1)
+              .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));
 
             const errors = [...apiErrors, ...validationErrors];
 
@@ -423,28 +420,28 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   />
                 )}
                 {variant && (
-                  <VariantChannelsDialog
-                    channelListings={variant.product.channelListings}
-                    selectedChannelListings={data.channelListings}
-                    open={isManageChannelsModalOpen}
-                    onClose={toggleManageChannels}
-                    onConfirm={handlers.updateChannels}
-                  />
+                  <>
+                    <VariantChannelsDialog
+                      channelListings={variant.product.channelListings}
+                      selectedChannelListings={data.channelListings}
+                      open={isManageChannelsModalOpen}
+                      onClose={toggleManageChannels}
+                      onConfirm={handlers.updateChannels}
+                    />
+                    <ProductVariantMediaSelectDialog
+                      onClose={toggleModal}
+                      onMediaSelect={handlers.changeMedia}
+                      open={isModalOpened}
+                      media={productMedia}
+                      selectedMedia={data.media}
+                    />
+                  </>
                 )}
               </>
             );
           }}
         </ProductVariantUpdateForm>
       </Container>
-      {variant && (
-        <ProductVariantMediaSelectDialog
-          onClose={toggleModal}
-          onMediaSelect={onMediaSelect}
-          open={isModalOpened}
-          media={productMedia}
-          selectedMedia={variant?.media.map(image => image.id)}
-        />
-      )}
       {!!variant?.preorder && (
         <ProductVariantEndPreorderDialog
           confirmButtonState={variantDeactivatePreoderButtonState}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -29,6 +29,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import { VariantDetailsChannelsAvailabilityCard } from "@saleor/products/components/ProductVariantChannels/ChannelsAvailabilityCard";
 import { productUrl } from "@saleor/products/urls";
+import { getSelectedMedia } from "@saleor/products/utils/data";
 import { FetchMoreProps, RelayToFlat, ReorderAction } from "@saleor/types";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
@@ -240,9 +241,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
             const selectionAttributes = data.attributes.filter(
               byAttributeScope(VariantAttributeScope.VARIANT_SELECTION),
             );
-            const media = productMedia
-              ?.filter(image => data.media.indexOf(image.id) !== -1)
-              .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));
+            const media = getSelectedMedia(productMedia, data.media);
 
             const errors = [...apiErrors, ...validationErrors];
 

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -429,7 +429,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                     />
                     <ProductVariantMediaSelectDialog
                       onClose={toggleModal}
-                      onMediaSelect={handlers.changeMedia}
+                      onConfirm={handlers.changeMedia}
                       open={isModalOpened}
                       media={productMedia}
                       selectedMedia={data.media}

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -44,6 +44,7 @@ import {
   getStockInputFromVariant,
 } from "@saleor/products/utils/data";
 import {
+  createMediaChangeHandler,
   createPreorderEndDateChangeHandler,
   getChannelsInput,
 } from "@saleor/products/utils/handlers";
@@ -78,6 +79,7 @@ export interface ProductVariantUpdateFormData extends MetadataFormData {
   hasPreorderEndDate: boolean;
   preorderEndDateTime?: string;
   name: string;
+  media: string[];
 }
 export interface ProductVariantUpdateData extends ProductVariantUpdateFormData {
   channelListings: FormsetData<
@@ -126,6 +128,7 @@ export interface ProductVariantUpdateHandlers
     Record<"addStock" | "deleteStock", (id: string) => void> {
   changePreorderEndDate: FormChange;
   changeMetadata: FormChange;
+  changeMedia: (id: string) => void;
   updateChannels: (selectedChannelsIds: string[]) => void;
   fetchReferences: (value: string) => void;
   fetchMoreReferences: FetchMoreProps;
@@ -191,6 +194,7 @@ function useProductVariantUpdateForm(
     weight: variant?.weight?.value.toString() || "",
     quantityLimitPerCustomer: variant?.quantityLimitPerCustomer || null,
     name: variant?.name ?? "",
+    media: variant?.media?.map(({ id }) => id) || [],
   };
 
   const form = useForm(initial, undefined, {
@@ -299,6 +303,8 @@ function useProductVariantUpdateForm(
     triggerChange,
     intl.formatMessage(errorMessages.preorderEndDateInFutureErrorText),
   );
+
+  const handleMediaChange = createMediaChangeHandler(form, triggerChange);
 
   const handleUpdateChannels = (selectedIds: string[]) => {
     const allChannels = variant.product.channelListings.map(listing => {
@@ -428,6 +434,7 @@ function useProductVariantUpdateForm(
       changeMetadata,
       changeStock: handleStockChange,
       changePreorderEndDate: handlePreorderEndDateChange,
+      changeMedia: handleMediaChange,
       deleteStock: handleStockDelete,
       fetchMoreReferences: handleFetchMoreReferences,
       fetchReferences: handleFetchReferences,

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -128,7 +128,7 @@ export interface ProductVariantUpdateHandlers
     Record<"addStock" | "deleteStock", (id: string) => void> {
   changePreorderEndDate: FormChange;
   changeMetadata: FormChange;
-  changeMedia: (id: string) => void;
+  changeMedia: (ids: string[]) => void;
   updateChannels: (selectedChannelsIds: string[]) => void;
   fetchReferences: (value: string) => void;
   fetchMoreReferences: FetchMoreProps;

--- a/src/products/utils/data.test.ts
+++ b/src/products/utils/data.test.ts
@@ -4,6 +4,7 @@ type GetSelectedMediaParams = Parameters<typeof getSelectedMedia>;
 
 describe("Product media utils", () => {
   it("should return selected media in proper order when media ids passed", () => {
+    // Arrange
     const media: GetSelectedMediaParams[0] = [
       {
         id: "1",
@@ -24,7 +25,10 @@ describe("Product media utils", () => {
     ];
     const selectedIds: GetSelectedMediaParams[1] = ["1", "3", "4"];
 
+    // Act
     const result = getSelectedMedia(media, selectedIds);
+
+    // Assert
     const expectedResult = [
       {
         id: "4",
@@ -44,6 +48,7 @@ describe("Product media utils", () => {
   });
 
   it("should return empty array of media when no media ids passed", () => {
+    // Arrange
     const media: GetSelectedMediaParams[0] = [
       {
         id: "1",
@@ -64,8 +69,10 @@ describe("Product media utils", () => {
     ];
     const selectedIds: GetSelectedMediaParams[1] = [];
 
+    // Act
     const result = getSelectedMedia(media, selectedIds);
 
+    // Assert
     expect(result).toEqual([]);
   });
 });

--- a/src/products/utils/data.test.ts
+++ b/src/products/utils/data.test.ts
@@ -3,7 +3,7 @@ import { getSelectedMedia } from "./data";
 type GetSelectedMediaParams = Parameters<typeof getSelectedMedia>;
 
 describe("Product media utils", () => {
-  it("should return selected media in proper order", () => {
+  it("should return selected media in proper order when media ids passed", () => {
     const media: GetSelectedMediaParams[0] = [
       {
         id: "1",
@@ -41,5 +41,31 @@ describe("Product media utils", () => {
     ];
 
     expect(result).toEqual(expectedResult);
+  });
+
+  it("should return empty array of media when no media ids passed", () => {
+    const media: GetSelectedMediaParams[0] = [
+      {
+        id: "1",
+        sortOrder: 2,
+      },
+      {
+        id: "2",
+        sortOrder: 3,
+      },
+      {
+        id: "3",
+        sortOrder: 4,
+      },
+      {
+        id: "4",
+        sortOrder: 1,
+      },
+    ];
+    const selectedIds: GetSelectedMediaParams[1] = [];
+
+    const result = getSelectedMedia(media, selectedIds);
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/products/utils/data.test.ts
+++ b/src/products/utils/data.test.ts
@@ -1,0 +1,45 @@
+import { getSelectedMedia } from "./data";
+
+type GetSelectedMediaParams = Parameters<typeof getSelectedMedia>;
+
+describe("Product media utils", () => {
+  it("should return selected media in proper order", () => {
+    const media: GetSelectedMediaParams[0] = [
+      {
+        id: "1",
+        sortOrder: 2,
+      },
+      {
+        id: "2",
+        sortOrder: 3,
+      },
+      {
+        id: "3",
+        sortOrder: 4,
+      },
+      {
+        id: "4",
+        sortOrder: 1,
+      },
+    ];
+    const selectedIds: GetSelectedMediaParams[1] = ["1", "3", "4"];
+
+    const result = getSelectedMedia(media, selectedIds);
+    const expectedResult = [
+      {
+        id: "4",
+        sortOrder: 1,
+      },
+      {
+        id: "1",
+        sortOrder: 2,
+      },
+      {
+        id: "3",
+        sortOrder: 4,
+      },
+    ];
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -11,6 +11,7 @@ import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompl
 import {
   ProductDetailsVariantFragment,
   ProductFragment,
+  ProductMediaFragment,
   ProductTypeQuery,
   ProductVariantCreateDataQuery,
   ProductVariantFragment,
@@ -247,3 +248,13 @@ export const getPreorderEndDateFormData = (endDate?: string) =>
 
 export const getPreorderEndHourFormData = (endDate?: string) =>
   endDate ? moment(endDate).format("HH:mm") : "";
+
+export const getSelectedMedia = <
+  T extends Pick<ProductMediaFragment, "id" | "sortOrder">
+>(
+  media: T[] = [],
+  selectedMediaIds: string[],
+) =>
+  media
+    .filter(image => selectedMediaIds.indexOf(image.id) !== -1)
+    .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1));

--- a/src/products/utils/handlers.test.ts
+++ b/src/products/utils/handlers.test.ts
@@ -6,6 +6,7 @@ type HandleAssignMediaParams = Parameters<typeof handleAssignMedia>;
 
 describe("Product handlers", () => {
   it("should not alter product variant media when the same selected media ids as previously passed", async () => {
+    // Arrange
     const media: HandleAssignMediaParams[0] = ["1", "2"];
     const variant: HandleAssignMediaParams[1] = {
       id: "1",
@@ -29,13 +30,16 @@ describe("Product handlers", () => {
     const assignMedia = jest.fn(() => Promise.resolve({}));
     const unassignMedia = jest.fn(() => Promise.resolve({}));
 
+    // Act
     await handleAssignMedia(media, variant, assignMedia, unassignMedia);
 
+    // Assert
     expect(assignMedia).not.toHaveBeenCalled();
     expect(unassignMedia).not.toHaveBeenCalled();
   });
 
   it("should assign media to product variant when more then all previous selected media ids passed", async () => {
+    // Arrange
     const media: HandleAssignMediaParams[0] = ["1", "2", "3"];
     const variant: HandleAssignMediaParams[1] = {
       id: "1",
@@ -52,8 +56,10 @@ describe("Product handlers", () => {
     const assignMedia = jest.fn(() => Promise.resolve({}));
     const unassignMedia = jest.fn(() => Promise.resolve({}));
 
+    // Act
     await handleAssignMedia(media, variant, assignMedia, unassignMedia);
 
+    // Assert
     expect(assignMedia).toHaveBeenCalledTimes(2);
     expect(assignMedia).toHaveBeenCalledWith({
       variantId: "1",
@@ -67,6 +73,7 @@ describe("Product handlers", () => {
   });
 
   it("should unassign media from product variant when not all previous selected media ids passed", async () => {
+    // Arrange
     const media: HandleAssignMediaParams[0] = ["3"];
     const variant: HandleAssignMediaParams[1] = {
       id: "1",
@@ -97,8 +104,10 @@ describe("Product handlers", () => {
     const assignMedia = jest.fn(() => Promise.resolve({}));
     const unassignMedia = jest.fn(() => Promise.resolve({}));
 
+    // Act
     await handleAssignMedia(media, variant, assignMedia, unassignMedia);
 
+    // Assert
     expect(assignMedia).not.toHaveBeenCalled();
     expect(unassignMedia).toHaveBeenCalledTimes(2);
     expect(unassignMedia).toHaveBeenCalledWith({
@@ -112,6 +121,7 @@ describe("Product handlers", () => {
   });
 
   it("should assign and unassign media from product variant when not all but more selected media ids from previously selected passed", async () => {
+    // Arrange
     const media: HandleAssignMediaParams[0] = ["1", "3"];
     const variant: HandleAssignMediaParams[1] = {
       id: "1",
@@ -135,8 +145,10 @@ describe("Product handlers", () => {
     const assignMedia = jest.fn(() => Promise.resolve({}));
     const unassignMedia = jest.fn(() => Promise.resolve({}));
 
+    // Act
     await handleAssignMedia(media, variant, assignMedia, unassignMedia);
 
+    // Assert
     expect(assignMedia).toHaveBeenCalledTimes(1);
     expect(assignMedia).toHaveBeenCalledWith({
       variantId: "1",

--- a/src/products/utils/handlers.test.ts
+++ b/src/products/utils/handlers.test.ts
@@ -1,0 +1,151 @@
+import { ProductMediaType } from "@saleor/graphql";
+
+import { handleAssignMedia } from "./handlers";
+
+type HandleAssignMediaParams = Parameters<typeof handleAssignMedia>;
+
+describe("Product handlers", () => {
+  it("should not alter product variant media when the same selected media ids as previously passed", async () => {
+    const media: HandleAssignMediaParams[0] = ["1", "2"];
+    const variant: HandleAssignMediaParams[1] = {
+      id: "1",
+      media: [
+        {
+          id: "1",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+        {
+          id: "2",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+      ],
+    };
+    const assignMedia = jest.fn(() => Promise.resolve({}));
+    const unassignMedia = jest.fn(() => Promise.resolve({}));
+
+    await handleAssignMedia(media, variant, assignMedia, unassignMedia);
+
+    expect(assignMedia).not.toHaveBeenCalled();
+    expect(unassignMedia).not.toHaveBeenCalled();
+  });
+
+  it("should assign media to product variant when more then all previous selected media ids passed", async () => {
+    const media: HandleAssignMediaParams[0] = ["1", "2", "3"];
+    const variant: HandleAssignMediaParams[1] = {
+      id: "1",
+      media: [
+        {
+          id: "3",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+      ],
+    };
+    const assignMedia = jest.fn(() => Promise.resolve({}));
+    const unassignMedia = jest.fn(() => Promise.resolve({}));
+
+    await handleAssignMedia(media, variant, assignMedia, unassignMedia);
+
+    expect(assignMedia).toHaveBeenCalledTimes(2);
+    expect(assignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "1",
+    });
+    expect(assignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "2",
+    });
+    expect(unassignMedia).not.toHaveBeenCalled();
+  });
+
+  it("should unassign media from product variant when not all previous selected media ids passed", async () => {
+    const media: HandleAssignMediaParams[0] = ["3"];
+    const variant: HandleAssignMediaParams[1] = {
+      id: "1",
+      media: [
+        {
+          id: "1",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+        {
+          id: "2",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+        {
+          id: "3",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+      ],
+    };
+    const assignMedia = jest.fn(() => Promise.resolve({}));
+    const unassignMedia = jest.fn(() => Promise.resolve({}));
+
+    await handleAssignMedia(media, variant, assignMedia, unassignMedia);
+
+    expect(assignMedia).not.toHaveBeenCalled();
+    expect(unassignMedia).toHaveBeenCalledTimes(2);
+    expect(unassignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "1",
+    });
+    expect(unassignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "2",
+    });
+  });
+
+  it("should assign and unassign media from product variant when not all but more selected media ids from previously selected passed", async () => {
+    const media: HandleAssignMediaParams[0] = ["1", "3"];
+    const variant: HandleAssignMediaParams[1] = {
+      id: "1",
+      media: [
+        {
+          id: "1",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+        {
+          id: "2",
+          url: "",
+          type: ProductMediaType.IMAGE,
+          oembedData: null,
+          __typename: "ProductMedia",
+        },
+      ],
+    };
+    const assignMedia = jest.fn(() => Promise.resolve({}));
+    const unassignMedia = jest.fn(() => Promise.resolve({}));
+
+    await handleAssignMedia(media, variant, assignMedia, unassignMedia);
+
+    expect(assignMedia).toHaveBeenCalledTimes(1);
+    expect(assignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "3",
+    });
+    expect(unassignMedia).toHaveBeenCalledTimes(1);
+    expect(unassignMedia).toHaveBeenCalledWith({
+      variantId: "1",
+      mediaId: "2",
+    });
+  });
+});

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -1,11 +1,20 @@
+import { FetchResult } from "@apollo/client";
 import {
   ChannelData,
   ChannelPriceAndPreorderData,
   ChannelPriceArgs,
   ChannelPriceData,
 } from "@saleor/channels/utils";
-import { ProductChannelListingAddInput } from "@saleor/graphql";
+import {
+  ProductChannelListingAddInput,
+  ProductVariantFragment,
+  VariantMediaAssignMutation,
+  VariantMediaAssignMutationVariables,
+  VariantMediaUnassignMutation,
+  VariantMediaUnassignMutationVariables,
+} from "@saleor/graphql";
 import { FormChange, UseFormResult } from "@saleor/hooks/useForm";
+import { diff } from "fast-array-diff";
 import moment from "moment";
 
 export function createChannelsPriceChangeHandler(
@@ -143,4 +152,80 @@ export const createPreorderEndDateChangeHandler = (
     form.clearErrors("preorderEndDateTime");
   }
   triggerChange();
+};
+
+export const createMediaChangeHandler = (
+  form: UseFormResult<{ media: string[] }>,
+  triggerChange: () => void,
+) => (id: string) => {
+  const media = form.data.media;
+  const isMediaAssigned = media.includes(id);
+
+  if (isMediaAssigned) {
+    form.change({
+      target: {
+        name: "media",
+        value: media.filter(mediaId => mediaId !== id),
+      },
+    });
+  } else {
+    form.change({
+      target: {
+        name: "media",
+        value: [...media, id],
+      },
+    });
+  }
+
+  triggerChange();
+};
+
+export const handleAssignMedia = async (
+  media: string[],
+  variant: ProductVariantFragment,
+  assignMedia: (
+    variables: VariantMediaAssignMutationVariables,
+  ) => Promise<FetchResult<VariantMediaAssignMutation>>,
+  unassignMedia: (
+    variables: VariantMediaUnassignMutationVariables,
+  ) => Promise<FetchResult<VariantMediaUnassignMutation>>,
+) => {
+  const { added, removed } = diff(
+    variant.media.map(mediaObj => mediaObj.id),
+    media,
+  );
+
+  const assignResults = await Promise.all(
+    added.map(mediaId =>
+      assignMedia({
+        mediaId,
+        variantId: variant.id,
+      }),
+    ),
+  );
+  const unassignResults = await Promise.all(
+    removed.map(mediaId =>
+      unassignMedia({
+        mediaId,
+        variantId: variant.id,
+      }),
+    ),
+  );
+
+  const assignErrors = assignResults.reduce(
+    (errors, result) => [
+      ...errors,
+      ...(result.data?.variantMediaAssign.errors || []),
+    ],
+    [],
+  );
+  const unassignErrors = unassignResults.reduce(
+    (errors, result) => [
+      ...errors,
+      ...(result.data?.variantMediaUnassign.errors || []),
+    ],
+    [],
+  );
+
+  return [...assignErrors, ...unassignErrors];
 };

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -157,25 +157,13 @@ export const createPreorderEndDateChangeHandler = (
 export const createMediaChangeHandler = (
   form: UseFormResult<{ media: string[] }>,
   triggerChange: () => void,
-) => (id: string) => {
-  const media = form.data.media;
-  const isMediaAssigned = media.includes(id);
-
-  if (isMediaAssigned) {
-    form.change({
-      target: {
-        name: "media",
-        value: media.filter(mediaId => mediaId !== id),
-      },
-    });
-  } else {
-    form.change({
-      target: {
-        name: "media",
-        value: [...media, id],
-      },
-    });
-  }
+) => (ids: string[]) => {
+  form.change({
+    target: {
+      name: "media",
+      value: ids,
+    },
+  });
 
   triggerChange();
 };

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -180,9 +180,11 @@ export const createMediaChangeHandler = (
   triggerChange();
 };
 
-export const handleAssignMedia = async (
+export const handleAssignMedia = async <
+  T extends Pick<ProductVariantFragment, "id" | "media">
+>(
   media: string[],
-  variant: ProductVariantFragment,
+  variant: T,
   assignMedia: (
     variables: VariantMediaAssignMutationVariables,
   ) => Promise<FetchResult<VariantMediaAssignMutation>>,

--- a/src/storybook/stories/products/ProductVariantImageSelectDialog.tsx
+++ b/src/storybook/stories/products/ProductVariantImageSelectDialog.tsx
@@ -19,7 +19,7 @@ storiesOf("Products / ProductVariantImageSelectDialog", module)
       media={variantProductImages}
       selectedMedia={variantImages.map(image => image.id)}
       onClose={() => undefined}
-      onMediaSelect={() => undefined}
+      onConfirm={() => undefined}
       open={true}
     />
   ));

--- a/src/storybook/stories/products/ProductVariantPage.tsx
+++ b/src/storybook/stories/products/ProductVariantPage.tsx
@@ -25,7 +25,6 @@ storiesOf("Views / Products / Product variant details", module)
       variant={variant}
       onDelete={undefined}
       onSetDefaultVariant={() => undefined}
-      onMediaSelect={() => undefined}
       onSubmit={() => undefined}
       onVariantReorder={() => undefined}
       saveButtonBarState="default"
@@ -54,7 +53,6 @@ storiesOf("Views / Products / Product variant details", module)
       placeholderImage={placeholderImage}
       onDelete={undefined}
       onSetDefaultVariant={() => undefined}
-      onMediaSelect={() => undefined}
       onSubmit={() => undefined}
       onVariantReorder={() => undefined}
       saveButtonBarState="default"
@@ -82,7 +80,6 @@ storiesOf("Views / Products / Product variant details", module)
       variant={variant}
       onDelete={undefined}
       onSetDefaultVariant={() => undefined}
-      onMediaSelect={() => undefined}
       onSubmit={() => undefined}
       onVariantReorder={() => undefined}
       saveButtonBarState="default"
@@ -108,7 +105,6 @@ storiesOf("Views / Products / Product variant details", module)
       variant={variant}
       onDelete={undefined}
       onSetDefaultVariant={() => undefined}
-      onMediaSelect={() => undefined}
       onSubmit={() => undefined}
       onVariantReorder={() => undefined}
       saveButtonBarState="default"

--- a/src/storybook/webpack.d.ts
+++ b/src/storybook/webpack.d.ts
@@ -1,5 +1,0 @@
-declare interface Window {
-  __SALEOR_CONFIG__: {
-    APP_MOUNT_URI?: string;
-  };
-}

--- a/src/storybook/webpack.d.ts
+++ b/src/storybook/webpack.d.ts
@@ -1,0 +1,5 @@
+declare interface Window {
+  __SALEOR_CONFIG__: {
+    APP_MOUNT_URI?: string;
+  };
+}


### PR DESCRIPTION
It changes saving images for variant from saving on select in the modal to saving on submit in the form page. Fixes https://github.com/saleor/saleor-dashboard/issues/2561.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://saleor-6391-simple-taxes.api.saleor.rocks/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1