### PR TITLE
fix: progressbar & center configuration page

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -26,11 +26,9 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         visible={isNavigatorVisible}
         setVisibility={setNavigatorVisibility}
       />
-      <Box display="grid" __gridTemplateColumns="auto auto 1fr">
-        {appState.loading ? (
+      <Box display="grid" __gridTemplateColumns="auto 1fr">
+        {appState.loading && (
           <LinearProgress className={classes.appLoader} color="primary" />
-        ) : (
-          <div className={classes.appLoaderPlaceholder} />
         )}
         <Box
           height="100vh"

--- a/src/components/AppLayout/consts.ts
+++ b/src/components/AppLayout/consts.ts
@@ -1,5 +1,5 @@
 export const topBarHeight = "77px";
-export const appLoaderHeight = 4;
+export const appLoaderHeight = 2;
 export const contentMaxWidth = "1440px";
 export const savebarHeight = "64px";
 export const borderHeight = "1px";

--- a/src/components/AppLayout/styles.ts
+++ b/src/components/AppLayout/styles.ts
@@ -16,14 +16,10 @@ export const useStyles = makeStyles(
     },
     appLoader: {
       height: appLoaderHeight,
-      marginBottom: theme.spacing(4),
       zIndex: 1201,
+      position: "fixed",
+      width: "100%",
     },
-    appLoaderPlaceholder: {
-      height: appLoaderHeight,
-      marginBottom: theme.spacing(4),
-    },
-
     content: {
       flex: 1,
       [theme.breakpoints.up("md")]: {

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -1,4 +1,5 @@
 import { Content } from "@dashboard/components/AppLayout/Content";
+import { DetailedContent } from "@dashboard/components/AppLayout/DetailedContent";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { UserFragment } from "@dashboard/graphql";
 import { sectionNames } from "@dashboard/intl";
@@ -94,7 +95,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
   const intl = useIntl();
 
   return (
-    <>
+    <DetailedContent useSingleColumn>
       <TopNav title={intl.formatMessage(sectionNames.configuration)}>
         {isSmUp && renderVersionInfo}
       </TopNav>
@@ -137,7 +138,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
             ))}
         </Box>
       </Content>
-    </>
+    </DetailedContent>
   );
 };
 ConfigurationPage.displayName = "ConfigurationPage";


### PR DESCRIPTION
I want to merge this change because it brings back progress bar & centers configuration page.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
