### PR TITLE
Add @oldRelease tag to selected tests -3.1

### DIFF
--- a/cypress/e2e/apps.js
+++ b/cypress/e2e/apps.js
@@ -40,7 +40,7 @@ describe("As a staff user I want to manage apps", () => {
 
   it(
     "should be able to create app. TC: SALEOR_3001",
-    { tags: ["@app", "@allEnv", "@stable"] },
+    { tags: ["@app", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const randomAppName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/catalog/categories.js
+++ b/cypress/e2e/catalog/categories.js
@@ -75,7 +75,7 @@ describe("As an admin I want to manage categories", () => {
 
   it(
     "should be able to create category. TC: SALEOR_0201",
-    { tags: ["@category", "@allEnv"] },
+    { tags: ["@category", "@allEnv", "@oldRelease"] },
     () => {
       const categoryName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/catalog/collections.js
+++ b/cypress/e2e/catalog/collections.js
@@ -112,7 +112,7 @@ filterTests({ definedTags: ["all"] }, () => {
 
     it(
       "should create published collection. TC: SALEOR_0302",
-      { tags: ["@collection", "@allEnv", "@stable"] },
+      { tags: ["@collection", "@allEnv", "@stable", "@oldRelease"] },
       () => {
         const collectionName = `${startsWith}${faker.datatype.number()}`;
         let collection;

--- a/cypress/e2e/checkout/purchaseWithProductTypes.js
+++ b/cypress/e2e/checkout/purchaseWithProductTypes.js
@@ -49,7 +49,7 @@ describe("As an unlogged customer I want to order physical and digital products"
 
   it(
     "should purchase digital product as unlogged customer. TC: SALEOR_0402",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createAndCompleteCheckoutWithoutShipping({
         channelSlug: defaultChannel.slug,
@@ -73,7 +73,7 @@ describe("As an unlogged customer I want to order physical and digital products"
 
   it(
     "should purchase physical product as unlogged customer. TC: SALEOR_0403",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         channelSlug: defaultChannel.slug,

--- a/cypress/e2e/checkout/stocksInCheckout.js
+++ b/cypress/e2e/checkout/stocksInCheckout.js
@@ -61,7 +61,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should not be possible to add product with quantity greater than stock to checkout. TC: SALEOR_0405",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createCheckout({
         channelSlug: defaultChannel.slug,
@@ -85,7 +85,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should buy product with no quantity if tracking is not set. TC: SALEOR_0406",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         address,
@@ -101,7 +101,7 @@ describe("Manage products stocks in checkout", () => {
 
   it(
     "should create checkout with last product in stock. TC: SALEOR_0419",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createWaitingForCaptureOrder({
         address,

--- a/cypress/e2e/checkout/warehouses.js
+++ b/cypress/e2e/checkout/warehouses.js
@@ -24,7 +24,7 @@ describe("Warehouses in checkout", () => {
 
   it(
     "should not be possible to buy product for country not listed in warehouse",
-    { tags: ["@checkout", "@allEnv", "@stable"] },
+    { tags: ["@checkout", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.clearSessionData().loginUserViaRequest();
       deleteShippingStartsWith(startsWith);

--- a/cypress/e2e/configuration/attributes/createProductAttributes.js
+++ b/cypress/e2e/configuration/attributes/createProductAttributes.js
@@ -65,7 +65,7 @@ describe("As an admin I want to create product attribute", () => {
   attributesTypes.forEach(attributeType => {
     it(
       `should be able to create ${attributeType.type} attribute. TC:${attributeType.testCase}`,
-      { tags: ["@attribute", "@allEnv"] },
+      { tags: ["@attribute", "@allEnv", "@stable", "@oldRelease"] },
       () => {
         const attributeName = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/configuration/customer.js
+++ b/cypress/e2e/configuration/customer.js
@@ -35,7 +35,7 @@ describe("Tests for customer", () => {
 
   it(
     "should create customer. TC: SALEOR_1201",
-    { tags: ["@customer", "@allEnv", "@stable"] },
+    { tags: ["@customer", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const randomName = `${startsWith}${faker.datatype.number()}`;
       const email = `${randomName}@example.com`;

--- a/cypress/e2e/configuration/productTypes/createProductType.js
+++ b/cypress/e2e/configuration/productTypes/createProductType.js
@@ -25,7 +25,7 @@ describe("As an admin I want to create product types", () => {
 
   it(
     "should be able to create product type without shipping required. TC: SALEOR_1501",
-    { tags: ["@productType", "@allEnv", "@stable"] },
+    { tags: ["@productType", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
 

--- a/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
+++ b/cypress/e2e/configuration/shippingMethods/createShippingMethod.js
@@ -32,8 +32,6 @@ describe("As a staff user I want to create shipping zone and rate", () => {
   let secondVariantsList;
   let warehouse;
   let attribute;
-  let category;
-  let productType;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
@@ -63,8 +61,6 @@ describe("As a staff user I want to create shipping zone and rate", () => {
           attribute: attributeResp
         }) => {
           attribute = attributeResp;
-          category = categoryResp;
-          productType = productTypeResp;
 
           productsUtils.createProductInChannel({
             name,
@@ -103,7 +99,7 @@ describe("As a staff user I want to create shipping zone and rate", () => {
 
   it(
     "should be able to create price based shipping method. TC: SALEOR_0803",
-    { tags: ["@shipping", "@allEnv"] },
+    { tags: ["@shipping", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       const shippingName = `${startsWith}${faker.datatype.number()}`;
       cy.clearSessionData().loginUserViaRequest(

--- a/cypress/e2e/configuration/warehouses/warehouse.js
+++ b/cypress/e2e/configuration/warehouses/warehouse.js
@@ -38,28 +38,32 @@ describe("Warehouse settings", () => {
     cy.clearSessionData().loginUserViaRequest();
   });
 
-  it("should create warehouse", { tags: ["@warehouse", "@allEnv"] }, () => {
-    const name = `${startsWith}${faker.datatype.number()}`;
-    cy.visit(urlList.warehouses)
-      .get(WAREHOUSES_LIST.createNewButton)
-      .click()
-      .get(WAREHOUSES_DETAILS.nameInput)
-      .type(name)
-      .fillUpBasicAddress(usAddress)
-      .addAliasToGraphRequest("WarehouseCreate")
-      .get(BUTTON_SELECTORS.confirm)
-      .click()
-      .waitForRequestAndCheckIfNoErrors("@WarehouseCreate")
-      .its("response.body.data.createWarehouse.warehouse")
-      .then(warehouse => {
-        getWarehouse(warehouse.id);
-      })
-      .then(warehouse => {
-        const addressResp = warehouse.address;
-        expect(warehouse.name).to.be.eq(name);
-        cy.expectCorrectBasicAddress(addressResp, usAddress);
-      });
-  });
+  it(
+    "should create warehouse",
+    { tags: ["@warehouse", "@allEnv", "@oldRelease"] },
+    () => {
+      const name = `${startsWith}${faker.datatype.number()}`;
+      cy.visit(urlList.warehouses)
+        .get(WAREHOUSES_LIST.createNewButton)
+        .click()
+        .get(WAREHOUSES_DETAILS.nameInput)
+        .type(name)
+        .fillUpBasicAddress(usAddress)
+        .addAliasToGraphRequest("WarehouseCreate")
+        .get(BUTTON_SELECTORS.confirm)
+        .click()
+        .waitForRequestAndCheckIfNoErrors("@WarehouseCreate")
+        .its("response.body.data.createWarehouse.warehouse")
+        .then(warehouse => {
+          getWarehouse(warehouse.id);
+        })
+        .then(warehouse => {
+          const addressResp = warehouse.address;
+          expect(warehouse.name).to.be.eq(name);
+          cy.expectCorrectBasicAddress(addressResp, usAddress);
+        });
+    }
+  );
 
   it(
     "should add warehouse to shipping zone",

--- a/cypress/e2e/homePage/homePage.js
+++ b/cypress/e2e/homePage/homePage.js
@@ -8,7 +8,7 @@ import { expectWelcomeMessageIncludes } from "../../support/pages/homePage";
 describe("Displaying welcome message on home page", () => {
   it(
     "should display user name on home page",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest().visit(urlList.homePage);
       expectWelcomeMessageIncludes(
@@ -19,7 +19,7 @@ describe("Displaying welcome message on home page", () => {
 
   it(
     "should display user email on home page",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest("auth", USER_WITHOUT_NAME).visit(urlList.homePage);
       expectWelcomeMessageIncludes(`${USER_WITHOUT_NAME.email}`);
@@ -28,7 +28,7 @@ describe("Displaying welcome message on home page", () => {
 
   it(
     "should refresh page without errors",
-    { tags: ["@homePage", "@allEnv", "@stable"] },
+    { tags: ["@homePage", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.loginUserViaRequest()
         .visit(urlList.homePage)

--- a/cypress/e2e/login.js
+++ b/cypress/e2e/login.js
@@ -12,7 +12,7 @@ describe("User authorization", () => {
 
   it(
     "should successfully log in an user",
-    { tags: ["@login", "@allEnv", "@stable"] },
+    { tags: ["@login", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.visit(urlList.homePage);
       cy.loginUser();

--- a/cypress/e2e/navigation.js
+++ b/cypress/e2e/navigation.js
@@ -47,7 +47,7 @@ describe("As a staff user I want to navigate through shop using different permis
     if (key !== "all") {
       it(
         `should be able to navigate through shop as a staff member using ${key} permission. ${permissionsOptions[key].testCase}`,
-        { tags: ["@allEnv", "@navigation"] },
+        { tags: ["@allEnv", "@navigation", "@stable", "@oldRelease"] },
         () => {
           const permissionOption = permissionsOptions[key];
           const permissions = permissionOption.permissions;
@@ -92,7 +92,7 @@ describe("As a staff user I want to navigate through shop using different permis
 
   it(
     `should be able to navigate through shop as a staff member using all permissions. ${permissionsOptions.all.testCase}`,
-    { tags: ["@critical", "@allEnv", "@navigation", "@stable"] },
+    { tags: ["@critical", "@allEnv", "@navigation", "@stable", "@oldRelease"] },
     () => {
       const permissionOption = permissionsOptions.all;
       cy.clearSessionData();

--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -107,7 +107,7 @@ describe("Orders", () => {
 
   xit(
     "should create order with selected channel. TC: SALEOR_2104",
-    { tags: ["@orders", "@allEnv"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       cy.visit(urlList.orders)
         .get(ORDERS_SELECTORS.createOrder)
@@ -125,7 +125,7 @@ describe("Orders", () => {
 
   it(
     "should not be possible to change channel in order. TC: SALEOR_2105",
-    { tags: ["@orders", "@allEnv", "@stable"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       createOrder({
         customerId: customer.id,
@@ -145,7 +145,7 @@ describe("Orders", () => {
 
   it(
     "should cancel fulfillment. TC: SALEOR_2106",
-    { tags: ["@orders", "@allEnv"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       let order;
       createFulfilledOrder({
@@ -184,7 +184,7 @@ describe("Orders", () => {
 
   it(
     "should make a refund. TC: 2107",
-    { tags: ["@orders", "@allEnv", "@stable"] },
+    { tags: ["@orders", "@allEnv", "@stable", "@oldRelease"] },
     () => {
       let order;
       createReadyToFulfillOrder({

--- a/cypress/e2e/products/createProduct.js
+++ b/cypress/e2e/products/createProduct.js
@@ -60,7 +60,7 @@ describe("As an admin I should be able to create product", () => {
 
   it(
     "should be able to create product with variants as an admin. SALEOR_2701",
-    { tags: ["@products", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@products", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const randomName = `${startsWith}${faker.datatype.number()}`;
       seo.slug = randomName;
@@ -96,7 +96,7 @@ describe("As an admin I should be able to create product", () => {
 
   it(
     "should be able to create product without variants as an admin. SALEOR_2702",
-    { tags: ["@products", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@products", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const prices = { sellingPrice: 6, costPrice: 3 };
       const randomName = `${startsWith}${faker.datatype.number()}`;

--- a/cypress/e2e/products/productsVariants.js
+++ b/cypress/e2e/products/productsVariants.js
@@ -58,7 +58,7 @@ describe("As an admin I should be able to create variant", () => {
 
   it(
     "should be able to create variant visible for the customers in all channels. TC: SALEOR_2901",
-    { tags: ["@variants", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@variants", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const price = 10;
@@ -111,7 +111,7 @@ describe("As an admin I should be able to create variant", () => {
 
   it(
     "should be able to create several variants visible for the customers. TC: SALEOR_2902",
-    { tags: ["@variants", "@allEnv", "@critical", "@stable"] },
+    { tags: ["@variants", "@allEnv", "@critical", "@stable", "@oldRelease"] },
     () => {
       const name = `${startsWith}${faker.datatype.number()}`;
       const secondVariantSku = `${startsWith}${faker.datatype.number()}`;


### PR DESCRIPTION
I want to merge this change because I want to have @oldRelease tag on all versions

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1