### PR TITLE
Construct full API URL in case not full provided

### DIFF
--- a/src/apps/urls.test.ts
+++ b/src/apps/urls.test.ts
@@ -1,31 +1,47 @@
 import { resolveAppIframeUrl } from "@saleor/apps/urls";
-
-jest.mock("@saleor/config", () => ({
-  ...jest.requireActual("@saleor/config"),
-  getApiUrl: () => "https://shop.saleor.cloud/graphql/",
-}));
+import * as config from "@saleor/config";
 
 describe("resolveAppIframeUrl", () => {
   afterAll(() => {
     jest.clearAllMocks();
   });
 
-  it.each<[string, string, Record<string, unknown>, string]>([
-    [
-      "XyZ123",
-      "https://my-app.vercel.app",
-      { param1: "param1" },
-      "https://my-app.vercel.app?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=XyZ123&param1=param1",
-    ],
-    [
-      "AbC987",
-      "https://my-app.vercel.app/configuration",
-      { param1: "param1", param2: "param2" },
-      "https://my-app.vercel.app/configuration?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=AbC987&param1=param1&param2=param2",
-    ],
-  ])("Generates valid URL from segments", (id, appUrl, params, expectedUrl) => {
-    const result = resolveAppIframeUrl(id, appUrl, params);
+  describe("For full URL provided in env", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(config, "getApiUrl")
+        .mockImplementation(() => "https://shop.saleor.cloud/graphql/");
+    });
 
-    expect(result).toEqual(expectedUrl);
+    it.each<[string, string, Record<string, string>, string]>([
+      [
+        "XyZ123",
+        "https://my-app.vercel.app",
+        { param1: "param1" },
+        "https://my-app.vercel.app?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=XyZ123&param1=param1",
+      ],
+      [
+        "AbC987",
+        "https://my-app.vercel.app/configuration",
+        { param1: "param1", param2: "param2" },
+        "https://my-app.vercel.app/configuration?domain=shop.saleor.cloud&saleorApiUrl=https%3A%2F%2Fshop.saleor.cloud%2Fgraphql%2F&id=AbC987&param1=param1&param2=param2",
+      ],
+    ])(
+      "Generates valid URL from segments",
+      (id, appUrl, params, expectedUrl) => {
+        const result = resolveAppIframeUrl(id, appUrl, params);
+
+        expect(result).toEqual(expectedUrl);
+      },
+    );
   });
+
+  /**
+   * Test this scenario for cloud deployments where origin is computed.
+   *
+   * Current jest is not set up for testing location/URL
+   */
+  test.todo(
+    "Test if URL is valid when API_URL in env is absolute path like /graphql/",
+  );
 });

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -123,7 +123,7 @@ export const resolveAppIframeUrl = (
   appUrl: string,
   params: AppDetailsUrlQueryParams,
 ) => {
-  const apiUrl = getApiUrl();
+  const apiUrl = new URL(getApiUrl(), window.location.origin);
   const apiUrlHost = new URL(getApiUrl()).hostname;
 
   const iframeContextQueryString = `?${stringifyQs(

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -121,13 +121,13 @@ export const appsListUrl = (params?: AppListUrlQueryParams) =>
 export const resolveAppIframeUrl = (
   appId: string,
   appUrl: string,
-  params: Record<string, string>,
+  params: AppDetailsUrlQueryParams,
 ) => {
   const apiUrl = new URL(getApiUrl(), window.location.origin).href;
   /**
    * Use host to preserve port, in case of multiple Saleors running on localhost
    */
-  const apiUrlHost = new URL(getApiUrl()).host;
+  const apiUrlHost = new URL(apiUrl).host;
 
   const iframeContextQueryString = `?${stringifyQs(
     {

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -121,10 +121,13 @@ export const appsListUrl = (params?: AppListUrlQueryParams) =>
 export const resolveAppIframeUrl = (
   appId: string,
   appUrl: string,
-  params: AppDetailsUrlQueryParams,
+  params: Record<string, string>,
 ) => {
-  const apiUrl = new URL(getApiUrl(), window.location.origin);
-  const apiUrlHost = new URL(getApiUrl()).hostname;
+  const apiUrl = new URL(getApiUrl(), window.location.origin).href;
+  /**
+   * Use host to preserve port, in case of multiple Saleors running on localhost
+   */
+  const apiUrlHost = new URL(getApiUrl()).host;
 
   const iframeContextQueryString = `?${stringifyQs(
     {


### PR DESCRIPTION
I want to merge this change because...

Cloud deployment needs `API_URL` to be `/graphql/`, not a full path. This caused breaking apps because they tried to run `new URL("/graphql/")`.

This PR should fix this problem, however this scenario is not tested, because jest is not configured to mock location

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1