### PR TITLE
Fix tests for SKU 

### DIFF
--- a/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/createProductWithoutSku.js
@@ -10,10 +10,7 @@ import { urlList } from "../../../fixtures/urlList";
 import { ONE_PERMISSION_USERS } from "../../../fixtures/users";
 import { updateVariantWarehouse } from "../../../support/api/requests/Product";
 import { createTypeProduct } from "../../../support/api/requests/ProductType";
-import {
-  deleteChannelsStartsWith,
-  getDefaultChannel,
-} from "../../../support/api/utils/channelsUtils";
+import { deleteChannelsStartsWith } from "../../../support/api/utils/channelsUtils";
 import { createWaitingForCaptureOrder } from "../../../support/api/utils/ordersUtils";
 import * as productUtils from "../../../support/api/utils/products/productsUtils";
 import * as shippingUtils from "../../../support/api/utils/shippingUtils";
@@ -55,25 +52,20 @@ describe("Creating variants", () => {
 
     const name = `${startsWith}${faker.datatype.number()}`;
     const simpleProductTypeName = `${startsWith}${faker.datatype.number()}`;
-    getDefaultChannel()
-      .then(channel => {
-        defaultChannel = channel;
-        cy.fixture("addresses");
-      })
-      .then(fixtureAddresses => {
-        address = fixtureAddresses.usAddress;
-        shippingUtils.createShipping({
-          channelId: defaultChannel.id,
-          name,
-          address,
-        });
-      })
-      .then(
-        ({ warehouse: warehouseResp, shippingMethod: shippingMethodResp }) => {
-          warehouse = warehouseResp;
-          shippingMethod = shippingMethodResp;
-        },
-      );
+
+    cy.fixture("addresses").then(fixtureAddresses => {
+      address = fixtureAddresses.plAddress;
+    });
+
+    shippingUtils
+      .createShippingWithDefaultChannelAndAddress(name)
+      .then(resp => {
+        category = resp.category;
+        defaultChannel = resp.defaultChannel;
+        warehouse = resp.warehouse;
+        shippingMethod = resp.shippingMethod;
+      });
+
     productUtils
       .createTypeAttributeAndCategoryForProduct({ name, attributeValues })
       .then(

--- a/cypress/e2e/products/productsWithoutSku/updatingProductsWithoutSku.js
+++ b/cypress/e2e/products/productsWithoutSku/updatingProductsWithoutSku.js
@@ -26,6 +26,7 @@ import {
   createShipping,
   deleteShippingStartsWith,
 } from "../../../support/api/utils/shippingUtils";
+import { deleteWarehouseStartsWith } from "../../../support/api/utils/warehouseUtils";
 
 describe("Updating products without sku", () => {
   const startsWith = "UpdateProductsSku";
@@ -49,6 +50,7 @@ describe("Updating products without sku", () => {
     cy.clearSessionData().loginUserViaRequest();
     deleteProductsStartsWith(startsWith);
     deleteShippingStartsWith(startsWith);
+    deleteWarehouseStartsWith(startsWith);
     getDefaultChannel()
       .then(channel => {
         defaultChannel = channel;
@@ -111,7 +113,7 @@ describe("Updating products without sku", () => {
   });
 
   it(
-    "should add sku to variant",
+    "should add sku to variant TC: SALEOR_2803",
     { tags: ["@products", "@allEnv", "@stable"] },
     () => {
       const sku = "NewSku";
@@ -146,7 +148,7 @@ describe("Updating products without sku", () => {
   );
 
   it(
-    "should remove sku from variant",
+    "should remove sku from variant TC: SALEOR_2805",
     { tags: ["@products", "@allEnv", "@stable"] },
     () => {
       let variant;

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -218,7 +218,6 @@ export function createVariantForSimpleProduct({
   quantityInWarehouse = 1,
   trackInventory = true,
   weight = 1,
-
   attributeId,
   attributeName = "value",
 }) {

--- a/cypress/support/api/requests/Product.js
+++ b/cypress/support/api/requests/Product.js
@@ -211,6 +211,59 @@ export function createVariant({
     .its("body.data.productVariantBulkCreate.productVariants");
 }
 
+export function createVariantForSimpleProduct({
+  productId,
+  sku,
+  warehouseId,
+  quantityInWarehouse = 1,
+  trackInventory = true,
+  weight = 1,
+
+  attributeId,
+  attributeName = "value",
+}) {
+  const skuLines = getValueWithDefault(sku, `sku: "${sku}"`);
+
+  const attributeLines = getValueWithDefault(
+    attributeId,
+    `attributes: [{
+    id:"${attributeId}"
+    values: ["${attributeName}"]
+  }]`,
+    "attributes:[]",
+  );
+
+  const stocks = getValueWithDefault(
+    warehouseId,
+    `stocks:{
+      warehouse:"${warehouseId}"
+      quantity:${quantityInWarehouse}
+    }`,
+  );
+  const mutation = `mutation{
+    productVariantCreate(input: {
+      ${attributeLines}
+      ${skuLines}
+      trackInventory:${trackInventory}
+      weight: ${weight}
+      product: "${productId}"
+      ${stocks}
+    }) {
+      productVariant{
+        id
+        name
+      }
+      errors{
+        field
+        message
+      }
+    }
+  }`;
+  return cy
+    .sendRequestWithQuery(mutation)
+    .its("body.data.productVariantCreate.productVariant");
+}
+
 export function deleteProduct(productId) {
   const mutation = `mutation{
     productDelete(id: "${productId}"){
@@ -304,12 +357,18 @@ export function updateVariantPrice({ variantId, channelId, price }) {
     .its("body.data.productVariantChannelListingUpdate");
 }
 
-export function updateVariantWarehouse({ variantId, warehouseId }) {
+export function updateVariantWarehouse({ variantId, warehouseId, quantity }) {
+  const quantityInWarehouse = getValueWithDefault(
+    quantity,
+    `quantity:${quantity}`,
+    `quantity: 0`,
+  );
+
   const mutation = `mutation{
     productVariantStocksCreate(variantId: "${variantId}", 
       stocks: 
       {
-        quantity: 0,
+        ${quantityInWarehouse}
         warehouse: "${warehouseId}"
       }
       ){

--- a/cypress/support/api/utils/products/productsUtils.js
+++ b/cypress/support/api/utils/products/productsUtils.js
@@ -444,20 +444,29 @@ export function createShippingProductTypeAttributeAndCategory(
 ) {
   let warehouse;
   let defaultChannel;
+  let shippingMethod;
 
   return createShippingWithDefaultChannelAndAddress(name)
-    .then(({ warehouse: warehouseResp, defaultChannel: channel }) => {
-      warehouse = warehouseResp;
-      defaultChannel = channel;
+    .then(
+      ({
+        warehouse: warehouseResp,
+        defaultChannel: channel,
+        shippingMethod: shippingMethodResp,
+      }) => {
+        warehouse = warehouseResp;
+        defaultChannel = channel;
+        shippingMethod = shippingMethodResp;
 
-      createTypeAttributeAndCategoryForProduct({ name, attributeValues });
-    })
+        createTypeAttributeAndCategoryForProduct({ name, attributeValues });
+      },
+    )
     .then(({ attribute, productType, category }) => ({
       attribute,
       productType,
       category,
       warehouse,
       defaultChannel,
+      shippingMethod,
     }));
 }
 

--- a/cypress/support/customCommands/sharedElementsOperations/selects.js
+++ b/cypress/support/customCommands/sharedElementsOperations/selects.js
@@ -50,7 +50,7 @@ Cypress.Commands.add("fillAutocompleteSelect", (selectSelector, option) => {
         });
         cy.contains(BUTTON_SELECTORS.selectOption, option)
           .should("be.visible")
-          .click();
+          .click({ force: true });
         cy.wrap(option).as("option");
       });
   } else {

--- a/cypress/support/pages/catalog/products/VariantsPage.js
+++ b/cypress/support/pages/catalog/products/VariantsPage.js
@@ -3,6 +3,7 @@ import { PRODUCT_DETAILS } from "../../../../elements/catalog/products/product-d
 import { VARIANTS_SELECTORS } from "../../../../elements/catalog/products/variants-selectors";
 import { AVAILABLE_CHANNELS_FORM } from "../../../../elements/channels/available-channels-form";
 import { BUTTON_SELECTORS } from "../../../../elements/shared/button-selectors";
+import { updateVariantWarehouse } from "../../../../support/api/requests/Product";
 import { formatDate } from "../../../formatData/formatDate";
 import { selectChannelVariantInDetailsPage } from "../../channelsPage";
 
@@ -14,6 +15,7 @@ export function variantsShouldBeVisible({ price }) {
 export function createVariant({
   sku,
   warehouseName,
+  warehouseId,
   attributeName,
   price,
   costPrice = price,
@@ -23,6 +25,7 @@ export function createVariant({
     attributeName,
     sku,
     warehouseName,
+    warehouseId,
     quantity,
     costPrice,
     price,
@@ -62,11 +65,21 @@ export function fillUpVariantDetails({
   attributeType = "DROPDOWN",
   sku,
   warehouseName,
+  warehouseId,
   quantity,
   costPrice,
   price,
 }) {
   selectAttributeWithType({ attributeType, attributeName });
+  cy.get(PRICE_LIST.priceInput)
+    .each(input => {
+      cy.wrap(input).type(price);
+    })
+    .get(PRICE_LIST.costPriceInput)
+    .each(input => {
+      cy.wrap(input).type(costPrice);
+    });
+
   if (sku) {
     cy.get(VARIANTS_SELECTORS.skuInputInAddVariant).type(sku);
   }
@@ -79,17 +92,13 @@ export function fillUpVariantDetails({
       .get(VARIANTS_SELECTORS.stockInput)
       .type(quantity);
   }
-
-  cy.get(PRICE_LIST.priceInput)
-    .each(input => {
-      cy.wrap(input).type(price);
-    })
-    .get(PRICE_LIST.costPriceInput)
-    .each(input => {
-      cy.wrap(input).type(costPrice);
+  if (warehouseId) {
+    saveVariant().then(({ response }) => {
+      const variantId =
+        response.body.data.productVariantCreate.productVariant.id;
+      updateVariantWarehouse({ variantId, warehouseId, quantity });
     });
-
-  cy.get(VARIANTS_SELECTORS.saveButton).click();
+  }
 }
 
 export function fillUpVariantAttributeAndSku({ attributeName, sku }) {


### PR DESCRIPTION
I want to merge this change because...
- it fixes tests for adding/updating SKU in variants and simple products.
- it fixes tests for creating variants or simple products without SKU
- it adds/fixes TC numbers 
- updates creating variants via UI of setting warehouse via API as the list of warehouses in UI is limited


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1