### PR TITLE
Fix rate limits in release tests

### DIFF
--- a/.github/workflows/getEnvironmentVariables.js
+++ b/.github/workflows/getEnvironmentVariables.js
@@ -9,6 +9,7 @@ program
   .name("Approve PR")
   .description("Approve and merge PR if patch release")
   .option("--version <version>", "version of a project")
+  .option("--token <token>", "token fo login to cloud")
   .option("--repo_token <repo_token>", "github token")
   .action(async options => {
     const isOldVersion = await checkIfOldVersion(

--- a/.github/workflows/getEnvironmentVariables.js
+++ b/.github/workflows/getEnvironmentVariables.js
@@ -9,9 +9,12 @@ program
   .name("Approve PR")
   .description("Approve and merge PR if patch release")
   .option("--version <version>", "version of a project")
-  .option("--token <token>", "token fo login to cloud")
+  .option("--repo_token <token>", "token for login to cloud")
   .action(async options => {
-    const isOldVersion = await checkIfOldVersion(options.version);
+    const isOldVersion = await checkIfOldVersion(
+      options.version,
+      options.repo_token,
+    );
     core.setOutput("IS_OLD_VERSION", isOldVersion);
 
     if (!isPatchRelease(options.version)) {
@@ -176,17 +179,17 @@ async function getDomainForUpdatedEnvironment(environmentId, token) {
   return responseInJson.domain;
 }
 
-async function checkIfOldVersion(version) {
-  const newestVersion = await getTheNewestVersion();
+async function checkIfOldVersion(version, token) {
+  const newestVersion = await getTheNewestVersion(token);
   const howManyVersionsBehind =
     getFormattedVersion(newestVersion) - getFormattedVersion(version);
   //All versions besides last three are old versions
   return howManyVersionsBehind > 2 ? "true" : "false";
 }
 
-async function getTheNewestVersion() {
+async function getTheNewestVersion(token) {
   const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
+    auth: token,
   });
 
   const response = await octokit.request(

--- a/.github/workflows/getEnvironmentVariables.js
+++ b/.github/workflows/getEnvironmentVariables.js
@@ -9,7 +9,7 @@ program
   .name("Approve PR")
   .description("Approve and merge PR if patch release")
   .option("--version <version>", "version of a project")
-  .option("--repo_token <token>", "token for login to cloud")
+  .option("--repo_token <repo_token>", "github token")
   .action(async options => {
     const isOldVersion = await checkIfOldVersion(
       options.version,

--- a/.github/workflows/getEnvironmentVariables.js
+++ b/.github/workflows/getEnvironmentVariables.js
@@ -72,7 +72,7 @@ async function createEnvironment(version, token, versionBefore, snapshot) {
     throw new Error(
       `Can't create environment- ${JSON.stringify(responseInJson)}`,
     );
-  const throwErrorAfterTimeoutWhenCreatingEnv = setTimeout(function() {
+  const throwErrorAfterTimeoutWhenCreatingEnv = setTimeout(function () {
     throw new Error("Environment didn't crated after 20 minutes");
   }, 1200000);
   return await waitUntilTaskInProgress(
@@ -106,7 +106,7 @@ async function updateEnvironment(environmentId, version, token) {
     throw new Error(
       `Can't update environment- ${JSON.stringify(responseInJson)}`,
     );
-  const throwErrorAfterTimeout = setTimeout(function() {
+  const throwErrorAfterTimeout = setTimeout(function () {
     throw new Error("Environment didn't upgraded after 20 minutes");
   }, 1200000);
   await waitUntilTaskInProgress(
@@ -135,7 +135,7 @@ async function waitUntilTaskInProgress(taskId, token) {
     responseInJson.status == "IN_PROGRESS"
   ) {
     await new Promise(resolve =>
-      setTimeout(function() {
+      setTimeout(function () {
         resolve(waitUntilTaskInProgress(taskId, token));
       }, 10000),
     );
@@ -185,7 +185,9 @@ async function checkIfOldVersion(version) {
 }
 
 async function getTheNewestVersion() {
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+  });
 
   const response = await octokit.request(
     "GET /repos/{owner}/{repo}/releases/latest",
@@ -233,7 +235,7 @@ function sortServicesByVersion(services) {
   // This function is used to sort environments by their version
   // It returns sorted list of services in descending order
 
-  return services.sort(function(a, b) {
+  return services.sort(function (a, b) {
     //Convert version from string to array eg. from "3.5.7" to [3, 5, 7]
     // Where 3 is main version, 5 is major version and 7 is patch version
 

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -158,6 +158,7 @@ jobs:
       url: ${{ steps.get-environment-variables.outputs.url }}
       is_old_version: ${{ steps.get-environment-variables.outputs.IS_OLD_VERSION }}
     env:
+      REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TOKEN: ${{ secrets.CLOUD_ACCESS_TOKEN }}
       VERSION: ${{github.event.client_payload.version}}
     steps:
@@ -179,7 +180,8 @@ jobs:
         run: |
               node .github/workflows/getEnvironmentVariables.js \
               --version $VERSION \
-              --token "$TOKEN"
+              --token "$TOKEN" \
+              --repo_token "$REPO_TOKEN"
 
   run-tests-on-release:
     if: ${{ github.event_name == 'repository_dispatch' && (github.event.client_payload.environment == 'SANDBOX' || github.event.client_payload.environment == 'STAGING')}}


### PR DESCRIPTION
I want to merge this change because it will fix - https://github.com/saleor/saleor-dashboard/actions/runs/4082131921/jobs/7036155242

Rate limit increased to 1000 after using GITHUB_TOKEN

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
MARKETPLACE_URL=https://apps.saleor.io
APPS_MARKETPLACE_API_URI=https://marketplace-gray.vercel.app/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
