### PR TITLE
Fix order subtotal to use net amount instead of gross

### DIFF
--- a/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
+++ b/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
@@ -202,7 +202,7 @@ const OrderDraftDetailsSummary: React.FC<
         <tr>
           <td>{intl.formatMessage(messages.subtotal)}</td>
           <td className={classes.textRight}>
-            <Money money={subtotal.gross} />
+            <Money money={subtotal.net} />
           </td>
         </tr>
         <tr>

--- a/src/orders/components/OrderPayment/OrderPayment.tsx
+++ b/src/orders/components/OrderPayment/OrderPayment.tsx
@@ -150,7 +150,7 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
           <div>
             <FormattedMessage {...orderPaymentMessages.subtotal} />
             <div className={classes.leftmostRightAlignedElement}>
-              {<Money money={order?.subtotal.gross} /> ?? <Skeleton />}
+              {<Money money={order?.subtotal.net} /> ?? <Skeleton />}
             </div>
           </div>
           <div>

--- a/src/orders/components/OrderSummaryCard/OrderSummaryCard.tsx
+++ b/src/orders/components/OrderSummaryCard/OrderSummaryCard.tsx
@@ -53,7 +53,7 @@ const OrderSummaryCard: React.FC<OrderPaymentProps> = ({ order }) => {
         <SummaryList className={classes.list}>
           <SummaryLine
             text={<FormattedMessage {...orderSummaryMessages.subtotal} />}
-            money={order?.subtotal?.gross}
+            money={order?.subtotal?.net}
           />
           <SummaryLine
             text={<FormattedMessage {...orderSummaryMessages.shipping} />}


### PR DESCRIPTION
I want to merge this change because it fixes the order subtotal display.

See the following for more context: https://github.com/saleor/saleor/discussions/12395

There's a display bug for the subtotal amounts, given the current current logic it should be using `.net` instead of `.gross` to show the subtotal when there are taxes in the following components:

[OrderPayment](https://github.com/saleor/saleor-dashboard/blob/5dabfc315fda1c871dab03da9b514a144f6c5b62/src/orders/components/OrderPayment/OrderPayment.tsx#L153)
[OrderDraftDetailsSummary](https://github.com/saleor/saleor-dashboard/blob/5dabfc315fda1c871dab03da9b514a144f6c5b62/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx#L205)
[OrderSummaryCard](https://github.com/saleor/saleor-dashboard/blob/5dabfc315fda1c871dab03da9b514a144f6c5b62/src/orders/components/OrderSummaryCard/OrderSummaryCard.tsx#L56)


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

### Before
<img width="974" alt="subtotal_before" src="https://user-images.githubusercontent.com/4250593/229305466-0139a317-3400-4c59-9679-0169e3b056cd.png">

### After
<img width="975" alt="subtotal_after" src="https://user-images.githubusercontent.com/4250593/229305484-af972ae5-8994-4e4d-9e2e-c9760397aa28.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
