### PR TITLE
Add redirect to GraphiQL from product & order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix pagination errors on voucher and sale pages - #2317 by @orzechdev
 - Add format tip for text attribute rows - #2340 by @orzechdev
 - Add GraphiQL editor to webhook form for defining the subscription query #2885 by @2can @zaiste
+- Add redirect to GraphiQL from product & order details pages - #2940 by @zaiste
 
 ## 3.4
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1994,6 +1994,10 @@
   "DWs4ba": {
     "string": "No menus found"
   },
+  "DaIlPd": {
+    "context": "link",
+    "string": "Open this product in GraphiQL"
+  },
   "Dgp38J": {
     "context": "checkbox label",
     "string": "Restrict order value"
@@ -7160,6 +7164,10 @@
   "s8FlDW": {
     "context": "hide error log label in notification",
     "string": "Hide log"
+  },
+  "s8bQaF": {
+    "context": "link",
+    "string": "Open this order in GraphiQL"
   },
   "s97tLq": {
     "string": "Search Collections"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1015,6 +1015,10 @@
     "context": "translations section name",
     "string": "Translations"
   },
+  "5i/InH": {
+    "context": "open new window button",
+    "string": "Open this order in GraphiQL"
+  },
   "5kvaFR": {
     "context": "product field",
     "string": "Export Variant SKU"
@@ -1993,10 +1997,6 @@
   },
   "DWs4ba": {
     "string": "No menus found"
-  },
-  "DaIlPd": {
-    "context": "link",
-    "string": "Open this product in GraphiQL"
   },
   "Dgp38J": {
     "context": "checkbox label",
@@ -7164,10 +7164,6 @@
   "s8FlDW": {
     "context": "hide error log label in notification",
     "string": "Hide log"
-  },
-  "s8bQaF": {
-    "context": "link",
-    "string": "Open this order in GraphiQL"
   },
   "s97tLq": {
     "string": "Search Collections"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "jwt-decode": "^3.1.2",
         "keycode": "^2.2.0",
         "lodash": "^4.17.20",
+        "lz-string": "^1.4.4",
         "marked": "^4.0.17",
         "moment-timezone": "^0.5.32",
         "qs": "^6.9.0",
@@ -26935,7 +26936,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-      "optional": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -60132,8 +60132,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-      "optional": true
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ=="
     },
     "macos-release": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jwt-decode": "^3.1.2",
     "keycode": "^2.2.0",
     "lodash": "^4.17.20",
+    "lz-string": "^1.4.4",
     "marked": "^4.0.17",
     "moment-timezone": "^0.5.32",
     "qs": "^6.9.0",

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -25,12 +25,13 @@ import useNavigator from "@dashboard/hooks/useNavigator";
 import { sectionNames } from "@dashboard/intl";
 import OrderChannelSectionCard from "@dashboard/orders/components/OrderChannelSectionCard";
 import { orderListUrl } from "@dashboard/orders/urls";
+import { encodeGraphQLStatement } from "@dashboard/utils/graphql";
 import { mapMetadataItemToInput } from "@dashboard/utils/maps";
 import useMetadataChangeTrigger from "@dashboard/utils/metadata/useMetadataChangeTrigger";
 import { Typography } from "@material-ui/core";
-import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { Button, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { getMutationErrors, maybe } from "../../../misc";
 import OrderCustomer from "../OrderCustomer";
@@ -46,6 +47,22 @@ import { messages } from "./messages";
 import { useStyles } from "./styles";
 import Title from "./Title";
 import { filteredConditionalItems, hasAnyItemsReplaceable } from "./utils";
+
+// FIXME should be moved elsewhere eventually
+const DefaultTestQuery = `query OrderDetails($id: ID!) { 
+  order(id: $id) { 
+    id
+    number
+    status
+    isShippingRequired
+    canFinalize
+    created
+    customerNote
+    paymentStatus
+    userEmail
+    isPaid
+  } 
+}`;
 
 export interface OrderDetailsPageProps {
   order: OrderDetailsFragment;
@@ -211,9 +228,29 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
               inline
               title={<Title order={order} />}
               cardMenu={
-                <CardMenu
-                  menuItems={[...selectCardMenuItems, ...extensionMenuItems]}
-                />
+                <>
+                  <Button
+                    onClick={() => {
+                      const playgroundURL = new URL(process.env.API_URI);
+                      playgroundURL.hash = encodeGraphQLStatement({
+                        query: DefaultTestQuery,
+                        headers: "",
+                        operationName: "",
+                        variables: `{ "id": "${order.id}" }`,
+                      });
+                      window.open(playgroundURL, "_blank").focus();
+                    }}
+                  >
+                    <FormattedMessage
+                      id="s8bQaF"
+                      defaultMessage="Open this order in GraphiQL"
+                      description="link"
+                    />
+                  </Button>
+                  <CardMenu
+                    menuItems={[...selectCardMenuItems, ...extensionMenuItems]}
+                  />
+                </>
               }
             />
             <div className={classes.date}>

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -26,13 +26,13 @@ import { sectionNames } from "@dashboard/intl";
 import OrderChannelSectionCard from "@dashboard/orders/components/OrderChannelSectionCard";
 import { defaultGraphiQLQuery } from "@dashboard/orders/queries";
 import { orderListUrl } from "@dashboard/orders/urls";
-import { encodeGraphQLStatement } from "@dashboard/utils/graphql";
+import { playgroundOpenHandler } from "@dashboard/utils/graphql";
 import { mapMetadataItemToInput } from "@dashboard/utils/maps";
 import useMetadataChangeTrigger from "@dashboard/utils/metadata/useMetadataChangeTrigger";
 import { Typography } from "@material-ui/core";
-import { Button, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { getMutationErrors, maybe } from "../../../misc";
 import OrderCustomer from "../OrderCustomer";
@@ -198,6 +198,13 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     order?.id,
   );
 
+  const openPlaygroundURL = playgroundOpenHandler({
+    query: defaultGraphiQLQuery,
+    headers: "",
+    operationName: "",
+    variables: `{ "id": "${order?.id}" }`,
+  });
+
   return (
     <Form confirmLeave initial={initial} onSubmit={handleSubmit}>
       {({ change, data, submit }) => {
@@ -214,27 +221,16 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
               title={<Title order={order} />}
               cardMenu={
                 <>
-                  <Button
-                    data-test-id="graphiql-redirect"
-                    onClick={() => {
-                      const playgroundURL = new URL(process.env.API_URI);
-                      playgroundURL.hash = encodeGraphQLStatement({
-                        query: defaultGraphiQLQuery,
-                        headers: "",
-                        operationName: "",
-                        variables: `{ "id": "${order.id}" }`,
-                      });
-                      window.open(playgroundURL, "_blank").focus();
-                    }}
-                  >
-                    <FormattedMessage
-                      id="s8bQaF"
-                      defaultMessage="Open this order in GraphiQL"
-                      description="link"
-                    />
-                  </Button>
                   <CardMenu
-                    menuItems={[...selectCardMenuItems, ...extensionMenuItems]}
+                    menuItems={[
+                      ...selectCardMenuItems,
+                      ...extensionMenuItems,
+                      {
+                        label: intl.formatMessage(messages.openGraphiQL),
+                        onSelect: openPlaygroundURL,
+                        testId: "graphiql-redirect",
+                      },
+                    ]}
                   />
                 </>
               }

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -230,6 +230,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
               cardMenu={
                 <>
                   <Button
+                    data-test-id="graphiql-redirect"
                     onClick={() => {
                       const playgroundURL = new URL(process.env.API_URI);
                       playgroundURL.hash = encodeGraphQLStatement({

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -24,6 +24,7 @@ import { SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { sectionNames } from "@dashboard/intl";
 import OrderChannelSectionCard from "@dashboard/orders/components/OrderChannelSectionCard";
+import { defaultGraphiQLQuery } from "@dashboard/orders/queries";
 import { orderListUrl } from "@dashboard/orders/urls";
 import { encodeGraphQLStatement } from "@dashboard/utils/graphql";
 import { mapMetadataItemToInput } from "@dashboard/utils/maps";
@@ -47,22 +48,6 @@ import { messages } from "./messages";
 import { useStyles } from "./styles";
 import Title from "./Title";
 import { filteredConditionalItems, hasAnyItemsReplaceable } from "./utils";
-
-// FIXME should be moved elsewhere eventually
-const DefaultTestQuery = `query OrderDetails($id: ID!) { 
-  order(id: $id) { 
-    id
-    number
-    status
-    isShippingRequired
-    canFinalize
-    created
-    customerNote
-    paymentStatus
-    userEmail
-    isPaid
-  } 
-}`;
 
 export interface OrderDetailsPageProps {
   order: OrderDetailsFragment;
@@ -234,7 +219,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
                     onClick={() => {
                       const playgroundURL = new URL(process.env.API_URI);
                       playgroundURL.hash = encodeGraphQLStatement({
-                        query: DefaultTestQuery,
+                        query: defaultGraphiQLQuery,
                         headers: "",
                         operationName: "",
                         variables: `{ "id": "${order.id}" }`,

--- a/src/orders/components/OrderDetailsPage/messages.ts
+++ b/src/orders/components/OrderDetailsPage/messages.ts
@@ -16,4 +16,9 @@ export const messages = defineMessages({
     defaultMessage: "Return / Replace order",
     description: "return button",
   },
+  openGraphiQL: {
+    id: "5i/InH",
+    defaultMessage: "Open this order in GraphiQL",
+    description: "open new window button",
+  },
 });

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -200,3 +200,18 @@ export const channelUsabilityData = gql`
     }
   }
 `;
+
+export const defaultGraphiQLQuery = `query OrderDetails($id: ID!) { 
+  order(id: $id) { 
+    id
+    number
+    status
+    isShippingRequired
+    canFinalize
+    created
+    customerNote
+    paymentStatus
+    userEmail
+    isPaid
+  } 
+}`;

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
@@ -117,5 +117,13 @@ describe("Product details page", () => {
     );
     // Assert
     expect(onSubmit.mock.calls[0][0].attributes[0].value.length).toEqual(0);
+
+    // Act
+    const moreButton = screen.queryAllByTestId("show-more-button")[0];
+    await user.click(moreButton);
+    const graphiQLLink = screen.queryAllByTestId("graphiql-redirect")[0];
+
+    // Assert
+    expect(graphiQLLink).toBeInTheDocument();
   });
 });

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -49,10 +49,10 @@ import { productImageUrl, productListUrl } from "@dashboard/products/urls";
 import { ProductVariantListError } from "@dashboard/products/views/ProductUpdate/handlers/errors";
 import { UseProductUpdateHandlerError } from "@dashboard/products/views/ProductUpdate/handlers/useProductUpdateHandler";
 import { FetchMoreProps, RelayToFlat } from "@dashboard/types";
-import { encodeGraphQLStatement } from "@dashboard/utils/graphql";
-import { Button, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { playgroundOpenHandler } from "@dashboard/utils/graphql";
+import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { getChoices } from "../../utils/data";
 import ProductDetailsForm from "../ProductDetailsForm";
@@ -61,6 +61,7 @@ import ProductOrganization from "../ProductOrganization";
 import ProductTaxes from "../ProductTaxes";
 import ProductVariants from "../ProductVariants";
 import ProductUpdateForm from "./form";
+import { messages } from "./messages";
 import ProductChannelsListingsDialog from "./ProductChannelsListingsDialog";
 import {
   ProductUpdateData,
@@ -244,6 +245,13 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
     productId,
   );
 
+  const openPlaygroundURL = playgroundOpenHandler({
+    query: defaultGraphiQLQuery,
+    headers: "",
+    operationName: "",
+    variables: `{ "id": "${product?.id}" }`,
+  });
+
   return (
     <ProductUpdateForm
       isSimpleProduct={isSimpleProduct}
@@ -322,38 +330,18 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               <Backlink href={productListUrl()}>
                 {intl.formatMessage(sectionNames.products)}
               </Backlink>
-              <PageHeader
-                title={header}
-                cardMenu={
-                  <>
-                    <Button
-                      data-test-id="graphiql-redirect"
-                      onClick={() => {
-                        const playgroundURL = new URL(process.env.API_URI);
-                        playgroundURL.hash = encodeGraphQLStatement({
-                          query: defaultGraphiQLQuery,
-                          headers: "",
-                          operationName: "",
-                          variables: `{ "id": "${product.id}" }`,
-                        });
-                        window.open(playgroundURL, "_blank").focus();
-                      }}
-                    >
-                      <FormattedMessage
-                        id="DaIlPd"
-                        defaultMessage="Open this product in GraphiQL"
-                        description="link"
-                      />
-                    </Button>
-                  </>
-                }
-              >
-                {extensionMenuItems.length > 0 && (
-                  <CardMenu
-                    menuItems={extensionMenuItems}
-                    data-test-id="menu"
-                  />
-                )}
+              <PageHeader title={header}>
+                <CardMenu
+                  menuItems={[
+                    ...extensionMenuItems,
+                    {
+                      label: intl.formatMessage(messages.openGraphiQL),
+                      onSelect: openPlaygroundURL,
+                      testId: "graphiql-redirect",
+                    },
+                  ]}
+                  data-test-id="menu"
+                />
               </PageHeader>
               <Grid richText>
                 <div>

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -44,6 +44,7 @@ import useStateFromProps from "@dashboard/hooks/useStateFromProps";
 import { sectionNames } from "@dashboard/intl";
 import { maybe } from "@dashboard/misc";
 import ProductExternalMediaDialog from "@dashboard/products/components/ProductExternalMediaDialog";
+import { defaultGraphiQLQuery } from "@dashboard/products/queries";
 import { productImageUrl, productListUrl } from "@dashboard/products/urls";
 import { ProductVariantListError } from "@dashboard/products/views/ProductUpdate/handlers/errors";
 import { UseProductUpdateHandlerError } from "@dashboard/products/views/ProductUpdate/handlers/useProductUpdateHandler";
@@ -66,16 +67,6 @@ import {
   ProductUpdateHandlers,
   ProductUpdateSubmitData,
 } from "./types";
-
-// FIXME should be moved elsewhere eventually
-const DefaultTestQuery = `query ProductDetails($id: ID!) {
-  product(id: $id) {
-    id
-    name
-    slug
-    description
-  }
-}`;
 
 export interface ProductUpdatePageProps {
   channels: ChannelFragment[];
@@ -340,7 +331,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
                       onClick={() => {
                         const playgroundURL = new URL(process.env.API_URI);
                         playgroundURL.hash = encodeGraphQLStatement({
-                          query: DefaultTestQuery,
+                          query: defaultGraphiQLQuery,
                           headers: "",
                           operationName: "",
                           variables: `{ "id": "${product.id}" }`,

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -48,9 +48,10 @@ import { productImageUrl, productListUrl } from "@dashboard/products/urls";
 import { ProductVariantListError } from "@dashboard/products/views/ProductUpdate/handlers/errors";
 import { UseProductUpdateHandlerError } from "@dashboard/products/views/ProductUpdate/handlers/useProductUpdateHandler";
 import { FetchMoreProps, RelayToFlat } from "@dashboard/types";
-import { ConfirmButtonTransitionState } from "@saleor/macaw-ui";
+import { encodeGraphQLStatement } from "@dashboard/utils/graphql";
+import { Button, ConfirmButtonTransitionState } from "@saleor/macaw-ui";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { getChoices } from "../../utils/data";
 import ProductDetailsForm from "../ProductDetailsForm";
@@ -65,6 +66,16 @@ import {
   ProductUpdateHandlers,
   ProductUpdateSubmitData,
 } from "./types";
+
+// FIXME should be moved elsewhere eventually
+const DefaultTestQuery = `query ProductDetails($id: ID!) {
+  product(id: $id) {
+    id
+    name
+    slug
+    description
+  }
+}`;
 
 export interface ProductUpdatePageProps {
   channels: ChannelFragment[];
@@ -320,7 +331,31 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               <Backlink href={productListUrl()}>
                 {intl.formatMessage(sectionNames.products)}
               </Backlink>
-              <PageHeader title={header}>
+              <PageHeader
+                title={header}
+                cardMenu={
+                  <>
+                    <Button
+                      onClick={() => {
+                        const playgroundURL = new URL(process.env.API_URI);
+                        playgroundURL.hash = encodeGraphQLStatement({
+                          query: DefaultTestQuery,
+                          headers: "",
+                          operationName: "",
+                          variables: `{ "id": "${product.id}" }`,
+                        });
+                        window.open(playgroundURL, "_blank").focus();
+                      }}
+                    >
+                      <FormattedMessage
+                        id="DaIlPd"
+                        defaultMessage="Open this product in GraphiQL"
+                        description="link"
+                      />
+                    </Button>
+                  </>
+                }
+              >
                 {extensionMenuItems.length > 0 && (
                   <CardMenu
                     menuItems={extensionMenuItems}

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -336,6 +336,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
                 cardMenu={
                   <>
                     <Button
+                      data-test-id="graphiql-redirect"
                       onClick={() => {
                         const playgroundURL = new URL(process.env.API_URI);
                         playgroundURL.hash = encodeGraphQLStatement({

--- a/src/products/components/ProductUpdatePage/messages.ts
+++ b/src/products/components/ProductUpdatePage/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  openGraphiQL: {
+    id: "5i/InH",
+    defaultMessage: "Open this order in GraphiQL",
+    description: "open new window button",
+  },
+});

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -260,3 +260,12 @@ export const gridAttributes = gql`
     }
   }
 `;
+
+export const defaultGraphiQLQuery = `query ProductDetails($id: ID!) {
+  product(id: $id) {
+    id
+    name
+    slug
+    description
+  }
+}`;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -38,3 +38,26 @@ export const encodeGraphQLStatement = (editorContent: EditorContent) => {
 
   return `saleor/${editorContentToSaveInUrl}`;
 };
+
+interface PlaygroundOpenHandlerInput {
+  query: string;
+  headers: string;
+  operationName: string;
+  variables: string;
+}
+
+export const playgroundOpenHandler = ({
+  query,
+  headers,
+  operationName,
+  variables,
+}: PlaygroundOpenHandlerInput) => () => {
+  const playgroundURL = new URL(process.env.API_URI);
+  playgroundURL.hash = encodeGraphQLStatement({
+    query,
+    headers,
+    operationName,
+    variables,
+  });
+  window.open(playgroundURL, "_blank").focus();
+};

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,0 +1,40 @@
+import LzString from "lz-string";
+
+export type EditorContent = Record<keyof typeof longKeysToShortKeys, string>;
+
+type ShorterEditorContent = Record<
+  typeof longKeysToShortKeys[keyof typeof longKeysToShortKeys],
+  string
+>;
+
+export function removeEmptyValues<T extends object>(
+  editorContent: T,
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(editorContent).filter(([, val]) => !!val),
+  ) as Partial<T>;
+}
+
+const longKeysToShortKeys = {
+  query: "q",
+  headers: "h",
+  operationName: "o",
+  variables: "v",
+} as const;
+
+export const encodeGraphQLStatement = (editorContent: EditorContent) => {
+  const shorterContent: ShorterEditorContent = {
+    q: editorContent.query,
+    h: editorContent.headers,
+    o: editorContent.operationName,
+    v: editorContent.variables,
+  };
+  const stringifiedContent = JSON.stringify(removeEmptyValues(shorterContent));
+
+  const editorContentToSaveInUrl =
+    stringifiedContent === "{}"
+      ? ""
+      : LzString.compressToEncodedURIComponent(stringifiedContent);
+
+  return `saleor/${editorContentToSaveInUrl}`;
+};


### PR DESCRIPTION
I want to merge this change because it adds an ability to open a GraphiQL playground from the product & order details pages along with the automatically filled query and object ID.

**PR intended to be tested with API branch:** `main`

### Screenshots

| Before | After |
| --- | --- |
| <img width="1913" alt="CleanShot 2023-01-09 at 16 27 03@2x" src="https://user-images.githubusercontent.com/200613/211344630-180cc8b1-758f-4006-a6c4-554961466201.png"> | <img width="1913" alt="CleanShot 2023-01-09 at 16 26 46@2x" src="https://user-images.githubusercontent.com/200613/211344576-1c0b0d16-ba78-4f5b-a73f-0289c4e75477.png"> |


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?
To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [x] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1