### PR TITLE
Add markAsPaidStrategy configuration to ChannelDetails

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2302,6 +2302,9 @@
     "context": "sale name",
     "string": "Name"
   },
+  "F5OqYa": {
+    "string": "Creates a single payment when unchecked"
+  },
   "F69lwk": {
     "context": "settings menu item",
     "string": "Settings"
@@ -3532,6 +3535,9 @@
   "Nj9iSB": {
     "context": "table header column",
     "string": "Tax rate"
+  },
+  "NkLZBG": {
+    "string": "Mark as paid uses Transactions API"
   },
   "NlEVVT": {
     "context": "label for button",
@@ -6369,6 +6375,10 @@
   "idr+JK": {
     "context": "assign reference to a page, button",
     "string": "Assign and save"
+  },
+  "if9gAZ": {
+    "context": "Transaction event status - unknown status, info without event data",
+    "string": "Info"
   },
   "ij7olm": {
     "context": "error message",

--- a/src/channels/components/ChannelForm/ChannelForm.tsx
+++ b/src/channels/components/ChannelForm/ChannelForm.tsx
@@ -4,6 +4,7 @@ import {
 } from "@dashboard/channels/pages/ChannelDetailsPage/types";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import CardTitle from "@dashboard/components/CardTitle";
+import ControlledSwitch from "@dashboard/components/ControlledSwitch";
 import FormSpacer from "@dashboard/components/FormSpacer";
 import SingleAutocompleteSelectField, {
   SingleAutocompleteChoiceType,
@@ -13,7 +14,12 @@ import {
   CountryCode,
   StockSettingsInput,
 } from "@dashboard/graphql";
+import {
+  ChannelOrderSettingsFragment,
+  MarkAsPaidStrategyEnum,
+} from "@dashboard/graphql/types.transactions.generated";
 import useClipboard from "@dashboard/hooks/useClipboard";
+import { useFlags } from "@dashboard/hooks/useFlags";
 import { ChangeEvent, FormChange } from "@dashboard/hooks/useForm";
 import { commonMessages } from "@dashboard/intl";
 import { getFormErrors } from "@dashboard/utils/errors";
@@ -42,6 +48,7 @@ export interface FormData extends StockSettingsInput {
   shippingZonesToDisplay: ChannelShippingZones;
   warehousesToDisplay: ChannelWarehouses;
   defaultCountry: CountryCode;
+  markAsPaidStrategy: MarkAsPaidStrategyEnum;
 }
 
 export interface ChannelFormProps {
@@ -55,6 +62,8 @@ export interface ChannelFormProps {
   onChange: FormChange;
   onCurrencyCodeChange?: (event: ChangeEvent) => void;
   onDefaultCountryChange: (event: ChangeEvent) => void;
+  onMarkAsPaidStrategyChange: () => void;
+  orderSettings: ChannelOrderSettingsFragment["orderSettings"];
 }
 
 export const ChannelForm: React.FC<ChannelFormProps> = ({
@@ -68,6 +77,7 @@ export const ChannelForm: React.FC<ChannelFormProps> = ({
   onChange,
   onCurrencyCodeChange,
   onDefaultCountryChange,
+  onMarkAsPaidStrategyChange,
 }) => {
   const intl = useIntl();
   const [copied, copy] = useClipboard();
@@ -76,6 +86,7 @@ export const ChannelForm: React.FC<ChannelFormProps> = ({
     errors,
   );
   const classes = useStyles();
+  const { orderTransactions } = useFlags(["orderTransactions"]);
 
   return (
     <>
@@ -216,6 +227,25 @@ export const ChannelForm: React.FC<ChannelFormProps> = ({
             displayValue={selectedCountryDisplayName}
             value={data.defaultCountry}
             onChange={onDefaultCountryChange}
+          />
+          <FormSpacer />
+          <ControlledSwitch
+            data-test-id="order-settings-mark-as-paid"
+            disabled={disabled || !orderTransactions.enabled}
+            checked={
+              data.markAsPaidStrategy ===
+              MarkAsPaidStrategyEnum.TRANSACTION_FLOW
+            }
+            onChange={onMarkAsPaidStrategyChange}
+            name="markAsPaidStrategy"
+            label={intl.formatMessage({
+              defaultMessage: "Mark as paid uses Transactions API",
+              id: "NkLZBG",
+            })}
+            secondLabel={intl.formatMessage({
+              defaultMessage: "Creates a single payment when unchecked",
+              id: "F5OqYa",
+            })}
           />
         </CardContent>
       </Card>

--- a/src/channels/mutations.transactions.ts
+++ b/src/channels/mutations.transactions.ts
@@ -13,3 +13,17 @@ export const channelOrderSettingsUpdateMutation = gql`
     }
   }
 `;
+
+export const channelCreateWithSettingsMutation = gql`
+  mutation ChannelCreateWithSettings($input: ChannelCreateInput!) {
+    channelCreate(input: $input) {
+      channel {
+        ...ChannelDetails
+        ...ChannelOrderSettings
+      }
+      errors {
+        ...ChannelError
+      }
+    }
+  }
+`;

--- a/src/channels/mutations.transactions.ts
+++ b/src/channels/mutations.transactions.ts
@@ -1,0 +1,15 @@
+import { gql } from "@apollo/client";
+
+export const channelOrderSettingsUpdateMutation = gql`
+  mutation ChannelOrderSettingsUpdate($id: ID!, $input: ChannelUpdateInput!) {
+    channelUpdate(id: $id, input: $input) {
+      channel {
+        ...ChannelDetails
+        ...ChannelOrderSettings
+      }
+      errors {
+        ...ChannelError
+      }
+    }
+  }
+`;

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
@@ -1,6 +1,7 @@
 import { channel, channelCreateErrors } from "@dashboard/channels/fixtures";
 import { countries } from "@dashboard/fixtures";
 import { ChannelErrorFragment } from "@dashboard/graphql";
+import { MarkAsPaidStrategyEnum } from "@dashboard/graphql/types.transactions.generated";
 import Decorator from "@dashboard/storybook/Decorator";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -14,6 +15,10 @@ const props: ChannelDetailsPageProps<ChannelErrorFragment[]> = {
     { label: "USD", value: "USD" },
     { label: "PLN", value: "PLN" },
   ],
+  orderSettings: {
+    markAsPaidStrategy: MarkAsPaidStrategyEnum.PAYMENT_FLOW,
+    __typename: "OrderSettings",
+  },
   disabled: false,
   disabledStatus: false,
   errors: [],

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -23,6 +23,10 @@ import {
   SearchWarehousesQuery,
   StockSettingsInput,
 } from "@dashboard/graphql";
+import {
+  ChannelOrderSettingsFragment,
+  MarkAsPaidStrategyEnum,
+} from "@dashboard/graphql/types.transactions.generated";
 import { SearchData } from "@dashboard/hooks/makeTopLevelSearch";
 import { getParsedSearchData } from "@dashboard/hooks/makeTopLevelSearch/utils";
 import { SubmitPromise } from "@dashboard/hooks/useForm";
@@ -69,6 +73,7 @@ export interface ChannelDetailsPageProps<
   updateChannelStatus?: () => void;
   searchShippingZones: (query: string) => void;
   searchWarehouses: (query: string) => void;
+  orderSettings: ChannelOrderSettingsFragment["orderSettings"];
 }
 
 const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
@@ -92,6 +97,7 @@ const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
   channelWarehouses = [],
   allWarehousesCount,
   countries,
+  orderSettings,
 }: ChannelDetailsPageProps<TErrors>) {
   const navigate = useNavigator();
   const intl = useIntl();
@@ -125,6 +131,7 @@ const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
     ...initialStockSettings,
     shippingZonesToDisplay: channelShippingZones,
     warehousesToDisplay: channelWarehouses,
+    markAsPaidStrategy: orderSettings.markAsPaidStrategy,
   };
 
   const getFilteredShippingZonesChoices = (
@@ -194,6 +201,15 @@ const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
           triggerChange,
         );
         const reorderWarehouse = createWarehouseReorderHandler(data, set);
+        const handleMarkAsPaidStrategyChange = () => {
+          set({
+            markAsPaidStrategy:
+              // Swap enum values
+              data.markAsPaidStrategy === MarkAsPaidStrategyEnum.PAYMENT_FLOW
+                ? MarkAsPaidStrategyEnum.TRANSACTION_FLOW
+                : MarkAsPaidStrategyEnum.PAYMENT_FLOW,
+          });
+        };
 
         const allErrors = [...errors, ...validationErrors];
 
@@ -213,6 +229,7 @@ const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
             <Content>
               <ChannelForm
                 data={data}
+                orderSettings={orderSettings}
                 disabled={disabled}
                 currencyCodes={currencyCodes}
                 countries={countryChoices}
@@ -221,6 +238,7 @@ const ChannelDetailsPage = function <TErrors extends ChannelErrorFragment[]>({
                 onChange={change}
                 onCurrencyCodeChange={handleCurrencyCodeSelect}
                 onDefaultCountryChange={handleDefaultCountrySelect}
+                onMarkAsPaidStrategyChange={handleMarkAsPaidStrategyChange}
                 errors={allErrors}
               />
             </Content>

--- a/src/channels/queries.transactions.ts
+++ b/src/channels/queries.transactions.ts
@@ -1,0 +1,9 @@
+import { gql } from "@apollo/client";
+
+export const channelOrderSettings = gql`
+  query ChannelOrderSettings($id: ID!) {
+    channel(id: $id) {
+      ...ChannelOrderSettings
+    }
+  }
+`;

--- a/src/fragments/channel.transactions.ts
+++ b/src/fragments/channel.transactions.ts
@@ -1,0 +1,9 @@
+import { gql } from "@apollo/client";
+
+export const channelOrderSettings = gql`
+  fragment ChannelOrderSettings on Channel {
+    orderSettings {
+      markAsPaidStrategy
+    }
+  }
+`;

--- a/src/graphql/hooks.transactions.generated.ts
+++ b/src/graphql/hooks.transactions.generated.ts
@@ -196,6 +196,13 @@ export const CategoryDetailsFragmentDoc = gql`
   }
 }
     ${MetadataFragmentDoc}`;
+export const ChannelOrderSettingsFragmentDoc = gql`
+    fragment ChannelOrderSettings on Channel {
+  orderSettings {
+    markAsPaidStrategy
+  }
+}
+    `;
 export const ChannelErrorFragmentDoc = gql`
     fragment ChannelError on ChannelError {
   code
@@ -3267,6 +3274,83 @@ export const WebhookDetailsFragmentDoc = gql`
   customHeaders
 }
     ${WebhookFragmentDoc}`;
+export const ChannelOrderSettingsUpdateDocument = gql`
+    mutation ChannelOrderSettingsUpdate($id: ID!, $input: ChannelUpdateInput!) {
+  channelUpdate(id: $id, input: $input) {
+    channel {
+      ...ChannelDetails
+      ...ChannelOrderSettings
+    }
+    errors {
+      ...ChannelError
+    }
+  }
+}
+    ${ChannelDetailsFragmentDoc}
+${ChannelOrderSettingsFragmentDoc}
+${ChannelErrorFragmentDoc}`;
+export type ChannelOrderSettingsUpdateMutationFn = Apollo.MutationFunction<Types.ChannelOrderSettingsUpdateMutation, Types.ChannelOrderSettingsUpdateMutationVariables>;
+
+/**
+ * __useChannelOrderSettingsUpdateMutation__
+ *
+ * To run a mutation, you first call `useChannelOrderSettingsUpdateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useChannelOrderSettingsUpdateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [channelOrderSettingsUpdateMutation, { data, loading, error }] = useChannelOrderSettingsUpdateMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useChannelOrderSettingsUpdateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<Types.ChannelOrderSettingsUpdateMutation, Types.ChannelOrderSettingsUpdateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<Types.ChannelOrderSettingsUpdateMutation, Types.ChannelOrderSettingsUpdateMutationVariables>(ChannelOrderSettingsUpdateDocument, options);
+      }
+export type ChannelOrderSettingsUpdateMutationHookResult = ReturnType<typeof useChannelOrderSettingsUpdateMutation>;
+export type ChannelOrderSettingsUpdateMutationResult = Apollo.MutationResult<Types.ChannelOrderSettingsUpdateMutation>;
+export type ChannelOrderSettingsUpdateMutationOptions = Apollo.BaseMutationOptions<Types.ChannelOrderSettingsUpdateMutation, Types.ChannelOrderSettingsUpdateMutationVariables>;
+export const ChannelOrderSettingsDocument = gql`
+    query ChannelOrderSettings($id: ID!) {
+  channel(id: $id) {
+    ...ChannelOrderSettings
+  }
+}
+    ${ChannelOrderSettingsFragmentDoc}`;
+
+/**
+ * __useChannelOrderSettingsQuery__
+ *
+ * To run a query within a React component, call `useChannelOrderSettingsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useChannelOrderSettingsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useChannelOrderSettingsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useChannelOrderSettingsQuery(baseOptions: ApolloReactHooks.QueryHookOptions<Types.ChannelOrderSettingsQuery, Types.ChannelOrderSettingsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.ChannelOrderSettingsQuery, Types.ChannelOrderSettingsQueryVariables>(ChannelOrderSettingsDocument, options);
+      }
+export function useChannelOrderSettingsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.ChannelOrderSettingsQuery, Types.ChannelOrderSettingsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.ChannelOrderSettingsQuery, Types.ChannelOrderSettingsQueryVariables>(ChannelOrderSettingsDocument, options);
+        }
+export type ChannelOrderSettingsQueryHookResult = ReturnType<typeof useChannelOrderSettingsQuery>;
+export type ChannelOrderSettingsLazyQueryHookResult = ReturnType<typeof useChannelOrderSettingsLazyQuery>;
+export type ChannelOrderSettingsQueryResult = Apollo.QueryResult<Types.ChannelOrderSettingsQuery, Types.ChannelOrderSettingsQueryVariables>;
 export const OrderTransactionRequestActionDocument = gql`
     mutation OrderTransactionRequestAction($action: TransactionActionEnum!, $transactionId: ID!) {
   transactionRequestAction(actionType: $action, id: $transactionId) {

--- a/src/graphql/hooks.transactions.generated.ts
+++ b/src/graphql/hooks.transactions.generated.ts
@@ -3316,6 +3316,47 @@ export function useChannelOrderSettingsUpdateMutation(baseOptions?: ApolloReactH
 export type ChannelOrderSettingsUpdateMutationHookResult = ReturnType<typeof useChannelOrderSettingsUpdateMutation>;
 export type ChannelOrderSettingsUpdateMutationResult = Apollo.MutationResult<Types.ChannelOrderSettingsUpdateMutation>;
 export type ChannelOrderSettingsUpdateMutationOptions = Apollo.BaseMutationOptions<Types.ChannelOrderSettingsUpdateMutation, Types.ChannelOrderSettingsUpdateMutationVariables>;
+export const ChannelCreateWithSettingsDocument = gql`
+    mutation ChannelCreateWithSettings($input: ChannelCreateInput!) {
+  channelCreate(input: $input) {
+    channel {
+      ...ChannelDetails
+      ...ChannelOrderSettings
+    }
+    errors {
+      ...ChannelError
+    }
+  }
+}
+    ${ChannelDetailsFragmentDoc}
+${ChannelOrderSettingsFragmentDoc}
+${ChannelErrorFragmentDoc}`;
+export type ChannelCreateWithSettingsMutationFn = Apollo.MutationFunction<Types.ChannelCreateWithSettingsMutation, Types.ChannelCreateWithSettingsMutationVariables>;
+
+/**
+ * __useChannelCreateWithSettingsMutation__
+ *
+ * To run a mutation, you first call `useChannelCreateWithSettingsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useChannelCreateWithSettingsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [channelCreateWithSettingsMutation, { data, loading, error }] = useChannelCreateWithSettingsMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useChannelCreateWithSettingsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<Types.ChannelCreateWithSettingsMutation, Types.ChannelCreateWithSettingsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<Types.ChannelCreateWithSettingsMutation, Types.ChannelCreateWithSettingsMutationVariables>(ChannelCreateWithSettingsDocument, options);
+      }
+export type ChannelCreateWithSettingsMutationHookResult = ReturnType<typeof useChannelCreateWithSettingsMutation>;
+export type ChannelCreateWithSettingsMutationResult = Apollo.MutationResult<Types.ChannelCreateWithSettingsMutation>;
+export type ChannelCreateWithSettingsMutationOptions = Apollo.BaseMutationOptions<Types.ChannelCreateWithSettingsMutation, Types.ChannelCreateWithSettingsMutationVariables>;
 export const ChannelOrderSettingsDocument = gql`
     query ChannelOrderSettings($id: ID!) {
   channel(id: $id) {

--- a/src/graphql/types.transactions.generated.ts
+++ b/src/graphql/types.transactions.generated.ts
@@ -7049,6 +7049,13 @@ export type ChannelOrderSettingsUpdateMutationVariables = Exact<{
 
 export type ChannelOrderSettingsUpdateMutation = { __typename: 'Mutation', channelUpdate: { __typename: 'ChannelUpdate', channel: { __typename: 'Channel', hasOrders: boolean, id: string, isActive: boolean, name: string, slug: string, currencyCode: string, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }>, orderSettings: { __typename: 'OrderSettings', markAsPaidStrategy: MarkAsPaidStrategyEnum }, defaultCountry: { __typename: 'CountryDisplay', code: string, country: string }, stockSettings: { __typename: 'StockSettings', allocationStrategy: AllocationStrategyEnum } } | null, errors: Array<{ __typename: 'ChannelError', code: ChannelErrorCode, field: string | null, message: string | null }> } | null };
 
+export type ChannelCreateWithSettingsMutationVariables = Exact<{
+  input: ChannelCreateInput;
+}>;
+
+
+export type ChannelCreateWithSettingsMutation = { __typename: 'Mutation', channelCreate: { __typename: 'ChannelCreate', channel: { __typename: 'Channel', hasOrders: boolean, id: string, isActive: boolean, name: string, slug: string, currencyCode: string, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }>, orderSettings: { __typename: 'OrderSettings', markAsPaidStrategy: MarkAsPaidStrategyEnum }, defaultCountry: { __typename: 'CountryDisplay', code: string, country: string }, stockSettings: { __typename: 'StockSettings', allocationStrategy: AllocationStrategyEnum } } | null, errors: Array<{ __typename: 'ChannelError', code: ChannelErrorCode, field: string | null, message: string | null }> } | null };
+
 export type ChannelOrderSettingsQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;

--- a/src/graphql/types.transactions.generated.ts
+++ b/src/graphql/types.transactions.generated.ts
@@ -7041,6 +7041,21 @@ export enum WeightUnitsEnum {
   TONNE = 'TONNE'
 }
 
+export type ChannelOrderSettingsUpdateMutationVariables = Exact<{
+  id: Scalars['ID'];
+  input: ChannelUpdateInput;
+}>;
+
+
+export type ChannelOrderSettingsUpdateMutation = { __typename: 'Mutation', channelUpdate: { __typename: 'ChannelUpdate', channel: { __typename: 'Channel', hasOrders: boolean, id: string, isActive: boolean, name: string, slug: string, currencyCode: string, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }>, orderSettings: { __typename: 'OrderSettings', markAsPaidStrategy: MarkAsPaidStrategyEnum }, defaultCountry: { __typename: 'CountryDisplay', code: string, country: string }, stockSettings: { __typename: 'StockSettings', allocationStrategy: AllocationStrategyEnum } } | null, errors: Array<{ __typename: 'ChannelError', code: ChannelErrorCode, field: string | null, message: string | null }> } | null };
+
+export type ChannelOrderSettingsQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type ChannelOrderSettingsQuery = { __typename: 'Query', channel: { __typename: 'Channel', orderSettings: { __typename: 'OrderSettings', markAsPaidStrategy: MarkAsPaidStrategyEnum } } | null };
+
 export type AddressFragment = { __typename: 'Address', city: string, cityArea: string, companyName: string, countryArea: string, firstName: string, id: string, lastName: string, phone: string | null, postalCode: string, streetAddress1: string, streetAddress2: string, country: { __typename: 'CountryDisplay', code: string, country: string } };
 
 export type AppManifestFragment = { __typename: 'Manifest', identifier: string, version: string, about: string | null, name: string, appUrl: string | null, configurationUrl: string | null, tokenTargetUrl: string | null, dataPrivacy: string | null, dataPrivacyUrl: string | null, homepageUrl: string | null, supportUrl: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null };
@@ -7078,6 +7093,8 @@ export type UserBaseAvatarFragment = { __typename: 'User', id: string, firstName
 export type CategoryFragment = { __typename: 'Category', id: string, name: string, children: { __typename: 'CategoryCountableConnection', totalCount: number | null } | null, products: { __typename: 'ProductCountableConnection', totalCount: number | null } | null };
 
 export type CategoryDetailsFragment = { __typename: 'Category', id: string, name: string, slug: string, description: any | null, seoDescription: string | null, seoTitle: string | null, backgroundImage: { __typename: 'Image', alt: string | null, url: string } | null, parent: { __typename: 'Category', id: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> };
+
+export type ChannelOrderSettingsFragment = { __typename: 'Channel', orderSettings: { __typename: 'OrderSettings', markAsPaidStrategy: MarkAsPaidStrategyEnum } };
 
 export type ChannelErrorFragment = { __typename: 'ChannelError', code: ChannelErrorCode, field: string | null, message: string | null };
 


### PR DESCRIPTION
I want to merge this change because it adds `orderSettings.markAsPaidStrategy` to ChannelDetails view

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
