### PR TITLE
replace filter method from fuzzaldrin with native filter method of javascript to fix country select issue #2751

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "faker": "^5.1.0",
         "fast-array-diff": "^0.2.0",
         "find-test-names": "^1.17.1",
+        "fuse.js": "^6.6.2",
         "fuzzaldrin": "^2.1.0",
         "graphql": "^15.4.0",
         "hotkeys-js": "^3.8.1",
@@ -9323,6 +9324,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "optional": true
+    },
+    "node_modules/@storybook/ui/node_modules/fuse.js": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
+      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@storybook/ui/node_modules/react": {
       "version": "16.14.0",
@@ -21914,12 +21924,11 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
-      "optional": true,
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/fuzzaldrin": {
@@ -51560,6 +51569,12 @@
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "optional": true
         },
+        "fuse.js": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
+          "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
+          "dev": true
+        },
         "react": {
           "version": "16.14.0",
           "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
@@ -61539,10 +61554,9 @@
       "devOptional": true
     },
     "fuse.js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
-      "optional": true
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "fuzzaldrin": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "faker": "^5.1.0",
     "fast-array-diff": "^0.2.0",
     "find-test-names": "^1.17.1",
+    "fuse.js": "^6.6.2",
     "fuzzaldrin": "^2.1.0",
     "graphql": "^15.4.0",
     "hotkeys-js": "^3.8.1",

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -11,7 +11,6 @@ import { ChevronIcon } from "@saleor/macaw-ui";
 import { FetchMoreProps } from "@saleor/types";
 import clsx from "clsx";
 import Downshift from "downshift";
-import { filter } from "fuzzaldrin";
 import React from "react";
 
 import Debounce, { DebounceProps } from "../Debounce";
@@ -301,9 +300,12 @@ const SingleAutocompleteSelectField: React.FC<SingleAutocompleteSelectFieldProps
   return (
     <SingleAutocompleteSelectFieldComponent
       fetchChoices={q => setQuery(q || "")}
-      choices={filter(choices, query, {
-        key: "label",
-      })}
+      choices={choices.filter(c =>
+        c.label
+          .toString()
+          .toLowerCase()
+          .includes(query.toLowerCase()),
+      )}
       {...rest}
     />
   );

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -298,12 +298,12 @@ const SingleAutocompleteSelectField: React.FC<SingleAutocompleteSelectFieldProps
     );
   }
 
-  const fuse = new Fuse(choices, { useExtendedSearch: true, keys: ["label"] });
+  const fuse = new Fuse(choices, { keys: ["label"] });
 
   return (
     <SingleAutocompleteSelectFieldComponent
       fetchChoices={q => setQuery(q || "")}
-      choices={fuse.search(`'${query}`).map(v => v.item)}
+      choices={query !== "" ? fuse.search(query).map(v => v.item) : choices}
       {...rest}
     />
   );

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -11,6 +11,7 @@ import { ChevronIcon } from "@saleor/macaw-ui";
 import { FetchMoreProps } from "@saleor/types";
 import clsx from "clsx";
 import Downshift from "downshift";
+import Fuse from "fuse.js";
 import React from "react";
 
 import Debounce, { DebounceProps } from "../Debounce";
@@ -297,15 +298,12 @@ const SingleAutocompleteSelectField: React.FC<SingleAutocompleteSelectFieldProps
     );
   }
 
+  const fuse = new Fuse(choices, { useExtendedSearch: true, keys: ["label"] });
+
   return (
     <SingleAutocompleteSelectFieldComponent
       fetchChoices={q => setQuery(q || "")}
-      choices={choices.filter(c =>
-        c.label
-          .toString()
-          .toLowerCase()
-          .includes(query.toLowerCase()),
-      )}
+      choices={fuse.search(`'${query}`).map(v => v.item)}
       {...rest}
     />
   );


### PR DESCRIPTION
I want to merge this change because filter method of fuzzaldrin doesn't work properly in `SingleAutocompleteSelectField` component.
There is already an issue(#2751) related to this one.

### Screenshots
after changes..
![Screenshot from 2022-12-02 00-12-02](https://user-images.githubusercontent.com/61251512/205236517-0df4c221-53a8-4141-b976-eeac5775e0f4.png)
![Screenshot from 2022-12-02 00-12-15](https://user-images.githubusercontent.com/61251512/205236536-edcc1aaf-aafd-4778-829d-24d66fa1cb7a.png)


### Pull Request Checklist
This code doesn't contain any UI changes.
And this code meets all requirements above.
<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1