### PR TITLE
Refactor media section in product details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@material-ui/lab": "^4.0.0-alpha.61",
         "@material-ui/styles": "^4.11.4",
         "@reach/auto-id": "^0.16.0",
-        "@saleor/macaw-ui": "^0.8.0-pre.49",
+        "@saleor/macaw-ui": "^0.8.0-pre.54",
         "@saleor/sdk": "^0.4.4",
         "@sentry/react": "^6.0.0",
         "@types/faker": "^5.1.6",
@@ -7271,9 +7271,9 @@
       }
     },
     "node_modules/@saleor/macaw-ui": {
-      "version": "0.8.0-pre.49",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.8.0-pre.49.tgz",
-      "integrity": "sha512-SHUfBE1AaDsam/K3ZcotDtUH6/jcyRR9Gi/Zpvw/cTcwoosq09WcewMWZNdHgY5Fkbgve7HTKb+wCyah+sBO8w==",
+      "version": "0.8.0-pre.54",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.8.0-pre.54.tgz",
+      "integrity": "sha512-7fnji0STPpArqcHAcXDJoM0TO5CvH3aRRrrFj8haciTfQfb1uCzbsCXhvzzKly48JMGYevlhskL2KOGBFnCOQw==",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.5.0",
         "@radix-ui/react-radio-group": "^1.1.1",
@@ -41575,9 +41575,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "0.8.0-pre.49",
-      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.8.0-pre.49.tgz",
-      "integrity": "sha512-SHUfBE1AaDsam/K3ZcotDtUH6/jcyRR9Gi/Zpvw/cTcwoosq09WcewMWZNdHgY5Fkbgve7HTKb+wCyah+sBO8w==",
+      "version": "0.8.0-pre.54",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.8.0-pre.54.tgz",
+      "integrity": "sha512-7fnji0STPpArqcHAcXDJoM0TO5CvH3aRRrrFj8haciTfQfb1uCzbsCXhvzzKly48JMGYevlhskL2KOGBFnCOQw==",
       "requires": {
         "@floating-ui/react-dom-interactions": "^0.5.0",
         "@radix-ui/react-radio-group": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/styles": "^4.11.4",
     "@reach/auto-id": "^0.16.0",
-    "@saleor/macaw-ui": "^0.8.0-pre.49",
+    "@saleor/macaw-ui": "^0.8.0-pre.54",
     "@saleor/sdk": "^0.4.4",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -1,121 +1,16 @@
-import { Button } from "@dashboard/components/Button";
-import CardTitle from "@dashboard/components/CardTitle";
 import ImageUpload from "@dashboard/components/ImageUpload";
 import MediaTile from "@dashboard/components/MediaTile";
 import { ProductMediaFragment, ProductMediaType } from "@dashboard/graphql";
 import { ProductMediaPopper } from "@dashboard/products/components/ProductMediaPopper/ProductMediaPopper";
 import { ReorderAction } from "@dashboard/types";
 import createMultiFileUploadHandler from "@dashboard/utils/handlers/multiFileUploadHandler";
-import { Card, CardContent } from "@material-ui/core";
-import { makeStyles } from "@saleor/macaw-ui";
-import { vars } from "@saleor/macaw-ui/next";
-import clsx from "clsx";
+import { Skeleton } from "@material-ui/lab";
+import { Box, Button, sprinkles, Text } from "@saleor/macaw-ui/next";
 import React from "react";
-import { defineMessages, useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 
-const messages = defineMessages({
-  media: {
-    id: "/Mcvt4",
-    defaultMessage: "Media",
-    description: "section header",
-  },
-  upload: {
-    id: "mGiA6q",
-    defaultMessage: "Upload",
-    description: "modal button upload",
-  },
-});
-
-const useStyles = makeStyles(
-  theme => ({
-    card: {
-      marginTop: theme.spacing(2),
-      [theme.breakpoints.down("sm")]: {
-        marginTop: 0,
-      },
-    },
-    fileField: {
-      display: "none",
-    },
-    icon: {
-      color: "rgba(255, 255, 255, 0.54)",
-    },
-    image: {
-      height: "100%",
-      objectFit: "contain",
-      userSelect: "none",
-      width: "100%",
-    },
-    imageContainer: {
-      "&:hover, &.dragged": {
-        "& $imageOverlay": {
-          display: "block",
-        },
-      },
-      background: "#ffffff",
-      border: `1px solid ${vars.colors.border.neutralPlain}`,
-      borderRadius: theme.spacing(),
-      height: 140,
-      margin: "auto",
-      overflow: "hidden",
-      padding: theme.spacing(2),
-      position: "relative",
-      width: 140,
-    },
-    imageGridContainer: {
-      position: "relative",
-    },
-    imageOverlay: {
-      background: "rgba(0, 0, 0, 0.6)",
-      cursor: "move",
-      display: "none",
-      height: 140,
-      left: 0,
-      padding: theme.spacing(2),
-      position: "absolute",
-      top: 0,
-      width: 140,
-    },
-    imageOverlayToolbar: {
-      alignContent: "flex-end",
-      display: "flex",
-      position: "relative",
-      right: theme.spacing(-3),
-      top: theme.spacing(-2),
-    },
-    imageUpload: {
-      height: "100%",
-      left: 0,
-      outline: 0,
-      position: "absolute",
-      top: 0,
-      width: "100%",
-    },
-    imageUploadActive: {
-      zIndex: 1,
-    },
-    imageUploadIconActive: {
-      display: "block",
-    },
-    root: {
-      display: "grid",
-      gridColumnGap: theme.spacing(2),
-      gridRowGap: theme.spacing(2),
-      gridTemplateColumns: "repeat(4, 1fr)",
-      [theme.breakpoints.down("sm")]: {
-        gridTemplateColumns: "repeat(3, 1fr)",
-      },
-      [theme.breakpoints.down("xs")]: {
-        gridTemplateColumns: "repeat(2, 1fr)",
-      },
-    },
-    rootDragActive: {
-      opacity: 0.2,
-    },
-  }),
-  { name: "ProductMedia" },
-);
+import { messages } from "./messages";
 
 interface SortableMediaProps {
   media: {
@@ -163,7 +58,6 @@ const MediaListContainer = SortableContainer<MediaListContainerProps>(
 );
 
 interface ProductMediaProps {
-  placeholderImage?: string;
   media: ProductMediaFragment[];
   loading?: boolean;
   getImageEditUrl: (id: string) => string;
@@ -176,7 +70,6 @@ interface ProductMediaProps {
 const ProductMedia: React.FC<ProductMediaProps> = props => {
   const {
     media,
-    placeholderImage,
     getImageEditUrl,
     onImageDelete,
     onImageReorder,
@@ -184,7 +77,6 @@ const ProductMedia: React.FC<ProductMediaProps> = props => {
     openMediaUrlModal,
   } = props;
 
-  const classes = useStyles(props);
   const intl = useIntl();
   const imagesUpload = React.useRef<HTMLInputElement>(null);
   const anchor = React.useRef<HTMLButtonElement>();
@@ -219,84 +111,90 @@ const ProductMedia: React.FC<ProductMediaProps> = props => {
   });
 
   return (
-    <Card className={classes.card}>
-      <CardTitle
-        title={intl.formatMessage(messages.media)}
-        toolbar={
-          <>
-            <Button
-              onClick={() => setPopperOpenStatus(true)}
-              variant="tertiary"
-              data-test-id="button-upload-image"
-              ref={anchor}
-            >
-              {intl.formatMessage(messages.upload)}
-            </Button>
+    <Box>
+      <Box padding={9} display="flex" justifyContent="space-between">
+        <Text variant="heading">
+          <FormattedMessage {...messages.media} />
+        </Text>
+        <Box>
+          <Button
+            onClick={() => setPopperOpenStatus(true)}
+            variant="secondary"
+            type="button"
+            data-test-id="button-upload-image"
+            ref={anchor}
+          >
+            {intl.formatMessage(messages.upload)}
+          </Button>
 
-            <ProductMediaPopper
-              anchorRef={anchor.current}
-              imagesUploadRef={imagesUpload.current}
-              setPopperStatus={setPopperOpenStatus}
-              popperStatus={popperOpenStatus}
-              openMediaUrlModal={openMediaUrlModal}
-            />
+          <ProductMediaPopper
+            anchorRef={anchor.current}
+            imagesUploadRef={imagesUpload.current}
+            setPopperStatus={setPopperOpenStatus}
+            popperStatus={popperOpenStatus}
+            openMediaUrlModal={openMediaUrlModal}
+          />
 
-            <input
-              className={classes.fileField}
-              id="fileUpload"
-              onChange={event => handleImageUpload(event.target.files)}
-              multiple
-              type="file"
-              ref={imagesUpload}
-              accept="image/*"
-            />
-          </>
-        }
-      />
-      <div className={classes.imageGridContainer}>
+          <Box
+            as="input"
+            display="none"
+            id="fileUpload"
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              handleImageUpload(event.target.files)
+            }
+            multiple
+            type="file"
+            ref={imagesUpload}
+            accept="image/*"
+          />
+        </Box>
+      </Box>
+      <Box position="relative">
         {media === undefined ? (
-          <CardContent>
-            <div className={classes.root}>
-              <div className={classes.imageContainer}>
-                <img className={classes.image} src={placeholderImage} />
-              </div>
-            </div>
-          </CardContent>
+          <Box padding={8}>
+            <Skeleton />
+          </Box>
         ) : media.length > 0 ? (
           <>
             <ImageUpload
-              className={classes.imageUpload}
-              isActiveClassName={classes.imageUploadActive}
+              className={sprinkles({
+                height: "100%",
+                width: "100%",
+                position: "absolute",
+                top: 0,
+                left: 0,
+              })}
+              isActiveClassName={sprinkles({ zIndex: "1" })}
               disableClick={true}
               hideUploadIcon={true}
-              iconContainerActiveClassName={classes.imageUploadIconActive}
+              iconContainerActiveClassName={sprinkles({ display: "block" })}
               onImageUpload={handleImageUpload}
             >
               {({ isDragActive }) => (
-                <CardContent>
-                  <MediaListContainer
-                    distance={20}
-                    helperClass="dragged"
-                    axis="xy"
-                    media={media}
-                    preview={imagesToUpload}
-                    onSortEnd={onImageReorder}
-                    className={clsx({
-                      [classes.root]: true,
-                      [classes.rootDragActive]: isDragActive,
-                    })}
-                    onDelete={onImageDelete}
-                    getEditHref={getImageEditUrl}
-                  />
-                </CardContent>
+                <MediaListContainer
+                  distance={20}
+                  helperClass="dragged"
+                  axis="xy"
+                  media={media}
+                  preview={imagesToUpload}
+                  onSortEnd={onImageReorder}
+                  className={sprinkles({
+                    display: "grid",
+                    gap: 8,
+                    gridTemplateColumns: { mobile: 2, tablet: 3, desktop: 4 },
+                    opacity: isDragActive ? "0.2" : "1",
+                  })}
+                  onDelete={onImageDelete}
+                  getEditHref={getImageEditUrl}
+                />
               )}
             </ImageUpload>
           </>
         ) : (
           <ImageUpload onImageUpload={handleImageUpload} />
         )}
-      </div>
-    </Card>
+      </Box>
+    </Box>
   );
 };
 ProductMedia.displayName = "ProductMedia";

--- a/src/products/components/ProductMedia/messages.ts
+++ b/src/products/components/ProductMedia/messages.ts
@@ -1,0 +1,14 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  media: {
+    id: "/Mcvt4",
+    defaultMessage: "Media",
+    description: "section header",
+  },
+  upload: {
+    id: "mGiA6q",
+    defaultMessage: "Upload",
+    description: "modal button upload",
+  },
+});

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.stories.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.stories.tsx
@@ -56,7 +56,6 @@ const props: ProductUpdatePageProps = {
   onSubmit: () => undefined,
   onVariantShow: () => undefined,
   refetch: () => undefined,
-  placeholderImage,
   product,
   referencePages: [],
   referenceProducts: [],

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.test.tsx
@@ -66,7 +66,6 @@ const props: ProductUpdatePageProps = {
   onMediaUrlUpload: () => undefined,
   onSubmit,
   onVariantShow: () => undefined,
-  placeholderImage,
   product,
   referencePages: [],
   referenceProducts: [],

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -71,7 +71,6 @@ export interface ProductUpdatePageProps {
   channelsErrors: ProductChannelListingErrorFragment[];
   variantListErrors: ProductVariantListError[];
   errors: UseProductUpdateHandlerError[];
-  placeholderImage: string;
   collections: RelayToFlat<SearchCollectionsQuery["search"]>;
   categories: RelayToFlat<SearchCategoriesQuery["search"]>;
   attributeValues: RelayToFlat<
@@ -138,7 +137,6 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
   media,
   header,
   limits,
-  placeholderImage,
   product,
   saveButtonBarState,
   variants,
@@ -348,7 +346,6 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
               <CardSpacer />
               <ProductMedia
                 media={media}
-                placeholderImage={placeholderImage}
                 onImageDelete={onImageDelete}
                 onImageReorder={onImageReorder}
                 onImageUpload={onImageUpload}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -1,4 +1,3 @@
-import placeholderImg from "@assets/images/placeholder255x255.png";
 import ActionDialog from "@dashboard/components/ActionDialog";
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { AttributeInput } from "@dashboard/components/Attributes";
@@ -114,10 +113,8 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     },
   });
 
-  const [
-    reorderProductImages,
-    reorderProductImagesOpts,
-  ] = useProductMediaReorderMutation({});
+  const [reorderProductImages, reorderProductImagesOpts] =
+    useProductMediaReorderMutation({});
 
   const [deleteProduct, deleteProductOpts] = useProductDeleteMutation({
     onCompleted: () => {
@@ -132,25 +129,23 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     },
   });
 
-  const [
-    createProductImage,
-    createProductImageOpts,
-  ] = useProductMediaCreateMutation({
-    onCompleted: data => {
-      const imageError = data.productMediaCreate.errors.find(
-        error =>
-          error.field ===
-          ("image" as keyof ProductMediaCreateMutationVariables),
-      );
-      if (imageError) {
-        notify({
-          status: "error",
-          title: intl.formatMessage(errorMessages.imgageUploadErrorTitle),
-          text: intl.formatMessage(errorMessages.imageUploadErrorText),
-        });
-      }
-    },
-  });
+  const [createProductImage, createProductImageOpts] =
+    useProductMediaCreateMutation({
+      onCompleted: data => {
+        const imageError = data.productMediaCreate.errors.find(
+          error =>
+            error.field ===
+            ("image" as keyof ProductMediaCreateMutationVariables),
+        );
+        if (imageError) {
+          notify({
+            status: "error",
+            title: intl.formatMessage(errorMessages.imgageUploadErrorTitle),
+            text: intl.formatMessage(errorMessages.imageUploadErrorText),
+          });
+        }
+      },
+    });
 
   const [deleteProductImage] = useProductMediaDeleteMutation({
     onCompleted: () =>
@@ -175,28 +170,26 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     },
   });
 
-  const [
-    createProductMedia,
-    createProductMediaOpts,
-  ] = useProductMediaCreateMutation({
-    onCompleted: data => {
-      const errors = data.productMediaCreate.errors;
+  const [createProductMedia, createProductMediaOpts] =
+    useProductMediaCreateMutation({
+      onCompleted: data => {
+        const errors = data.productMediaCreate.errors;
 
-      if (errors.length) {
-        errors.map(error =>
+        if (errors.length) {
+          errors.map(error =>
+            notify({
+              status: "error",
+              text: getProductErrorMessage(error, intl),
+            }),
+          );
+        } else {
           notify({
-            status: "error",
-            text: getProductErrorMessage(error, intl),
-          }),
-        );
-      } else {
-        notify({
-          status: "success",
-          text: intl.formatMessage(commonMessages.savedChanges),
-        });
-      }
-    },
-  });
+            status: "success",
+            text: intl.formatMessage(commonMessages.savedChanges),
+          });
+        }
+      },
+    });
 
   const handleMediaUrlUpload = (mediaUrl: string) => {
     const variables = {
@@ -282,8 +275,9 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   );
 
   const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo
-      ?.hasNextPage,
+    hasMore:
+      !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo
+        ?.hasNextPage,
     loading: !!searchAttributeValuesOpts.loading,
     onFetchMore: loadMoreAttributeValues,
   };
@@ -316,7 +310,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         saveButtonBarState={formTransitionState}
         media={data?.product?.media}
         header={product?.name}
-        placeholderImage={placeholderImg}
         product={product}
         warehouses={warehouses}
         taxClasses={taxClasses ?? []}


### PR DESCRIPTION
I want to merge this change because it drops MUI from media section in product details. Implementation of new design has been postponed (#3388)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
