### PR TITLE
Sort permissions and add enum name 

### DIFF
--- a/src/components/AccountPermissions/AccountPermissions.tsx
+++ b/src/components/AccountPermissions/AccountPermissions.tsx
@@ -16,6 +16,11 @@ import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
+const byAlphabeticalOrder =
+  <T extends {}>(field: string) =>
+  (a: T, b: T) =>
+    a[field].localeCompare(b[field]);
+
 const useStyles = makeStyles(
   theme => ({
     checkboxContainer: {
@@ -50,13 +55,16 @@ const AccountPermissions: React.FC<AccountPermissionsProps> = props => {
   const {
     data,
     disabled,
-    permissions,
     permissionsExceeded,
     onChange,
     description,
     fullAccessLabel,
     errorMessage,
   } = props;
+
+  const permissions = Object.values(props.permissions).sort(
+    byAlphabeticalOrder("name"),
+  );
 
   const classes = useStyles(props);
   const intl = useIntl();
@@ -192,13 +200,14 @@ const AccountPermissions: React.FC<AccountPermissionsProps> = props => {
                         id={perm.code}
                         primary={perm.name.replace(/\./, "")}
                         secondary={
-                          perm.lastSource &&
-                          intl.formatMessage({
-                            id: "VmMDLN",
-                            defaultMessage:
-                              "This group is last source of that permission",
-                            description: "permission list item description",
-                          })
+                          perm.lastSource
+                            ? intl.formatMessage({
+                                id: "VmMDLN",
+                                defaultMessage:
+                                  "This group is last source of that permission",
+                                description: "permission list item description",
+                              })
+                            : perm.code
                         }
                       />
                     </ListItem>


### PR DESCRIPTION
I want to merge this change because it sorts the permission box and adds the actual enum name for clarity.


**PR intended to be tested with API branch:** `main`

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

Before | After
--- | ---
<img width="1642" alt="CleanShot 2023-03-03 at 10 17 34@2x" src="https://user-images.githubusercontent.com/200613/222681526-e9caeb4c-dbc7-40e6-8ed1-7de424020c3e.png"> | <img width="1642" alt="CleanShot 2023-03-03 at 10 18 40@2x" src="https://user-images.githubusercontent.com/200613/222681537-e1922f03-dff5-4c72-a640-d154bc58ce88.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [x] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
