### PR TITLE
Add "disabled" label on app list, when app is disabled

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1269,6 +1269,10 @@
     "context": "select title",
     "string": "Select channels you want for {contentType} to be available on"
   },
+  "7u9Ep7": {
+    "context": "Label when app is disabled",
+    "string": "Disabled"
+  },
   "7v2oBd": {
     "context": "header",
     "string": "Error"

--- a/src/new-apps/components/InstalledAppListRow/InstalledAppListRow.tsx
+++ b/src/new-apps/components/InstalledAppListRow/InstalledAppListRow.tsx
@@ -94,7 +94,12 @@ export const InstalledAppListRow: React.FC<InstalledApp> = props => {
           justifyContent={{ mobile: "flex-end", desktop: "flex-start" }}
           gap={6}
         >
-          <Box marginLeft="auto">
+          <Box marginLeft="auto" display="flex" alignItems="center" gap={8}>
+            {!app.isActive && (
+              <Text variant="caption" color="textNeutralSubdued">
+                <FormattedMessage {...messages.appDisabled} />
+              </Text>
+            )}
             <AppPermissions permissions={app.permissions} />
           </Box>
           <TableButtonWrapper>

--- a/src/new-apps/components/InstalledAppListRow/messages.ts
+++ b/src/new-apps/components/InstalledAppListRow/messages.ts
@@ -11,4 +11,9 @@ export const messages = defineMessages({
     defaultMessage: "Settings",
     description: "button label",
   },
+  appDisabled: {
+    id: "7u9Ep7",
+    defaultMessage: "Disabled",
+    description: "Label when app is disabled",
+  },
 });


### PR DESCRIPTION
I want to merge this change because...

It adds "disabled" label near the app, so its clear for the user that app is not accessible

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
![Zrzut ekranu 2023-03-3 o 14 11 07](https://user-images.githubusercontent.com/9268745/222728940-9baeac4d-aa54-4803-87d4-6688aa3cf469.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
