### PR TITLE
Hide shipping zones when you do not have access (#2333)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/channels/components/AssignmentList/AssignmentListHeader.tsx
+++ b/src/channels/components/AssignmentList/AssignmentListHeader.tsx
@@ -14,11 +14,11 @@ const AssignmentListHeader: React.FC<AssignmentListHeaderProps> = ({
   assignCount,
   itemsName,
 }) => {
-  const classes = useHeaderStyles();
+  const { container, ...accordion } = useHeaderStyles();
 
   return (
-    <div className={classes.container}>
-      <AccordionSummary expandIcon={<IconChevronDown />} classes={classes}>
+    <div className={container}>
+      <AccordionSummary expandIcon={<IconChevronDown />} classes={accordion}>
         <Typography variant="subtitle2" color="textSecondary">
           {`${assignCount} ${itemsName.toLowerCase()}`}
         </Typography>

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -4,6 +4,7 @@ import { channelsListUrl } from "@saleor/channels/urls";
 import CardSpacer from "@saleor/components/CardSpacer";
 import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
+import RequirePermissions from "@saleor/components/RequirePermissions";
 import Savebar from "@saleor/components/Savebar";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import {
@@ -11,6 +12,7 @@ import {
   ChannelErrorFragment,
   CountryCode,
   CountryFragment,
+  PermissionEnum,
   SearchShippingZonesQuery,
   SearchWarehousesQuery,
 } from "@saleor/graphql";
@@ -265,25 +267,37 @@ const ChannelDetailsPage = function<TErrors>({
                     <CardSpacer />
                   </>
                 )}
-                <ShippingZones
-                  shippingZonesChoices={getFilteredShippingZonesChoices()}
-                  shippingZones={shippingZonesToDisplay}
-                  addShippingZone={addShippingZone}
-                  removeShippingZone={removeShippingZone}
-                  searchShippingZones={searchShippingZones}
-                  fetchMoreShippingZones={fetchMoreShippingZones}
-                  totalCount={allShippingZonesCount}
-                />
-                <CardSpacer />
-                <Warehouses
-                  warehousesChoices={getFilteredWarehousesChoices()}
-                  warehouses={warehousesToDisplay}
-                  addWarehouse={addWarehouse}
-                  removeWarehouse={removeWarehouse}
-                  searchWarehouses={searchWarehouses}
-                  fetchMoreWarehouses={fetchMoreWarehouses}
-                  totalCount={allWarehousesCount}
-                />
+                <RequirePermissions
+                  requiredPermissions={[PermissionEnum.MANAGE_SHIPPING]}
+                >
+                  <ShippingZones
+                    shippingZonesChoices={getFilteredShippingZonesChoices()}
+                    shippingZones={shippingZonesToDisplay}
+                    addShippingZone={addShippingZone}
+                    removeShippingZone={removeShippingZone}
+                    searchShippingZones={searchShippingZones}
+                    fetchMoreShippingZones={fetchMoreShippingZones}
+                    totalCount={allShippingZonesCount}
+                  />
+                  <CardSpacer />
+                </RequirePermissions>
+                <RequirePermissions
+                  oneOfPermissions={[
+                    PermissionEnum.MANAGE_SHIPPING,
+                    PermissionEnum.MANAGE_ORDERS,
+                    PermissionEnum.MANAGE_PRODUCTS,
+                  ]}
+                >
+                  <Warehouses
+                    warehousesChoices={getFilteredWarehousesChoices()}
+                    warehouses={warehousesToDisplay}
+                    addWarehouse={addWarehouse}
+                    removeWarehouse={removeWarehouse}
+                    searchWarehouses={searchWarehouses}
+                    fetchMoreWarehouses={fetchMoreWarehouses}
+                    totalCount={allWarehousesCount}
+                  />
+                </RequirePermissions>
               </div>
             </Grid>
             <Savebar

--- a/src/channels/views/ChannelCreate/ChannelCreate.tsx
+++ b/src/channels/views/ChannelCreate/ChannelCreate.tsx
@@ -3,12 +3,9 @@ import { Backlink } from "@saleor/components/Backlink";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import {
   ChannelCreateMutation,
   useChannelCreateMutation,
-  useShippingZonesCountQuery,
-  useWarehousesCountQuery,
 } from "@saleor/graphql";
 import { getSearchFetchMoreProps } from "@saleor/hooks/makeTopLevelSearch/utils";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -17,14 +14,14 @@ import { getDefaultNotifierSuccessErrorData } from "@saleor/hooks/useNotifier/ut
 import useShop from "@saleor/hooks/useShop";
 import { sectionNames } from "@saleor/intl";
 import { extractMutationErrors } from "@saleor/misc";
-import useShippingZonesSearch from "@saleor/searches/useShippingZonesSearch";
-import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import currencyCodes from "currency-codes";
 import React from "react";
 import { useIntl } from "react-intl";
 
 import ChannelDetailsPage from "../../pages/ChannelDetailsPage";
 import { channelPath, channelsListUrl } from "../../urls";
+import { useShippingZones } from "../ChannelDetails/useShippingZones";
+import { useWarehouses } from "../ChannelDetails/useWarehouses";
 
 export const ChannelCreateView = ({}) => {
   const navigate = useNavigator();
@@ -66,30 +63,20 @@ export const ChannelCreateView = ({}) => {
     );
 
   const {
-    data: shippingZonesCountData,
-    loading: shippingZonesCountLoading,
-  } = useShippingZonesCountQuery();
+    shippingZonesCountData,
+    shippingZonesCountLoading,
+    fetchMoreShippingZones,
+    searchShippingZones,
+    searchShippingZonesResult,
+  } = useShippingZones();
 
   const {
-    loadMore: fetchMoreShippingZones,
-    search: searchShippingZones,
-    result: searchShippingZonesResult,
-  } = useShippingZonesSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA,
-  });
-
-  const {
-    data: warehousesCountData,
-    loading: warehousesCountLoading,
-  } = useWarehousesCountQuery();
-
-  const {
-    loadMore: fetchMoreWarehouses,
-    search: searchWarehouses,
-    result: searchWarehousesResult,
-  } = useWarehouseSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA,
-  });
+    warehousesCountData,
+    warehousesCountLoading,
+    fetchMoreWarehouses,
+    searchWarehouses,
+    searchWarehousesResult,
+  } = useWarehouses();
 
   const currencyCodeChoices = currencyCodes.data.map(currencyData => ({
     label: intl.formatMessage(

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -5,7 +5,6 @@ import { Backlink } from "@saleor/components/Backlink";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import {
   ChannelDeleteMutation,
   ChannelErrorFragment,
@@ -14,12 +13,8 @@ import {
   useChannelDeactivateMutation,
   useChannelDeleteMutation,
   useChannelQuery,
-  useChannelShippingZonesQuery,
   useChannelsQuery,
   useChannelUpdateMutation,
-  useChannelWarehousesQuery,
-  useShippingZonesCountQuery,
-  useWarehousesCountQuery,
 } from "@saleor/graphql";
 import { getSearchFetchMoreProps } from "@saleor/hooks/makeTopLevelSearch/utils";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -28,8 +23,6 @@ import { getDefaultNotifierSuccessErrorData } from "@saleor/hooks/useNotifier/ut
 import useShop from "@saleor/hooks/useShop";
 import { sectionNames } from "@saleor/intl";
 import { extractMutationErrors } from "@saleor/misc";
-import useShippingZonesSearch from "@saleor/searches/useShippingZonesSearch";
-import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import getChannelsErrorMessage from "@saleor/utils/errors/channels";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import React from "react";
@@ -42,6 +35,8 @@ import {
   ChannelUrlDialog,
   ChannelUrlQueryParams,
 } from "../../urls";
+import { useShippingZones } from "./useShippingZones";
+import { useWarehouses } from "./useWarehouses";
 
 interface ChannelDetailsProps {
   id: string;
@@ -166,52 +161,24 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
   };
 
   const {
-    data: shippingZonesCountData,
-    loading: shippingZonesCountLoading,
-  } = useShippingZonesCountQuery();
+    shippingZonesCountData,
+    shippingZonesCountLoading,
+    channelShippingZonesData,
+    channelsShippingZonesLoading,
+    fetchMoreShippingZones,
+    searchShippingZones,
+    searchShippingZonesResult,
+  } = useShippingZones(id);
 
   const {
-    data: channelShippingZonesData,
-    loading: channelsShippingZonesLoading,
-  } = useChannelShippingZonesQuery({
-    variables: {
-      filter: {
-        channels: [id],
-      },
-    },
-  });
-
-  const {
-    loadMore: fetchMoreShippingZones,
-    search: searchShippingZones,
-    result: searchShippingZonesResult,
-  } = useShippingZonesSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA,
-  });
-
-  const {
-    data: warehousesCountData,
-    loading: warehousesCountLoading,
-  } = useWarehousesCountQuery();
-
-  const {
-    data: channelWarehousesData,
-    loading: channelsWarehousesLoading,
-  } = useChannelWarehousesQuery({
-    variables: {
-      filter: {
-        channels: [id],
-      },
-    },
-  });
-
-  const {
-    loadMore: fetchMoreWarehouses,
-    search: searchWarehouses,
-    result: searchWarehousesResult,
-  } = useWarehouseSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA,
-  });
+    warehousesCountData,
+    warehousesCountLoading,
+    channelWarehousesData,
+    channelWarehousesLoading,
+    fetchMoreWarehouses,
+    searchWarehouses,
+    searchWarehousesResult,
+  } = useWarehouses();
 
   return (
     <>
@@ -257,7 +224,7 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
             shippingZonesCountLoading ||
             warehousesCountLoading ||
             channelsShippingZonesLoading ||
-            channelsWarehousesLoading
+            channelWarehousesLoading
           }
           disabledStatus={
             activateChannelOpts.loading || deactivateChannelOpts.loading

--- a/src/channels/views/ChannelDetails/useShippingZones.ts
+++ b/src/channels/views/ChannelDetails/useShippingZones.ts
@@ -1,0 +1,52 @@
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
+import { hasPermissions } from "@saleor/components/RequirePermissions";
+import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  PermissionEnum,
+  useChannelShippingZonesQuery,
+  useShippingZonesCountQuery,
+} from "@saleor/graphql";
+import useShippingZonesSearch from "@saleor/searches/useShippingZonesSearch";
+
+export const useShippingZones = (channelId?: string) => {
+  const userPermissions = useUserPermissions();
+  const canLoadShippingZones = hasPermissions(userPermissions, [
+    PermissionEnum.MANAGE_SHIPPING,
+  ]);
+
+  const {
+    data: shippingZonesCountData,
+    loading: shippingZonesCountLoading,
+  } = useShippingZonesCountQuery({ skip: !canLoadShippingZones });
+
+  const {
+    data: channelShippingZonesData,
+    loading: channelsShippingZonesLoading,
+  } = useChannelShippingZonesQuery({
+    variables: {
+      filter: {
+        channels: [channelId],
+      },
+    },
+    skip: !channelId || !canLoadShippingZones,
+  });
+
+  const {
+    loadMore: fetchMoreShippingZones,
+    search: searchShippingZones,
+    result: searchShippingZonesResult,
+  } = useShippingZonesSearch({
+    variables: DEFAULT_INITIAL_SEARCH_DATA,
+    skip: !canLoadShippingZones,
+  });
+
+  return {
+    shippingZonesCountData,
+    shippingZonesCountLoading,
+    channelShippingZonesData,
+    channelsShippingZonesLoading,
+    fetchMoreShippingZones,
+    searchShippingZones,
+    searchShippingZonesResult,
+  };
+};

--- a/src/channels/views/ChannelDetails/useWarehouses.ts
+++ b/src/channels/views/ChannelDetails/useWarehouses.ts
@@ -1,0 +1,57 @@
+import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
+import { hasOneOfPermissions } from "@saleor/components/RequirePermissions";
+import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  PermissionEnum,
+  useChannelWarehousesQuery,
+  useWarehousesCountQuery,
+} from "@saleor/graphql";
+import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
+
+export const useWarehouses = (channelId?: string) => {
+  const userPermissions = useUserPermissions();
+  const canLoadWarehouses = hasOneOfPermissions(userPermissions, [
+    PermissionEnum.MANAGE_SHIPPING,
+    PermissionEnum.MANAGE_ORDERS,
+    PermissionEnum.MANAGE_PRODUCTS,
+  ]);
+
+  const {
+    data: warehousesCountData,
+    loading: warehousesCountLoading,
+  } = useWarehousesCountQuery({ skip: !canLoadWarehouses });
+
+  const {
+    data: channelWarehousesData,
+    loading: channelWarehousesLoading,
+  } = useChannelWarehousesQuery(
+    channelId
+      ? {
+          variables: {
+            filter: {
+              channels: [channelId],
+            },
+          },
+        }
+      : undefined,
+  );
+
+  const {
+    loadMore: fetchMoreWarehouses,
+    search: searchWarehouses,
+    result: searchWarehousesResult,
+  } = useWarehouseSearch({
+    variables: DEFAULT_INITIAL_SEARCH_DATA,
+    skip: !canLoadWarehouses,
+  });
+
+  return {
+    warehousesCountData,
+    warehousesCountLoading,
+    channelWarehousesData,
+    channelWarehousesLoading,
+    fetchMoreWarehouses,
+    searchWarehouses,
+    searchWarehousesResult,
+  };
+};

--- a/src/components/RequirePermissions.tsx
+++ b/src/components/RequirePermissions.tsx
@@ -2,32 +2,58 @@ import { useUserPermissions } from "@saleor/auth/hooks/useUserPermissions";
 import { PermissionEnum, UserPermissionFragment } from "@saleor/graphql";
 import React from "react";
 
+const findPerm = (permList, perm) =>
+  permList.find(userPerm => userPerm.code === perm);
+
 export function hasPermissions(
   userPermissions: UserPermissionFragment[],
   requiredPermissions: PermissionEnum[],
 ): boolean {
   return requiredPermissions.reduce(
-    (acc, perm) =>
-      acc && !!userPermissions.find(userPerm => userPerm.code === perm),
+    (acc, perm) => acc && !!findPerm(userPermissions, perm),
     true,
   );
 }
 
+export function hasOneOfPermissions(
+  userPermissions: UserPermissionFragment[],
+  givenPermissions: PermissionEnum[],
+): boolean {
+  return givenPermissions.some(perm => !!findPerm(userPermissions, perm));
+}
+
 export interface RequirePermissionsProps {
   children: React.ReactNode | React.ReactNodeArray;
-  requiredPermissions: PermissionEnum[];
+  requiredPermissions?: PermissionEnum[];
+  oneOfPermissions?: PermissionEnum[];
 }
 
 const RequirePermissions: React.FC<RequirePermissionsProps> = ({
   children,
   requiredPermissions,
+  oneOfPermissions,
 }) => {
   const userPermissions = useUserPermissions();
 
-  return userPermissions &&
-    hasPermissions(userPermissions, requiredPermissions) ? (
-    <>{children}</>
-  ) : null;
+  if (!userPermissions) {
+    return null;
+  }
+
+  if (
+    requiredPermissions &&
+    hasPermissions(userPermissions, requiredPermissions)
+  ) {
+    return <>{children}</>;
+  }
+
+  if (
+    oneOfPermissions &&
+    hasOneOfPermissions(userPermissions, oneOfPermissions)
+  ) {
+    return <>{children}</>;
+  }
+
+  return null;
 };
 
 RequirePermissions.displayName = "RequirePermissions";


### PR DESCRIPTION
I want to merge this change because it is a port of #2333 to 3.6. Some merge conflicts occurred, review is not necessary but should be tested.

**Acceptance criteria:**

When I login as user without any of these permissions:
- MANAGE_SHIPPING,
- MANAGE_ORDERS,
- MANAGE_PRODUCTS,

to dashboard app then when I enter either of these views: 
- Configuration/Channels/Create New Channel
- Configuration/Channels/Edit Channel

I'm not able to see **Warehouses** card

When I login as user without MANAGE_SHIPPING permission to dashboard app then when I enter either of these views: 
- Configuration/Channels/Create New Channel
- Configuration/Channels/Edit Channel

I'm not able to see **Shipping Zones** card

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> 3.6

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://v36.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1