### PR TITLE
Enable use unknown in catch variables

### DIFF
--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -157,7 +157,11 @@ export function useAuthProvider({
 
       return result.data.tokenCreate;
     } catch (error) {
-      handleLoginError(error);
+      if (error instanceof ApolloError) {
+        handleLoginError(error);
+      } else {
+        setErrors(["unknownLoginError"]);
+      }
     }
   };
 
@@ -195,7 +199,11 @@ export function useAuthProvider({
 
       return result?.data?.externalObtainAccessTokens;
     } catch (error) {
-      handleLoginError(error);
+      if (error instanceof ApolloError) {
+        handleLoginError(error);
+      } else {
+        setErrors(["unknownLoginError"]);
+      }
     }
   };
 

--- a/src/components/Filter/FilterContent/FilterErrorsList.tsx
+++ b/src/components/Filter/FilterContent/FilterErrorsList.tsx
@@ -55,7 +55,7 @@ const FilterErrorsList: React.FC<FilterErrorsListProps> = ({
         { dependencies: dependencies?.join() },
       );
     } catch (e) {
-      errorTracker.captureException(e);
+      errorTracker.captureException(e as Error);
       console.warn("Translation missing for filter error code: ", code);
       return intl.formatMessage(validationMessages.UNKNOWN_ERROR);
     }

--- a/src/containers/BackgroundTasks/tasks.ts
+++ b/src/containers/BackgroundTasks/tasks.ts
@@ -37,7 +37,11 @@ export async function handleTask(task: QueuedTask): Promise<TaskStatus> {
       });
     }
   } catch (error) {
-    task.onError(error);
+    if (error instanceof Error) {
+      task.onError(error);
+    } else {
+      console.error("Unknown error", error);
+    }
   }
 
   return status;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitThis": true,
     "alwaysStrict": true,
     "strictBindCallApply": true,
+    "useUnknownInCatchVariables": true,
     "paths": {
       "@assets/*": ["assets/*"],
       "@locale/*": ["locale/*"],


### PR DESCRIPTION
I want to merge this change because it enables "Use unknown in catch variables" typescript rule. Fixes #2590.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1