### PR TITLE
Mark taxes as preview

### DIFF
--- a/src/taxes/components/TaxPageTitle/TaxPageTitle.tsx
+++ b/src/taxes/components/TaxPageTitle/TaxPageTitle.tsx
@@ -14,14 +14,15 @@ const useStyles = makeStyles(
   { name: "TaxPageTitle" },
 );
 
-export const TaxPageTitle: React.FC = () => {
+export const TaxPageTitle = () => {
   const classes = useStyles();
+
   return (
-    <span className={classes.wrapper}>
+    <div className={classes.wrapper}>
       <FormattedMessage {...sectionNames.taxes} />
       <HorizontalSpacer />
       <PreviewPill />
-    </span>
+    </div>
   );
 };
 

--- a/src/taxes/components/TaxPageTitle/TaxPageTitle.tsx
+++ b/src/taxes/components/TaxPageTitle/TaxPageTitle.tsx
@@ -1,0 +1,28 @@
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
+import PreviewPill from "@saleor/components/PreviewPill";
+import { sectionNames } from "@saleor/intl";
+import { makeStyles } from "@saleor/macaw-ui";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+const useStyles = makeStyles(
+  () => ({
+    wrapper: {
+      display: "flex",
+    },
+  }),
+  { name: "TaxPageTitle" },
+);
+
+export const TaxPageTitle: React.FC = () => {
+  const classes = useStyles();
+  return (
+    <span className={classes.wrapper}>
+      <FormattedMessage {...sectionNames.taxes} />
+      <HorizontalSpacer />
+      <PreviewPill />
+    </span>
+  );
+};
+
+export default TaxPageTitle;

--- a/src/taxes/components/TaxPageTitle/index.ts
+++ b/src/taxes/components/TaxPageTitle/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TaxPageTitle";
+export * from "./TaxPageTitle";

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -17,7 +17,6 @@ import {
   TaxConfigurationUpdateInput,
 } from "@saleor/graphql";
 import useNavigator from "@saleor/hooks/useNavigator";
-import { sectionNames } from "@saleor/intl";
 import {
   Button,
   ConfirmButtonTransitionState,
@@ -29,6 +28,7 @@ import {
   PageTabs,
 } from "@saleor/macaw-ui";
 import TaxCountryDialog from "@saleor/taxes/components/TaxCountryDialog";
+import TaxPageTitle from "@saleor/taxes/components/TaxPageTitle";
 import { taxesMessages } from "@saleor/taxes/messages";
 import { isLastElement } from "@saleor/taxes/utils/utils";
 import React from "react";
@@ -161,7 +161,7 @@ export const TaxChannelsPage: React.FC<TaxChannelsPageProps> = props => {
 
         return (
           <Container>
-            <PageHeader title={intl.formatMessage(sectionNames.taxes)} />
+            <PageHeader title={<TaxPageTitle />} />
             <PageTabs value="channels" onChange={handleTabChange}>
               <PageTab
                 label={intl.formatMessage(taxesMessages.channelsSection)}

--- a/src/taxes/pages/TaxClassesPage/TaxClassesPage.tsx
+++ b/src/taxes/pages/TaxClassesPage/TaxClassesPage.tsx
@@ -17,7 +17,6 @@ import { configurationMenuUrl } from "@saleor/configuration";
 import { TaxClassFragment } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useNavigator from "@saleor/hooks/useNavigator";
-import { sectionNames } from "@saleor/intl";
 import {
   ConfirmButtonTransitionState,
   List,
@@ -30,6 +29,7 @@ import {
 } from "@saleor/macaw-ui";
 import { getById } from "@saleor/misc";
 import { parseQuery } from "@saleor/orders/components/OrderCustomerAddressesEditDialog/utils";
+import TaxPageTitle from "@saleor/taxes/components/TaxPageTitle";
 import { taxesMessages } from "@saleor/taxes/messages";
 import { TaxClassesPageFormData } from "@saleor/taxes/types";
 import { useAutofocus } from "@saleor/taxes/utils/useAutofocus";
@@ -99,7 +99,7 @@ export const TaxClassesPage: React.FC<TaxClassesPageProps> = props => {
 
         return (
           <Container>
-            <PageHeader title={intl.formatMessage(sectionNames.taxes)} />
+            <PageHeader title={<TaxPageTitle />} />
             <PageTabs value="tax-classes" onChange={handleTabChange}>
               <PageTab
                 label={intl.formatMessage(taxesMessages.channelsSection)}

--- a/src/taxes/pages/TaxCountriesPage/TaxCountriesPage.tsx
+++ b/src/taxes/pages/TaxCountriesPage/TaxCountriesPage.tsx
@@ -20,7 +20,6 @@ import {
 } from "@saleor/graphql";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useNavigator from "@saleor/hooks/useNavigator";
-import { sectionNames } from "@saleor/intl";
 import {
   ConfirmButtonTransitionState,
   List,
@@ -32,6 +31,7 @@ import {
   SearchIcon,
 } from "@saleor/macaw-ui";
 import { parseQuery } from "@saleor/orders/components/OrderCustomerAddressesEditDialog/utils";
+import TaxPageTitle from "@saleor/taxes/components/TaxPageTitle";
 import { taxesMessages } from "@saleor/taxes/messages";
 import { isLastElement } from "@saleor/taxes/utils/utils";
 import React from "react";
@@ -91,7 +91,7 @@ export const TaxCountriesPage: React.FC<TaxCountriesPageProps> = props => {
 
         return (
           <Container>
-            <PageHeader title={intl.formatMessage(sectionNames.taxes)} />
+            <PageHeader title={<TaxPageTitle />} />
             <PageTabs value="countries" onChange={handleTabChange}>
               <PageTab
                 label={intl.formatMessage(taxesMessages.channelsSection)}


### PR DESCRIPTION
Fixes #2970.
I want to merge this change because it marks taxes views as feature preview.

### Screenshots
<img width="706" alt="image" src="https://user-images.githubusercontent.com/41952692/211643364-64d84a49-0e00-4b79-a33f-0049a5281194.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
APPS_MARKETPLACE_API_URI=https://marketplace-gray.vercel.app/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
