### PR TITLE
Bump macaw-ui to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@material-ui/lab": "^4.0.0-alpha.61",
         "@material-ui/styles": "^4.11.4",
         "@reach/auto-id": "^0.16.0",
-        "@saleor/macaw-ui": "0.7.1",
+        "@saleor/macaw-ui": "0.7.2",
         "@saleor/sdk": "^0.4.4",
         "@sentry/react": "^6.0.0",
         "@types/faker": "^5.1.6",
@@ -35,7 +35,6 @@
         "color-convert": "^2.0.1",
         "crc-32": "^1.2.0",
         "currency-codes": "^2.1.0",
-        "cypress-repeat": "^2.3.3",
         "downshift": "^6.1.7",
         "editorjs-inline-tool": "^0.4.0",
         "faker": "^5.1.0",
@@ -182,6 +181,7 @@
         "cypress-mailhog": "^1.3.0",
         "cypress-mochawesome-reporter": "^2.3.0",
         "cypress-multi-reporters": "^1.5.0",
+        "cypress-repeat": "^2.3.3",
         "cypress-timings": "^1.0.0",
         "eslint": "^7.4.0",
         "eslint-config-prettier": "^8.5.0",
@@ -8255,9 +8255,9 @@
       }
     },
     "node_modules/@saleor/macaw-ui": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.7.1.tgz",
-      "integrity": "sha512-DB4LleO04Ez0CjjMD07XnK40f8wf/XnYlJVggiGbHMEveBEAm6MfmvYgH4+kjPl49Vax8uCv4G39lDEivSJQ6Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.7.2.tgz",
+      "integrity": "sha512-Fli7fhTWuHu7q2CzxwTUpB4x9HYaxHSAzCLZLA23VY1ieIWbCxbsXadMiMGWp/nuYitswMr6JXMm+1SDe9K8LQ==",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.5.0",
         "clsx": "^1.1.1",
@@ -9330,7 +9330,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
       "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -14285,7 +14285,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "devOptional": true
     },
     "node_modules/blueimp-md5": {
       "version": "2.18.0",
@@ -17046,6 +17047,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/cypress-repeat/-/cypress-repeat-2.3.3.tgz",
       "integrity": "sha512-DoPiN5A/SMC9p6B2lRbvOxQvQUS6LO8Zeblkc3ZQQl5cQMmGBa15EOMLdBpQ1ctjOgssvcYawodBkxiNMHI49g==",
+      "optional": true,
       "dependencies": {
         "arg": "5.0.2",
         "bluebird": "3.7.2",
@@ -17062,12 +17064,14 @@
     "node_modules/cypress-repeat/node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "optional": true
     },
     "node_modules/cypress-repeat/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "optional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -17084,6 +17088,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -50738,9 +50743,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.7.1.tgz",
-      "integrity": "sha512-DB4LleO04Ez0CjjMD07XnK40f8wf/XnYlJVggiGbHMEveBEAm6MfmvYgH4+kjPl49Vax8uCv4G39lDEivSJQ6Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.7.2.tgz",
+      "integrity": "sha512-Fli7fhTWuHu7q2CzxwTUpB4x9HYaxHSAzCLZLA23VY1ieIWbCxbsXadMiMGWp/nuYitswMr6JXMm+1SDe9K8LQ==",
       "requires": {
         "@floating-ui/react-dom-interactions": "^0.5.0",
         "clsx": "^1.1.1",
@@ -51619,7 +51624,7 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
           "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
-          "dev": true
+          "optional": true
         },
         "react": {
           "version": "16.14.0",
@@ -55673,7 +55678,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "devOptional": true
     },
     "blueimp-md5": {
       "version": "2.18.0",
@@ -58237,6 +58243,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/cypress-repeat/-/cypress-repeat-2.3.3.tgz",
       "integrity": "sha512-DoPiN5A/SMC9p6B2lRbvOxQvQUS6LO8Zeblkc3ZQQl5cQMmGBa15EOMLdBpQ1ctjOgssvcYawodBkxiNMHI49g==",
+      "optional": true,
       "requires": {
         "arg": "5.0.2",
         "bluebird": "3.7.2",
@@ -58247,12 +58254,14 @@
         "arg": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+          "optional": true
         },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -58260,7 +58269,8 @@
         "dotenv": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/styles": "^4.11.4",
     "@reach/auto-id": "^0.16.0",
-    "@saleor/macaw-ui": "0.7.1",
+    "@saleor/macaw-ui": "0.7.2",
     "@saleor/sdk": "^0.4.4",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",


### PR DESCRIPTION
I want to merge this change because it changes version of MacawUI to 0.7.2

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1