### PR TITLE
Remove vidoes after cypress tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,14 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-console */
 const { defineConfig } = require("cypress");
-const _ = require("lodash");
 const fs = require("fs");
 
 module.exports = defineConfig({
   projectId: "51ef7c",
-  videoCompression: false,
   chromeWebSecurity: false,
-  videoUploadOnPasses: false,
   defaultCommandTimeout: 20000,
   requestTimeout: 20000,
   viewportWidth: 1400,
@@ -26,20 +23,13 @@ module.exports = defineConfig({
       config = require("./cypress/plugins/index.js")(on, config);
       on("after:spec", (spec, results) => {
         if (results && results.video) {
-          // Do we have failures for any retry attempts?
-          const failures = _.some(results.tests, test =>
-            _.some(test.attempts, { state: "failed" }),
-          );
-          if (!failures) {
-            // delete the video if the spec passed and no tests retried
-            return fs.unlink(results.video, function(err) {
-              if (err) {
-                console.warn(`Could not remove video - ${err}`);
-              } else {
-                console.log("File removed:", results.video);
-              }
-            });
-          }
+          return fs.unlink(results.video, function(err) {
+            if (err) {
+              console.warn(`Could not remove video - ${err}`);
+            } else {
+              console.log("File removed:", results.video);
+            }
+          });
         }
       });
       return config;

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 
 module.exports = defineConfig({
   projectId: "51ef7c",
-  videoCompression: 15,
+  videoCompression: false,
   chromeWebSecurity: false,
   videoUploadOnPasses: false,
   defaultCommandTimeout: 20000,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-console */
 const { defineConfig } = require("cypress");
+const _ = require("lodash");
+const fs = require("fs");
 
 module.exports = defineConfig({
   projectId: "51ef7c",
+  videoCompression: 15,
   chromeWebSecurity: false,
   videoUploadOnPasses: false,
   defaultCommandTimeout: 20000,
@@ -20,6 +24,24 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       config = require("./cypress/support/cypress-grep/plugin")(config);
       config = require("./cypress/plugins/index.js")(on, config);
+      on("after:spec", (spec, results) => {
+        if (results && results.video) {
+          // Do we have failures for any retry attempts?
+          const failures = _.some(results.tests, test =>
+            _.some(test.attempts, { state: "failed" }),
+          );
+          if (!failures) {
+            // delete the video if the spec passed and no tests retried
+            return fs.unlink(results.video, function(err) {
+              if (err) {
+                console.warn(`Could not remove video - ${err}`);
+              } else {
+                console.log("File removed:", results.video);
+              }
+            });
+          }
+        }
+      });
       return config;
     },
     baseUrl: "http://localhost:9000/",


### PR DESCRIPTION
I want to merge this change because I do not want to upload videos to the cypress dashboard. Videos are not helpful, and its compression takes time

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1