### PR TITLE
Hold product view state in local storage

### DIFF
--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -18,6 +18,7 @@ import {
   RefreshLimitsQuery,
   SearchAvailableInGridAttributesQuery,
 } from "@dashboard/graphql";
+import useLocalStorage from "@dashboard/hooks/useLocalStorage";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { sectionNames } from "@dashboard/intl";
 import {
@@ -72,6 +73,9 @@ export interface ProductListPageProps
   onColumnQueryChange: (query: string) => void;
 }
 
+export type ProductListViewType = "datagrid" | "tile";
+const DEFAULT_PRODUCT_LIST_VIEW_TYPE: ProductListViewType = "datagrid";
+
 export const ProductListPage: React.FC<ProductListPageProps> = props => {
   const {
     columnQuery,
@@ -120,7 +124,12 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
   );
   const extensionCreateButtonItems = mapToMenuItems(PRODUCT_OVERVIEW_CREATE);
 
-  const [isDatagridView, setDatagridView] = React.useState(true);
+  const [storedProductListViewType, setProductListViewType] =
+    useLocalStorage<ProductListViewType>(
+      "productListViewType",
+      DEFAULT_PRODUCT_LIST_VIEW_TYPE,
+    );
+  const isDatagridView = storedProductListViewType === "datagrid";
 
   return (
     <ListPageLayout>
@@ -228,7 +237,9 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
           {/* Temporary solution until header is reworked */}
           <Button
             variant="tertiary"
-            onClick={() => setDatagridView(state => !state)}
+            onClick={() =>
+              setProductListViewType(isDatagridView ? "tile" : "datagrid")
+            }
           >
             {!isDatagridView ? (
               <>

--- a/src/products/components/ProductTile/ProductTile.tsx
+++ b/src/products/components/ProductTile/ProductTile.tsx
@@ -4,6 +4,8 @@ import { RelayToFlat } from "@dashboard/types";
 import { Box, ProductsIcons, sprinkles, Text } from "@saleor/macaw-ui/next";
 import React from "react";
 
+import { getTileStatus } from "./utils";
+
 export interface ProductTileProps {
   product: RelayToFlat<ProductListQuery["products"]>[0];
   onClick: () => void;
@@ -71,13 +73,7 @@ export const ProductTile: React.FC<ProductTileProps> = ({
         {product.name}
       </Text>
       <Box padding={5}>
-        <StatusDot
-          status={
-            product.channelListings.some(channel => channel.isPublished)
-              ? "default"
-              : "error"
-          }
-        />
+        <StatusDot status={getTileStatus(product.channelListings)} />
       </Box>
     </Box>
   </Box>


### PR DESCRIPTION
I want to merge this change because it changes react state to local storage for chosen product view.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps
SALEOR_APPS_ENDPOINT=https://apps.saleor.io/api/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
