### PR TITLE
Fix adding empty order line in order drafts & unconfirmed orders

### DIFF
--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -277,6 +277,7 @@ const OrderProductAddDialog: React.FC<OrderProductAddDialogProps> = props => {
           transitionState={confirmButtonState}
           type="submit"
           onClick={handleSubmit}
+          disabled={variants.length === 0}
         >
           <FormattedMessage {...buttonMessages.confirm} />
         </ConfirmButton>

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -445,3 +445,10 @@ export const prepareMoney = (
   amount,
   currency: currency ?? "USD",
 });
+
+export const isAnyAddressEditModalOpen = (uri: string | undefined): boolean =>
+  [
+    "edit-customer-addresses",
+    "edit-shipping-address",
+    "edit-billing-address",
+  ].includes(uri);

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -24,7 +24,10 @@ import {
 } from "@dashboard/orders/components/OrderCustomerChangeDialog/form";
 import OrderCustomerChangeDialog from "@dashboard/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog";
 import { OrderBothTypes, OrderSharedType } from "@dashboard/orders/types";
-import { getVariantSearchAddress } from "@dashboard/orders/utils/data";
+import {
+  getVariantSearchAddress,
+  isAnyAddressEditModalOpen,
+} from "@dashboard/orders/utils/data";
 import { OrderDiscountProvider } from "@dashboard/products/components/OrderDiscountProviders/OrderDiscountProvider";
 import { OrderLineDiscountProvider } from "@dashboard/products/components/OrderDiscountProviders/OrderLineDiscountProvider";
 import useCustomerSearch from "@dashboard/searches/useCustomerSearch";
@@ -81,13 +84,6 @@ interface OrderDraftDetailsProps {
   openModal: (action: OrderUrlDialog, newParams?: OrderUrlQueryParams) => void;
   closeModal: any;
 }
-
-export const isAnyAddressEditModalOpen = (uri: string | undefined): boolean =>
-  [
-    "edit-customer-addresses",
-    "edit-shipping-address",
-    "edit-billing-address",
-  ].includes(uri);
 
 export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
   id,

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -31,7 +31,10 @@ import OrderFulfillStockExceededDialog from "@dashboard/orders/components/OrderF
 import OrderInvoiceEmailSendDialog from "@dashboard/orders/components/OrderInvoiceEmailSendDialog";
 import { OrderManualTransactionDialog } from "@dashboard/orders/components/OrderManualTransactionDialog";
 import { OrderTransactionActionDialog } from "@dashboard/orders/components/OrderTransactionActionDialog/OrderTransactionActionDialog";
-import { transformFuflillmentLinesToStockFormsetData } from "@dashboard/orders/utils/data";
+import {
+  isAnyAddressEditModalOpen,
+  transformFuflillmentLinesToStockFormsetData,
+} from "@dashboard/orders/utils/data";
 import { PartialMutationProviderOutput } from "@dashboard/types";
 import {
   CloseModalFunction,
@@ -59,7 +62,6 @@ import {
   OrderUrlDialog,
   OrderUrlQueryParams,
 } from "../../../urls";
-import { isAnyAddressEditModalOpen } from "../OrderDraftDetails";
 
 interface OrderNormalDetailsProps {
   id: string;

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -23,6 +23,7 @@ import OrderFulfillmentApproveDialog from "@dashboard/orders/components/OrderFul
 import OrderInvoiceEmailSendDialog from "@dashboard/orders/components/OrderInvoiceEmailSendDialog";
 import { OrderManualTransactionDialog } from "@dashboard/orders/components/OrderManualTransactionDialog";
 import { OrderTransactionActionDialog } from "@dashboard/orders/components/OrderTransactionActionDialog/OrderTransactionActionDialog";
+import { isAnyAddressEditModalOpen } from "@dashboard/orders/utils/data";
 import { OrderDiscountProvider } from "@dashboard/products/components/OrderDiscountProviders/OrderDiscountProvider";
 import { OrderLineDiscountProvider } from "@dashboard/products/components/OrderDiscountProviders/OrderLineDiscountProvider";
 import { useOrderVariantSearch } from "@dashboard/searches/useOrderVariantSearch";
@@ -55,7 +56,6 @@ import {
   orderUrl,
   OrderUrlQueryParams,
 } from "../../../urls";
-import { isAnyAddressEditModalOpen } from "../OrderDraftDetails";
 
 interface OrderUnconfirmedDetailsProps {
   id: string;


### PR DESCRIPTION
I want to merge this change because it fixes #3335. I also moved `isAnyAddressEditModalOpen` function to a separate utils file, so that view files only export components (required for HMR).

Views affected:
 - Order draft view
 - Unconfirmed order view

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before             |  After
:-------------------------:|:-------------------------:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/41952692/225662129-3f90ddd9-0681-4b09-a7df-403c68212a7a.png">  |  <img width="608" alt="image" src="https://user-images.githubusercontent.com/41952692/225661612-e15d6bb9-d40e-457d-9864-2dce8cc1a7a0.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [x] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
