### PR TITLE
Refresh README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@
   <a href="https://githubbox.com/saleor/saleor-dashboard">🔎 Explore Code</a>
 </div>
 
-## Quickstart
-
-### Prerequisites
+## Prerequisites
 
 - Node.js v18+
 - A running instance of [Saleor](https://github.com/saleor/saleor/)
 
-### Installation
+## Development
 
 1. Clone the repository:
 
@@ -62,7 +60,7 @@ npm run dev
 > Note:
 > If you see CORS errors, check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
 
-## Development
+## Docs
 
 - [Configuration ⚙️](docs/configuration.md)
 - [Error tracking ⚠️](docs/error-tracking.md)

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@
 
 1. Clone the repository:
 
-```
+```bash
 git clone https://github.com/saleor/saleor-dashboard.git
 ```
 
 2. Enter the project directory:
 
-```
+```bash
 cd saleor-dashboard
 ```
 
 3. Install the dependencies:
 
-```
+```bash
 npm i
 ```
 
@@ -53,7 +53,7 @@ npm i
 
 5. Start the development server with:
 
-```
+```bash
 npm run dev
 ```
 
@@ -66,4 +66,5 @@ npm run dev
 - [Error tracking ⚠️](docs/error-tracking.md)
 - [Running tests 🏁](docs/running-tests.md)
 - [Usage with Docker 🐳](docs/docker.md)
-- [Sentry adapter 🗼](docs/sentry.md)
+- [Sentry adapter 🗼](docs/sentry-adapter.md)
+- [Deployment 🌐](docs/deployment.md)

--- a/README.md
+++ b/README.md
@@ -18,179 +18,53 @@
   <a href="https://twitter.com/getsaleor">🐦 Twitter</a>
 </div>
 
-
 <div align="center">
   <a href="https://demo.saleor.io/dashboard">▶️ Demo</a>
    <span> • </span>
   <a href="https://githubbox.com/saleor/saleor-dashboard">🔎 Explore Code</a>
 </div>
 
-## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
+## Quickstart
 
 ### Prerequisites
 
 - Node.js v18+
 - A running instance of [Saleor](https://github.com/saleor/saleor/).
 
-### Installing
+### Installation
 
-Clone the repository:
-
-```
-$ git clone https://github.com/saleor/saleor-dashboard.git
-```
-
-Enter the project directory:
+1. Clone the repository:
 
 ```
-$ cd saleor-dashboard
+git clone https://github.com/saleor/saleor-dashboard.git
 ```
 
-#### Using stable release
-
-Check [release log](https://github.com/saleor/saleor-dashboard/releases/) for the latest release.
-
-#### Using the development version
-
-If you want to use the latest development version, `checkout` to the `main` branch:
+2. Enter the project directory:
 
 ```
-$ git checkout main
+cd saleor-dashboard
 ```
 
-Install the dependencies:
+3. Install the dependencies:
 
 ```
-$ npm i
+npm i
 ```
 
-### Configuration
+4. Configure the env vars as described in [docs/configuration.md](docs/configuration.md).
 
-Create `.env` file in a root directory or set environment variables with the following values:
-
-- `API_URI` (required) - URI of Saleor GraphQL API instance.
-  If you are running Saleor locally with the default settings, set `API_URI` to: "http://localhost:8000/graphql/".
-  Make sure you have "/" at the end of `API_URI`.
-
-- `APP_MOUNT_URI` - URI at which the Dashboard app will be mounted.
-  E.g., if you set `APP_MOUNT_URI` to "/dashboard/", your app will be mounted at "http://localhost:9000/dashboard/".
-
-- `STATIC_URL` - URL where the static files are located.
-  E.g., if you use an S3 bucket, you should set it to the bucket's URL. By default, Saleor assumes you serve static files from the root of your site at "http://localhost:9000/".
-
-- `MARKETPLACE_URL`  - URL where Marketplace App is located. If not found, it will not render a navigation link to the Marketplace.
-
-- `SALEOR_APPS_PAGE_PATH` - Path appended to `MARKETPLACE_URL` to render Saleor Apps page.
- 
-- `SALEOR_APPS_JSON_PATH` - Path appended to `MARKETPLACE_URL` to fetch a list of Saleor Apps as JSON.
-
-- `APP_TEMPLATE_GALLERY_PATH` - Path appended to `MARKETPLACE_URL` to render App Template Gallery page.
-
-### Development
-
-To start the development server, run:
+5. Start the development server with:
 
 ```
-$ npm run dev
+npm run dev
 ```
 
-If you see CORS errors, check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
+> Note:
+> If you see CORS errors, check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
 
-### Production
-
-To build the application bundle, run:
-
-```
-$ npm run build
-```
-
-### Error Tracking
-
-Saleor Dashboard uses a generic error-tracking wrapper function that takes care of the most popular use cases:
-
-- initializing the tracker
-- capturing exceptions and (optionally) displaying the event id
-- setting basic user data (this is opt-in and disabled by default)
-
-By default, it ships with a Sentry adapter, but you can use any error-tracking software by creating a custom adapter (using Sentry and TS types as an example).
-
-Example:
-
-```javascript
-// src/services/errorTracking/index.ts
-
-import { CustomAdapter } from "./adapters/";
-
-const errorTracker = ErrorTrackerFactory(CustomAdapter(config));
-```
-
-### Running e2e tests
-
-Add Cypress-specific env variables to `.env` file (created in the configuration section above):
-
-```
-CYPRESS_USER_NAME=
-CYPRESS_USER_PASSWORD=
-CYPRESS_SECOND_USER_NAME=
-CYPRESS_PERMISSIONS_USERS_PASSWORD=
-
-CYPRESS_mailHogUrl=
-STRIPE_SECRET_KEY=
-STRIPE_PUBLIC_KEY=
-
-// not required
-CYPRESS_RECORD_KEY= // if you want your local runs recorded
-```
-
-For values of those variables, refer to our internal documentation.
-
-You are ready to run Cypress commands like:
-
-```shell
-npm run cy:open
-```
-
-### Usage with Docker
-
-Build Docker image:
-
-```shell
-docker build --tag saleor-dashboard .
-```
-
-Run nginx from Docker and bind it to port on your machine (in this example, it is "8080"):
-
-```shell
-docker run --publish 8080:80 --env "API_URL=<YOUR_API_URL>" saleor-dashboard
-```
-
-Enter `http://localhost:8080/` to use the dashboard.
-
-If you want to change `API_URL` in runtime, you can use (assuming you have a running container named `saleor-dashboard`):
-
-```shell
-docker exec -it -e API_URL=NEW_URL saleor-dashboard /docker-entrypoint.d/50-replace-api-url.sh
-```
-
-### Usage with Sentry adapter
-
-We use Sentry as the default tracker. No changes in code are required for it to work. You can configure it with the environment variables.
-
-The following environment variables are available:
-
-```
-# Required
-SENTRY_DSN=
-
-# Optional
-# https://docs.sentry.io/product/cli/configuration/
-SENTRY_AUTH_TOKEN=
-SENTRY_ORG=
-SENTRY_PROJECT=
-SENTRY_URL_PREFIX=
-ENVIRONMENT=
-```
-
-#### Crafted with ❤️ by [Saleor Commerce](https://saleor.io)
+## Development
+- [Error tracking](docs/error-tracking.md)
+- [Running tests](docs/running-tests.md)
+- [Running with Docker](docs/docker.md)
+- [Sentry adapter](docs/sentry.md)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ### Prerequisites
 
 - Node.js v18+
-- A running instance of [Saleor](https://github.com/saleor/saleor/).
+- A running instance of [Saleor](https://github.com/saleor/saleor/)
 
 ### Installation
 
@@ -64,7 +64,8 @@ npm run dev
 
 ## Development
 
-- [Error tracking](docs/error-tracking.md)
-- [Running tests](docs/running-tests.md)
-- [Usage with Docker](docs/docker.md)
-- [Sentry adapter](docs/sentry.md)
+- [Configuration ⚙️](docs/configuration.md)
+- [Error tracking ⚠️](docs/error-tracking.md)
+- [Running tests 🏁](docs/running-tests.md)
+- [Usage with Docker 🐳](docs/docker.md)
+- [Sentry adapter 🗼](docs/sentry.md)

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@
   <a href="https://twitter.com/getsaleor">🐦 Twitter</a>
 </div>
 
-## Demo
 
-See the [public demo](https://demo.saleor.io/dashboard/) of Saleor Dashboard!
-
-Or launch the demo on a free Heroku instance.
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+<div align="center">
+  <a href="https://demo.saleor.io/dashboard">▶️ Demo</a>
+   <span> • </span>
+  <a href="https://githubbox.com/saleor/saleor-dashboard">🔎 Explore Code</a>
+</div>
 
 ## Getting Started
 
@@ -51,7 +50,7 @@ $ cd saleor-dashboard
 
 #### Using stable release
 
-Check [release log](https://github.com/saleor/saleor-dashboard/releases/) for the latest release
+Check [release log](https://github.com/saleor/saleor-dashboard/releases/) for the latest release.
 
 #### Using development version
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
   <a href="https://githubbox.com/saleor/saleor-dashboard">🔎 Explore Code</a>
 </div>
 
-
 ## Quickstart
 
 ### Prerequisites
@@ -64,7 +63,8 @@ npm run dev
 > If you see CORS errors, check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
 
 ## Development
+
 - [Error tracking](docs/error-tracking.md)
 - [Running tests](docs/running-tests.md)
-- [Running with Docker](docs/docker.md)
+- [Usage with Docker](docs/docker.md)
 - [Sentry adapter](docs/sentry.md)

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ $ cd saleor-dashboard
 
 Check [release log](https://github.com/saleor/saleor-dashboard/releases/) for the latest release.
 
-#### Using development version
+#### Using the development version
 
-If you want to use the latest development version, checkout to the `main` branch:
+If you want to use the latest development version, `checkout` to the `main` branch:
 
 ```
 $ git checkout main
 ```
 
-Install NPM dependencies:
+Install the dependencies:
 
 ```
 $ npm i
@@ -68,39 +68,39 @@ $ npm i
 
 ### Configuration
 
-Create `.env` file in a root directory or set environment variables with following values:
+Create `.env` file in a root directory or set environment variables with the following values:
 
-- `API_URI` (required) - URI of a running instance of Saleor GraphQL API.
-  If you are running Saleor locally with the default settings, set `API_URI` to: `http://localhost:8000/graphql/`.
-  Make sure that you have `/` at the end of `API_URI`.
+- `API_URI` (required) - URI of Saleor GraphQL API instance.
+  If you are running Saleor locally with the default settings, set `API_URI` to: "http://localhost:8000/graphql/".
+  Make sure you have "/" at the end of `API_URI`.
 
 - `APP_MOUNT_URI` - URI at which the Dashboard app will be mounted.
-  E.g. if you set `APP_MOUNT_URI` to `/dashboard/`, your app will be mounted at `http://localhost:9000/dashboard/`.
+  E.g., if you set `APP_MOUNT_URI` to "/dashboard/", your app will be mounted at "http://localhost:9000/dashboard/".
 
 - `STATIC_URL` - URL where the static files are located.
-  E.g. if you use S3 bucket, you should set it to the bucket's URL. By default Saleor assumes you serve static files from the root of your site at `http://localhost:9000/`.
+  E.g., if you use an S3 bucket, you should set it to the bucket's URL. By default, Saleor assumes you serve static files from the root of your site at "http://localhost:9000/".
 
-- `MARKETPLACE_URL`  - URL where Marketplace App can is located, if not found, will not render navigation link to Marketplace
+- `MARKETPLACE_URL`  - URL where Marketplace App is located. If not found, it will not render a navigation link to the Marketplace.
 
-- `SALEOR_APPS_PAGE_PATH` - Path joined to `MARKETPLACE_URL` to render Saleor Apps page
+- `SALEOR_APPS_PAGE_PATH` - Path appended to `MARKETPLACE_URL` to render Saleor Apps page.
  
-- `SALEOR_APPS_JSON_PATH` - Path joined to `MARKETPLACE_URL` to fetch list of Saleor Apps as JSON
+- `SALEOR_APPS_JSON_PATH` - Path appended to `MARKETPLACE_URL` to fetch a list of Saleor Apps as JSON.
 
-- `APP_TEMPLATE_GALLERY_PATH` - Path joined to `MARKETPLACE_URL` to render App Template Gallery page
+- `APP_TEMPLATE_GALLERY_PATH` - Path appended to `MARKETPLACE_URL` to render App Template Gallery page.
 
 ### Development
 
-To start the development server run:
+To start the development server, run:
 
 ```
 $ npm run dev
 ```
 
-In case you see CORS errors make sure to check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
+If you see CORS errors, check [CORS configuration](https://docs.saleor.io/docs/3.x/developer/running-saleor/configuration#allowed_client_hosts) of your Saleor instance or CORS settings in the Cloud Console.
 
 ### Production
 
-To build the application bundle run:
+To build the application bundle, run:
 
 ```
 $ npm run build
@@ -108,13 +108,13 @@ $ npm run build
 
 ### Error Tracking
 
-Saleor Dashboard is using a generic error tracking wrapper function that takes care of the most popular use cases:
+Saleor Dashboard uses a generic error-tracking wrapper function that takes care of the most popular use cases:
 
 - initializing the tracker
 - capturing exceptions and (optionally) displaying the event id
 - setting basic user data (this is opt-in and disabled by default)
 
-By default it ships with a Sentry adapter but any kind of error tracking software can be used by creating a custom adapter (using Sentry and TS types as an example).
+By default, it ships with a Sentry adapter, but you can use any error-tracking software by creating a custom adapter (using Sentry and TS types as an example).
 
 Example:
 
@@ -128,7 +128,7 @@ const errorTracker = ErrorTrackerFactory(CustomAdapter(config));
 
 ### Running e2e tests
 
-Add Cypress specific env variables to `.env` file (created in configuration section above):
+Add Cypress-specific env variables to `.env` file (created in the configuration section above):
 
 ```
 CYPRESS_USER_NAME=
@@ -144,31 +144,31 @@ STRIPE_PUBLIC_KEY=
 CYPRESS_RECORD_KEY= // if you want your local runs recorded
 ```
 
-For values of those variables refer to our internal documentation.
+For values of those variables, refer to our internal documentation.
 
-You are ready to run cypress commands like:
+You are ready to run Cypress commands like:
 
 ```shell
 npm run cy:open
 ```
 
-### Usage with docker
+### Usage with Docker
 
-Build docker image:
+Build Docker image:
 
 ```shell
 docker build --tag saleor-dashboard .
 ```
 
-Run nginx from docker and bind it to port on your machine (in this example 8080):
+Run nginx from Docker and bind it to port on your machine (in this example, it is "8080"):
 
 ```shell
 docker run --publish 8080:80 --env "API_URL=<YOUR_API_URL>" saleor-dashboard
 ```
 
-Enter `http://localhost:8080/` to use dashboard.
+Enter `http://localhost:8080/` to use the dashboard.
 
-If you want to dynamically change `API_URL` in runtime you can use (assuming you have running container named `saleor-dashboard`):
+If you want to change `API_URL` in runtime, you can use (assuming you have a running container named `saleor-dashboard`):
 
 ```shell
 docker exec -it -e API_URL=NEW_URL saleor-dashboard /docker-entrypoint.d/50-replace-api-url.sh
@@ -176,7 +176,7 @@ docker exec -it -e API_URL=NEW_URL saleor-dashboard /docker-entrypoint.d/50-repl
 
 ### Usage with Sentry adapter
 
-Sentry is used as the default tracker so no changes in code are necessary and the configuration is done via environment variables.
+We use Sentry as the default tracker. No changes in code are required for it to work. You can configure it with the environment variables.
 
 The following environment variables are available:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,21 @@
+# Configuration
+
+Create `.env` file in a root directory or set environment variables with the following values:
+
+- `API_URI` (required) - URI of Saleor GraphQL API instance.
+  If you are running Saleor locally with the default settings, set `API_URI` to: "http://localhost:8000/graphql/".
+  Make sure you have "/" at the end of `API_URI`.
+
+- `APP_MOUNT_URI` - URI at which the Dashboard app will be mounted.
+  E.g., if you set `APP_MOUNT_URI` to "/dashboard/", your app will be mounted at "http://localhost:9000/dashboard/".
+
+- `STATIC_URL` - URL where the static files are located.
+  E.g., if you use an S3 bucket, you should set it to the bucket's URL. By default, Saleor assumes you serve static files from the root of your site at "http://localhost:9000/".
+
+- `MARKETPLACE_URL`  - URL where Marketplace App is located. If not found, it will not render a navigation link to the Marketplace.
+
+- `SALEOR_APPS_PAGE_PATH` - Path appended to `MARKETPLACE_URL` to render Saleor Apps page.
+
+- `SALEOR_APPS_JSON_PATH` - Path appended to `MARKETPLACE_URL` to fetch a list of Saleor Apps as JSON.
+
+- `APP_TEMPLATE_GALLERY_PATH` - Path appended to `MARKETPLACE_URL` to render App Template Gallery page.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,19 @@
+# Deployment
+
+## Overview
+
+`saleor-dashboard` is a single-page application that the build process turns into a set of static files. You can deploy them anywhere (e.g. [Vercel](https://www.vercel.com/), [Netlify](https://www.netlify.com/)).
+
+## Build
+
+To build your `saleor-dashboard` instance, please run:
+
+```bash
+npm run build
+```
+
+If you want to preview your build, you can do it with:
+
+```bash
+npm run preview
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,21 @@
+# Usage with Docker
+
+Build Docker image:
+
+```shell
+docker build --tag saleor-dashboard .
+```
+
+Run nginx from Docker and bind it to port on your machine (in this example, it is "8080"):
+
+```shell
+docker run --publish 8080:80 --env "API_URL=<YOUR_API_URL>" saleor-dashboard
+```
+
+Enter `http://localhost:8080/` to use the dashboard.
+
+If you want to change `API_URL` in runtime, you can use (assuming you have a running container named `saleor-dashboard`):
+
+```shell
+docker exec -it -e API_URL=NEW_URL saleor-dashboard /docker-entrypoint.d/50-replace-api-url.sh
+```

--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -1,0 +1,19 @@
+# Error Tracking
+
+Saleor Dashboard uses a generic error-tracking wrapper function that takes care of the most popular use cases:
+
+- initializing the tracker
+- capturing exceptions and (optionally) displaying the event id
+- setting basic user data (this is opt-in and disabled by default)
+
+By default, it ships with a Sentry adapter, but you can use any error-tracking software by creating a custom adapter (using Sentry and TS types as an example).
+
+Example:
+
+```javascript
+// src/services/errorTracking/index.ts
+
+import { CustomAdapter } from "./adapters/";
+
+const errorTracker = ErrorTrackerFactory(CustomAdapter(config));
+```

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -1,0 +1,25 @@
+# Running E2E tests
+
+Add Cypress-specific env variables to `.env` file (created in the configuration section above):
+
+```
+CYPRESS_USER_NAME=
+CYPRESS_USER_PASSWORD=
+CYPRESS_SECOND_USER_NAME=
+CYPRESS_PERMISSIONS_USERS_PASSWORD=
+
+CYPRESS_mailHogUrl=
+STRIPE_SECRET_KEY=
+STRIPE_PUBLIC_KEY=
+
+// not required
+CYPRESS_RECORD_KEY= // if you want your local runs recorded
+```
+
+For values of those variables, refer to our internal documentation.
+
+You are ready to run Cypress commands like:
+
+```shell
+npm run cy:open
+```

--- a/docs/sentry-adapter.md
+++ b/docs/sentry-adapter.md
@@ -1,0 +1,18 @@
+# Sentry adapter
+
+We use Sentry as the default tracker. No changes in code are required for it to work. You can configure it with the environment variables.
+
+The following environment variables are available:
+
+```
+# Required
+SENTRY_DSN=
+
+# Optional
+# https://docs.sentry.io/product/cli/configuration/
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_URL_PREFIX=
+ENVIRONMENT=
+```


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44495184/205128584-b94eac9f-09f5-4d87-9daa-c82005b1a92c.png)

**Featuring:**
- Removed 🗑️:
  - "Using stable release", "To build the application bundle, run" - I wasn't sure where to put it and I hope it's pretty self-explanatory.
  - "Using the development version" - When you clone the repository, the default branch is `main`. IMO, it's redundant.
- Moved 📦:
  - "Configuration", "Running E2E tests", "Error Tracking", "Usage with Docker", and "Usage with Sentry adapter" - to separate `docs/ articles. Linked to the articles in the "Docs" section in the README.
- Restructured README.md 🔄.
- Proofchecked articles for typos ✍️.
  

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

CONTAINERS=1