### PR TITLE
[CLOUD-2287] Don't automerge CORE deployments to SANDBOXES

### DIFF
--- a/.github/workflows/approveAndMergeReleasePR.js
+++ b/.github/workflows/approveAndMergeReleasePR.js
@@ -13,7 +13,7 @@ program
   .description("Approve and merge PR if patch release")
   .option("--version <version>", "version of a project")
   .option("--pull_request_number <pull_request_number>", "Pull Request number")
-  .option("--auto_release <auto_release>", "is auto release")
+  .option("--auto_release", "is auto release")
   .option("--dashboard_url <dashboard_url>", "Cypress dashboard url")
   .action(async options => {
     const octokit = new Octokit({

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -272,11 +272,11 @@ jobs:
 
       - name: Add review and merge if patch DASHBOARD
         env: 
-         tests_status: ${{ needs.run-tests-on-release.outputs.status}}
-         version: ${{github.event.client_payload.version}}
-         pull_request_number: ${{ github.event.client_payload.pullRequestNumber}}
-         auto_release: ${{github.event.client_payload.autoRelease}}
-         dashboard_url: ${{ needs.run-tests-on-release.outputs.dashboard_url}}
+         tests_status: ${{ needs.run-tests-on-release.outputs.status }}
+         version: ${{ github.event.client_payload.version }}
+         pull_request_number: ${{ github.event.client_payload.pullRequestNumber }}
+         dashboard_url: ${{ needs.run-tests-on-release.outputs.dashboard_url }}
+         auto_release: ${{ (github.event.client_payload.autoRelease && '--auto_release') || '' }}
         run: |
             export GITHUB_TOKEN=$( \
             curl --request GET --url ${{ secrets.VAULT_URL}} --header "Authorization: JWT ${{ secrets.VAULT_JWT }}" | jq -r .token \
@@ -284,5 +284,5 @@ jobs:
             node .github/workflows/approveAndMergeReleasePR.js \
             --version $version \
             --pull_request_number $pull_request_number \
-            --auto_release $auto_release \
-            --dashboard_url $dashboard_url
+            --dashboard_url $dashboard_url \
+            $auto_release


### PR DESCRIPTION
I want to merge this change because we don't wan't to auto-release CORE changes to SANDBOXES.
