### PR TITLE
Fix exit form issue in product translations

### DIFF
--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -7,7 +7,7 @@ import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTex
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import useRichText from "@saleor/utils/richText/useRichText";
-import React, { useEffect } from "react";
+import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import TranslationFieldsSave from "./TranslationFieldsSave";
@@ -46,17 +46,8 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
     triggerChange: () => setIsDirty(true),
   });
 
-  const handleSubmit = React.useCallback(
-    async () => onSubmit(await getValue()),
-    [getValue, onSubmit],
-  );
-  useEffect(() => setExitDialogSubmitRef(handleSubmit), [
-    handleSubmit,
-    setExitDialogSubmitRef,
-  ]);
-
-  const submit = async () => {
-    const result = handleSubmit();
+  const handleSubmit = React.useCallback(async () => {
+    const result = onSubmit(await getValue());
     const errors = await result;
     if (errors?.length === 0) {
       setIsDirty(false);
@@ -65,10 +56,15 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
     }
 
     return errors;
-  };
+  }, [getValue, onSubmit, setIsDirty]);
+
+  React.useEffect(() => setExitDialogSubmitRef(handleSubmit), [
+    handleSubmit,
+    setExitDialogSubmitRef,
+  ]);
 
   return edit ? (
-    <form onSubmit={submit}>
+    <form onSubmit={handleSubmit}>
       {isReadyForMount ? (
         <RichTextEditor
           defaultValue={defaultValue}
@@ -97,7 +93,7 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
       <TranslationFieldsSave
         saveButtonState={saveButtonState}
         onDiscard={onDiscard}
-        onSave={submit}
+        onSave={handleSubmit}
       />
     </form>
   ) : initial === null ? (

--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -46,9 +46,26 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
     triggerChange: () => setIsDirty(true),
   });
 
-  useEffect(() => setExitDialogSubmitRef(onSubmit), [onSubmit]);
+  const handleSubmit = React.useCallback(
+    async () => onSubmit(await getValue()),
+    [getValue, onSubmit],
+  );
+  useEffect(() => setExitDialogSubmitRef(handleSubmit), [
+    handleSubmit,
+    setExitDialogSubmitRef,
+  ]);
 
-  const submit = async () => onSubmit(await getValue());
+  const submit = async () => {
+    const result = handleSubmit();
+    const errors = await result;
+    if (errors?.length === 0) {
+      setIsDirty(false);
+
+      return [];
+    }
+
+    return errors;
+  };
 
   return edit ? (
     <form onSubmit={submit}>

--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -1,16 +1,15 @@
 import { OutputData } from "@editorjs/editorjs";
 import { Typography } from "@material-ui/core";
-import { useExitFormDialog } from "@saleor/components/Form/useExitFormDialog";
 import RichTextEditor from "@saleor/components/RichTextEditor";
 import RichTextEditorContent from "@saleor/components/RichTextEditor/RichTextEditorContent";
 import { RichTextEditorLoading } from "@saleor/components/RichTextEditor/RichTextEditorLoading";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
-import useRichText from "@saleor/utils/richText/useRichText";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import TranslationFieldsSave from "./TranslationFieldsSave";
+import { useRichTextSubmit } from "./useRichTextSubmit";
 
 interface TranslationFieldsRichProps {
   disabled: boolean;
@@ -33,35 +32,13 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
 }) => {
   const intl = useIntl();
 
-  const { setIsDirty, setExitDialogSubmitRef } = useExitFormDialog();
-
   const {
-    defaultValue,
-    editorRef,
     isReadyForMount,
-    handleChange,
-    getValue,
-  } = useRichText({
-    initial,
-    triggerChange: () => setIsDirty(true),
-  });
-
-  const handleSubmit = React.useCallback(async () => {
-    const result = onSubmit(await getValue());
-    const errors = await result;
-    if (errors?.length === 0) {
-      setIsDirty(false);
-
-      return [];
-    }
-
-    return errors;
-  }, [getValue, onSubmit, setIsDirty]);
-
-  React.useEffect(() => setExitDialogSubmitRef(handleSubmit), [
     handleSubmit,
-    setExitDialogSubmitRef,
-  ]);
+    defaultValue,
+    handleChange,
+    editorRef,
+  } = useRichTextSubmit(initial, onSubmit);
 
   return edit ? (
     <form onSubmit={handleSubmit}>

--- a/src/translations/components/TranslationFields/useRichTextSubmit.test.ts
+++ b/src/translations/components/TranslationFields/useRichTextSubmit.test.ts
@@ -1,40 +1,23 @@
-import { SubmitPromise } from "@saleor/hooks/useForm";
+import useRichText from "@saleor/utils/richText/useRichText";
 import { renderHook } from "@testing-library/react-hooks";
 
 import { useRichTextSubmit } from "./useRichTextSubmit";
 
-const richTextMock = `{
-  time: 1669371906847,
-  blocks: [
-    {
-      id: "TLzBn1f3y0",
-      data: { text: "40x40 Terracota" },
-      type: "paragraph",
-    },
-  ],
-  version: "2.24.3",
-}`;
-
-const setup = (inital: string, submitFn: () => SubmitPromise) =>
-  renderHook(() => {
-    const { handleSubmit, editorRef } = useRichTextSubmit(inital, submitFn);
-
-    return {
-      handleSubmit,
-      editorRef,
-    };
-  });
+jest.mock("@saleor/utils/richText/useRichText", () => jest.fn());
 
 describe("useRichTextSubmit", () => {
-  it("Submits the data", async () => {
+  it("submits value from editor succesfully", async () => {
     // Given
-    const submitFn = jest.fn(() => Promise.resolve([]));
-    const { result } = setup(richTextMock, submitFn);
+    const textEditorValue = "text editor value";
+    const getValue = jest.fn(() => textEditorValue);
+    (useRichText as jest.Mock).mockImplementation(() => ({ getValue }));
+    const submitFn = jest.fn();
+    const { result } = renderHook(() => useRichTextSubmit("initial", submitFn));
 
     // When
-    result.current.handleSubmit();
+    await result.current.handleSubmit();
 
     // Then
-    expect(submitFn).toHaveBeenCalledWith(richTextMock);
+    expect(submitFn).toHaveBeenCalledWith(textEditorValue);
   });
 });

--- a/src/translations/components/TranslationFields/useRichTextSubmit.test.ts
+++ b/src/translations/components/TranslationFields/useRichTextSubmit.test.ts
@@ -1,0 +1,40 @@
+import { SubmitPromise } from "@saleor/hooks/useForm";
+import { renderHook } from "@testing-library/react-hooks";
+
+import { useRichTextSubmit } from "./useRichTextSubmit";
+
+const richTextMock = `{
+  time: 1669371906847,
+  blocks: [
+    {
+      id: "TLzBn1f3y0",
+      data: { text: "40x40 Terracota" },
+      type: "paragraph",
+    },
+  ],
+  version: "2.24.3",
+}`;
+
+const setup = (inital: string, submitFn: () => SubmitPromise) =>
+  renderHook(() => {
+    const { handleSubmit, editorRef } = useRichTextSubmit(inital, submitFn);
+
+    return {
+      handleSubmit,
+      editorRef,
+    };
+  });
+
+describe("useRichTextSubmit", () => {
+  it("Submits the data", async () => {
+    // Given
+    const submitFn = jest.fn(() => Promise.resolve([]));
+    const { result } = setup(richTextMock, submitFn);
+
+    // When
+    result.current.handleSubmit();
+
+    // Then
+    expect(submitFn).toHaveBeenCalledWith(richTextMock);
+  });
+});

--- a/src/translations/components/TranslationFields/useRichTextSubmit.ts
+++ b/src/translations/components/TranslationFields/useRichTextSubmit.ts
@@ -23,6 +23,7 @@ export function useRichTextSubmit(
 
   const handleSubmit = React.useCallback(async () => {
     const result = onSubmit(await getValue());
+
     const errors = await result;
     if (errors?.length === 0) {
       setIsDirty(false);

--- a/src/translations/components/TranslationFields/useRichTextSubmit.ts
+++ b/src/translations/components/TranslationFields/useRichTextSubmit.ts
@@ -1,0 +1,48 @@
+import { OutputData } from "@editorjs/editorjs";
+import { useExitFormDialog } from "@saleor/components/Form/useExitFormDialog";
+import { SubmitPromise } from "@saleor/hooks/useForm";
+import useRichText from "@saleor/utils/richText/useRichText";
+import React from "react";
+
+export function useRichTextSubmit(
+  initial: string,
+  onSubmit: (data: OutputData) => SubmitPromise,
+) {
+  const { setIsDirty, setExitDialogSubmitRef } = useExitFormDialog();
+
+  const {
+    defaultValue,
+    editorRef,
+    isReadyForMount,
+    handleChange,
+    getValue,
+  } = useRichText({
+    initial,
+    triggerChange: () => setIsDirty(true),
+  });
+
+  const handleSubmit = React.useCallback(async () => {
+    const result = onSubmit(await getValue());
+    const errors = await result;
+    if (errors?.length === 0) {
+      setIsDirty(false);
+
+      return [];
+    }
+
+    return errors;
+  }, [getValue, onSubmit, setIsDirty]);
+
+  React.useEffect(() => setExitDialogSubmitRef(handleSubmit), [
+    handleSubmit,
+    setExitDialogSubmitRef,
+  ]);
+
+  return {
+    defaultValue,
+    editorRef,
+    isReadyForMount,
+    handleChange,
+    handleSubmit,
+  };
+}


### PR DESCRIPTION
Fixes: https://github.com/saleor/saleor-dashboard/issues/2599

I want to merge this change because it fixes exit form feature in product translations. Fixes #2599.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1