### PR TITLE
Fix the API URL construction

### DIFF
--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,9 +1,10 @@
+import { getApiUrl } from "@dashboard/config";
 import LzString from "lz-string";
 
 export type EditorContent = Record<keyof typeof longKeysToShortKeys, string>;
 
 type ShorterEditorContent = Record<
-  typeof longKeysToShortKeys[keyof typeof longKeysToShortKeys],
+  (typeof longKeysToShortKeys)[keyof typeof longKeysToShortKeys],
   string
 >;
 
@@ -46,18 +47,17 @@ interface PlaygroundOpenHandlerInput {
   variables: string;
 }
 
-export const playgroundOpenHandler = ({
-  query,
-  headers,
-  operationName,
-  variables,
-}: PlaygroundOpenHandlerInput) => () => {
-  const playgroundURL = new URL(process.env.API_URI);
-  playgroundURL.hash = encodeGraphQLStatement({
-    query,
-    headers,
-    operationName,
-    variables,
-  });
-  window.open(playgroundURL, "_blank").focus();
-};
+const thisURL = new URL(getApiUrl(), window.location.origin).href;
+
+export const playgroundOpenHandler =
+  ({ query, headers, operationName, variables }: PlaygroundOpenHandlerInput) =>
+  () => {
+    const playgroundURL = new URL(thisURL);
+    playgroundURL.hash = encodeGraphQLStatement({
+      query,
+      headers,
+      operationName,
+      variables,
+    });
+    window.open(playgroundURL, "_blank").focus();
+  };


### PR DESCRIPTION
I want to merge this change because it fixes how the API URL is constructed. There are some discrepancies between the build and how it's deployed on the cloud. 

<!-- Please mention all relevant issue numbers. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
