### PR TITLE
Handle NotifyReady event from app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "@pollyjs/core": "^5.0.0",
         "@pollyjs/persister-fs": "^5.0.0",
         "@release-it/bumper": "^2.0.0",
-        "@saleor/app-sdk": "~0.23.0",
+        "@saleor/app-sdk": "~0.24.0",
         "@sentry/webpack-plugin": "^1.14.0",
         "@storybook/react": "^5.1.9",
         "@testing-library/react": "^12.1.5",
@@ -6400,9 +6400,9 @@
       }
     },
     "node_modules/@saleor/app-sdk": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@saleor/app-sdk/-/app-sdk-0.23.0.tgz",
-      "integrity": "sha512-tlSwuMhK0CsPI+HoEPZny4hnpUWLd2uPtKH1I0B3z6/Smv8VPUV4bSEKVsPseZ97KQG472yDDaqmSzsZyo43nQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@saleor/app-sdk/-/app-sdk-0.24.0.tgz",
+      "integrity": "sha512-vrWRcrB1D2EA0d/yzPFf+npfAOukIqBm6FzQhWDsHI1v+ZPjaZkjmiqMtjWvGrhRuRKtEJ9YHsAQYjNOhc1Pvg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -44379,9 +44379,9 @@
       }
     },
     "@saleor/app-sdk": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@saleor/app-sdk/-/app-sdk-0.23.0.tgz",
-      "integrity": "sha512-tlSwuMhK0CsPI+HoEPZny4hnpUWLd2uPtKH1I0B3z6/Smv8VPUV4bSEKVsPseZ97KQG472yDDaqmSzsZyo43nQ==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@saleor/app-sdk/-/app-sdk-0.24.0.tgz",
+      "integrity": "sha512-vrWRcrB1D2EA0d/yzPFf+npfAOukIqBm6FzQhWDsHI1v+ZPjaZkjmiqMtjWvGrhRuRKtEJ9YHsAQYjNOhc1Pvg==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@pollyjs/core": "^5.0.0",
     "@pollyjs/persister-fs": "^5.0.0",
     "@release-it/bumper": "^2.0.0",
-    "@saleor/app-sdk": "~0.23.0",
+    "@saleor/app-sdk": "~0.24.0",
     "@sentry/webpack-plugin": "^1.14.0",
     "@storybook/react": "^5.1.9",
     "@testing-library/react": "^12.1.5",

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -27,6 +27,15 @@ interface Props {
 
 const getOrigin = (url: string) => new URL(url).origin;
 
+/**
+ * Hide app initially and wait till app informs Dashboard thats its ready to be shown
+ *
+ * TODO - what about older apps? They will never appear. Add timeout? Or add field to manifest?
+ */
+const iframeStyle = {
+  height: 0,
+};
+
 export const AppFrame: React.FC<Props> = ({
   src,
   appToken,
@@ -101,6 +110,7 @@ export const AppFrame: React.FC<Props> = ({
 
   return (
     <iframe
+      style={iframeStyle}
       ref={frameRef}
       src={resolveAppIframeUrl(appId, src, params)}
       onError={onError}

--- a/src/apps/components/AppFrame/useAppActions.ts
+++ b/src/apps/components/AppFrame/useAppActions.ts
@@ -33,6 +33,9 @@ const isAppDeepUrlChange = (appId: string, from: string, to: string) => {
   return to.startsWith(appCompletePath) && from.startsWith(appCompletePath);
 };
 
+/**
+ * TODO - refactor, introduce SRP, each action should be encapsulated
+ */
 export const useAppActions = (
   frameEl: React.MutableRefObject<HTMLIFrameElement>,
   appOrigin: string,
@@ -117,6 +120,11 @@ export const useAppActions = (
         window.history.pushState(null, "", appCompletePath + newRoute);
 
         return sendResponseStatus(actionId, true);
+      }
+      case "notifyReady": {
+        frameEl.current.style.height = "";
+
+        return sendResponseStatus(action.payload.actionId, true);
       }
       default: {
         throw new Error("Unknown action type");

--- a/src/apps/components/AppPage/styles.ts
+++ b/src/apps/components/AppPage/styles.ts
@@ -54,11 +54,10 @@ export const useStyles = makeStyles(
       lineHeight: 0, // It removes extra space between iframe and container
       "& > iframe": {
         border: "none",
-        minHeight: "60vh",
-        height: `calc(100vh - 27.8rem)`,
+        height: `calc(100vh - 30rem)`,
         width: "100%",
         [theme.breakpoints.up("md")]: {
-          height: `calc(100vh - 23.4rem)`,
+          height: `calc(100vh - 25rem)`,
         },
       },
     },


### PR DESCRIPTION
I want to merge this change because...

This PR handles FOUC problem when app initially renders light/dark and flashes before dashboard sends proper theme.
Even if theme is provided in URL, it doesn't solve the problem because Macaw etc doesn't exist yet.

This approach hides iframe before App sends (via appbridge) action that app is ready to be displayed

rel
https://github.com/saleor/saleor-app-template/pull/131
https://github.com/saleor/saleor-app-marketplace/issues/117

**Problem to be solved first:**

How to handle old apps? We can add timeout, but it will be fragile. 
Possibly best to add configuration to AppManifest and make this change optional

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1