### PR TITLE
Fix issues with feature flags and build-types commands

### DIFF
--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -39,7 +39,7 @@ for (const rawSuffix of schemaSuffixes) {
           ],
         },
         [getOutputPath("types", suffix)]: {
-          documents: getDocumentsPaths(suffix),
+          documents: getDocumentsPaths(suffix, rawSuffix),
           config: {
             nonOptionalTypename: true,
             avoidOptionals: {
@@ -64,7 +64,7 @@ for (const rawSuffix of schemaSuffixes) {
           ],
         },
         [getOutputPath("hooks", suffix)]: {
-          documents: getDocumentsPaths(suffix),
+          documents: getDocumentsPaths(suffix, rawSuffix),
           preset: "import-types",
           presetConfig: {
             typesPath: "./types" + suffix + ".generated",
@@ -92,12 +92,18 @@ function getOutputPath(path, suffix) {
   return `./src/graphql/${path}${suffix}.generated.ts`;
 }
 
-function getDocumentsPaths(suffix) {
+function getDocumentsPaths(suffix, rawSuffix) {
   return [
     `./src/**/queries${suffix}.ts`,
     `./src/**/mutations${suffix}.ts`,
     `./src/**/fragments/*${suffix}.ts`,
     `./src/searches/*${suffix}.ts`,
+    // Remove feature flag files from default suffix (matches glob)
+    ...FEATURE_FLAGS.filter(flag => flag !== rawSuffix).map(
+      flag => `!./src/**/*${prepareSuffix(flag)}.ts`,
+    ),
+    // Always add all fragments (e.g. Money)
+    ...(rawSuffix !== "default" ? ["./src/**/fragments/*.ts"] : []),
   ];
 }
 


### PR DESCRIPTION
I want to merge this change because it fixes an issue when feature flags in `build-types` command were used:

- Documents from feature flaged files were loaded with default schema due to invalid glob pattern (e.g. `fragments/orders.transactions.ts` were loaded with `introspection.json` - should be `introspection.transactions.json` only)
- Fragments from other files couldn't be used in feature flagged documents (e.g. `Money` fragment cannot be used in `fragments/orders.<my-suffix>.ts`

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
APPS_MARKETPLACE_API_URI=https://marketplace-gray.vercel.app/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
