### PR TITLE
TranslationFieldsRich and ExitDialog error

### DIFF
--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -46,9 +46,12 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
     triggerChange: () => setIsDirty(true),
   });
 
-  useEffect(() => setExitDialogSubmitRef(onSubmit), [onSubmit]);
+  useEffect(() => setExitDialogSubmitRef(submit), [onSubmit]);
 
-  const submit = async () => onSubmit(await getValue());
+  const submit = async () => {
+    setIsDirty(false);
+    return onSubmit(await getValue());
+  };
 
   return edit ? (
     <form onSubmit={submit}>


### PR DESCRIPTION
I want to merge this change to prevent this errors:
1. Showing the ExitDialog if changes are submited
2. Save changes if ExitDialog is showed

### Screenshots

![Captura de pantalla 2022-11-29 a les 8 58 43](https://user-images.githubusercontent.com/19432516/204472073-01a8fb70-19b1-4462-a264-9b75d75c7501.png)

![Captura de pantalla 2022-11-29 a les 8 59 00](https://user-images.githubusercontent.com/19432516/204472000-64968e45-1756-4ab9-843c-a4062fd9f799.png)

### Test environment config

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1