### PR TITLE
Fix products filtering

### DIFF
--- a/src/products/components/ProductListPage/filters.ts
+++ b/src/products/components/ProductListPage/filters.ts
@@ -2,6 +2,7 @@ import { IFilter } from "@saleor/components/Filter";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import { AttributeInputTypeEnum, StockAvailability } from "@saleor/graphql";
 import { commonMessages, sectionNames } from "@saleor/intl";
+import { ProductListUrlFiltersAsDictWithMultipleValues } from "@saleor/products/urls";
 import {
   AutocompleteFilterOpts,
   FilterOpts,
@@ -20,17 +21,18 @@ import {
 } from "@saleor/utils/filters/fields";
 import { defineMessages, IntlShape } from "react-intl";
 
-export enum ProductFilterKeys {
-  attributes = "attributes",
-  categories = "categories",
-  collections = "collections",
-  metadata = "metadata",
-  price = "price",
-  productType = "productType",
-  stock = "stock",
-  channel = "channel",
-  productKind = "productKind",
-}
+export const ProductFilterKeys = {
+  ...ProductListUrlFiltersAsDictWithMultipleValues,
+  categories: "categories",
+  collections: "collections",
+  metadata: "metadata",
+  price: "price",
+  productType: "productType",
+  stock: "stock",
+  channel: "channel",
+  productKind: "productKind",
+} as const;
+export type ProductFilterKeys = typeof ProductFilterKeys[keyof typeof ProductFilterKeys];
 
 export type AttributeFilterOpts = FilterOpts<string[]> & {
   id: string;
@@ -260,7 +262,7 @@ export function createFilterStructure(
         },
       ),
       active: attr.active,
-      group: ProductFilterKeys.attributes,
+      group: ProductFilterKeys.booleanAttributes,
     })),
     ...dateAttributes.map(attr => ({
       ...createDateField(attr.slug, attr.name, {
@@ -268,7 +270,7 @@ export function createFilterStructure(
         max: attr.value[1] ?? attr.value[0],
       }),
       active: attr.active,
-      group: ProductFilterKeys.attributes,
+      group: ProductFilterKeys.dateAttributes,
     })),
     ...dateTimeAttributes.map(attr => ({
       ...createDateTimeField(attr.slug, attr.name, {
@@ -276,7 +278,7 @@ export function createFilterStructure(
         max: attr.value[1] ?? attr.value[0],
       }),
       active: attr.active,
-      group: ProductFilterKeys.attributes,
+      group: ProductFilterKeys.dateTimeAttributes,
     })),
     ...numericAttributes.map(attr => ({
       ...createNumberField(attr.slug, attr.name, {
@@ -284,7 +286,7 @@ export function createFilterStructure(
         max: attr.value[1] ?? attr.value[0],
       }),
       active: attr.active,
-      group: ProductFilterKeys.attributes,
+      group: ProductFilterKeys.numericAttributes,
     })),
     ...defaultAttributes.map(attr => ({
       ...createAutocompleteField(
@@ -304,7 +306,7 @@ export function createFilterStructure(
         attr.id,
       ),
       active: attr.active,
-      group: ProductFilterKeys.attributes,
+      group: ProductFilterKeys.stringAttributes,
     })),
   ];
 }

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -42,9 +42,14 @@ export enum ProductListUrlFiltersWithMultipleValues {
   collections = "collections",
   productTypes = "productTypes",
 }
-export enum ProductListUrlFiltersAsDictWithMultipleValues {
-  attributes = "attributes",
-}
+export const ProductListUrlFiltersAsDictWithMultipleValues = {
+  booleanAttributes: "boolean-attributes",
+  dateAttributes: "date-attributes",
+  dateTimeAttributes: "datetime-attributes",
+  numericAttributes: "numeric-attributes",
+  stringAttributes: "string-attributes",
+} as const;
+export type ProductListUrlFiltersAsDictWithMultipleValues = typeof ProductListUrlFiltersAsDictWithMultipleValues[keyof typeof ProductListUrlFiltersAsDictWithMultipleValues];
 export enum ProductListUrlFiltersWithKeyValueValues {
   metadata = "metadata",
 }

--- a/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
+++ b/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
@@ -2,7 +2,27 @@
 
 exports[`Filtering URL params should not be empty if active filters are present 1`] = `
 Object {
-  "attributes": Object {
+  "categories": Array [
+    "878752",
+  ],
+  "channel": "default-channel",
+  "collections": Array [
+    "Q29sbGVjdGlvbjoc",
+  ],
+  "metadata": Array [
+    Object {
+      "key": "metadataKey",
+      "value": "metadataValue",
+    },
+  ],
+  "priceFrom": "10",
+  "priceTo": "20",
+  "productKind": "NORMAL",
+  "productTypes": Array [
+    "UHJvZHVjdFR5cGU6MQ==",
+  ],
+  "stockStatus": "IN_STOCK",
+  "string-attributes": Object {
     "author": Array [
       "john-doe",
       false,
@@ -52,27 +72,7 @@ Object {
       "m",
     ],
   },
-  "categories": Array [
-    "878752",
-  ],
-  "channel": "default-channel",
-  "collections": Array [
-    "Q29sbGVjdGlvbjoc",
-  ],
-  "metadata": Array [
-    Object {
-      "key": "metadataKey",
-      "value": "metadataValue",
-    },
-  ],
-  "priceFrom": "10",
-  "priceTo": "20",
-  "productKind": "NORMAL",
-  "productTypes": Array [
-    "UHJvZHVjdFR5cGU6MQ==",
-  ],
-  "stockStatus": "IN_STOCK",
 }
 `;
 
-exports[`Filtering URL params should not be empty if active filters are present 2`] = `"channel=default-channel&metadata%5B0%5D%5Bkey%5D=metadataKey&metadata%5B0%5D%5Bvalue%5D=metadataValue&productKind=NORMAL&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc&productTypes%5B0%5D=UHJvZHVjdFR5cGU6MQ%3D%3D&attributes%5Bauthor%5D%5B0%5D=john-doe&attributes%5Bauthor%5D%5B1%5D=false&attributes%5Bbox-size%5D%5B0%5D=100g&attributes%5Bbox-size%5D%5B1%5D=500g&attributes%5Bbrand%5D%5B0%5D=saleor&attributes%5Bbrand%5D%5B1%5D=false&attributes%5Bcandy-box-size%5D%5B0%5D=100g&attributes%5Bcandy-box-size%5D%5B1%5D=500g&attributes%5Bcoffee-genre%5D%5B0%5D=arabica&attributes%5Bcoffee-genre%5D%5B1%5D=false&attributes%5Bcollar%5D%5B0%5D=round&attributes%5Bcollar%5D%5B1%5D=polo&attributes%5Bcolor%5D%5B0%5D=blue&attributes%5Bcolor%5D%5B1%5D=false&attributes%5Bcover%5D%5B0%5D=soft&attributes%5Bcover%5D%5B1%5D=middle-soft&attributes%5Bflavor%5D%5B0%5D=sour&attributes%5Bflavor%5D%5B1%5D=false&attributes%5Blanguage%5D%5B0%5D=english&attributes%5Blanguage%5D%5B1%5D=false&attributes%5Bpublisher%5D%5B0%5D=mirumee-press&attributes%5Bpublisher%5D%5B1%5D=false&attributes%5Bsize%5D%5B0%5D=xs&attributes%5Bsize%5D%5B1%5D=m"`;
+exports[`Filtering URL params should not be empty if active filters are present 2`] = `"channel=default-channel&metadata%5B0%5D%5Bkey%5D=metadataKey&metadata%5B0%5D%5Bvalue%5D=metadataValue&productKind=NORMAL&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc&productTypes%5B0%5D=UHJvZHVjdFR5cGU6MQ%3D%3D&string-attributes%5Bauthor%5D%5B0%5D=john-doe&string-attributes%5Bauthor%5D%5B1%5D=false&string-attributes%5Bbox-size%5D%5B0%5D=100g&string-attributes%5Bbox-size%5D%5B1%5D=500g&string-attributes%5Bbrand%5D%5B0%5D=saleor&string-attributes%5Bbrand%5D%5B1%5D=false&string-attributes%5Bcandy-box-size%5D%5B0%5D=100g&string-attributes%5Bcandy-box-size%5D%5B1%5D=500g&string-attributes%5Bcoffee-genre%5D%5B0%5D=arabica&string-attributes%5Bcoffee-genre%5D%5B1%5D=false&string-attributes%5Bcollar%5D%5B0%5D=round&string-attributes%5Bcollar%5D%5B1%5D=polo&string-attributes%5Bcolor%5D%5B0%5D=blue&string-attributes%5Bcolor%5D%5B1%5D=false&string-attributes%5Bcover%5D%5B0%5D=soft&string-attributes%5Bcover%5D%5B1%5D=middle-soft&string-attributes%5Bflavor%5D%5B0%5D=sour&string-attributes%5Bflavor%5D%5B1%5D=false&string-attributes%5Blanguage%5D%5B0%5D=english&string-attributes%5Blanguage%5D%5B1%5D=false&string-attributes%5Bpublisher%5D%5B0%5D=mirumee-press&string-attributes%5Bpublisher%5D%5B1%5D=false&string-attributes%5Bsize%5D%5B0%5D=xs&string-attributes%5Bsize%5D%5B1%5D=m"`;

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -1,4 +1,4 @@
-import { StockAvailability } from "@saleor/graphql";
+import { AttributeInputTypeEnum, StockAvailability } from "@saleor/graphql";
 import { createFilterStructure } from "@saleor/products/components/ProductListPage";
 import { ProductListUrlFilters } from "@saleor/products/urls";
 import { getFilterQueryParams } from "@saleor/utils/filters";
@@ -7,7 +7,15 @@ import { getExistingKeys, setFilterOptsStatus } from "@test/filters";
 import { config } from "@test/intl";
 import { createIntl } from "react-intl";
 
-import { getFilterQueryParam, getFilterVariables } from "./filters";
+import { ProductListUrlFiltersAsDictWithMultipleValues } from "../../urls";
+import {
+  FilterParam,
+  getAttributeValuesFromParams,
+  getFilterQueryParam,
+  getFilterVariables,
+  mapAttributeParamsToFilterOpts,
+  parseFilterValue,
+} from "./filters";
 import { productListFilterOpts } from "./fixtures";
 
 describe("Filtering query params", () => {
@@ -28,6 +36,150 @@ describe("Filtering query params", () => {
     const filterVariables = getFilterVariables(params, true);
 
     expect(getExistingKeys(filterVariables)).toHaveLength(2);
+  });
+});
+
+describe("Get attribute values from URL params", () => {
+  type GetAttributeValuesFromParams = Parameters<
+    typeof getAttributeValuesFromParams
+  >;
+
+  it("should return empty array when attribute doesn't exist in params", () => {
+    // Arrange
+    const params: GetAttributeValuesFromParams[0] = {};
+    const attribute: GetAttributeValuesFromParams[1] = {
+      slug: "test",
+      inputType: AttributeInputTypeEnum.DROPDOWN,
+    };
+
+    // Act
+    const attributeValues = getAttributeValuesFromParams(params, attribute);
+
+    // Assert
+    expect(attributeValues).toHaveLength(0);
+  });
+
+  it("should return attribute values when attribute exists in params", () => {
+    // Arrange
+    const params: GetAttributeValuesFromParams[0] = {
+      "string-attributes": {
+        test: ["value-1", "value-2"],
+      },
+    };
+    const attribute: GetAttributeValuesFromParams[1] = {
+      slug: "test",
+      inputType: AttributeInputTypeEnum.DROPDOWN,
+    };
+
+    // Act
+    const attributeValues = getAttributeValuesFromParams(params, attribute);
+
+    // Assert
+    expect(attributeValues).toEqual(["value-1", "value-2"]);
+  });
+});
+
+describe("Map attribute params to filter opts", () => {
+  type MapAttributeParamsToFilterOpts = Parameters<
+    typeof mapAttributeParamsToFilterOpts
+  >;
+  type MapAttributeParamsToFilterOptsReturn = ReturnType<
+    typeof mapAttributeParamsToFilterOpts
+  >;
+
+  it("should return empty array when no params given", () => {
+    // Arrange
+    const attributes: MapAttributeParamsToFilterOpts[0] = [
+      {
+        id: "1",
+        slug: "test",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test",
+        __typename: "Attribute",
+      },
+    ];
+    const params: MapAttributeParamsToFilterOpts[1] = {};
+
+    // Act
+    const filterOpts = mapAttributeParamsToFilterOpts(attributes, params);
+
+    // Assert
+    const expectedFilterOpts: MapAttributeParamsToFilterOptsReturn = [
+      {
+        id: "1",
+        slug: "test",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test",
+        active: false,
+        value: [],
+      },
+    ];
+    expect(filterOpts).toEqual(expectedFilterOpts);
+  });
+
+  it("should return filter opts with proper values selected according to passed values selection in params", () => {
+    // Arrange
+    const attributes: MapAttributeParamsToFilterOpts[0] = [
+      {
+        id: "1",
+        slug: "test-1",
+        inputType: AttributeInputTypeEnum.MULTISELECT,
+        name: "Test 1",
+        __typename: "Attribute",
+      },
+      {
+        id: "2",
+        slug: "test-2",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test 2",
+        __typename: "Attribute",
+      },
+      {
+        id: "3",
+        slug: "test-3",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test 3",
+        __typename: "Attribute",
+      },
+    ];
+    const params: MapAttributeParamsToFilterOpts[1] = {
+      "string-attributes": {
+        "test-1": ["value-1", "value-2"],
+        "test-2": ["value-3"],
+      },
+    };
+
+    // Act
+    const filterOpts = mapAttributeParamsToFilterOpts(attributes, params);
+
+    // Assert
+    const expectedFilterOpts: MapAttributeParamsToFilterOptsReturn = [
+      {
+        id: "1",
+        slug: "test-1",
+        inputType: AttributeInputTypeEnum.MULTISELECT,
+        name: "Test 1",
+        active: true,
+        value: ["value-1", "value-2"],
+      },
+      {
+        id: "2",
+        slug: "test-2",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test 2",
+        active: true,
+        value: ["value-3"],
+      },
+      {
+        id: "3",
+        slug: "test-3",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        name: "Test 3",
+        active: false,
+        value: [],
+      },
+    ];
+    expect(filterOpts).toEqual(expectedFilterOpts);
   });
 });
 
@@ -53,5 +205,163 @@ describe("Filtering URL params", () => {
 
     expect(filterQueryParams).toMatchSnapshot();
     expect(stringifyQs(filterQueryParams)).toMatchSnapshot();
+  });
+});
+
+describe("Parsing filter value", () => {
+  it("should return boolean values when boolean attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "boolean-attributes": {
+        "test-1": ["true"],
+        "test-2": ["false"],
+      },
+    };
+    const type =
+      ProductListUrlFiltersAsDictWithMultipleValues.booleanAttributes;
+
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      boolean: true,
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      boolean: false,
+    };
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
+  });
+
+  it("should return numeric values when numeric attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "numeric-attributes": {
+        "test-1": ["1"],
+        "test-2": ["1", "2"],
+      },
+    };
+    const type =
+      ProductListUrlFiltersAsDictWithMultipleValues.numericAttributes;
+
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      valuesRange: {
+        gte: 1,
+        lte: 1,
+      },
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      valuesRange: {
+        gte: 1,
+        lte: 2,
+      },
+    };
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
+  });
+
+  it("should return string values when string attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "string-attributes": {
+        "test-1": ["value-1"],
+        "test-2": ["value-2", "value-3"],
+      },
+    };
+    const type = ProductListUrlFiltersAsDictWithMultipleValues.stringAttributes;
+
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      values: ["value-1"],
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      values: ["value-2", "value-3"],
+    };
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
+  });
+
+  it("should return date values when date attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "date-attributes": {
+        "test-1": ["2020-01-01"],
+        "test-2": ["2020-01-01", "2020-02-02"],
+      },
+    };
+    const type = ProductListUrlFiltersAsDictWithMultipleValues.dateAttributes;
+
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      date: {
+        gte: "2020-01-01",
+        lte: "2020-01-01",
+      },
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      date: {
+        gte: "2020-01-01",
+        lte: "2020-02-02",
+      },
+    };
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
+  });
+
+  it("should return datetime values when datetime attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "datetime-attributes": {
+        "test-1": ["2020-01-01T00:00:00"],
+        "test-2": ["2020-01-01T00:00:00", "2020-02-02T00:00:00"],
+      },
+    };
+    const type =
+      ProductListUrlFiltersAsDictWithMultipleValues.dateTimeAttributes;
+
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      dateTime: {
+        gte: "2020-01-01T00:00:00",
+        lte: "2020-01-01T00:00:00",
+      },
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      dateTime: {
+        gte: "2020-01-01T00:00:00",
+        lte: "2020-02-02T00:00:00",
+      },
+    };
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
   });
 });

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -73,7 +73,7 @@ function getAttributeFilterParamType(inputType: AttributeInputTypeEnum) {
   }
 }
 
-function getAttributeValuesFromParams(
+export function getAttributeValuesFromParams(
   params: ProductListUrlFilters,
   attribute: Pick<AttributeFragment, "inputType" | "slug">,
 ) {
@@ -84,7 +84,7 @@ function getAttributeValuesFromParams(
   );
 }
 
-function mapAttributeParamsToFilterOpts(
+export function mapAttributeParamsToFilterOpts(
   attributes: RelayToFlat<InitialProductFilterAttributesQuery["attributes"]>,
   params: ProductListUrlFilters,
 ) {
@@ -289,14 +289,14 @@ interface DefaultFilterParam extends BaseFilterParam {
 interface NumericFilterParam extends BaseFilterParam {
   valuesRange: GteLte<number>;
 }
-type FilterParam =
+export type FilterParam =
   | BooleanFilterParam
   | DateFilterParam
   | DateTimeFilterParam
   | DefaultFilterParam
   | NumericFilterParam;
 
-const parseFilterValue = (
+export const parseFilterValue = (
   params: ProductListUrlFilters,
   key: string,
   type: ProductListUrlFiltersAsDictWithMultipleValues,


### PR DESCRIPTION
Instead of just passing `attributes` in the query params I changed it into explicitly typed query params `boolean-attributes`, `date-attributes`, `datetime-attributes`, `numeric-attributes`, `string-attributes`. That way we can walk around the parsing issues e.g. https://github.com/saleor/saleor-dashboard/issues/2673#issuecomment-1327683202. We shouldn't guess what is the type of attribute based on its value - e.g. "2022" may be parsed as year, number or string, but it should be exactly equal to the type that core expects, the type of underneath attribute.

Fixes https://github.com/saleor/saleor-dashboard/issues/2673
Fixes https://github.com/saleor/saleor-dashboard/issues/2326

It may not be an ideal solution, but filters are planned to be rebuilt. Please share your thoughts what do you think.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [x] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1