### PR TITLE
On release tests run only critical paths 3.1

### DIFF
--- a/.github/workflows/approveAndMergeReleasePR.js
+++ b/.github/workflows/approveAndMergeReleasePR.js
@@ -1,0 +1,257 @@
+const { Octokit } = require("@octokit/core");
+const { Command } = require("commander");
+const { GraphQLClient } = require("graphql-request");
+
+const program = new Command();
+const client = new GraphQLClient("https://dashboard.cypress.io/graphql");
+
+const repo = "saleor-cloud-deployments";
+const owner = "saleor";
+
+program
+  .name("Approve PR")
+  .description("Approve and merge PR if patch release")
+  .option("--version <version>", "version of a project")
+  .option("--pull_request_number <pull_request_number>", "Pull Request number")
+  .option("--auto_release <auto_release>", "is auto release")
+  .option("--dashboard_url <dashboard_url>", "Cypress dashboard url")
+  .action(async options => {
+    const octokit = new Octokit({
+      auth: process.env.GITHUB_TOKEN
+    });
+
+    const pullNumber = options.pull_request_number;
+
+    const pullRequest = await octokit.request(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+      {
+        owner,
+        repo,
+        pull_number: pullNumber
+      }
+    );
+
+    const commitId = pullRequest.data.merge_commit_sha;
+
+    const data = await getTestsStatusAndId(options.dashboard_url);
+
+    let testsStatus = data.status;
+
+    let requestBody = `Cypress tests passed. See results at ${options.dashboard_url}`;
+
+    if (testsStatus === "FAILED") {
+      const failedNewTests = [];
+      const listOfTestIssues = await getListOfTestsIssues(octokit);
+      const testCases = await getFailedTestCases(data.runId);
+      testCases.forEach(testCase => {
+        if (testCase.titleParts) {
+          const issue = issueOnGithub(listOfTestIssues, testCase.titleParts[1]);
+          if (issue) {
+            const knownBug = isIssueAKnownBugForReleaseVersion(
+              issue,
+              options.version
+            );
+            if (!knownBug) {
+              failedNewTests.push({
+                title: testCase.titleParts[1],
+                url: issue.html_url,
+                spec: testCase.titleParts[0]
+              });
+            }
+          } else {
+            failedNewTests.push({
+              title: testCase.titleParts[1],
+              spec: testCase.titleParts[0]
+            });
+          }
+        }
+      });
+
+      if (failedNewTests.length === 0) {
+        requestBody = `All failed tests are known bugs, can be merged. See results at ${options.dashboard_url}`;
+        testsStatus = "PASSED";
+      } else if (failedNewTests.length > 10) {
+        //If there are more than 10 new bugs it's probably caused by something else. Server responses with 500, or test user was deleted, etc.
+
+        requestBody =
+          "There is more than 10 new bugs, check results manually and create issues for them if necessary";
+      } else {
+        requestBody = `New bugs found, results at: ${options.dashboard_url}. List of issues to check: `;
+        for (const newBug of failedNewTests) {
+          if (!newBug.url) {
+            const issueUrl = await createIssue(
+              newBug,
+              options.version,
+              octokit
+            );
+            requestBody += `\n${newBug.title} - ${issueUrl}`;
+          } else {
+            requestBody += `\n${newBug.title} - ${newBug.url}`;
+          }
+        }
+        requestBody += `\nIf this bugs won't be fixed in next patch release for this version mark them as known issues`;
+      }
+    }
+
+    const event = "COMMENT";
+
+    await octokit.request(
+      "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      {
+        owner,
+        repo,
+        pull_number: pullNumber,
+        commit_id: commitId,
+        body: requestBody,
+        event,
+        comments: []
+      }
+    );
+
+    if (
+      options.auto_release &&
+      isPatchRelease(options.version) &&
+      testsStatus === "PASSED"
+    ) {
+      await octokit.request(
+        "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge",
+        {
+          owner,
+          repo,
+          pull_number: pullNumber,
+          merge_method: "squash"
+        }
+      );
+    }
+  })
+  .parse();
+
+function isPatchRelease(version) {
+  const regex = /\d+\.\d+\.[1-9]/;
+  return version.match(regex) ? true : false;
+}
+
+async function getTestsStatusAndId(dashboardUrl) {
+  const getProjectRegex = /\/projects\/([^\/]*)/;
+  const getRunRegex = /\/runs\/([^\/]*)/;
+
+  const requestVariables = {
+    projectId: dashboardUrl.match(getProjectRegex)[1],
+    buildNumber: dashboardUrl.match(getRunRegex)[1]
+  };
+
+  const throwErrorAfterTimeout = setTimeout(function() {
+    throw new Error("Run have still running status, after all tests executed");
+  }, 1200000);
+
+  const data = await waitForTestsToFinish(requestVariables);
+
+  clearTimeout(throwErrorAfterTimeout);
+  return { status: data.status, runId: data.id };
+}
+
+async function waitForTestsToFinish(requestVariables) {
+  return new Promise((resolve, reject) => {
+    client
+      .request(
+        `query ($projectId: String!, $buildNumber: ID!) {
+      runByBuildNumber(buildNumber: $buildNumber, projectId: $projectId) {
+        status,
+        id
+      }
+    }`,
+        requestVariables
+      )
+      .then(response => {
+        if (response.runByBuildNumber.status === "RUNNING") {
+          setTimeout(async function() {
+            resolve(await waitForTestsToFinish(requestVariables));
+          }, 10000);
+        } else {
+          resolve(response.runByBuildNumber);
+        }
+      });
+  });
+}
+
+async function getFailedTestCases(runId) {
+  const requestVariables = {
+    input: {
+      runId,
+      testResultState: ["FAILED"]
+    }
+  };
+
+  return new Promise((resolve, reject) => {
+    client
+      .request(
+        `query RunTestResults($input: TestResultsTableInput!) {
+          testResults(input: $input) {
+            ... on TestResult {
+            ...RunTestResult
+            }
+          }
+        }
+        fragment RunTestResult on TestResult {  id  titleParts  state}`,
+        requestVariables
+      )
+      .then(response => {
+        resolve(response.testResults);
+      });
+  });
+}
+
+async function getListOfTestsIssues(octokit) {
+  const result = await octokit.request(
+    "GET /repos/{owner}/saleor-dashboard/issues?labels=tests",
+    {
+      owner
+    }
+  );
+  return result.data;
+}
+
+function issueOnGithub(listOfTestIssues, testCaseTitle) {
+  if (listOfTestIssues.length > 0) {
+    return listOfTestIssues.find(issue => {
+      return issue.title.includes(testCaseTitle);
+    });
+  }
+}
+
+function isIssueAKnownBugForReleaseVersion(issue, releaseVersion) {
+  const issueBody = issue.body;
+  const regex = /Known bug for versions:([\s\S]*)Additional/;
+  const lines = issueBody.match(regex)[1].split("\n");
+  const lineContainReleaseVersionRegex = /v(\d{2,3}).*(true|false)/;
+  const releaseVersionLine = lines.find(line => {
+    if (line.match(lineContainReleaseVersionRegex)) {
+      const version = line.match(lineContainReleaseVersionRegex)[1];
+      if (version === getFormattedVersion(releaseVersion)) {
+        return line;
+      }
+    }
+  });
+  const knownBugOnReleaseVersion = releaseVersionLine
+    ? releaseVersionLine.match(lineContainReleaseVersionRegex)[2]
+    : false;
+  return knownBugOnReleaseVersion === "true" ? true : false;
+}
+
+function getFormattedVersion(version) {
+  const regex = /^\d+\.\d+\./;
+  return version.match(regex)[0].replace(/\./g, "");
+}
+
+async function createIssue(newBug, version, octokit) {
+  const issue = await octokit.request("POST /repos/{owner}/{repo}/issues", {
+    owner,
+    repo: "saleor-dashboard",
+    title: `Cypress test fail: ${newBug.title}`,
+    body: `**Known bug for versions:**\nv${getFormattedVersion(
+      version
+    )}: false\n**Additional Info:**\nSpec: ${newBug.spec}`,
+    labels: ["tests"]
+  });
+  return issue.data.html_url;
+}

--- a/.github/workflows/getEnvironmentVariables.js
+++ b/.github/workflows/getEnvironmentVariables.js
@@ -1,0 +1,143 @@
+const { Command } = require("commander");
+const core = require("@actions/core");
+const fetch = require("node-fetch");
+const { Octokit } = require("@octokit/core");
+
+const program = new Command();
+
+program
+  .name("Approve PR")
+  .description("Approve and merge PR if patch release")
+  .option("--version <version>", "version of a project")
+  .option("--token <token>", "token fo login to cloud")
+  .action(async options => {
+    const isOldVersion = await checkIfOldVersion(options.version);
+    core.setOutput("IS_OLD_VERSION", isOldVersion);
+
+    if (!isPatchRelease(options.version)) {
+      const taskId = await updateEnvironment(
+        environmentId,
+        options.version,
+        options.token
+      );
+      const throwErrorAfterTimeout = setTimeout(function() {
+        throw new Error("Environment didn't upgraded after 20 minutes");
+      }, 1200000);
+      await waitUntilTaskInProgress(
+        taskId,
+        options.token,
+        throwErrorAfterTimeout
+      );
+      const domain = await getDomainForUpdatedEnvironment(
+        environmentId,
+        options.token
+      );
+      clearTimeout(throwErrorAfterTimeout);
+      core.setOutput("url", `https://${domain}/`);
+    } else {
+      core.setOutput(
+        "url",
+        `https://v${getFormattedVersion(options.version)}.staging.saleor.cloud/`
+      );
+    }
+  })
+  .parse();
+
+async function updateEnvironment(environmentId, version, token) {
+  const response = await fetch(
+    `https://staging-cloud.saleor.io/api/organizations/qa/environments/${environmentId}/upgrade/`,
+    {
+      method: "PUT",
+      body: `{ "service": "saleor-staging-v${getFormattedVersion(version)}" }`,
+      headers: {
+        Authorization: `Token ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json;charset=UTF-8"
+      }
+    }
+  );
+  const responseInJson = await response.json();
+  if (!responseInJson.task_id)
+    throw new Error(
+      `Can't update environment- ${JSON.stringify(responseInJson)}`
+    );
+  return responseInJson.task_id;
+}
+
+async function waitUntilTaskInProgress(taskId, token) {
+  const response = await fetch(
+    `https://staging-cloud.saleor.io/api/service/task-status/${taskId}/`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json;charset=UTF-8"
+      }
+    }
+  );
+  const responseInJson = await response.json();
+  console.log(`Job status - ${responseInJson.status}`);
+  if (
+    responseInJson.status == "PENDING" ||
+    responseInJson.status == "IN_PROGRESS"
+  ) {
+    setTimeout(function() {
+      waitUntilTaskInProgress(taskId, token);
+    }, 10000);
+  } else if (responseInJson.status == "SUCCEEDED") {
+    return responseInJson.status;
+  } else if (responseInJson.status !== "SUCCEEDED") {
+    console.log("error");
+
+    throw new Error(
+      `Job ended with status - ${responseInJson.status} - ${responseInJson.job_name}`
+    );
+  }
+}
+
+function isPatchRelease(version) {
+  const regex = /\d+\.\d+\.[1-9]/;
+  return version.match(regex) ? true : false;
+}
+
+function getFormattedVersion(version) {
+  const regex = /^\d+\.\d+\./;
+  return version.match(regex)[0].replace(/\./g, "");
+}
+
+async function getDomainForUpdatedEnvironment(environmentId, token) {
+  const response = await fetch(
+    `https://staging-cloud.saleor.io/api/organizations/qa/environments/${environmentId}`,
+    {
+      method: "GET",
+      json: true,
+      responseType: "json",
+      headers: {
+        Authorization: `Token ${token}`
+      }
+    }
+  );
+  const responseInJson = await response.json();
+  return responseInJson.domain;
+}
+
+async function checkIfOldVersion(version) {
+  const newestVersion = await getTheNewestVersion();
+  const howManyVersionsBehind =
+    getFormattedVersion(newestVersion) - getFormattedVersion(version);
+  //All versions besides last three are old versions
+  return howManyVersionsBehind > 2 ? "true" : "false";
+}
+
+async function getTheNewestVersion() {
+  const octokit = new Octokit();
+
+  const response = await octokit.request(
+    "GET /repos/{owner}/{repo}/releases/latest",
+    {
+      owner: "saleor",
+      repo: "saleor-dashboard"
+    }
+  );
+  return response.data["tag_name"];
+}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -156,7 +156,27 @@ jobs:
         env:
           version: ${{github.event.client_payload.version}}
         run: |
-              echo "::set-output name=formatted_version::$(echo $version | grep -ohE "[0-9]\.[0-9]+" | sed s/\\.// )" 
+              echo "::set-output name=ref::$(echo $version | grep -ohE "[0-9]\.[0-9]+" )"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.branch.outputs.ref }}
+
+      - name: Set tag for tests
+        id: set-tag-for-tests
+        uses: actions/github-script@v6
+        env:
+          is_old_version: ${{ needs.get-environment-variables.outputs.is_old_version }}
+        with:
+          result-encoding: string
+          script: |
+            const { is_old_version } = process.env
+            if(is_old_version == "true"){
+              return "@oldRelease"
+            }else{
+              return "@stable"
+            }
               
       - name: Cypress run - automatically
         uses: cypress-io/github-action@v4

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -12,6 +12,7 @@ on:
         - '@allEnv'
         - '@critical'
         - '@stable'
+        - '@oldRelease'
       environment:
         required: true 
         description: 'Environment to run tests against'
@@ -94,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -138,15 +139,47 @@ jobs:
           record: true
           tag: ${{ steps.get-env-uri.outputs.ENV_URI }},${{ github.event.inputs.tags }}
 
+  get-environment-variables:
+    if: ${{ github.event_name == 'repository_dispatch' && (github.event.client_payload.environment == 'SANDBOX' || github.event.client_payload.environment == 'STAGING')}}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      url: ${{ steps.get-environment-variables.outputs.url }}
+      is_old_version: ${{ steps.get-environment-variables.outputs.IS_OLD_VERSION }}
+    env:
+      TOKEN: ${{ secrets.CLOUD_ACCESS_TOKEN }}
+      VERSION: ${{github.event.client_payload.version}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          
+      - name: Install dependencies
+        run: |
+              cd .github/workflows
+              npm ci
+
+      - name: get environment variables
+        id: get-environment-variables
+        run: |
+              node .github/workflows/getEnvironmentVariables.js \
+              --version $VERSION \
+              --token "$TOKEN"
+
   run-tests-on-release:
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment != 'PROD' && github.event.client_payload.environment != 'ENTERPRISE'}}
+    if: ${{ github.event_name == 'repository_dispatch' && (github.event.client_payload.environment == 'SANDBOX' || github.event.client_payload.environment == 'STAGING')}}
+    needs: get-environment-variables
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.16.0-chrome89-ff86
     strategy:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -181,9 +214,9 @@ jobs:
       - name: Cypress run - automatically
         uses: cypress-io/github-action@v4
         env:
-          API_URI: https://v${{ steps.version.outputs.formatted_version }}.staging.saleor.cloud/graphql/
+          API_URI: ${{ needs.get-environment-variables.outputs.url }}graphql/
           APP_MOUNT_URI: ${{ secrets.APP_MOUNT_URI }}
-          CYPRESS_baseUrl: https://v${{ steps.version.outputs.formatted_version }}.staging.saleor.cloud/dashboard/
+          CYPRESS_baseUrl: ${{ needs.get-environment-variables.outputs.url }}dashboard/
           CYPRESS_USER_NAME: ${{ secrets.CYPRESS_USER_NAME }}
           CYPRESS_SECOND_USER_NAME: ${{ secrets.CYPRESS_SECOND_USER_NAME }}
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
@@ -193,10 +226,47 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_mailHogUrl: ${{ secrets.CYPRESS_MAILHOG }}
-          COMMIT_INFO_MESSAGE: Critical triggered via release - ${{github.event.client_payload.project}} ${{github.event.client_payload.version}}, ${{github.event.client_payload.pullRequestUrl}}
-          CYPRESS_grepTags: '@stable'
+          COMMIT_INFO_MESSAGE: Triggered via release - ${{github.event.client_payload.project}} ${{github.event.client_payload.version}}, ${{github.event.client_payload.pullRequestUrl}}
+          CYPRESS_grepTags: ${{steps.set-tag-for-tests.outputs.TEST_TAG}}
         with:
           parallel: true
           group: 'UI - Chrome'
           record: true
-          tag: ${{github.event.client_payload.project}}, ${{github.event.client_payload.environment}}, Critical, https://v${{ steps.version.outputs.formatted_version }}.staging.saleor.cloud
+          tag: ${{github.event.client_payload.project}}, ${{github.event.client_payload.environment}}, ${{ needs.get-environment-variables.outputs.url }}
+
+
+  add-review-and-merge-patch:
+    if: ${{ always() && (needs.run-tests-on-release.outputs.status == 'success' || needs.run-tests-on-release.outputs.status == 'failure') }}
+    runs-on: ubuntu-latest
+    needs: [run-tests-on-release]
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install dependencies
+        run: |
+              cd .github/workflows
+              npm ci
+
+      - name: Add review and merge if patch DASHBOARD
+        env: 
+         tests_status: ${{ needs.run-tests-on-release.outputs.status}}
+         version: ${{github.event.client_payload.version}}
+         pull_request_number: ${{ github.event.client_payload.pullRequestNumber}}
+         auto_release: ${{github.event.client_payload.autoRelease}}
+         dashboard_url: ${{ needs.run-tests-on-release.outputs.dashboard_url}}
+        run: |
+            export GITHUB_TOKEN=$( \
+            curl --request GET --url ${{ secrets.VAULT_URL}} --header "Authorization: JWT ${{ secrets.VAULT_JWT }}" | jq -r .token \
+            )
+            node .github/workflows/approveAndMergeReleasePR.js \
+            --version $version \
+            --pull_request_number $pull_request_number \
+            --auto_release $auto_release \
+            --dashboard_url $dashboard_url

--- a/cypress/e2e/apps.js
+++ b/cypress/e2e/apps.js
@@ -40,7 +40,7 @@ describe("As a staff user I want to manage apps", () => {
 
   it(
     "should be able to create app. TC: SALEOR_3001",
-    { tags: ["@app", "@allEnv", "@stable"] },
+    { tags: ["@app", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const randomAppName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/catalog/categories.js
+++ b/cypress/e2e/catalog/categories.js
@@ -75,7 +75,7 @@ describe("As an admin I want to manage categories", () => {
 
   it(
     "should be able to create category. TC: SALEOR_0201",
-    { tags: ["@category", "@allEnv"] },
+    { tags: ["@category", "@allEnv", "@oldRelease"] },
     () => {
       const categoryName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/catalog/collections.js
+++ b/cypress/e2e/catalog/collections.js
@@ -112,7 +112,7 @@ filterTests({ definedTags: ["all"] }, () => {
 
     it(
       "should create published collection. TC: SALEOR_0302",
-      { tags: ["@collection", "@allEnv", "@stable"] },
+      { tags: ["@collection", "@allEnv", "@stable", "@oldRelease"] },
       () => {
         const collectionName = `${startsWith}${faker.datatype.number()}`;
         let collection;

--- a/cypress/e2e/checkout/purchaseWithProductTypes.js
+++ b/cypress/e2e/checkout/purchaseWithProductTypes.js
@@ -49,7 +49,7 @@ describe("As an unlogged customer I want to order physical and digital products"
 
   it(
     "should purchase digital product as unlogged customer. TC: SALEOR_0402",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createAndCompleteCheckoutWithoutShipping({
         channelSlug: defaultChannel.slug,
@@ -73,7 +73,7 @@ describe("As an unlogged customer I want to order physical and digital products"
 
   it(
     "should purchase physical product as unlogged customer. TC: SALEOR_0403",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         channelSlug: defaultChannel.slug,

--- a/cypress/e2e/checkout/stocksInCheckout.js
+++ b/cypress/e2e/checkout/stocksInCheckout.js
@@ -61,7 +61,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should not be possible to add product with quantity greater than stock to checkout. TC: SALEOR_0405",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createCheckout({
         channelSlug: defaultChannel.slug,
@@ -85,7 +85,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should buy product with no quantity if tracking is not set. TC: SALEOR_0406",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         address,
@@ -101,7 +101,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should create checkout with last product in stock. TC: SALEOR_0419",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         address,

--- a/cypress/e2e/checkout/warehouses.js
+++ b/cypress/e2e/checkout/warehouses.js
@@ -24,7 +24,7 @@ describe("Warehouses in checkout", () => {
 
   it(
     "should not be possible to buy product for country not listed in warehouse",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.clearSessionData().loginUserViaRequest();
       deleteShippingStartsWith(startsWith);

--- a/cypress/e2e/configuration/attributes/createProductAttributes.js
+++ b/cypress/e2e/configuration/attributes/createProductAttributes.js
@@ -65,7 +65,7 @@ describe("As an admin I want to create product attribute", () => {
   attributesTypes.forEach(attributeType => {
     it(
       `should be able to create ${attributeType.type} attribute. TC:${attributeType.testCase}`,
-      { tags: ["@attribute", "@allEnv"] },
+      { tags: ["@attribute", "@allEnv", "@stable", "@oldRelease"] },
       () => {
         const attributeName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/configuration/customer.js
+++ b/cypress/e2e/configuration/customer.js
@@ -35,7 +35,7 @@ describe("Tests for customer", () => {
 
   it(
     "should create customer. TC: SALEOR_1201",
-    { tags: ["@customer", "@allEnv", "@stable"] },
+    { tags: ["@customer", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const randomName = `${startsWith}${faker.datatype.number()}`;
       const email = `${randomName}@example.com`;

--- a/cypress/e2e/configuration/productTypes/createProductType.js
+++ b/cypress/e2e/configuration/productTypes/createProductType.js
@@ -25,7 +25,7 @@ describe("As an admin I want to create product types", () => {
 
   it(
     "should be able to create product type without shipping required. TC: SALEOR_1501",
-    { tags: ["@productType", "@allEnv", "@stable"] },
+    { tags: ["@productType", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
+++ b/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
@@ -32,8 +32,6 @@ describe("As a staff user I want to create shipping zone and rate", () => {
   let secondVariantsList;
   let warehouse;
   let attribute;
-  let category;
-  let productType;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
@@ -63,8 +61,6 @@ describe("As a staff user I want to create shipping zone and rate", () => {
           attribute: attributeResp
         }) => {
           attribute = attributeResp;
-          category = categoryResp;
-          productType = productTypeResp;
 
           productsUtils.createProductInChannel({
             name,
@@ -103,7 +99,7 @@ describe("As a staff user I want to create shipping zone and rate", () => {
 
   it(
     "should be able to create price based shipping method. TC: SALEOR_0803",
-    { tags: ["@shipping", "@allEnv"] },
+    { tags: ["@shipping", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const shippingName = `${startsWith}${faker.datatype.number()}`;
       cy.clearSessionData().loginUserViaRequest(

--- a/cypress/e2e/configuration/warehouses/warehouse.js
+++ b/cypress/e2e/configuration/warehouses/warehouse.js
@@ -38,28 +38,32 @@ describe("Warehouse settings", () => {
     cy.clearSessionData().loginUserViaRequest();
   });
 
-  it("should create warehouse", { tags: ["@warehouse", "@allEnv"] }, () => {
-    const name = `${startsWith}${faker.datatype.number()}`;
-    cy.visit(urlList.warehouses)
-      .get(WAREHOUSES_LIST.createNewButton)
-      .click()
-      .get(WAREHOUSES_DETAILS.nameInput)
-      .type(name)
-      .fillUpBasicAddress(usAddress)
-      .addAliasToGraphRequest("WarehouseCreate")
-      .get(BUTTON_SELECTORS.confirm)
-      .click()
-      .waitForRequestAndCheckIfNoErrors("@WarehouseCreate")
-      .its("response.body.data.createWarehouse.warehouse")
-      .then(warehouse => {
-        getWarehouse(warehouse.id);
-      })
-      .then(warehouse => {
-        const addressResp = warehouse.address;
-        expect(warehouse.name).to.be.eq(name);
-        cy.expectCorrectBasicAddress(addressResp, usAddress);
-      });
-  });
+  it(
+    "should create warehouse",
+    { tags: ["@warehouse", "@allEnv", "@oldRelease"] },
+    () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+      cy.visit(urlList.warehouses)
+        .get(WAREHOUSES_LIST.createNewButton)
+        .click()
+        .get(WAREHOUSES_DETAILS.nameInput)
+        .type(name)
+        .fillUpBasicAddress(usAddress)
+        .addAliasToGraphRequest("WarehouseCreate")
+        .get(BUTTON_SELECTORS.confirm)
+        .click()
+        .waitForRequestAndCheckIfNoErrors("@WarehouseCreate")
+        .its("response.body.data.createWarehouse.warehouse")
+        .then(warehouse => {
+          getWarehouse(warehouse.id);
+        })
+        .then(warehouse => {
+          const addressResp = warehouse.address;
+          expect(warehouse.name).to.be.eq(name);
+          cy.expectCorrectBasicAddress(addressResp, usAddress);
+        });
+    }
+  );
 
   it(
     "should add warehouse to shipping zone",

--- a/cypress/e2e/homePage/homePage.js
+++ b/cypress/e2e/homePage/homePage.js
@@ -8,7 +8,7 @@ import { expectWelcomeMessageIncludes } from "../../support/pages/homePage";
 describe("Displaying welcome message on home page", () => {
   it(
     "should display user name on home page",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest().visit(urlList.homePage);
       expectWelcomeMessageIncludes(
@@ -19,7 +19,7 @@ describe("Displaying welcome message on home page", () => {
 
   it(
     "should display user email on home page",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest("auth", USER_WITHOUT_NAME).visit(urlList.homePage);
       expectWelcomeMessageIncludes(`${USER_WITHOUT_NAME.email}`);
@@ -28,7 +28,7 @@ describe("Displaying welcome message on home page", () => {
 
   it(
     "should refresh page without errors",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest()
         .visit(urlList.homePage)

--- a/cypress/e2e/login.js
+++ b/cypress/e2e/login.js
@@ -12,7 +12,7 @@ describe("User authorization", () => {
 
   it(
     "should successfully log in an user",
-    { tags: ["@login", "@allEnv", "@stable"] },
+    { tags: ["@login", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.visit(urlList.homePage);
       cy.loginUser();

--- a/cypress/e2e/navigation.js
+++ b/cypress/e2e/navigation.js
@@ -47,7 +47,7 @@ describe("As a staff user I want to navigate through shop using different permis
     if (key !== "all") {
       it(
         `should be able to navigate through shop as a staff member using ${key} permission. ${permissionsOptions[key].testCase}`,
-        { tags: ["@allEnv", "@navigation"] },
+        { tags: ["@allEnv", "@navigation", "@stable", "@oldRelease"] },
         () => {
           const permissionOption = permissionsOptions[key];
           const permissions = permissionOption.permissions;
@@ -92,7 +92,7 @@ describe("As a staff user I want to navigate through shop using different permis
 
   it(
     `should be able to navigate through shop as a staff member using all permissions. ${permissionsOptions.all.testCase}`,
-    { tags: ["@critical", "@allEnv", "@navigation", "@stable"] },
+    { tags: ["@critical", "@allEnv", "@navigation", "@stable", "@oldRelease"] },
     () => {
       const permissionOption = permissionsOptions.all;
       cy.clearSessionData();

--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -107,7 +107,7 @@ describe("Orders", () => {
 
   xit(
     "should create order with selected channel. TC: SALEOR_2104",
-    { tags: ["@orders", "@allEnv"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.visit(urlList.orders)
         .get(ORDERS_SELECTORS.createOrder)
@@ -125,7 +125,7 @@ describe("Orders", () => {
 
   it(
     "should not be possible to change channel in order. TC: SALEOR_2105",
-    { tags: ["@orders", "@allEnv", "@stable"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createOrder({
         customerId: customer.id,
@@ -145,7 +145,7 @@ describe("Orders", () => {
 
   it(
     "should cancel fulfillment. TC: SALEOR_2106",
-    { tags: ["@orders", "@allEnv"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       let order;
       createFulfilledOrder({
@@ -184,7 +184,7 @@ describe("Orders", () => {
 
   it(
     "should make a refund. TC: 2107",
-    { tags: ["@orders", "@allEnv", "@stable"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       let order;
       createReadyToFulfillOrder({

--- a/cypress/e2e/products/createProduct.js
+++ b/cypress/e2e/products/createProduct.js
@@ -60,7 +60,7 @@ describe("As an admin I should be able to create product", () => {
 
   it(
     "should be able to create product with variants as an admin. SALEOR_2701",
-    { tags: ["@products", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@products", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const randomName = `${startsWith}${faker.datatype.number()}`;
       seo.slug = randomName;
@@ -96,7 +96,7 @@ describe("As an admin I should be able to create product", () => {
 
   it(
     "should be able to create product without variants as an admin. SALEOR_2702",
-    { tags: ["@products", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@products", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const prices = { sellingPrice: 6, costPrice: 3 };
       const randomName = `${startsWith}${faker.datatype.number()}`;

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -58,7 +58,7 @@ describe("As an admin I should be able to create variant", () => {
 
   it(
     "should be able to create variant visible for the customers in all channels. TC: SALEOR_2901",
-    { tags: ["@variants", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@variants", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const price = 10;
@@ -111,7 +111,7 @@ describe("As an admin I should be able to create variant", () => {
 
   it(
     "should be able to create several variants visible for the customers. TC: SALEOR_2902",
-    { tags: ["@variants", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@variants", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const secondVariantSku = `${startsWith}${faker.datatype.number()}`;


### PR DESCRIPTION
I want to merge this change because I want to run only critical paths on old release versions. It's cherry picked from SALEOR-8149-On-release-tests-run-only-critical-paths

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1