### PR TITLE
Fix displaying ountry are as readable name

### DIFF
--- a/src/components/AddressEdit/AddressEdit.tsx
+++ b/src/components/AddressEdit/AddressEdit.tsx
@@ -77,7 +77,9 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
   } = props;
   const classes = useStyles(props);
   const intl = useIntl();
-  const { areas, isFieldAllowed } = useAddressValidation(data.country);
+  const { areas, isFieldAllowed, getDisplayValue } = useAddressValidation(
+    data.country,
+  );
 
   const formErrors = getFormErrors<
     keyof AddressTypeInput,
@@ -269,7 +271,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
               disabled={disabled}
               autocomplete="new-password"
               data-test-id="address-edit-country-area-field"
-              displayValue={data.countryArea}
+              displayValue={getDisplayValue(data.countryArea)}
               error={!!formErrors.countryArea}
               helperText={getErrorMessage(formErrors.countryArea, intl)}
               label={intl.formatMessage({

--- a/src/components/AddressEdit/useAddressValidation.test.ts
+++ b/src/components/AddressEdit/useAddressValidation.test.ts
@@ -51,8 +51,8 @@ describe("useAddressValidation", () => {
 
     // Assert
     expect(current.areas).toEqual([
-      { label: "Alabama", value: "Alabama" },
-      { label: "Ancona", value: "Ancona" },
+      { label: "Alabama", value: "Alabama", raw: "AL" },
+      { label: "Ancona", value: "Ancona", raw: "AN" },
     ]);
     expect(current.loading).toBeFalsy();
     expect(useAddressValidationRulesQuery).toBeCalledWith({

--- a/src/components/AddressEdit/useAddressValidation.ts
+++ b/src/components/AddressEdit/useAddressValidation.ts
@@ -5,10 +5,17 @@ import {
 } from "@saleor/graphql";
 import { ChoiceValue } from "@saleor/sdk/dist/apollo/types";
 
-const prepareChoices = (values: ChoiceValue[]) =>
+interface AreaChoices {
+  label: string;
+  value: string;
+  raw: string;
+}
+
+const prepareChoices = (values: ChoiceValue[]): AreaChoices[] =>
   values.map(v => ({
     label: v.verbose,
     value: v.verbose,
+    raw: v.raw,
   }));
 
 const selectRules = (data: AddressValidationRulesQuery) =>
@@ -45,14 +52,33 @@ const useAllowedFields = (data: AddressValidationRulesQuery) => {
   return { isAllowed };
 };
 
+const useDisplayValues = (areas: AreaChoices[]) => {
+  const isProvinceCode = (code: string) =>
+    code.length === 2 && code.toLocaleUpperCase() === code;
+
+  const getDisplayValue = (value: string) => {
+    if (isProvinceCode(value)) {
+      const area = areas.find(area => area.raw === value);
+
+      return area.value;
+    }
+
+    return value;
+  };
+
+  return { getDisplayValue };
+};
+
 export const useAddressValidation = (country?: string) => {
   const { data, loading } = useValidationRules(country);
   const areas = useAreas(data);
   const { isAllowed } = useAllowedFields(data);
+  const { getDisplayValue } = useDisplayValues(areas);
 
   return {
     areas,
     isFieldAllowed: isAllowed,
+    getDisplayValue,
     loading,
   };
 };

--- a/src/components/CompanyAddressInput/CompanyAddressForm.tsx
+++ b/src/components/CompanyAddressInput/CompanyAddressForm.tsx
@@ -64,7 +64,9 @@ const CompanyAddressForm: React.FC<CompanyAddressFormProps> = props => {
     onChange,
     onCountryChange,
   } = props;
-  const { areas, isFieldAllowed } = useAddressValidation(data.country);
+  const { areas, isFieldAllowed, getDisplayValue } = useAddressValidation(
+    data.country,
+  );
   const classes = useStyles(props);
   const intl = useIntl();
 
@@ -200,7 +202,7 @@ const CompanyAddressForm: React.FC<CompanyAddressFormProps> = props => {
             disabled={disabled}
             autocomplete="new-password"
             data-test-id="address-edit-country-area-field"
-            displayValue={data.countryArea}
+            displayValue={getDisplayValue(data.countryArea)}
             error={!!formErrors.countryArea}
             helperText={getErrorMessage(formErrors.countryArea, intl)}
             label={intl.formatMessage({

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -35,13 +35,7 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import { RichTextContext } from "@saleor/utils/richText/context";
 import { useMultipleRichText } from "@saleor/utils/richText/useMultipleRichText";
 import useRichText from "@saleor/utils/richText/useRichText";
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useProductChannelListingsForm } from "./formChannels";
 import {
@@ -52,16 +46,6 @@ import {
   UseProductUpdateFormOpts,
   UseProductUpdateFormOutput,
 } from "./types";
-
-const useMemonizedReferences = references => {
-  const memRefs = useRef(references || []);
-
-  useLayoutEffect(() => {
-    memRefs.current = memRefs.current.concat(references);
-  }, [references]);
-
-  return memRefs.current;
-};
 
 function useProductUpdateForm(
   product: ProductFragment,
@@ -186,16 +170,13 @@ function useProductUpdateForm(
   );
   const changeMetadata = makeMetadataChangeHandler(handleChange);
 
-  const referencePages = useMemonizedReferences(opts.referencePages);
-  const referenceProducts = useMemonizedReferences(opts.referenceProducts);
-
   const data: ProductUpdateData = {
     ...formData,
     attributes: getAttributesDisplayData(
       attributes.data,
       attributesWithNewFileValue.data,
-      referencePages,
-      referenceProducts,
+      opts.referencePages,
+      opts.referenceProducts,
     ),
     channels,
     description: null,

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -35,7 +35,13 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import { RichTextContext } from "@saleor/utils/richText/context";
 import { useMultipleRichText } from "@saleor/utils/richText/useMultipleRichText";
 import useRichText from "@saleor/utils/richText/useRichText";
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 import { useProductChannelListingsForm } from "./formChannels";
 import {
@@ -46,6 +52,16 @@ import {
   UseProductUpdateFormOpts,
   UseProductUpdateFormOutput,
 } from "./types";
+
+const useMemonizedReferences = references => {
+  const memRefs = useRef(references || []);
+
+  useLayoutEffect(() => {
+    memRefs.current = memRefs.current.concat(references);
+  }, [references]);
+
+  return memRefs.current;
+};
 
 function useProductUpdateForm(
   product: ProductFragment,
@@ -170,13 +186,16 @@ function useProductUpdateForm(
   );
   const changeMetadata = makeMetadataChangeHandler(handleChange);
 
+  const referencePages = useMemonizedReferences(opts.referencePages);
+  const referenceProducts = useMemonizedReferences(opts.referenceProducts);
+
   const data: ProductUpdateData = {
     ...formData,
     attributes: getAttributesDisplayData(
       attributes.data,
       attributesWithNewFileValue.data,
-      opts.referencePages,
-      opts.referenceProducts,
+      referencePages,
+      referenceProducts,
     ),
     channels,
     description: null,

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -87,7 +87,7 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
   const navigate = useNavigator();
 
   const [displayCountry, setDisplayCountry] = useStateFromProps(
-    shop?.companyAddress?.country.code || "",
+    shop?.companyAddress?.country.country || "",
   );
 
   const {


### PR DESCRIPTION
It displays the country area by using a readable name instead of a country/area code


Steps to reproduce:
1. open view of address editing: site settings, customer addresses, warehouse addresses
2. change country (eg Italy, or united states)
3. change the corresponding country area 
4. Save
5. When you open the editing form once again you should see readable values instead of their codes (eg. United States instead of USA and Alabama instead of AL)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
6. [ ] All visible strings are translated with proper context including data-formatting
7. [ ] Attributes `[data-test-id]` are added for new elements
8. [ ] Changes are mentioned in the changelog
9. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
10. [ ] productType
11. [ ] shipping
12. [ ] customer
13. [ ] permissions
14. [ ] menuNavigation
15. [ ] pages
16. [ ] sales
17. [ ] vouchers
18. [ ] homePage
19. [ ] login
20. [ ] orders
21. [ ] products
22. [ ] app
23. [ ] plugins
24. [ ] translations
25. [ ] navigation
26. [ ] variants
27. [ ] payments

CONTAINERS=1