### PR TITLE
Enable dashboard v39 on demo

### DIFF
--- a/.github/workflows/deploy-demo-staging.yaml
+++ b/.github/workflows/deploy-demo-staging.yaml
@@ -2,7 +2,7 @@ name: Deploy to staging demo
 on:
   push:
     tags:
-      - 3.8**
+      - 3.9**
   workflow_dispatch:
     inputs:
       git_ref:


### PR DESCRIPTION
We would like to allow deployment of v39 demo
