### PR TITLE
Fix cut price in datagrid when more that 2 numbers without decimal point

### DIFF
--- a/src/products/components/ProductUpdatePage/utils.test.ts
+++ b/src/products/components/ProductUpdatePage/utils.test.ts
@@ -64,4 +64,16 @@ describe("parseCurrency", () => {
     // Assert
     expect(parsed).toBe(2.07);
   });
+  it("should not trim price without decimal", () => {
+    // Arrange
+    const value = "2123";
+    const currency = "EUR";
+    const locale = Locale.PL;
+
+    // Act
+    const parsed = parseCurrency(value, locale, currency);
+
+    // Assert
+    expect(parsed).toBe(2123);
+  });
 });

--- a/src/products/components/ProductUpdatePage/utils.ts
+++ b/src/products/components/ProductUpdatePage/utils.ts
@@ -26,12 +26,10 @@ export const parseCurrency = (
   // Thousand seperators are not allowedd
   const number = value.replace(/,/, ".");
   const fractionDigits = getFractionDigits(locale, currency);
-  const trimmedNumber = number.slice(
-    0,
-    number.lastIndexOf(".") + 1 + fractionDigits,
-  );
+  const lastDecimalPoint = number.lastIndexOf(".");
+  const trimmedNumber = number.slice(0, lastDecimalPoint + 1 + fractionDigits);
 
-  return parseFloat(trimmedNumber);
+  return parseFloat(lastDecimalPoint !== -1 ? trimmedNumber : number);
 };
 
 export const prepareVariantChangeData = (


### PR DESCRIPTION
I want to merge this change because it fix https://github.com/saleor/saleor-dashboard/issues/3071

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
APPS_MARKETPLACE_API_URI=https://marketplace-gray.vercel.app/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
