### PR TITLE
Fix issue with expired token when running tests in interactive mode

### DIFF
--- a/cypress/e2e/checkout/purchaseWithProductTypes.js
+++ b/cypress/e2e/checkout/purchaseWithProductTypes.js
@@ -43,7 +43,6 @@ describe("As an unlogged customer I want to order physical and digital products"
       shippingMethod = resp.shippingMethod;
       digitalVariants = resp.digitalVariants;
       physicalVariants = resp.physicalVariants;
-      cy.clearSessionData();
     });
   });
 

--- a/cypress/support/api/requests/utils/index.js
+++ b/cypress/support/api/requests/utils/index.js
@@ -5,42 +5,32 @@ import { urlList } from "../../../../fixtures/urlList";
 Cypress.Commands.add(
   "sendRequestWithQuery",
   (query, authorization = "auth", variables = "") => {
-    if (authorization.length !== 30) {
-      cy.request({
-        body: {
-          variables,
-          query,
-        },
-        headers: {
-          Authorization: `JWT ${window.sessionStorage.getItem(authorization)}`,
-        },
-        method: "POST",
-        url: urlList.apiUri,
-        log: true,
-      }).then(response => {
-        const respInSting = JSON.stringify(response.body);
-        if (respInSting.includes(`"errors":[{`)) {
-          cy.log(query).log(JSON.stringify(response.body));
-        }
-      });
+    let headers;
+
+    if (authorization && authorization.length !== 30) {
+      headers = {
+        Authorization: `JWT ${window.sessionStorage.getItem(authorization)}`,
+      };
+    } else if (authorization) {
+      headers = { Authorization: `Bearer ${authorization}` };
     } else {
-      cy.request({
-        body: {
-          variables,
-          query,
-        },
-        headers: {
-          Authorization: `Bearer ${authorization}`,
-        },
-        method: "POST",
-        url: urlList.apiUri,
-        log: true,
-      }).then(response => {
-        const respInSting = JSON.stringify(response.body);
-        if (respInSting.includes(`"errors":[{`)) {
-          cy.log(query).log(JSON.stringify(response.body));
-        }
-      });
+      headers = {};
     }
+
+    cy.request({
+      body: {
+        variables,
+        query,
+      },
+      headers,
+      method: "POST",
+      url: urlList.apiUri,
+      log: true,
+    }).then(response => {
+      const respInSting = JSON.stringify(response.body);
+      if (respInSting.includes(`"errors":[{`)) {
+        cy.log(query).log(JSON.stringify(response.body));
+      }
+    });
   },
 );

--- a/cypress/support/customCommands/user/index.js
+++ b/cypress/support/customCommands/user/index.js
@@ -35,7 +35,7 @@ Cypress.Commands.add(
       }
     }
   }`;
-    return cy.sendRequestWithQuery(mutation, authorization).then(resp => {
+    return cy.sendRequestWithQuery(mutation, null).then(resp => {
       window.localStorage.setItem(
         "_saleorCSRFToken",
         resp.body.data.tokenCreate.csrfToken,

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -27,6 +27,7 @@ cypressGrep();
 Cypress.Commands.add("clearSessionData", () => {
   cy.clearCookies();
   cy.clearLocalStorage();
+  window.sessionStorage.clear();
 });
 
 Cypress.Commands.add("addAliasToGraphRequest", operationName => {


### PR DESCRIPTION
I want to merge this change because I fixed issue with the expired token when running tests in interactive mode

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1