### PR TITLE
Allow subscription query for sync events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add redirect to GraphiQL from product & order details pages - #2940 by @zaiste
 - Extract permissions for subscription query - #3155 by @zaiste
 - Add custom request headers to webhook form - #3107 by @2can
+- Allow subscription query for sync events - #3099 by @2can
 
 ## 3.4
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1618,10 +1618,6 @@
     "context": "sale status",
     "string": "Active"
   },
-  "ApNw0L": {
-    "context": "Dry run objects unavailable",
-    "string": "The following objects are currently not available for dry run:"
-  },
   "AqHafs": {
     "context": "provided email input placeholder",
     "string": "Provided email address"
@@ -1730,6 +1726,10 @@
   "BYGJ/j": {
     "context": "button label",
     "string": "Settings"
+  },
+  "BYTvv/": {
+    "context": "Dry run events unavailable",
+    "string": "The following events from provided query are currently not available for dry run:"
   },
   "BZ7BkQ": {
     "context": "capture payment, button",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4187,6 +4187,10 @@
     "context": "pricing card title",
     "string": "Pricing"
   },
+  "TnnDjx": {
+    "context": "Dry run sync events alert",
+    "string": "Dry run currently is not available for synchronous events"
+  },
   "TnyLrZ": {
     "context": "PageTypeDeleteWarningDialog with items multiple description",
     "string": "You are about to delete multiple page types. Some of them are assigned to pages. Deleting those page types will also delete those pages"

--- a/src/components/DryRun/DryRun.test.tsx
+++ b/src/components/DryRun/DryRun.test.tsx
@@ -1,5 +1,8 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import { WebhookEventTypeAsyncEnum } from "@dashboard/graphql";
+import {
+  WebhookEventTypeAsyncEnum,
+  WebhookEventTypeSyncEnum,
+} from "@dashboard/graphql";
 import { ThemeProvider } from "@saleor/macaw-ui";
 import productsMocks from "@test/mocks/products";
 import { render, screen } from "@testing-library/react";
@@ -23,8 +26,15 @@ describe("DryRun", () => {
       query: "",
       showDialog: true,
       setShowDialog: jest.fn(),
-      asyncEvents: [] as WebhookEventTypeAsyncEnum[],
       setResult: jest.fn(),
+      data: {
+        asyncEvents: [] as WebhookEventTypeAsyncEnum[],
+        syncEvents: [] as WebhookEventTypeSyncEnum[],
+        isActive: false,
+        name: "",
+        targetUrl: "",
+        subscriptionQuery: "",
+      },
     };
 
     // Act

--- a/src/components/DryRun/DryRun.test.tsx
+++ b/src/components/DryRun/DryRun.test.tsx
@@ -1,8 +1,5 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import {
-  WebhookEventTypeAsyncEnum,
-  WebhookEventTypeSyncEnum,
-} from "@dashboard/graphql";
+import { WebhookEventTypeSyncEnum } from "@dashboard/graphql";
 import { ThemeProvider } from "@saleor/macaw-ui";
 import productsMocks from "@test/mocks/products";
 import { render, screen } from "@testing-library/react";
@@ -27,14 +24,7 @@ describe("DryRun", () => {
       showDialog: true,
       setShowDialog: jest.fn(),
       setResult: jest.fn(),
-      data: {
-        asyncEvents: [] as WebhookEventTypeAsyncEnum[],
-        syncEvents: [] as WebhookEventTypeSyncEnum[],
-        isActive: false,
-        name: "",
-        targetUrl: "",
-        subscriptionQuery: "",
-      },
+      syncEvents: [] as WebhookEventTypeSyncEnum[],
     };
 
     // Act

--- a/src/components/DryRun/DryRun.tsx
+++ b/src/components/DryRun/DryRun.tsx
@@ -1,7 +1,9 @@
 import Grid from "@dashboard/components/Grid";
-import { WebhookFormData } from "@dashboard/custom-apps/components/WebhookDetailsPage";
 import { useStyles } from "@dashboard/custom-apps/components/WebhookEvents/styles";
-import { useTriggerWebhookDryRunMutation } from "@dashboard/graphql";
+import {
+  useTriggerWebhookDryRunMutation,
+  WebhookEventTypeSyncEnum,
+} from "@dashboard/graphql";
 import {
   capitalize,
   Dialog,
@@ -24,15 +26,16 @@ import React, { Dispatch, SetStateAction, useState } from "react";
 import { useIntl } from "react-intl";
 
 import DryRunItemsList from "../DryRunItemsList/DryRunItemsList";
+import { DocumentMap } from "../DryRunItemsList/utils";
 import { messages } from "./messages";
-import { getObjects } from "./utils";
+import { getUnavailableObjects } from "./utils";
 
 interface DryRunProps {
   query: string;
   showDialog: boolean;
   setShowDialog: Dispatch<SetStateAction<boolean>>;
   setResult: Dispatch<SetStateAction<string>>;
-  data: WebhookFormData;
+  syncEvents: WebhookEventTypeSyncEnum[];
 }
 
 const DryRun: React.FC<DryRunProps> = ({
@@ -40,15 +43,16 @@ const DryRun: React.FC<DryRunProps> = ({
   showDialog,
   setShowDialog,
   query,
-  data: { syncEvents },
+  syncEvents,
 }: DryRunProps) => {
   const intl = useIntl();
   const classes = useStyles();
   const [objectId, setObjectId] = useState<string | null>(null);
   const [triggerWebhookDryRun] = useTriggerWebhookDryRunMutation();
-  const availableObjects = getObjects(query);
-  const unavailableObjects = getObjects(query, false);
-
+  const availableObjects = Object.keys(DocumentMap).map(object =>
+    capitalize(object.split("_").join(" ").toLowerCase()),
+  );
+  const unavailableObjects = getUnavailableObjects(query);
   const [object, setObject] = useState<string | null>(null);
 
   const dryRun = async () => {
@@ -100,8 +104,8 @@ const DryRun: React.FC<DryRunProps> = ({
         {!!unavailableObjects.length && (
           <Alert variant="warning" close={false}>
             <Typography>
-              {intl.formatMessage(messages.unavailableObjects)}
-              &nbsp;
+              {intl.formatMessage(messages.unavailableEvents)}
+              <br />
               <strong>{unavailableObjects.join(", ")}</strong>
             </Typography>
           </Alert>
@@ -174,7 +178,7 @@ const DryRun: React.FC<DryRunProps> = ({
           color="primary"
           variant="primary"
           onClick={dryRun}
-          disabled={!availableObjects.length}
+          disabled={!object}
         >
           {intl.formatMessage(messages.run)}
         </Button>

--- a/src/components/DryRun/DryRun.tsx
+++ b/src/components/DryRun/DryRun.tsx
@@ -1,9 +1,7 @@
 import Grid from "@dashboard/components/Grid";
+import { WebhookFormData } from "@dashboard/custom-apps/components/WebhookDetailsPage";
 import { useStyles } from "@dashboard/custom-apps/components/WebhookEvents/styles";
-import {
-  useTriggerWebhookDryRunMutation,
-  WebhookEventTypeAsyncEnum,
-} from "@dashboard/graphql";
+import { useTriggerWebhookDryRunMutation } from "@dashboard/graphql";
 import {
   capitalize,
   Dialog,
@@ -33,8 +31,8 @@ interface DryRunProps {
   query: string;
   showDialog: boolean;
   setShowDialog: Dispatch<SetStateAction<boolean>>;
-  asyncEvents: WebhookEventTypeAsyncEnum[];
   setResult: Dispatch<SetStateAction<string>>;
+  data: WebhookFormData;
 }
 
 const DryRun: React.FC<DryRunProps> = ({
@@ -42,6 +40,7 @@ const DryRun: React.FC<DryRunProps> = ({
   showDialog,
   setShowDialog,
   query,
+  data: { syncEvents },
 }: DryRunProps) => {
   const intl = useIntl();
   const classes = useStyles();
@@ -69,6 +68,23 @@ const DryRun: React.FC<DryRunProps> = ({
 
   if (!showDialog) {
     return <></>;
+  }
+
+  if (syncEvents.length > 0) {
+    return (
+      <Dialog open={showDialog} fullWidth maxWidth="md" data-test-id="dry-run">
+        <DialogHeader onClose={closeDialog}>
+          {intl.formatMessage(messages.header)}
+        </DialogHeader>
+        <DialogContent style={{ overflow: "scroll" }}>
+          <Alert variant="error" close={false}>
+            <Typography>
+              {intl.formatMessage(messages.unavailableSyncEvents)}
+            </Typography>
+          </Alert>
+        </DialogContent>
+      </Dialog>
+    );
   }
 
   return (

--- a/src/components/DryRun/DryRun.tsx
+++ b/src/components/DryRun/DryRun.tsx
@@ -37,7 +37,7 @@ interface DryRunProps {
   setResult: Dispatch<SetStateAction<string>>;
 }
 
-export const DryRun: React.FC<DryRunProps> = ({
+const DryRun: React.FC<DryRunProps> = ({
   setResult,
   showDialog,
   setShowDialog,

--- a/src/components/DryRun/messages.ts
+++ b/src/components/DryRun/messages.ts
@@ -16,11 +16,11 @@ export const messages = defineMessages({
     defaultMessage: "Select object type to perform dry run on provided query",
     description: "Dry run dialog object title",
   },
-  unavailableObjects: {
-    id: "ApNw0L",
+  unavailableEvents: {
+    id: "BYTvv/",
     defaultMessage:
-      "The following objects are currently not available for dry run:",
-    description: "Dry run objects unavailable",
+      "The following events from provided query are currently not available for dry run:",
+    description: "Dry run events unavailable",
   },
   objects: {
     id: "uccjUM",

--- a/src/components/DryRun/messages.ts
+++ b/src/components/DryRun/messages.ts
@@ -6,6 +6,11 @@ export const messages = defineMessages({
     defaultMessage: "Dry run",
     description: "Dry run dialog header",
   },
+  unavailableSyncEvents: {
+    id: "8+g1k3",
+    defaultMessage: "Dry run currently is not available for synchronous events",
+    description: "Dry ",
+  },
   selectObject: {
     id: "+RffqY",
     defaultMessage: "Select object type to perform dry run on provided query",

--- a/src/components/DryRun/messages.ts
+++ b/src/components/DryRun/messages.ts
@@ -7,9 +7,9 @@ export const messages = defineMessages({
     description: "Dry run dialog header",
   },
   unavailableSyncEvents: {
-    id: "8+g1k3",
+    id: "TnnDjx",
     defaultMessage: "Dry run currently is not available for synchronous events",
-    description: "Dry ",
+    description: "Dry run sync events alert",
   },
   selectObject: {
     id: "+RffqY",

--- a/src/components/DryRun/utils.test.ts
+++ b/src/components/DryRun/utils.test.ts
@@ -1,0 +1,24 @@
+import { getUnavailableObjects } from "./utils";
+
+describe("getUnavailableObjects", () => {
+  it("should return unavailable for dry run events from provided query", () => {
+    const query = `
+    subscription {
+      event {
+        ... on ProductUpdated {
+          __typename
+        }
+        ... on ProductDeleted {
+          __typename
+        }
+        ... on AddressUpdated {
+          __typename
+        }
+      }
+    }`;
+
+    const events = getUnavailableObjects(query);
+
+    expect(events).toEqual(["AddressUpdated"]);
+  });
+});

--- a/src/components/DryRun/utils.ts
+++ b/src/components/DryRun/utils.ts
@@ -34,20 +34,18 @@ const getEventsFromQuery = (query: string) => {
 
 export const getUnavailableObjects = (query: string) => {
   const queryEvents = getEventsFromQuery(query);
-  const unavailableObjects = [];
 
-  queryEvents.forEach(event => {
+  return queryEvents.reduce((acc, event) => {
     const formattedEvent = event
       .split(/(?=[A-Z])/)
       .join("_")
       .toUpperCase();
-
     if (checkEventPresence(formattedEvent)) {
-      unavailableObjects.push(event);
+      acc.push(event);
     }
-  });
 
-  return unavailableObjects;
+    return acc;
+  }, []);
 };
 
 const checkEventPresence = (event: string) => {

--- a/src/components/DryRun/utils.ts
+++ b/src/components/DryRun/utils.ts
@@ -1,8 +1,8 @@
-import { AsyncWebhookTypes } from "@dashboard/custom-apps/components/WebhookEvents";
+import { getWebhookTypes } from "@dashboard/custom-apps/components/WebhookEvents/utils";
+import { WebhookEventTypeAsyncEnum } from "@dashboard/graphql";
 import { InlineFragmentNode, ObjectFieldNode, parse, visit } from "graphql";
-import uniq from "lodash/uniq";
 
-import { ExcludedDocumentMap } from "../DryRunItemsList/utils";
+import { DocumentMap, ExcludedDocumentMap } from "../DryRunItemsList/utils";
 
 const getEventsFromQuery = (query: string) => {
   if (query.length === 0) {
@@ -32,28 +32,34 @@ const getEventsFromQuery = (query: string) => {
   }
 };
 
-export const getObjects = (query: string, available = true) => {
+export const getUnavailableObjects = (query: string) => {
   const queryEvents = getEventsFromQuery(query);
+  const unavailableObjects = [];
 
-  return uniq(
-    queryEvents.map(event => {
-      const object = event.split(/(?=[A-Z])/).slice(0, -1);
-      if (
-        Object.keys(AsyncWebhookTypes)
-          .filter(object =>
-            available
-              ? !Object.keys(ExcludedDocumentMap).includes(object.toUpperCase())
-              : Object.keys(ExcludedDocumentMap).includes(object.toUpperCase()),
-          )
-          .includes(object.join("_").toUpperCase())
-      ) {
-        return object.join(" ");
-      }
+  queryEvents.forEach(event => {
+    const formattedEvent = event
+      .split(/(?=[A-Z])/)
+      .join("_")
+      .toUpperCase();
 
-      return event
-        .split(/(?=[A-Z])/)
-        .slice(0, -2)
-        .join(" ");
-    }),
-  ).filter(object => object.length > 0);
+    if (checkEventPresence(formattedEvent)) {
+      unavailableObjects.push(event);
+    }
+  });
+
+  return unavailableObjects;
+};
+
+const checkEventPresence = (event: string) => {
+  const webhookTypes = getWebhookTypes(Object.keys(WebhookEventTypeAsyncEnum));
+  const availableObjects = Object.keys(DocumentMap);
+  const excludedObjects = Object.keys(webhookTypes).filter(
+    object => !availableObjects.includes(object),
+  );
+
+  Object.keys(ExcludedDocumentMap).forEach(
+    object => !excludedObjects.includes(object) && excludedObjects.push(object),
+  );
+
+  return excludedObjects.some(object => event.startsWith(object));
 };

--- a/src/components/DryRunItemsList/DryRunItemsList.tsx
+++ b/src/components/DryRunItemsList/DryRunItemsList.tsx
@@ -18,17 +18,21 @@ import { useIntl } from "react-intl";
 import Avatar from "../TableCellAvatar/Avatar";
 import { messages } from "./messages";
 import { DocumentMap, TData, TVariables } from "./utils";
-interface DryRunItemsListProps {
+
+export interface DryRunItemsListProps {
   objectId: string;
   setObjectId: React.Dispatch<any>;
   object: string;
 }
 
-const DryRunItemsList = (props: DryRunItemsListProps) => {
+const DryRunItemsList: React.FC<DryRunItemsListProps> = ({
+  object,
+  objectId,
+  setObjectId,
+}: DryRunItemsListProps) => {
   const intl = useIntl();
   const classes = useStyles();
   const { checkbox } = useListWidths();
-  const { object, objectId, setObjectId } = props;
   const objectDocument = DocumentMap[object];
   const objectCollection =
     objectDocument.collection ?? camelCase(`${object.toLowerCase()}s`);

--- a/src/components/GraphiQL/GraphiQL.tsx
+++ b/src/components/GraphiQL/GraphiQL.tsx
@@ -1,4 +1,4 @@
-import { WebhookEventTypeAsyncEnum } from "@dashboard/graphql";
+import { WebhookFormData } from "@dashboard/custom-apps/components/WebhookDetailsPage";
 import {
   CopyIcon,
   GraphiQLProvider,
@@ -78,7 +78,7 @@ export function GraphiQL({
   visiblePlugin,
   defaultHeaders,
   ...props
-}: GraphiQLProps & { asyncEvents: WebhookEventTypeAsyncEnum[] }) {
+}: GraphiQLProps & { data: WebhookFormData }) {
   // Ensure props are correct
   if (typeof fetcher !== "function") {
     throw new TypeError(
@@ -130,7 +130,7 @@ export function GraphiQL({
         setShowDialog={setShowDialog}
         query={query}
         setResult={setResult}
-        asyncEvents={props.asyncEvents}
+        data={props.data}
       />
     </GraphiQLProvider>
   );

--- a/src/components/GraphiQL/GraphiQL.tsx
+++ b/src/components/GraphiQL/GraphiQL.tsx
@@ -130,7 +130,7 @@ export function GraphiQL({
         setShowDialog={setShowDialog}
         query={query}
         setResult={setResult}
-        data={props.data}
+        syncEvents={props.data.syncEvents}
       />
     </GraphiQLProvider>
   );

--- a/src/custom-apps/components/WebhookDetailsPage/WebhookDetailsPage.tsx
+++ b/src/custom-apps/components/WebhookDetailsPage/WebhookDetailsPage.tsx
@@ -96,17 +96,18 @@ const WebhookDetailsPage: React.FC<WebhookDetailsPageProps> = ({
   return (
     <Form confirmLeave initial={initialForm} onSubmit={handleSubmit}>
       {({ data, submit, change }) => {
-        const handleSyncEventsSelect = createSyncEventsSelectHandler(
+        const handleSyncEventsSelect = createSyncEventsSelectHandler({
           change,
-          data.syncEvents,
-          setQuery,
-        );
-        const handleAsyncEventsSelect = createAsyncEventsSelectHandler(
-          change,
-          data.asyncEvents,
+          data,
           query,
           setQuery,
-        );
+        });
+        const handleAsyncEventsSelect = createAsyncEventsSelectHandler({
+          change,
+          data,
+          query,
+          setQuery,
+        });
 
         return (
           <DetailedContent useSingleColumn>
@@ -127,6 +128,7 @@ const WebhookDetailsPage: React.FC<WebhookDetailsPageProps> = ({
                 <FormSpacer />
                 <WebhookEvents
                   data={data}
+                  setQuery={setQuery}
                   onSyncEventChange={handleSyncEventsSelect}
                   onAsyncEventChange={handleAsyncEventsSelect}
                 />

--- a/src/custom-apps/components/WebhookEvents/WebhookEvents.tsx
+++ b/src/custom-apps/components/WebhookEvents/WebhookEvents.tsx
@@ -19,7 +19,7 @@ import {
   Pill,
   useListWidths,
 } from "@saleor/macaw-ui";
-import React, { useState } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { messages } from "./messages";
@@ -30,12 +30,14 @@ interface WebhookEventsProps {
     syncEvents: WebhookEventTypeSyncEnum[];
     asyncEvents: WebhookEventTypeAsyncEnum[];
   };
+  setQuery: Dispatch<SetStateAction<string>>;
   onSyncEventChange: (event: ChangeEvent) => void;
   onAsyncEventChange: (event: ChangeEvent) => void;
 }
 
 const WebhookEvents: React.FC<WebhookEventsProps> = ({
   data,
+  setQuery,
   onSyncEventChange,
   onAsyncEventChange,
 }) => {
@@ -56,6 +58,7 @@ const WebhookEvents: React.FC<WebhookEventsProps> = ({
 
   const handleTabChange = value => {
     setObject(null);
+    setQuery("");
     setTab(value);
   };
 

--- a/src/custom-apps/components/WebhookEvents/WebhookEvents.tsx
+++ b/src/custom-apps/components/WebhookEvents/WebhookEvents.tsx
@@ -24,6 +24,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { messages } from "./messages";
 import { useStyles } from "./styles";
+import { EventTypes, getEventName } from "./utils";
 
 interface WebhookEventsProps {
   data: {
@@ -184,55 +185,3 @@ const WebhookEvents: React.FC<WebhookEventsProps> = ({
 };
 WebhookEvents.displayName = "WebhookEvents";
 export default WebhookEvents;
-
-type Actions = string[];
-
-const getWebhookTypes = (webhookEvents: string[]) => {
-  const webhookTypes: Record<string, Actions> = {};
-  const multiWords = ["DRAFT_ORDER", "GIFT_CARD", "ANY_EVENTS"];
-
-  const setObject = (
-    keywords: string[],
-    object: string,
-    objectLength: number,
-  ) => {
-    const events = webhookTypes[object] || [];
-    const event = keywords.slice(objectLength).join("_");
-    events.push(!!event.length ? event : object);
-    webhookTypes[object] = events;
-  };
-
-  webhookEvents.map(key => {
-    const keywords = key.split("_");
-
-    // handle 2 word exceptions
-    if (multiWords.includes(keywords.slice(0, 2).join("_"))) {
-      setObject(keywords, keywords.slice(0, 2).join("_"), 2);
-      return;
-    }
-
-    setObject(keywords, keywords[0], 1);
-  });
-
-  return webhookTypes;
-};
-
-export const AsyncWebhookTypes: Record<string, Actions> = getWebhookTypes(
-  Object.keys(WebhookEventTypeAsyncEnum),
-);
-
-const SyncWebhookTypes: Record<string, Actions> = getWebhookTypes(
-  Object.keys(WebhookEventTypeSyncEnum),
-);
-
-const EventTypes = {
-  async: AsyncWebhookTypes,
-  sync: SyncWebhookTypes,
-};
-
-const getEventName = (object: string, event: string) => {
-  if (object === event) {
-    return object.toUpperCase() as WebhookEventTypeSyncEnum;
-  }
-  return [object, event].join("_").toUpperCase() as WebhookEventTypeSyncEnum;
-};

--- a/src/custom-apps/components/WebhookEvents/utils.test.ts
+++ b/src/custom-apps/components/WebhookEvents/utils.test.ts
@@ -1,0 +1,23 @@
+import { getWebhookTypes } from "./utils";
+
+const TestKeys = [
+  "DRAFT_ORDER_CREATED",
+  "DRAFT_ORDER_UPDATED",
+  "PRODUCT_CREATED",
+  "PRODUCT_UPDATED",
+  "PRODUCT_VARIANT_UPDATED",
+];
+
+describe("getWebhookTypes", () => {
+  it("should map array of enum keys to objects with events ", () => {
+    const TestWebhookTypes = getWebhookTypes(TestKeys);
+
+    expect(Object.keys(TestWebhookTypes)).toEqual(["DRAFT_ORDER", "PRODUCT"]);
+    expect(TestWebhookTypes.DRAFT_ORDER).toEqual(["CREATED", "UPDATED"]);
+    expect(TestWebhookTypes.PRODUCT).toEqual([
+      "CREATED",
+      "UPDATED",
+      "VARIANT_UPDATED",
+    ]);
+  });
+});

--- a/src/custom-apps/components/WebhookEvents/utils.ts
+++ b/src/custom-apps/components/WebhookEvents/utils.ts
@@ -6,34 +6,23 @@ import {
 type Actions = string[];
 
 export const getWebhookTypes = (webhookEvents: string[]) => {
-  const webhookTypes: Record<string, Actions> = {};
   const multiWords = ["DRAFT_ORDER", "GIFT_CARD", "ANY_EVENTS"];
 
-  const setObject = (
-    keywords: string[],
-    object: string,
-    objectLength: number,
-  ) => {
-    const events = webhookTypes[object] || [];
-    const event = keywords.slice(objectLength).join("_");
-    events.push(!!event.length ? event : object);
-    webhookTypes[object] = events;
-  };
-
-  webhookEvents.forEach(key => {
+  return webhookEvents.reduce((acc, key) => {
     const keywords = key.split("_");
-
-    // handle 2 word exceptions
     const multiKeyword = keywords.slice(0, 2).join("_");
-    if (multiWords.includes(multiKeyword)) {
-      setObject(keywords, multiKeyword, 2);
-      return;
-    }
 
-    setObject(keywords, keywords[0], 1);
-  });
+    const [keyword, sliceSize] = multiWords.includes(multiKeyword)
+      ? [multiKeyword, 2]
+      : [keywords[0], 1];
 
-  return webhookTypes;
+    const event = keywords.slice(sliceSize).join("_");
+    const events = acc[keyword] || [];
+    events.push(!!event.length ? event : multiKeyword);
+    acc[keyword] = events;
+
+    return acc;
+  }, {});
 };
 
 export const AsyncWebhookTypes: Record<string, Actions> = getWebhookTypes(

--- a/src/custom-apps/components/WebhookEvents/utils.ts
+++ b/src/custom-apps/components/WebhookEvents/utils.ts
@@ -8,7 +8,7 @@ type Actions = string[];
 export const getWebhookTypes = (webhookEvents: string[]) => {
   const multiWords = ["DRAFT_ORDER", "GIFT_CARD", "ANY_EVENTS"];
 
-  return webhookEvents.reduce((acc, key) => {
+  return webhookEvents.reduce<Record<string, Actions>>((acc, key) => {
     const keywords = key.split("_");
     const multiKeyword = keywords.slice(0, 2).join("_");
 

--- a/src/custom-apps/components/WebhookEvents/utils.ts
+++ b/src/custom-apps/components/WebhookEvents/utils.ts
@@ -1,0 +1,57 @@
+import {
+  WebhookEventTypeAsyncEnum,
+  WebhookEventTypeSyncEnum,
+} from "@dashboard/graphql";
+
+type Actions = string[];
+
+export const getWebhookTypes = (webhookEvents: string[]) => {
+  const webhookTypes: Record<string, Actions> = {};
+  const multiWords = ["DRAFT_ORDER", "GIFT_CARD", "ANY_EVENTS"];
+
+  const setObject = (
+    keywords: string[],
+    object: string,
+    objectLength: number,
+  ) => {
+    const events = webhookTypes[object] || [];
+    const event = keywords.slice(objectLength).join("_");
+    events.push(!!event.length ? event : object);
+    webhookTypes[object] = events;
+  };
+
+  webhookEvents.forEach(key => {
+    const keywords = key.split("_");
+
+    // handle 2 word exceptions
+    const multiKeyword = keywords.slice(0, 2).join("_");
+    if (multiWords.includes(multiKeyword)) {
+      setObject(keywords, multiKeyword, 2);
+      return;
+    }
+
+    setObject(keywords, keywords[0], 1);
+  });
+
+  return webhookTypes;
+};
+
+export const AsyncWebhookTypes: Record<string, Actions> = getWebhookTypes(
+  Object.keys(WebhookEventTypeAsyncEnum),
+);
+
+const SyncWebhookTypes: Record<string, Actions> = getWebhookTypes(
+  Object.keys(WebhookEventTypeSyncEnum),
+);
+
+export const EventTypes = {
+  async: AsyncWebhookTypes,
+  sync: SyncWebhookTypes,
+};
+
+export const getEventName = (object: string, event: string) => {
+  if (object === event) {
+    return object.toUpperCase() as WebhookEventTypeSyncEnum;
+  }
+  return [object, event].join("_").toUpperCase() as WebhookEventTypeSyncEnum;
+};

--- a/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
+++ b/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
@@ -4,7 +4,6 @@ import CardTitle from "@dashboard/components/CardTitle";
 import { useExplorerPlugin } from "@graphiql/plugin-explorer";
 import { createGraphiQLFetcher } from "@graphiql/toolkit";
 import { Card, CardContent } from "@material-ui/core";
-import clsx from "clsx";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
 
@@ -45,13 +44,8 @@ const WebhookSubscriptionQuery: React.FC<WebhookSubscriptionQueryProps> = ({
   const classes = useStyles();
 
   return (
-    <Card
-      className={clsx(classes.card, data.syncEvents.length && classes.disabled)}
-    >
-      <CardTitle
-        title={intl.formatMessage(messages.title)}
-        className={classes.cardTitle}
-      />
+    <Card className={classes.card}>
+      <CardTitle title={intl.formatMessage(messages.title)} />
       <CardContent className={classes.cardContent}>
         <GraphiQL
           data-test-id="graphiql-webhook"

--- a/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
+++ b/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
@@ -62,7 +62,7 @@ const WebhookSubscriptionQuery: React.FC<WebhookSubscriptionQueryProps> = ({
           onEditQuery={setQuery}
           plugins={[explorerPlugin]}
           isHeadersEditorEnabled={false}
-          asyncEvents={data.asyncEvents}
+          data={data}
         />
       </CardContent>
     </Card>

--- a/src/custom-apps/handlers.ts
+++ b/src/custom-apps/handlers.ts
@@ -12,28 +12,36 @@ import {
   print,
   visit,
 } from "graphql";
+import isEmpty from "lodash/isEmpty";
+import React, { Dispatch, SetStateAction } from "react";
 
+import { WebhookFormData } from "./components/WebhookDetailsPage";
 import { filterSelectedAsyncEvents } from "./utils";
 
+interface CreateSyncEventsSelectHandler {
+  change: (event: ChangeEvent, cb?: () => void) => void;
+  data: WebhookFormData;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+}
+
 export const createSyncEventsSelectHandler =
-  (
-    change: (event: ChangeEvent, cb?: () => void) => void,
-    syncEvents: WebhookEventTypeSyncEnum[],
-    setQuery: React.Dispatch<React.SetStateAction<string>>,
-  ) =>
+  ({ change, data, query, setQuery }: CreateSyncEventsSelectHandler) =>
   (event: ChangeEvent) => {
+    const { syncEvents, asyncEvents } = data;
     const events = toggle(event.target.value, syncEvents, (a, b) => a === b);
 
-    // Clear query
-    setQuery("");
-
     // Clear asyncEvents
-    change({
-      target: {
-        name: "asyncEvents",
-        value: [],
-      },
-    });
+    if (!isEmpty(asyncEvents)) {
+      setQuery("");
+
+      change({
+        target: {
+          name: "asyncEvents",
+          value: [],
+        },
+      });
+    }
 
     change({
       target: {
@@ -41,26 +49,35 @@ export const createSyncEventsSelectHandler =
         value: events,
       },
     });
+
+    handleQuery(events, query, setQuery);
   };
 
+interface CreateAsyncEventsSelectHandler {
+  change: (event: ChangeEvent, cb?: () => void) => void;
+  data: WebhookFormData;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+}
+
 export const createAsyncEventsSelectHandler =
-  (
-    change: (event: ChangeEvent, cb?: () => void) => void,
-    asyncEvents: WebhookEventTypeAsyncEnum[],
-    query: string,
-    setQuery: React.Dispatch<React.SetStateAction<string>>,
-  ) =>
+  ({ change, data, query, setQuery }: CreateAsyncEventsSelectHandler) =>
   (event: ChangeEvent) => {
+    const { syncEvents, asyncEvents } = data;
     const events = toggle(event.target.value, asyncEvents, (a, b) => a === b);
     const filteredEvents = filterSelectedAsyncEvents(events);
 
     // Clear syncEvents
-    change({
-      target: {
-        name: "syncEvents",
-        value: [],
-      },
-    });
+    if (!isEmpty(syncEvents)) {
+      setQuery("");
+
+      change({
+        target: {
+          name: "syncEvents",
+          value: [],
+        },
+      });
+    }
 
     change({
       target: {
@@ -73,7 +90,7 @@ export const createAsyncEventsSelectHandler =
   };
 
 const handleQuery = (
-  events: WebhookEventTypeAsyncEnum[],
+  events: WebhookEventTypeAsyncEnum[] | WebhookEventTypeSyncEnum[],
   query: string,
   setQuery: React.Dispatch<React.SetStateAction<string>>,
 ) => {


### PR DESCRIPTION
I want to merge this change because...

- it changes static event-object map to dynamically build one based on `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum`
- it enables the subscription query editor for synchronous events
- it shows the alert that dry run is yet not available for sync events


**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

![image](https://user-images.githubusercontent.com/779644/220329951-5974a75f-1374-4a38-b7cd-35cef52dfbd4.png)

![image](https://user-images.githubusercontent.com/779644/220330077-de8a68e8-600a-4f17-ba4d-cbb6faa559c4.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode


### Acceptance Criteria

1. [ ] This feature allows to define a synchronous subscription query of any shape
2. [ ] This feature must inform the user that Dry Run is not available for synchronous events

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
APPS_MARKETPLACE_API_URI=https://marketplace-gray.vercel.app/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
7. [ ] productType
8. [ ] shipping
9. [ ] customer
10. [ ] permissions
11. [ ] menuNavigation
12. [ ] pages
13. [ ] sales
14. [ ] vouchers
15. [ ] homePage
16. [ ] login
17. [ ] orders
18. [ ] products
19. [x] app
20. [ ] plugins
21. [ ] translations
22. [ ] navigation
23. [ ] variants
24. [ ] payments

CONTAINERS=1
