### PR TITLE
Fix mobile view in apps 

### DIFF
--- a/src/apps/views/AppsList/AppsList.tsx
+++ b/src/apps/views/AppsList/AppsList.tsx
@@ -64,12 +64,10 @@ export const AppsList: React.FC<AppsListProps> = ({ params }) => {
       installations.filter(item => item.id !== id),
     );
 
-  const {
-    data: appsInProgressData,
-    refetch: appsInProgressRefetch,
-  } = useAppsInstallationsQuery({
-    displayLoader: false,
-  });
+  const { data: appsInProgressData, refetch: appsInProgressRefetch } =
+    useAppsInstallationsQuery({
+      displayLoader: false,
+    });
   const { data, loading, refetch } = useAppsListQuery({
     displayLoader: true,
     variables: {
@@ -121,18 +119,16 @@ export const AppsList: React.FC<AppsListProps> = ({ params }) => {
     AppListUrlQueryParams
   >(navigate, appsListUrl, params);
 
-  const [
-    deleteInProgressApp,
-    deleteInProgressAppOpts,
-  ] = useAppDeleteFailedInstallationMutation({
-    onCompleted: data => {
-      if (!data?.appDeleteFailedInstallation?.errors?.length) {
-        removeAppNotify();
-        appsInProgressRefetch();
-        closeModal();
-      }
-    },
-  });
+  const [deleteInProgressApp, deleteInProgressAppOpts] =
+    useAppDeleteFailedInstallationMutation({
+      onCompleted: data => {
+        if (!data?.appDeleteFailedInstallation?.errors?.length) {
+          removeAppNotify();
+          appsInProgressRefetch();
+          closeModal();
+        }
+      },
+    });
 
   useEffect(() => {
     const appsInProgress = appsInProgressData?.appsInstallations || [];

--- a/src/new-apps/components/AllAppList/AllAppList.tsx
+++ b/src/new-apps/components/AllAppList/AllAppList.tsx
@@ -25,7 +25,15 @@ const AllAppList: React.FC<AllAppListProps> = ({
   }
 
   return (
-    <Box display="grid" gridTemplateColumns={2} gap={8} marginTop={8}>
+    <Box
+      display="grid"
+      gridTemplateColumns={{
+        mobile: 1,
+        desktop: 2,
+      }}
+      gap={8}
+      marginTop={8}
+    >
       {appList.map(app => (
         <AppListCard
           key={app.name.en}

--- a/src/new-apps/components/AppListPage/AppListPage.tsx
+++ b/src/new-apps/components/AppListPage/AppListPage.tsx
@@ -12,7 +12,6 @@ import InstalledAppList from "../InstalledAppList";
 import { InstallWithManifestFormButton } from "../InstallWithManifestFormButton";
 import MarketplaceAlert from "../MarketplaceAlert";
 import { messages } from "./messages";
-import { useStyles } from "./styles";
 import { AppListPageSections } from "./types";
 import {
   getVerifiedAppsInstallations,
@@ -37,7 +36,6 @@ export const AppListPage: React.FC<AppListPageProps> = props => {
     onUpdateListSettings,
   } = props;
   const intl = useIntl();
-  const classes = useStyles();
   const verifiedInstalledApps = getVerifiedInstalledApps(
     installedApps,
     installableMarketplaceApps,
@@ -79,7 +77,7 @@ export const AppListPage: React.FC<AppListPageProps> = props => {
         alignItems="center"
         marginY={8}
       >
-        <Box className={classes.appContent} marginY={8}>
+        <Box __width={{ desktop: "50vw", mobile: "100%" }} marginY={8}>
           {sectionsAvailability.installed && (
             <>
               <Box paddingX={8} paddingY={6}>

--- a/src/new-apps/components/AppListPage/AppListPage.tsx
+++ b/src/new-apps/components/AppListPage/AppListPage.tsx
@@ -12,6 +12,7 @@ import InstalledAppList from "../InstalledAppList";
 import { InstallWithManifestFormButton } from "../InstallWithManifestFormButton";
 import MarketplaceAlert from "../MarketplaceAlert";
 import { messages } from "./messages";
+import { useStyles } from "./styles";
 import { AppListPageSections } from "./types";
 import {
   getVerifiedAppsInstallations,
@@ -36,6 +37,7 @@ export const AppListPage: React.FC<AppListPageProps> = props => {
     onUpdateListSettings,
   } = props;
   const intl = useIntl();
+  const classes = useStyles();
   const verifiedInstalledApps = getVerifiedInstalledApps(
     installedApps,
     installableMarketplaceApps,
@@ -77,7 +79,7 @@ export const AppListPage: React.FC<AppListPageProps> = props => {
         alignItems="center"
         marginY={8}
       >
-        <Box __width={{ desktop: "50vw", mobile: "100%" }} marginY={8}>
+        <Box className={classes.appContent} marginY={8}>
           {sectionsAvailability.installed && (
             <>
               <Box paddingX={8} paddingY={6}>

--- a/src/new-apps/components/AppListPage/styles.ts
+++ b/src/new-apps/components/AppListPage/styles.ts
@@ -2,9 +2,6 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
   theme => ({
-    appContent: {
-      width: "50vw",
-    },
     sectionHeader: {
       fontSize: 14,
       fontWeight: 700,

--- a/src/new-apps/components/AppListPage/styles.ts
+++ b/src/new-apps/components/AppListPage/styles.ts
@@ -2,6 +2,12 @@ import { makeStyles } from "@saleor/macaw-ui";
 
 export const useStyles = makeStyles(
   theme => ({
+    appContent: {
+      with: "100%",
+      [theme.breakpoints.up("md")]: {
+        width: "50vw",
+      },
+    },
     sectionHeader: {
       fontSize: 14,
       fontWeight: 700,

--- a/src/new-apps/components/AppListPage/styles.ts
+++ b/src/new-apps/components/AppListPage/styles.ts
@@ -3,7 +3,7 @@ import { makeStyles } from "@saleor/macaw-ui";
 export const useStyles = makeStyles(
   theme => ({
     appContent: {
-      with: "100%",
+      width: "100%",
       [theme.breakpoints.up("md")]: {
         width: "50vw",
       },

--- a/src/new-apps/components/InstalledAppListRow/InstalledAppListRow.tsx
+++ b/src/new-apps/components/InstalledAppListRow/InstalledAppListRow.tsx
@@ -38,8 +38,14 @@ export const InstalledAppListRow: React.FC<InstalledApp> = props => {
         borderColor="neutralPlain"
         justifyContent="space-between"
         flexDirection="row"
+        flexWrap="wrap"
       >
-        <Box display="flex" gap={5} alignItems="center">
+        <Box
+          display="flex"
+          justifyContent={{ mobile: "space-between", desktop: "flex-start" }}
+          gap={5}
+          alignItems="center"
+        >
           <AppAvatar size="medium" logo={logo} />
           <Text variant="bodyStrong">{app.name}</Text>
           <Text variant="body" color="textNeutralSubdued">
@@ -62,7 +68,13 @@ export const InstalledAppListRow: React.FC<InstalledApp> = props => {
             </Text>
           ) : null}
         </Box>
-        <Box display="flex" flexDirection="row" gap={6}>
+        <Box
+          display="flex"
+          marginTop={{ mobile: 4, desktop: 0 }}
+          flexDirection="row"
+          justifyContent={{ mobile: "flex-end", desktop: "flex-start" }}
+          gap={6}
+        >
           <AppPermissions permissions={app.permissions} />
           <TableButtonWrapper>
             <Button

--- a/src/new-apps/components/NotInstalledAppListRow/NotInstalledAppListRow.tsx
+++ b/src/new-apps/components/NotInstalledAppListRow/NotInstalledAppListRow.tsx
@@ -14,7 +14,6 @@ import {
   Button,
   Chip,
   List,
-  sprinkles,
   Text,
   TrashBinIcon,
   WarningIcon,
@@ -37,12 +36,16 @@ export const NotInstalledAppListRow: React.FC<AppInstallation> = props => {
       borderTopStyle="solid"
       borderWidth={1}
       borderColor="neutralPlain"
-      className={sprinkles({
-        justifyContent: "space-between",
-        flexDirection: "row",
-      })}
+      justifyContent="space-between"
+      flexDirection="row"
+      flexWrap={{ mobile: "wrap", desktop: "nowrap" }}
     >
-      <Box display="flex" gap={5} alignItems="center">
+      <Box
+        display="flex"
+        gap={5}
+        alignItems="center"
+        justifyContent={{ mobile: "space-between", desktop: "flex-start" }}
+      >
         <AppAvatar size="medium" logo={logo} />
         <Text variant="bodyStrong">{appInstallation.appName}</Text>
         {isExternal && (

--- a/src/new-apps/components/NotInstalledAppListRow/styles.ts
+++ b/src/new-apps/components/NotInstalledAppListRow/styles.ts
@@ -47,10 +47,14 @@ export const useStyles = makeStyles<AppInstallation>(
       alignItems: "center",
       display: "flex",
       flexDirection: "row",
-      justifyContent: "flex-end",
+      justifyContent: "flex-start",
       textAlign: "right",
       gap: theme.spacing(1),
       width: "100%",
+      [theme.breakpoints.up("sm")]: {
+        width: "auto",
+        justifyContent: "flex-end",
+      },
     },
     externalAppLabel: {
       cursor: "pointer",

--- a/src/new-apps/components/NotInstalledAppListRow/styles.ts
+++ b/src/new-apps/components/NotInstalledAppListRow/styles.ts
@@ -50,6 +50,7 @@ export const useStyles = makeStyles<AppInstallation>(
       justifyContent: "flex-end",
       textAlign: "right",
       gap: theme.spacing(1),
+      width: "100%",
     },
     externalAppLabel: {
       cursor: "pointer",


### PR DESCRIPTION
I want to merge this change because it fix this issue https://github.com/saleor/saleor-dashboard/issues/2999#issuecomment-1434307727

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
Before:
![Screenshot 2023-02-17 at 22 08 33](https://user-images.githubusercontent.com/16362049/219793653-612aa24d-77f7-4c12-82dd-2a01912aa75e.png)
After:
![Screenshot 2023-02-17 at 22 06 57](https://user-images.githubusercontent.com/16362049/219793388-d0019eb0-7084-41f8-b13a-e50c02849ce5.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
