### PR TITLE
[cypress] add tests for gift cards bulk create and export

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,6 +121,7 @@ jobs:
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
           CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_mailHogUrl: ${{ secrets.CYPRESS_MAILHOG }}
           COMMIT_INFO_MESSAGE: Tests triggered on PR - ${{ github.ref_name }} with selected tags
           CYPRESS_grepTags: ${{ needs.get-selected-tags-and-containers.outputs.tags }}
         with:

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -225,6 +225,7 @@ jobs:
           CYPRESS_USER_PASSWORD: ${{ secrets.CYPRESS_USER_PASSWORD }}
           CYPRESS_PERMISSIONS_USERS_PASSWORD: ${{ secrets.CYPRESS_PERMISSIONS_USERS_PASSWORD }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_mailHogUrl: ${{ secrets.CYPRESS_MAILHOG }}
           COMMIT_INFO_MESSAGE: Critical tests triggered on PR - ${{ github.ref_name }}
           CYPRESS_grepTags: ${{ needs.prepare-tests.outputs.tags }}
         with:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
       });
       return config;
     },
-    baseUrl: "http://localhost:9000/",
+    baseUrl: "http://localhost:4173/",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
   },
 });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
       });
       return config;
     },
-    baseUrl: "http://localhost:9000/",
+    baseUrl: "http://localhost:4174/",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
   },
 });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
       });
       return config;
     },
-    baseUrl: "http://localhost:4174/",
+    baseUrl: "http://localhost:9000/",
     specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
   },
 });

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -92,7 +92,6 @@ describe("As an admin I want to export gift card", () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;
       const giftCard02 = `${startsWith}${faker.datatype.number()}`;
       const exportId = `${faker.datatype.number()}`;
-      cy.log(exportId);
       let giftCard01hash;
       let giftCard02hash;
 

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -33,7 +33,6 @@ describe("As an admin I want to export gift card", () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;
       const giftCard02 = `${startsWith}${faker.datatype.number()}`;
       const exportId = `${faker.datatype.number()}`;
-      cy.log(exportId);
       let giftCard01hash;
       let giftCard02hash;
 

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -70,6 +70,8 @@ describe("As an admin I want to export gift card", () => {
             .click({ force: true })
             .get(GIFT_CARD_SHOW_MORE.exportCodesMenu)
             .click()
+            .get(GIFT_CARD_SHOW_MORE.exportAsRadioBtn.csv)
+            .click()
             .get(BUTTON_SELECTORS.submit)
             .click().confirmationMessageShouldDisappear;
           getMailWithGiftCardExport(
@@ -115,7 +117,8 @@ describe("As an admin I want to export gift card", () => {
         .then(hash2 => {
           giftCard02hash = hash2.id;
           enterAndSelectGiftCards([giftCard01hash, giftCard02hash]);
-          cy.get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
+          cy
+            .get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
             .first()
             .check()
             .should("be.checked")
@@ -125,15 +128,18 @@ describe("As an admin I want to export gift card", () => {
             .get(BUTTON_SELECTORS.showMoreButton)
             .click({ force: true })
             .get(GIFT_CARD_SHOW_MORE.exportCodesMenu)
-            .click();
-          //   .get(BUTTON_SELECTORS.submit)
-          //   .click().confirmationMessageShouldDisappear;
-          // getMailWithGiftCardExport(
-          //   TEST_ADMIN_USER.email,
-          //   `Your exported gift cards data #${exportId} is ready`, 'xlsx'
-          // ).then((body) => {
-          //   expect(body).to.contain('.xlsx')
-          // });
+            .click()
+            .get(GIFT_CARD_SHOW_MORE.exportAsRadioBtn.xlsx)
+            .click()
+            .get(BUTTON_SELECTORS.submit)
+            .click().confirmationMessageShouldDisappear;
+          getMailWithGiftCardExport(
+            TEST_ADMIN_USER.email,
+            `Your exported gift cards data #${exportId} is ready`,
+            "xlsx",
+          ).then(body => {
+            expect(body).to.contain(".xlsx");
+          });
         });
     },
   );

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -133,7 +133,7 @@ describe("As an admin I want to export gift card", () => {
             .click()
             .get(BUTTON_SELECTORS.submit)
             .click().confirmationMessageShouldDisappear;
-          getMailWithGiftCardExport(
+          getMailWithGiftCardExportWithAttachment(
             TEST_ADMIN_USER.email,
             `Your exported gift cards data #${exportId} is ready`,
             "xlsx",

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -67,7 +67,7 @@ describe("As an admin I want to export gift card", () => {
             .contains("Selected 2 items")
             .should("be.visible")
             .get(BUTTON_SELECTORS.showMoreButton)
-            .click()
+            .click({ force: true })
             .get(GIFT_CARD_SHOW_MORE.exportCodesMenu)
             .click()
             .get(BUTTON_SELECTORS.submit)

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -4,11 +4,12 @@
 import faker from "faker";
 
 import { GIFT_CARD_LIST } from "../../../elements/catalog/giftCard/giftCardList";
-import { GIFT_CARD_SHOWMORE } from "../../../elements/catalog/giftCard/giftCardShowMore";
+import { GIFT_CARD_SHOW_MORE } from "../../../elements/catalog/giftCard/giftCardShowMore";
 import { ASSIGN_ELEMENTS_SELECTORS } from "../../../elements/shared/assign-elements-selectors.js";
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import { TEST_ADMIN_USER } from "../../../fixtures/users";
 import { createGiftCard } from "../../../support/api/requests/GiftCard";
+import { updatePlugin } from "../../../support/api/requests/Plugins";
 import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/catalog/giftCardUtils";
 import { getMailWithGiftCardExport } from "../../../support/api/utils/users";
 import { enterAndSelectGiftCards } from "../../../support/pages/catalog/giftCardPage";
@@ -31,9 +32,16 @@ describe("As an admin I want to export gift card", () => {
     () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;
       const giftCard02 = `${startsWith}${faker.datatype.number()}`;
+      const exportId = `${faker.datatype.number()}`;
+      cy.log(exportId);
       let giftCard01hash;
       let giftCard02hash;
 
+      updatePlugin(
+        "mirumee.notifications.admin_email",
+        "csv_export_success_subject",
+        `Your exported {{ data_type }} data #${exportId} is ready`,
+      );
       createGiftCard({
         tag: giftCard01,
         amount: 5,
@@ -60,13 +68,13 @@ describe("As an admin I want to export gift card", () => {
             .should("be.visible")
             .get(BUTTON_SELECTORS.showMoreButton)
             .click()
-            .get(GIFT_CARD_SHOWMORE.exportCodesMenu)
+            .get(GIFT_CARD_SHOW_MORE.exportCodesMenu)
             .click()
             .get(BUTTON_SELECTORS.submit)
             .click().confirmationMessageShouldDisappear;
           getMailWithGiftCardExport(
             TEST_ADMIN_USER.email,
-            "Your exported gift cards data is ready",
+            `Your exported gift cards data #${exportId} is ready`,
           );
         });
     },

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -27,7 +27,7 @@ describe("As an admin I want to export gift card", () => {
   });
 
   it(
-    "should be able to export several gift cards. TC: SALEOR_1010",
+    "should be able to export several gift cards to csv file. TC: SALEOR_1010",
     { tags: ["@giftCard", "@allEnv", "@stable"] },
     () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;
@@ -75,7 +75,65 @@ describe("As an admin I want to export gift card", () => {
           getMailWithGiftCardExport(
             TEST_ADMIN_USER.email,
             `Your exported gift cards data #${exportId} is ready`,
-          );
+            "csv",
+          ).then(body => {
+            expect(body).to.contain(".csv");
+          });
+        });
+    },
+  );
+
+  it(
+    "should be able to export several gift cards to xlsx file. TC: SALEOR_1014",
+    { tags: ["@giftCard", "@allEnv", "@stable"] },
+    () => {
+      const giftCard01 = `${startsWith}${faker.datatype.number()}`;
+      const giftCard02 = `${startsWith}${faker.datatype.number()}`;
+      const exportId = `${faker.datatype.number()}`;
+      cy.log(exportId);
+      let giftCard01hash;
+      let giftCard02hash;
+
+      updatePlugin(
+        "mirumee.notifications.admin_email",
+        "csv_export_success_subject",
+        `Your exported {{ data_type }} data #${exportId} is ready`,
+      );
+      createGiftCard({
+        tag: giftCard01,
+        amount: 5,
+        currency: "THB",
+      })
+        .then(hash => {
+          giftCard01hash = hash.id;
+          createGiftCard({
+            tag: giftCard02,
+            amount: 10,
+            currency: "THB",
+          });
+        })
+        .then(hash2 => {
+          giftCard02hash = hash2.id;
+          enterAndSelectGiftCards([giftCard01hash, giftCard02hash]);
+          cy.get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
+            .first()
+            .check()
+            .should("be.checked")
+            .get(GIFT_CARD_LIST.selectedAmount)
+            .contains("Selected 2 items")
+            .should("be.visible")
+            .get(BUTTON_SELECTORS.showMoreButton)
+            .click({ force: true })
+            .get(GIFT_CARD_SHOW_MORE.exportCodesMenu)
+            .click();
+          //   .get(BUTTON_SELECTORS.submit)
+          //   .click().confirmationMessageShouldDisappear;
+          // getMailWithGiftCardExport(
+          //   TEST_ADMIN_USER.email,
+          //   `Your exported gift cards data #${exportId} is ready`, 'xlsx'
+          // ).then((body) => {
+          //   expect(body).to.contain('.xlsx')
+          // });
         });
     },
   );

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -7,6 +7,7 @@ import { GIFT_CARD_LIST } from "../../../elements/catalog/giftCard/giftCardList"
 import { GIFT_CARD_SHOWMORE } from "../../../elements/catalog/giftCard/giftCardShowMore";
 import { ASSIGN_ELEMENTS_SELECTORS } from "../../../elements/shared/assign-elements-selectors.js";
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
+import { TEST_ADMIN_USER } from "../../../fixtures/users";
 import { createGiftCard } from "../../../support/api/requests/GiftCard";
 import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/catalog/giftCardUtils";
 import { getMailWithGiftCardExport } from "../../../support/api/utils/users";
@@ -64,7 +65,7 @@ describe("As an admin I want to export gift card", () => {
             .get(BUTTON_SELECTORS.submit)
             .click().confirmationMessageShouldDisappear;
           getMailWithGiftCardExport(
-            "testers+dashboard@saleor.io",
+            TEST_ADMIN_USER.email,
             "Your exported gift cards data is ready",
           );
         });

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -9,6 +9,7 @@ import { ASSIGN_ELEMENTS_SELECTORS } from "../../../elements/shared/assign-eleme
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import { createGiftCard } from "../../../support/api/requests/GiftCard";
 import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/catalog/giftCardUtils";
+import { getMailWithGiftCardExport } from "../../../support/api/utils/users";
 import { enterAndSelectGiftCards } from "../../../support/pages/catalog/giftCardPage";
 
 describe("As an admin I want to export gift card", () => {
@@ -24,7 +25,7 @@ describe("As an admin I want to export gift card", () => {
   });
 
   it(
-    "should be able to export several gift cards. TC: SALEOR_101010",
+    "should be able to export several gift cards. TC: SALEOR_1010",
     { tags: ["@giftCard", "@allEnv", "@stable"] },
     () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;
@@ -34,21 +35,22 @@ describe("As an admin I want to export gift card", () => {
 
       createGiftCard({
         tag: giftCard01,
-        amount: 3,
+        amount: 5,
         currency: "THB",
       })
         .then(hash => {
           giftCard01hash = hash.id;
           createGiftCard({
             tag: giftCard02,
-            amount: 7,
+            amount: 10,
             currency: "THB",
           });
         })
         .then(hash2 => {
           giftCard02hash = hash2.id;
           enterAndSelectGiftCards([giftCard01hash, giftCard02hash]);
-          cy.get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
+          cy
+            .get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
             .first()
             .check()
             .should("be.checked")
@@ -60,11 +62,11 @@ describe("As an admin I want to export gift card", () => {
             .get(GIFT_CARD_SHOWMORE.exportCodesMenu)
             .click()
             .get(BUTTON_SELECTORS.submit)
-            .click();
-          //   .get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
-          //   .should("not.be.visible");
-          // getGiftCardWithId(giftCard01.id).should("be.null");
-          // getGiftCardWithId(giftCard02.id).should("be.null");
+            .click().confirmationMessageShouldDisappear;
+          getMailWithGiftCardExport(
+            "testers+dashboard@saleor.io",
+            "Your exported gift cards data is ready",
+          );
         });
     },
   );

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -11,7 +11,7 @@ import { TEST_ADMIN_USER } from "../../../fixtures/users";
 import { createGiftCard } from "../../../support/api/requests/GiftCard";
 import { updatePlugin } from "../../../support/api/requests/Plugins";
 import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/catalog/giftCardUtils";
-import { getMailWithGiftCardExport } from "../../../support/api/utils/users";
+import { getMailWithGiftCardExportWithAttachment } from "../../../support/api/utils/users";
 import { enterAndSelectGiftCards } from "../../../support/pages/catalog/giftCardPage";
 
 describe("As an admin I want to export gift card", () => {
@@ -74,7 +74,7 @@ describe("As an admin I want to export gift card", () => {
             .click()
             .get(BUTTON_SELECTORS.submit)
             .click().confirmationMessageShouldDisappear;
-          getMailWithGiftCardExport(
+          getMailWithGiftCardExportWithAttachment(
             TEST_ADMIN_USER.email,
             `Your exported gift cards data #${exportId} is ready`,
             "csv",

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+/// <reference types="../../../support"/>
+
+import faker from "faker";
+
+import { GIFT_CARD_LIST } from "../../../elements/catalog/giftCard/giftCardList";
+import { GIFT_CARD_SHOWMORE } from "../../../elements/catalog/giftCard/giftCardShowMore";
+import { ASSIGN_ELEMENTS_SELECTORS } from "../../../elements/shared/assign-elements-selectors.js";
+import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
+import { createGiftCard } from "../../../support/api/requests/GiftCard";
+import { deleteGiftCardsWithTagStartsWith } from "../../../support/api/utils/catalog/giftCardUtils";
+import { enterAndSelectGiftCards } from "../../../support/pages/catalog/giftCardPage";
+
+describe("As an admin I want to export gift card", () => {
+  const startsWith = "updateGCard";
+
+  before(() => {
+    cy.clearSessionData().loginUserViaRequest();
+    deleteGiftCardsWithTagStartsWith(startsWith);
+  });
+
+  beforeEach(() => {
+    cy.clearSessionData().loginUserViaRequest();
+  });
+
+  it(
+    "should be able to export several gift cards. TC: SALEOR_101010",
+    { tags: ["@giftCard", "@allEnv", "@stable"] },
+    () => {
+      const giftCard01 = `${startsWith}${faker.datatype.number()}`;
+      const giftCard02 = `${startsWith}${faker.datatype.number()}`;
+      let giftCard01hash;
+      let giftCard02hash;
+
+      createGiftCard({
+        tag: giftCard01,
+        amount: 3,
+        currency: "THB",
+      })
+        .then(hash => {
+          giftCard01hash = hash.id;
+          createGiftCard({
+            tag: giftCard02,
+            amount: 7,
+            currency: "THB",
+          });
+        })
+        .then(hash2 => {
+          giftCard02hash = hash2.id;
+          enterAndSelectGiftCards([giftCard01hash, giftCard02hash]);
+          cy.get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
+            .first()
+            .check()
+            .should("be.checked")
+            .get(GIFT_CARD_LIST.selectedAmount)
+            .contains("Selected 2 items")
+            .should("be.visible")
+            .get(BUTTON_SELECTORS.showMoreButton)
+            .click()
+            .get(GIFT_CARD_SHOWMORE.exportCodesMenu)
+            .click();
+          //   .get(BUTTON_SELECTORS.submit)
+          //   .click()
+          //   .get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
+          //   .should("not.be.visible");
+          // getGiftCardWithId(giftCard01.id).should("be.null");
+          // getGiftCardWithId(giftCard02.id).should("be.null");
+        });
+    },
+  );
+});

--- a/cypress/e2e/catalog/giftCards/exportGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/exportGiftCards.js
@@ -58,9 +58,9 @@ describe("As an admin I want to export gift card", () => {
             .get(BUTTON_SELECTORS.showMoreButton)
             .click()
             .get(GIFT_CARD_SHOWMORE.exportCodesMenu)
+            .click()
+            .get(BUTTON_SELECTORS.submit)
             .click();
-          //   .get(BUTTON_SELECTORS.submit)
-          //   .click()
           //   .get(ASSIGN_ELEMENTS_SELECTORS.checkbox)
           //   .should("not.be.visible");
           // getGiftCardWithId(giftCard01.id).should("be.null");

--- a/cypress/e2e/catalog/giftCards/updatingGiftCards.js
+++ b/cypress/e2e/catalog/giftCards/updatingGiftCards.js
@@ -97,7 +97,7 @@ describe("As an admin I want to update gift card", () => {
   );
 
   it(
-    "should be able to delete several gift cards. TC: SALEOR_1009",
+    "should be able to delete several gift cards. TC: SALEOR_1011",
     { tags: ["@giftCard", "@allEnv", "@stable"] },
     () => {
       const giftCard01 = `${startsWith}${faker.datatype.number()}`;

--- a/cypress/elements/catalog/giftCard/giftCardShowMore.js
+++ b/cypress/elements/catalog/giftCard/giftCardShowMore.js
@@ -2,4 +2,8 @@ export const GIFT_CARD_SHOW_MORE = {
   settingsMenu: '[data-test-id="settingsMenuItem"]',
   bulkIssueMenu: '[data-test-id="bulkIssueMenuItem"]',
   exportCodesMenu: '[data-test-id="exportCodesMenuItem"]',
+  exportAsRadioBtn: {
+    csv: 'input[value="CSV"]',
+    xlsx: 'input[value="XLSX"]',
+  },
 };

--- a/cypress/elements/catalog/giftCard/giftCardShowMore.js
+++ b/cypress/elements/catalog/giftCard/giftCardShowMore.js
@@ -1,0 +1,5 @@
+export const GIFT_CARD_SHOWMORE = {
+  settingsMenu: '[data-test-id="settingsMenuItem"]',
+  bulkIssueMenu: '[data-test-id="bulkIssueMenuItem"]',
+  exportCodesMenu: '[data-test-id="exportCodesMenuItem"]',
+};

--- a/cypress/elements/catalog/giftCard/giftCardShowMore.js
+++ b/cypress/elements/catalog/giftCard/giftCardShowMore.js
@@ -1,4 +1,4 @@
-export const GIFT_CARD_SHOWMORE = {
+export const GIFT_CARD_SHOW_MORE = {
   settingsMenu: '[data-test-id="settingsMenuItem"]',
   bulkIssueMenu: '[data-test-id="bulkIssueMenuItem"]',
   exportCodesMenu: '[data-test-id="exportCodesMenuItem"]',

--- a/cypress/support/api/requests/Plugins.js
+++ b/cypress/support/api/requests/Plugins.js
@@ -25,7 +25,7 @@ export function activatePlugin({ id, channel, active = true }) {
 
   const mutation = `mutation{
     pluginUpdate(id: "${id}" ${channelLine} input:{
-      active:${active}
+      active:${active},configuration:
     }){
       errors{
         field

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -106,3 +106,18 @@ export function getMailsForUser(email, i = 0) {
     }
   });
 }
+
+export function getMailWithGiftCardExport(email, subject, i = 0) {
+  if (i > 5) {
+    throw new Error(`There is no email Gift Card export for user ${email}`);
+  }
+  return cy.mhGetMailsByRecipient(email).should(mails => {
+    if (!mails.length) {
+      cy.wait(3000);
+      getMailWithGiftCardExport(email, subject, i + 1);
+    } else {
+      cy.mhGetMailsBySubject(subject);
+      return mails;
+    }
+  });
+}

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -107,14 +107,19 @@ export function getMailsForUser(email, i = 0) {
   });
 }
 
-export function getMailWithGiftCardExport(email, subject, i = 0) {
+export function getMailWithGiftCardExport(
+  email,
+  subject,
+  attachmentFileType,
+  i = 0,
+) {
   if (i > 5) {
     throw new Error(`There is no email Gift Card export for user ${email}`);
   }
   return cy.mhGetMailsByRecipient(email).should(mails => {
     if (!mails.length) {
       cy.wait(3000);
-      getMailWithGiftCardExport(email, subject, i + 1);
+      getMailWithGiftCardExport(email, subject, attachmentFileType, i + 1);
     } else {
       cy.mhGetMailsBySubject(subject).should(mailsWithSubject => {
         if (!mailsWithSubject.length) {
@@ -125,9 +130,7 @@ export function getMailWithGiftCardExport(email, subject, i = 0) {
             .mhFirst()
             .should("not.eq", undefined)
             .mhGetBody()
-            .then(body => {
-              expect(body).to.contain(".csv");
-            });
+            .then(body => body);
         }
       });
     }

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -107,7 +107,7 @@ export function getMailsForUser(email, i = 0) {
   });
 }
 
-export function getMailWithGiftCardExport(
+export function getMailWithGiftCardExportWithAttachment(
   email,
   subject,
   attachmentFileType,

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -116,8 +116,20 @@ export function getMailWithGiftCardExport(email, subject, i = 0) {
       cy.wait(3000);
       getMailWithGiftCardExport(email, subject, i + 1);
     } else {
-      cy.mhGetMailsBySubject(subject);
-      return mails;
+      cy.mhGetMailsBySubject(subject).should(mailsWithSubject => {
+        if (!mailsWithSubject.length) {
+          cy.wait(10000);
+          getMailWithGiftCardExport(email, subject, i + 1);
+        } else {
+          cy.wrap(mailsWithSubject)
+            .mhFirst()
+            .should("not.eq", undefined)
+            .mhGetBody()
+            .then(body => {
+              expect(body).to.contain(".csv");
+            });
+        }
+      });
     }
   });
 }

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -119,12 +119,22 @@ export function getMailWithGiftCardExportWithAttachment(
   return cy.mhGetMailsByRecipient(email).should(mails => {
     if (!mails.length) {
       cy.wait(3000);
-      getMailWithGiftCardExport(email, subject, attachmentFileType, i + 1);
+      getMailWithGiftCardExportWithAttachment(
+        email,
+        subject,
+        attachmentFileType,
+        i + 1,
+      );
     } else {
       cy.mhGetMailsBySubject(subject).should(mailsWithSubject => {
         if (!mailsWithSubject.length) {
           cy.wait(10000);
-          getMailWithGiftCardExport(email, subject, i + 1);
+          getMailWithGiftCardExportWithAttachment(
+            email,
+            subject,
+            attachmentFileType,
+            i + 1,
+          );
         } else {
           cy.wrap(mailsWithSubject)
             .mhFirst()

--- a/src/giftCards/GiftCardExportDialogContent/GiftCardExportDialogContent.tsx
+++ b/src/giftCards/GiftCardExportDialogContent/GiftCardExportDialogContent.tsx
@@ -148,7 +148,7 @@ const GiftCardExportDialog: React.FC<Pick<DialogProps, "onClose"> & {
           transitionState={exportGiftCardsOpts.status}
           variant="primary"
           type="submit"
-          data-test="submit"
+          data-test-id="submit"
           onClick={submit}
         >
           <FormattedMessage {...messages.confirmButtonLabel} />


### PR DESCRIPTION
I want to merge this change because it adds a new auto test for bulk exporting gift cards
Test case SALEOR_1010

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [x] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1