### PR TITLE
Fix test for email case insensitive

### DIFF
--- a/cypress/e2e/configuration/customer.js
+++ b/cypress/e2e/configuration/customer.js
@@ -71,7 +71,9 @@ describe("Tests for customer", () => {
           expect(customer.lastName, "Expect correct last name").to.eq(
             randomName,
           );
-          expect(customer.email, "Expect correct email").to.eq(email);
+          expect(customer.email, "Expect correct email").to.eq(
+            email.toLowerCase(),
+          );
           expect(customer.note, "Expect correct note").to.eq(note);
           cy.expectCorrectFullAddress(customer.addresses[0], address);
         });
@@ -277,7 +279,7 @@ describe("Tests for customer", () => {
           );
           expect(user.lastName, "Expect correct last name").to.eq(updatedName);
           expect(user.email, "Expect correct email").to.eq(
-            `${updatedName}@example.com`,
+            `${updatedName}@example.com`.toLowerCase(),
           );
           expect(user.note, "Expect correct note").to.eq(updatedName);
         });

--- a/cypress/e2e/staffMembers.js
+++ b/cypress/e2e/staffMembers.js
@@ -91,18 +91,22 @@ describe("Staff members", () => {
   );
 
   it("should activate user", { tags: ["@staffMembers", "@stagedOnly"] }, () => {
+    const serverStoredEmail = email.toLowerCase();
+
     updateStaffMember({ userId: user.id, isActive: false });
     updateUserActiveFlag(user.id);
     cy.clearSessionData()
       .loginUserViaRequest("auth", { email, password })
       .visit(urlList.homePage);
-    expectWelcomeMessageIncludes(email);
+    expectWelcomeMessageIncludes(serverStoredEmail);
   });
 
   it(
     "should remove user permissions",
     { tags: ["@staffMembers", "@stagedOnly"] },
     () => {
+      const serverStoredEmail = email.toLowerCase();
+
       cy.visit(userDetailsUrl(user.id))
         .get(STAFF_MEMBER_DETAILS.removePermissionButton)
         .click()
@@ -114,7 +118,7 @@ describe("Staff members", () => {
         .clearSessionData()
         .loginUserViaRequest("auth", { email, password })
         .visit(urlList.homePage);
-      expectWelcomeMessageIncludes(email);
+      expectWelcomeMessageIncludes(serverStoredEmail);
       getDisplayedSelectors().then(displayedSelectors => {
         expect(Object.values(displayedSelectors)).to.have.length(1);
         expect(Object.values(displayedSelectors)[0]).to.eq(

--- a/cypress/support/api/requests/Customer.js
+++ b/cypress/support/api/requests/Customer.js
@@ -1,14 +1,14 @@
 import {
   getDefaultAddress,
   getDefaultAddressWithoutType,
-  getValueWithDefault
+  getValueWithDefault,
 } from "./utils/Utils";
 
 export function createCustomer(email, customerName, address, isActive = false) {
   const addressesLines = getValueWithDefault(
     address,
     `${getDefaultAddress(address, "defaultBillingAddress")}
-    ${getDefaultAddress(address, "defaultShippingAddress")}`
+    ${getDefaultAddress(address, "defaultShippingAddress")}`,
   );
   const mutation = `
   mutation{
@@ -76,7 +76,7 @@ export function getCustomers(startsWith) {
 export function customerRegistration({
   email,
   password = Cypress.env("USER_PASSWORD"),
-  channel
+  channel,
 }) {
   const mutation = `mutation{
     accountRegister(input:{
@@ -113,8 +113,10 @@ export function requestPasswordReset(email, channel) {
 }
 
 export function confirmAccount(email, token) {
+  const serverStoredEmail = email.toLowerCase();
+
   const mutation = `mutation{
-    confirmAccount(email:"${email}", token:"${token}"){
+    confirmAccount(email:"${serverStoredEmail}", token:"${token}"){
       user{
         email
       }

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -23,14 +23,18 @@ export function inviteStaffMemberWithFirstPermission({
  * It cloud happened that invite email from saleor has not been received yet, so in this case the action should be retried.
  */
 export function getMailActivationLinkForUser(email, regex, i = 0) {
+  const serverStoredEmail = email.toLowerCase();
+
   const urlRegex = regex ? regex : /\[\w*password\w*\]\(([^\)]*)/;
   if (i > 3) {
-    throw new Error(`There is no email invitation for user ${email}`);
+    throw new Error(
+      `There is no email invitation for user ${serverStoredEmail}`,
+    );
   }
-  return cy.mhGetMailsByRecipient(email).should(mails => {
+  return cy.mhGetMailsByRecipient(serverStoredEmail).should(mails => {
     if (!mails.length) {
       cy.wait(10000);
-      getMailActivationLinkForUser(email, regex, i + 1);
+      getMailActivationLinkForUser(serverStoredEmail, regex, i + 1);
     } else {
       cy.wrap(mails)
         .mhFirst()
@@ -45,20 +49,28 @@ export function getMailActivationLinkForUser(email, regex, i = 0) {
 }
 
 export function getMailActivationLinkForUserAndSubject(email, subject, i = 0) {
+  const serverStoredEmail = email.toLowerCase();
+
   if (i > 3) {
-    throw new Error(`There is no email invitation for user ${email}`);
+    throw new Error(
+      `There is no email invitation for user ${serverStoredEmail}`,
+    );
   }
-  return cy.mhGetMailsByRecipient(email).should(mails => {
+  return cy.mhGetMailsByRecipient(serverStoredEmail).should(mails => {
     if (!mails.length) {
       cy.wait(10000);
-      getMailActivationLinkForUserAndSubject(email, subject, i + 1);
+      getMailActivationLinkForUserAndSubject(serverStoredEmail, subject, i + 1);
     } else {
       cy.wrap(mails)
         .mhGetMailsBySubject(subject)
         .should(mailsWithSubject => {
           if (!mailsWithSubject.length) {
             cy.wait(10000);
-            getMailActivationLinkForUserAndSubject(email, subject, i + 1);
+            getMailActivationLinkForUserAndSubject(
+              serverStoredEmail,
+              subject,
+              i + 1,
+            );
           } else {
             cy.wrap(mailsWithSubject)
               .mhFirst()
@@ -79,13 +91,17 @@ export function getMailActivationLinkForUserAndSubject(email, subject, i = 0) {
 }
 
 export function getMailWithResetPasswordLink(email, subject, i = 0) {
+  const serverStoredEmail = email.toLowerCase();
+
   if (i > 5) {
-    throw new Error(`There is no email with reset password for user ${email}`);
+    throw new Error(
+      `There is no email with reset password for user ${serverStoredEmail}`,
+    );
   }
-  return cy.mhGetMailsByRecipient(email).should(mails => {
+  return cy.mhGetMailsByRecipient(serverStoredEmail).should(mails => {
     if (!mails.length) {
       cy.wait(3000);
-      getMailWithResetPasswordLink(email, subject, i + 1);
+      getMailWithResetPasswordLink(serverStoredEmail, subject, i + 1);
     } else {
       cy.mhGetMailsBySubject(subject);
       return mails;
@@ -94,13 +110,17 @@ export function getMailWithResetPasswordLink(email, subject, i = 0) {
 }
 
 export function getMailsForUser(email, i = 0) {
+  const serverStoredEmail = email.toLowerCase();
+
   if (i > 5) {
-    throw new Error(`There is no email invitation for user ${email}`);
+    throw new Error(
+      `There is no email invitation for user ${serverStoredEmail}`,
+    );
   }
-  return cy.mhGetMailsByRecipient(email).should(mails => {
+  return cy.mhGetMailsByRecipient(serverStoredEmail).should(mails => {
     if (!mails.length) {
       cy.wait(3000);
-      getMailsForUser(email, i + 1);
+      getMailsForUser(serverStoredEmail, i + 1);
     } else {
       return mails;
     }

--- a/cypress/support/pages/draftOrderPage.js
+++ b/cypress/support/pages/draftOrderPage.js
@@ -12,7 +12,9 @@ export function finalizeDraftOrder(name) {
     .get(DRAFT_ORDER_SELECTORS.selectCustomer)
     .type(name);
   return cy
-    .contains(DRAFT_ORDER_SELECTORS.selectCustomerOption, name)
+    .contains(DRAFT_ORDER_SELECTORS.selectCustomerOption, name, {
+      matchCase: false,
+    })
     .click()
     .get(DRAFT_ORDER_SELECTORS.customerEmail)
     .should("be.visible")


### PR DESCRIPTION
I want to merge this change because core introduced changes for storing emails in lowercase only: [Make email authentication case insensitive #11284](https://github.com/saleor/saleor/pull/11284) and some test require fixes:

should create order with selected channel. TC: SALEOR_2104
should invite user
should create customer. TC: SALEOR_1201
should update customer. TC: SALEOR_1202
should change user email. TC: SALEOR_3601
should register customer

https://github.com/saleor/saleor-dashboard/issues/2795 
<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1