### PR TITLE
Fix strict null check in SiteSettings module

### DIFF
--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -45,7 +45,7 @@ export interface SiteSettingsPageFormData
 export interface SiteSettingsPageProps {
   disabled: boolean;
   errors: ShopErrorFragment[];
-  shop: SiteSettingsQuery["shop"];
+  shop?: SiteSettingsQuery["shop"];
   saveButtonBarState: ConfirmButtonTransitionState;
   onSubmit: (data: SiteSettingsPageFormData) => SubmitPromise;
 }
@@ -107,10 +107,11 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
   const initialForm: SiteSettingsPageFormData = {
     ...initialFormAddress,
     description: shop?.description || "",
-    reserveStockDurationAnonymousUser: shop?.reserveStockDurationAnonymousUser,
+    reserveStockDurationAnonymousUser:
+      shop?.reserveStockDurationAnonymousUser ?? 0,
     reserveStockDurationAuthenticatedUser:
-      shop?.reserveStockDurationAuthenticatedUser,
-    limitQuantityPerCheckout: shop?.limitQuantityPerCheckout,
+      shop?.reserveStockDurationAuthenticatedUser ?? 0,
+    limitQuantityPerCheckout: shop?.limitQuantityPerCheckout ?? 0,
   };
 
   return (
@@ -179,7 +180,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
             </Grid>
             <Savebar
               state={saveButtonBarState}
-              disabled={isSaveDisabled}
+              disabled={!!isSaveDisabled}
               onCancel={() => navigate(configurationMenuUrl)}
               onSubmit={submit}
             />

--- a/src/siteSettings/fixtures.ts
+++ b/src/siteSettings/fixtures.ts
@@ -12,14 +12,14 @@ export const shop: SiteSettingsQuery["shop"] = {
       code: "UA",
       country: "United Arab Emirates",
     },
-    countryArea: null,
-    firstName: null,
+    countryArea: "",
+    firstName: "",
     id: "1",
-    lastName: null,
+    lastName: "",
     phone: "+41 876-373-9137",
     postalCode: "89880-6342",
     streetAddress1: "01419 Bernhard Plain",
-    streetAddress2: null,
+    streetAddress2: "s",
   },
   countries: [
     {

--- a/src/siteSettings/index.tsx
+++ b/src/siteSettings/index.tsx
@@ -6,8 +6,7 @@ import { siteSettingsPath, SiteSettingsUrlQueryParams } from "./urls";
 import SiteSettingsComponent from "./views/";
 
 const SiteSettings: React.FC<RouteComponentProps<{}>> = ({ location }) => {
-  const qs = parseQs(location.search.substr(1));
-  const params: SiteSettingsUrlQueryParams = qs;
+  const params: SiteSettingsUrlQueryParams = parseQs(location.search.slice(1));
 
   return <SiteSettingsComponent params={params} />;
 };

--- a/src/siteSettings/urls.ts
+++ b/src/siteSettings/urls.ts
@@ -8,4 +8,4 @@ export const siteSettingsPath = siteSettingsSection;
 export type SiteSettingsUrlDialog = "add-key";
 export type SiteSettingsUrlQueryParams = Dialog<SiteSettingsUrlDialog>;
 export const siteSettingsUrl = (params?: SiteSettingsUrlQueryParams) =>
-  siteSettingsPath + "?" + stringifyQs(params);
+  `${siteSettingsPath}?${stringifyQs(params)}`;

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -34,8 +34,10 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
   ] = useShopSettingsUpdateMutation({
     onCompleted: data => {
       if (
-        [...data.shopAddressUpdate.errors, ...data.shopSettingsUpdate.errors]
-          .length === 0
+        [
+          ...(data?.shopAddressUpdate?.errors || []),
+          ...(data?.shopSettingsUpdate?.errors || []),
+        ].length === 0
       ) {
         notify({
           status: "success",
@@ -46,8 +48,8 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
   });
 
   const errors = [
-    ...(updateShopSettingsOpts.data?.shopSettingsUpdate.errors || []),
-    ...(updateShopSettingsOpts.data?.shopAddressUpdate.errors || []),
+    ...(updateShopSettingsOpts.data?.shopSettingsUpdate?.errors || []),
+    ...(updateShopSettingsOpts.data?.shopAddressUpdate?.errors || []),
   ];
   const loading = siteSettings.loading || updateShopSettingsOpts.loading;
 


### PR DESCRIPTION
I want to merge this change because it fixes strict null checks in siteSettings directory. Fixes https://github.com/saleor/saleor-dashboard/issues/2840

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1