### PR TITLE
Revert author field on app details page

### DIFF
--- a/introspection.json
+++ b/introspection.json
@@ -550,12 +550,6 @@
             "deprecationReason": null
           },
           {
-            "name": "PASSWORD_RESET_ALREADY_REQUESTED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "REQUIRED",
             "description": null,
             "isDeprecated": false,
@@ -3106,18 +3100,6 @@
             "deprecationReason": null
           },
           {
-            "name": "author",
-            "description": "The App's author name.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "extensions",
             "description": "App's dashboard extensions.\n\nAdded in Saleor 3.1.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
             "args": [],
@@ -3867,12 +3849,6 @@
           },
           {
             "name": "OUT_OF_SCOPE_PERMISSION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "UNSUPPORTED_SALEOR_VERSION",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -4895,49 +4871,6 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "AppExtensionTargetEnum",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppManifestRequiredSaleorVersion",
-        "description": null,
-        "fields": [
-          {
-            "name": "constraint",
-            "description": "Required Saleor version as semver range.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "satisfied",
-            "description": "Informs if the Saleor version matches the required one.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -10640,7 +10573,7 @@
           },
           {
             "name": "values",
-            "description": "The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.This field will be removed in Saleor 4.0.",
+            "description": "The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -10659,159 +10592,11 @@
             "deprecationReason": null
           },
           {
-            "name": "dropdown",
-            "description": "Attribute value ID.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "AttributeValueSelectableTypeInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "swatch",
-            "description": "Attribute value ID.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "AttributeValueSelectableTypeInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "multiselect",
-            "description": "List of attribute value IDs.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "AttributeValueSelectableTypeInput",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "numeric",
-            "description": "Numeric value of an attribute.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "file",
-            "description": "URL of the file attribute. Every time, a new value is created.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "contentType",
-            "description": "File content type.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "references",
-            "description": "List of entity IDs that will be used as references.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "richText",
-            "description": "Text content in JSON format.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "JSONString",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "plainText",
-            "description": "Plain text content.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "boolean",
             "description": "The boolean value of an attribute to resolve. If the passed value is non-existent, it will be created.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "date",
-            "description": "Represents the date value of the attribute value.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Date",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dateTime",
-            "description": "Represents the date/time value of the attribute value.\n\nAdded in Saleor 3.12.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
               "ofType": null
             },
             "defaultValue": null,
@@ -11822,7 +11607,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -11834,7 +11619,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -18622,7 +18407,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -18634,7 +18419,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -41434,30 +41219,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "requiredSaleorVersion",
-            "description": "Determines the app's required Saleor version as semver range.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AppManifestRequiredSaleorVersion",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "author",
-            "description": "The App's author name.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -45828,55 +45589,6 @@
             "type": {
               "kind": "OBJECT",
               "name": "TaxExemptionManage",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "stockBulkUpdate",
-            "description": "Updates stocks for a given variant and warehouse.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point. \n\nRequires one of the following permissions: MANAGE_PRODUCTS.",
-            "args": [
-              {
-                "name": "errorPolicy",
-                "description": "Policies of error handling. DEFAULT: REJECT_EVERYTHING",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "ErrorPolicyEnum",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "stocks",
-                "description": "Input list of stocks to update.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "INPUT_OBJECT",
-                        "name": "StockBulkUpdateInput",
-                        "ofType": null
-                      }
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "StockBulkUpdate",
               "ofType": null
             },
             "isDeprecated": false,
@@ -59081,7 +58793,7 @@
           },
           {
             "name": "shippingTaxClass",
-            "description": "Denormalized tax class assigned to the shipping method.\n\nAdded in Saleor 3.9.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.",
+            "description": "Denormalized tax class assigned to the shipping method.\n\nAdded in Saleor 3.9.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -63597,7 +63309,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -63609,7 +63321,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -63802,7 +63514,7 @@
           },
           {
             "name": "taxClass",
-            "description": "Denormalized tax class of the product in this order line.\n\nAdded in Saleor 3.9.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.",
+            "description": "Denormalized tax class of the product in this order line.\n\nAdded in Saleor 3.9.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -68326,7 +68038,7 @@
           },
           {
             "name": "availableAttributes",
-            "description": "Attributes that can be assigned to the page type.\n\nRequires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.",
+            "description": "Attributes that can be assigned to the page type.\n\nRequires one of the following permissions: MANAGE_PAGES.",
             "args": [
               {
                 "name": "filter",
@@ -68411,7 +68123,7 @@
           },
           {
             "name": "hasPages",
-            "description": "Whether page type has pages assigned.\n\nRequires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.",
+            "description": "Whether page type has pages assigned.\n\nRequires one of the following permissions: MANAGE_PAGES.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -74096,7 +73808,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -74108,7 +73820,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -74509,7 +74221,7 @@
           },
           {
             "name": "taxClass",
-            "description": "Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.",
+            "description": "Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -75860,7 +75572,7 @@
           },
           {
             "name": "taxCode",
-            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.",
+            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -76941,7 +76653,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -76953,7 +76665,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -77102,7 +76814,7 @@
           },
           {
             "name": "taxCode",
-            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.",
+            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -77464,7 +77176,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -77476,7 +77188,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -79486,7 +79198,7 @@
           },
           {
             "name": "taxClass",
-            "description": "Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.",
+            "description": "Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -80304,7 +80016,7 @@
           },
           {
             "name": "taxCode",
-            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.",
+            "description": "Tax rate for enabled tax gateway. \n\nDEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -94167,7 +93879,7 @@
           },
           {
             "name": "taxClass",
-            "description": "Tax class assigned to this shipping method.\n\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.",
+            "description": "Tax class assigned to this shipping method.\n\nRequires one of the following permissions: MANAGE_TAXES, MANAGE_SHIPPING.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -99740,285 +99452,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "StockBulkResult",
-        "description": null,
-        "fields": [
-          {
-            "name": "stock",
-            "description": "Stock data.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Stock",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "errors",
-            "description": "List of errors occurred on create or update attempt.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "StockBulkUpdateError",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "StockBulkUpdate",
-        "description": "Updates stocks for a given variant and warehouse.\n\nAdded in Saleor 3.13.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point. \n\nRequires one of the following permissions: MANAGE_PRODUCTS.",
-        "fields": [
-          {
-            "name": "count",
-            "description": "Returns how many objects were updated.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "results",
-            "description": "List of the updated stocks.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "StockBulkResult",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "errors",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "StockBulkUpdateError",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "StockBulkUpdateError",
-        "description": null,
-        "fields": [
-          {
-            "name": "field",
-            "description": "Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": "The error message.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "code",
-            "description": "The error code.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "StockBulkUpdateErrorCode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "StockBulkUpdateErrorCode",
-        "description": "An enumeration.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "GRAPHQL_ERROR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "INVALID",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "NOT_FOUND",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "REQUIRED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "StockBulkUpdateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "variantId",
-            "description": "Variant ID.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "variantExternalReference",
-            "description": "Variant external reference.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "warehouseId",
-            "description": "Warehouse ID.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "warehouseExternalReference",
-            "description": "Warehouse external reference.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "quantity",
-            "description": "Quantity of items available for sell.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "StockCountableConnection",
         "description": null,
         "fields": [
@@ -103609,18 +103042,6 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "ORIGINAL",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "AVIF",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "WEBP",
             "description": null,
             "isDeprecated": false,
@@ -107055,7 +106476,7 @@
             "args": [
               {
                 "name": "size",
-                "description": "Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).",
+                "description": "Size of the image. If not provided, the original image will be returned.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -107067,7 +106488,7 @@
               },
               {
                 "name": "format",
-                "description": "The format of the image. When not provided, format of the original image will be used.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
+                "description": "The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.\n\nAdded in Saleor 3.6.\n\nNote: this API is currently in Feature Preview and can be subject to changes at later point.",
                 "type": {
                   "kind": "ENUM",
                   "name": "ThumbnailFormatEnum",
@@ -117437,11 +116858,7 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -117465,11 +116882,7 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -117518,9 +116931,7 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behaviour of this scalar.",
         "isRepeatable": false,
-        "locations": [
-          "SCALAR"
-        ],
+        "locations": ["SCALAR"],
         "args": [
           {
             "name": "url",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1188,9 +1188,6 @@
     "context": "unassign collection from sale and save, button",
     "string": "Unassign and save"
   },
-  "6SL46U": {
-    "string": "by {author}"
-  },
   "6WRFp2": {
     "context": "order history message",
     "string": "Note was added to the order"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/styles": "^4.11.4",
     "@reach/auto-id": "^0.16.0",
-    "@saleor/macaw-ui": "^0.8.0-pre.52",
+    "@saleor/macaw-ui": "^0.8.0-pre.50",
     "@saleor/sdk": "^0.4.6",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",

--- a/schema.graphql
+++ b/schema.graphql
@@ -85,7 +85,6 @@ enum AccountErrorCode {
   PASSWORD_TOO_COMMON
   PASSWORD_TOO_SHORT
   PASSWORD_TOO_SIMILAR
-  PASSWORD_RESET_ALREADY_REQUESTED
   REQUIRED
   UNIQUE
   JWT_SIGNATURE_EXPIRED
@@ -598,15 +597,6 @@ type App implements Node & ObjectWithMetadata {
   accessToken: String
 
   """
-  The App's author name.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  author: String
-
-  """
   App's dashboard extensions.
   
   Added in Saleor 3.1.
@@ -744,7 +734,6 @@ enum AppErrorCode {
   UNIQUE
   OUT_OF_SCOPE_APP
   OUT_OF_SCOPE_PERMISSION
-  UNSUPPORTED_SALEOR_VERSION
 }
 
 """Represents app data."""
@@ -930,26 +919,6 @@ type AppManifestExtension {
 
   """Type of way how app extension will be opened."""
   target: AppExtensionTargetEnum!
-}
-
-type AppManifestRequiredSaleorVersion {
-  """
-  Required Saleor version as semver range.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  constraint: String!
-
-  """
-  Informs if the Saleor version matches the required one.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  satisfied: Boolean!
 }
 
 type AppManifestWebhook {
@@ -2258,91 +2227,14 @@ input BulkAttributeValueInput {
   id: ID
 
   """
-  The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.This field will be removed in Saleor 4.0.
+  The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.
   """
   values: [String!]
-
-  """
-  Attribute value ID.
-  
-  Added in Saleor 3.12.
-  """
-  dropdown: AttributeValueSelectableTypeInput
-
-  """
-  Attribute value ID.
-  
-  Added in Saleor 3.12.
-  """
-  swatch: AttributeValueSelectableTypeInput
-
-  """
-  List of attribute value IDs.
-  
-  Added in Saleor 3.12.
-  """
-  multiselect: [AttributeValueSelectableTypeInput!]
-
-  """
-  Numeric value of an attribute.
-  
-  Added in Saleor 3.12.
-  """
-  numeric: String
-
-  """
-  URL of the file attribute. Every time, a new value is created.
-  
-  Added in Saleor 3.12.
-  """
-  file: String
-
-  """
-  File content type.
-  
-  Added in Saleor 3.12.
-  """
-  contentType: String
-
-  """
-  List of entity IDs that will be used as references.
-  
-  Added in Saleor 3.12.
-  """
-  references: [ID!]
-
-  """
-  Text content in JSON format.
-  
-  Added in Saleor 3.12.
-  """
-  richText: JSONString
-
-  """
-  Plain text content.
-  
-  Added in Saleor 3.12.
-  """
-  plainText: String
 
   """
   The boolean value of an attribute to resolve. If the passed value is non-existent, it will be created.
   """
   boolean: Boolean
-
-  """
-  Represents the date value of the attribute value.
-  
-  Added in Saleor 3.12.
-  """
-  date: Date
-
-  """
-  Represents the date/time value of the attribute value.
-  
-  Added in Saleor 3.12.
-  """
-  dateTime: DateTime
 }
 
 type BulkProductError {
@@ -2585,12 +2477,12 @@ type Category implements Node & ObjectWithMetadata {
   ): CategoryCountableConnection
   backgroundImage(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -4150,12 +4042,12 @@ type Collection implements Node & ObjectWithMetadata {
   ): ProductCountableConnection
   backgroundImage(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -8742,24 +8634,6 @@ type Manifest {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   audience: String
-
-  """
-  Determines the app's required Saleor version as semver range.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  requiredSaleorVersion: AppManifestRequiredSaleorVersion
-
-  """
-  The App's author name.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  author: String
 }
 
 type Margin {
@@ -9771,23 +9645,6 @@ type Mutation {
     """Determines if a taxes should be exempt."""
     taxExemption: Boolean!
   ): TaxExemptionManage
-
-  """
-  Updates stocks for a given variant and warehouse.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS.
-  """
-  stockBulkUpdate(
-    """Policies of error handling. DEFAULT: REJECT_EVERYTHING"""
-    errorPolicy: ErrorPolicyEnum
-
-    """Input list of stocks to update."""
-    stocks: [StockBulkUpdateInput!]!
-  ): StockBulkUpdate
 
   """
   Creates a new staff notification recipient. 
@@ -13672,7 +13529,7 @@ type Order implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   shippingTaxClass: TaxClass
 
@@ -14634,12 +14491,12 @@ type OrderLine implements Node & ObjectWithMetadata {
   digitalContentUrl: DigitalContentUrl
   thumbnail(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -14700,7 +14557,7 @@ type OrderLine implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   taxClass: TaxClass
 
@@ -15734,7 +15591,7 @@ type PageType implements Node & ObjectWithMetadata {
   """
   Attributes that can be assigned to the page type.
   
-  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions: MANAGE_PAGES.
   """
   availableAttributes(
     filter: AttributeFilterInput
@@ -15756,7 +15613,7 @@ type PageType implements Node & ObjectWithMetadata {
   """
   Whether page type has pages assigned.
   
-  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions: MANAGE_PAGES.
   """
   hasPages: Boolean
 }
@@ -16987,12 +16844,12 @@ type Product implements Node & ObjectWithMetadata {
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   thumbnail(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -17108,7 +16965,7 @@ type Product implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   taxClass: TaxClass
 
@@ -17417,7 +17274,7 @@ input ProductCreateInput {
   """
   Tax rate for enabled tax gateway. 
   
-  DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+  DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.
   """
   taxCode: String
 
@@ -17661,12 +17518,12 @@ type ProductImage {
   sortOrder: Int
   url(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -17714,7 +17571,7 @@ input ProductInput {
   """
   Tax rate for enabled tax gateway. 
   
-  DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+  DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.
   """
   taxCode: String
 
@@ -17816,12 +17673,12 @@ type ProductMedia implements Node & ObjectWithMetadata {
   oembedData: JSONString!
   url(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     
@@ -18316,7 +18173,7 @@ type ProductType implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   taxClass: TaxClass
 
@@ -18468,7 +18325,7 @@ input ProductTypeInput {
   """
   Tax rate for enabled tax gateway. 
   
-  DEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+  DEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type.
   """
   taxCode: String
 
@@ -22025,7 +21882,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this shipping method.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Requires one of the following permissions: MANAGE_TAXES, MANAGE_SHIPPING.
   """
   taxClass: TaxClass
 }
@@ -23304,70 +23161,6 @@ enum StockAvailability {
   OUT_OF_STOCK
 }
 
-type StockBulkResult {
-  """Stock data."""
-  stock: Stock
-
-  """List of errors occurred on create or update attempt."""
-  errors: [StockBulkUpdateError!]
-}
-
-"""
-Updates stocks for a given variant and warehouse.
-
-Added in Saleor 3.13.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
-
-Requires one of the following permissions: MANAGE_PRODUCTS.
-"""
-type StockBulkUpdate {
-  """Returns how many objects were updated."""
-  count: Int!
-
-  """List of the updated stocks."""
-  results: [StockBulkResult!]!
-  errors: [StockBulkUpdateError!]!
-}
-
-type StockBulkUpdateError {
-  """
-  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
-  """
-  field: String
-
-  """The error message."""
-  message: String
-
-  """The error code."""
-  code: StockBulkUpdateErrorCode!
-}
-
-"""An enumeration."""
-enum StockBulkUpdateErrorCode {
-  GRAPHQL_ERROR
-  INVALID
-  NOT_FOUND
-  REQUIRED
-}
-
-input StockBulkUpdateInput {
-  """Variant ID."""
-  variantId: ID
-
-  """Variant external reference."""
-  variantExternalReference: String
-
-  """Warehouse ID."""
-  warehouseId: ID
-
-  """Warehouse external reference."""
-  warehouseExternalReference: String
-
-  """Quantity of items available for sell."""
-  quantity: Int!
-}
-
 type StockCountableConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -24237,8 +24030,6 @@ type ThumbnailCreated implements Event {
 
 """An enumeration."""
 enum ThumbnailFormatEnum {
-  ORIGINAL
-  AVIF
   WEBP
 }
 
@@ -24994,12 +24785,12 @@ type User implements Node & ObjectWithMetadata {
   editableGroups: [Group!]
   avatar(
     """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    Size of the image. If not provided, the original image will be returned.
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used.
+    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
     
     Added in Saleor 3.6.
     

--- a/src/apps/components/AppPage/AppPage.tsx
+++ b/src/apps/components/AppPage/AppPage.tsx
@@ -28,7 +28,6 @@ export const AppPage: React.FC<AppPageProps> = ({
       name={data?.name}
       supportUrl={data?.supportUrl}
       homepageUrl={data?.homepageUrl}
-      author={data?.author}
     />
     <DetailPageLayout.Content>
       <Box

--- a/src/apps/components/AppPage/AppPageNav.tsx
+++ b/src/apps/components/AppPage/AppPageNav.tsx
@@ -11,14 +11,12 @@ interface AppPageNavProps {
   name: string | undefined | null;
   supportUrl: string | undefined | null;
   homepageUrl: string | undefined | null;
-  author: string | undefined | null;
 }
 
 export const AppPageNav: React.FC<AppPageNavProps> = ({
   name,
   supportUrl,
   homepageUrl,
-  author,
 }) => {
   const location = useLocation<LinkState>();
   const goBackLink = location.state?.from ?? AppUrls.resolveAppListUrl();
@@ -35,48 +33,33 @@ export const AppPageNav: React.FC<AppPageNavProps> = ({
           <TopNavLink to={goBackLink} variant="tertiary" />
           <Box display="flex" gap={5} alignItems="center">
             <AppAvatar />
-            <Box display="flex" flexDirection="column">
-              <Text variant="heading">{name}</Text>
-              <Text
-                variant="caption"
-                color="textNeutralSubdued"
-                textTransform="uppercase"
-              >
-                {author && (
-                  <FormattedMessage
-                    defaultMessage="by {author}"
-                    id="6SL46U"
-                    values={{ author }}
-                  />
-                )}
-              </Text>
-            </Box>
+            <Text variant="heading">{name}</Text>
           </Box>
         </Box>
-      </Box>
-      <Box display="flex" gap={4}>
-        {supportUrl && (
-          <Button
-            variant="secondary"
-            size="medium"
-            onClick={() => {
-              window.open(supportUrl, "_blank");
-            }}
-          >
-            <FormattedMessage defaultMessage="Support" id="HqRNN8" />
-          </Button>
-        )}
-        {homepageUrl && (
-          <Button
-            variant="secondary"
-            size="medium"
-            onClick={() => {
-              window.open(homepageUrl, "_blank");
-            }}
-          >
-            <FormattedMessage defaultMessage="Homepage" id="rxNddi" />
-          </Button>
-        )}
+        <Box display="flex" gap={4}>
+          {supportUrl && (
+            <Button
+              variant="secondary"
+              size="medium"
+              onClick={() => {
+                window.open(supportUrl, "_blank");
+              }}
+            >
+              <FormattedMessage defaultMessage="Support" id="HqRNN8" />
+            </Button>
+          )}
+          {homepageUrl && (
+            <Button
+              variant="secondary"
+              size="medium"
+              onClick={() => {
+                window.open(homepageUrl, "_blank");
+              }}
+            >
+              <FormattedMessage defaultMessage="Homepage" id="rxNddi" />
+            </Button>
+          )}
+        </Box>
       </Box>
     </TopNavWrapper>
   );

--- a/src/apps/fixtures.ts
+++ b/src/apps/fixtures.ts
@@ -105,7 +105,6 @@ export const appDetails: NonNullable<AppQuery["app"]> = {
   isActive: true,
   metadata: [],
   name: "app1",
-  author: "Saleor Commerce",
   permissions: [
     {
       __typename: "Permission",

--- a/src/apps/queries.ts
+++ b/src/apps/queries.ts
@@ -46,7 +46,6 @@ export const appDetails = gql`
     app(id: $id) {
       ...App
       aboutApp
-      author
       permissions {
         code
         name

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -3414,7 +3414,6 @@ export const AppDocument = gql`
   app(id: $id) {
     ...App
     aboutApp
-    author
     permissions {
       code
       name

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -158,7 +158,7 @@ export type AllocationFieldPolicy = {
 	quantity?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type AppKeySpecifier = ('id' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'metadata' | 'metafield' | 'metafields' | 'permissions' | 'created' | 'isActive' | 'name' | 'type' | 'tokens' | 'webhooks' | 'aboutApp' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'supportUrl' | 'configurationUrl' | 'appUrl' | 'manifestUrl' | 'version' | 'accessToken' | 'author' | 'extensions' | AppKeySpecifier)[];
+export type AppKeySpecifier = ('id' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'metadata' | 'metafield' | 'metafields' | 'permissions' | 'created' | 'isActive' | 'name' | 'type' | 'tokens' | 'webhooks' | 'aboutApp' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'supportUrl' | 'configurationUrl' | 'appUrl' | 'manifestUrl' | 'version' | 'accessToken' | 'extensions' | AppKeySpecifier)[];
 export type AppFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -184,7 +184,6 @@ export type AppFieldPolicy = {
 	manifestUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	version?: FieldPolicy<any> | FieldReadFunction<any>,
 	accessToken?: FieldPolicy<any> | FieldReadFunction<any>,
-	author?: FieldPolicy<any> | FieldReadFunction<any>,
 	extensions?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type AppActivateKeySpecifier = ('appErrors' | 'errors' | 'app' | AppActivateKeySpecifier)[];
@@ -303,11 +302,6 @@ export type AppManifestExtensionFieldPolicy = {
 	url?: FieldPolicy<any> | FieldReadFunction<any>,
 	mount?: FieldPolicy<any> | FieldReadFunction<any>,
 	target?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type AppManifestRequiredSaleorVersionKeySpecifier = ('constraint' | 'satisfied' | AppManifestRequiredSaleorVersionKeySpecifier)[];
-export type AppManifestRequiredSaleorVersionFieldPolicy = {
-	constraint?: FieldPolicy<any> | FieldReadFunction<any>,
-	satisfied?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type AppManifestWebhookKeySpecifier = ('name' | 'asyncEvents' | 'syncEvents' | 'query' | 'targetUrl' | AppManifestWebhookKeySpecifier)[];
 export type AppManifestWebhookFieldPolicy = {
@@ -2093,7 +2087,7 @@ export type LimitsFieldPolicy = {
 	staffUsers?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouses?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ManifestKeySpecifier = ('identifier' | 'version' | 'name' | 'about' | 'permissions' | 'appUrl' | 'configurationUrl' | 'tokenTargetUrl' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'supportUrl' | 'extensions' | 'webhooks' | 'audience' | 'requiredSaleorVersion' | 'author' | ManifestKeySpecifier)[];
+export type ManifestKeySpecifier = ('identifier' | 'version' | 'name' | 'about' | 'permissions' | 'appUrl' | 'configurationUrl' | 'tokenTargetUrl' | 'dataPrivacy' | 'dataPrivacyUrl' | 'homepageUrl' | 'supportUrl' | 'extensions' | 'webhooks' | 'audience' | ManifestKeySpecifier)[];
 export type ManifestFieldPolicy = {
 	identifier?: FieldPolicy<any> | FieldReadFunction<any>,
 	version?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2109,9 +2103,7 @@ export type ManifestFieldPolicy = {
 	supportUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	extensions?: FieldPolicy<any> | FieldReadFunction<any>,
 	webhooks?: FieldPolicy<any> | FieldReadFunction<any>,
-	audience?: FieldPolicy<any> | FieldReadFunction<any>,
-	requiredSaleorVersion?: FieldPolicy<any> | FieldReadFunction<any>,
-	author?: FieldPolicy<any> | FieldReadFunction<any>
+	audience?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type MarginKeySpecifier = ('start' | 'stop' | MarginKeySpecifier)[];
 export type MarginFieldPolicy = {
@@ -2321,7 +2313,7 @@ export type MoneyRangeFieldPolicy = {
 	start?: FieldPolicy<any> | FieldReadFunction<any>,
 	stop?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type MutationKeySpecifier = ('webhookCreate' | 'webhookDelete' | 'webhookUpdate' | 'eventDeliveryRetry' | 'webhookDryRun' | 'webhookTrigger' | 'createWarehouse' | 'updateWarehouse' | 'deleteWarehouse' | 'assignWarehouseShippingZone' | 'unassignWarehouseShippingZone' | 'taxClassCreate' | 'taxClassDelete' | 'taxClassUpdate' | 'taxConfigurationUpdate' | 'taxCountryConfigurationUpdate' | 'taxCountryConfigurationDelete' | 'taxExemptionManage' | 'stockBulkUpdate' | 'staffNotificationRecipientCreate' | 'staffNotificationRecipientUpdate' | 'staffNotificationRecipientDelete' | 'shopDomainUpdate' | 'shopSettingsUpdate' | 'shopFetchTaxRates' | 'shopSettingsTranslate' | 'shopAddressUpdate' | 'orderSettingsUpdate' | 'giftCardSettingsUpdate' | 'shippingMethodChannelListingUpdate' | 'shippingPriceCreate' | 'shippingPriceDelete' | 'shippingPriceBulkDelete' | 'shippingPriceUpdate' | 'shippingPriceTranslate' | 'shippingPriceExcludeProducts' | 'shippingPriceRemoveProductFromExclude' | 'shippingZoneCreate' | 'shippingZoneDelete' | 'shippingZoneBulkDelete' | 'shippingZoneUpdate' | 'productAttributeAssign' | 'productAttributeAssignmentUpdate' | 'productAttributeUnassign' | 'categoryCreate' | 'categoryDelete' | 'categoryBulkDelete' | 'categoryUpdate' | 'categoryTranslate' | 'collectionAddProducts' | 'collectionCreate' | 'collectionDelete' | 'collectionReorderProducts' | 'collectionBulkDelete' | 'collectionRemoveProducts' | 'collectionUpdate' | 'collectionTranslate' | 'collectionChannelListingUpdate' | 'productCreate' | 'productDelete' | 'productBulkDelete' | 'productUpdate' | 'productTranslate' | 'productChannelListingUpdate' | 'productMediaCreate' | 'productVariantReorder' | 'productMediaDelete' | 'productMediaBulkDelete' | 'productMediaReorder' | 'productMediaUpdate' | 'productTypeCreate' | 'productTypeDelete' | 'productTypeBulkDelete' | 'productTypeUpdate' | 'productTypeReorderAttributes' | 'productReorderAttributeValues' | 'digitalContentCreate' | 'digitalContentDelete' | 'digitalContentUpdate' | 'digitalContentUrlCreate' | 'productVariantCreate' | 'productVariantDelete' | 'productVariantBulkCreate' | 'productVariantBulkUpdate' | 'productVariantBulkDelete' | 'productVariantStocksCreate' | 'productVariantStocksDelete' | 'productVariantStocksUpdate' | 'productVariantUpdate' | 'productVariantSetDefault' | 'productVariantTranslate' | 'productVariantChannelListingUpdate' | 'productVariantReorderAttributeValues' | 'productVariantPreorderDeactivate' | 'variantMediaAssign' | 'variantMediaUnassign' | 'paymentCapture' | 'paymentRefund' | 'paymentVoid' | 'paymentInitialize' | 'paymentCheckBalance' | 'transactionCreate' | 'transactionUpdate' | 'transactionRequestAction' | 'pageCreate' | 'pageDelete' | 'pageBulkDelete' | 'pageBulkPublish' | 'pageUpdate' | 'pageTranslate' | 'pageTypeCreate' | 'pageTypeUpdate' | 'pageTypeDelete' | 'pageTypeBulkDelete' | 'pageAttributeAssign' | 'pageAttributeUnassign' | 'pageTypeReorderAttributes' | 'pageReorderAttributeValues' | 'draftOrderComplete' | 'draftOrderCreate' | 'draftOrderDelete' | 'draftOrderBulkDelete' | 'draftOrderLinesBulkDelete' | 'draftOrderUpdate' | 'orderAddNote' | 'orderCancel' | 'orderCapture' | 'orderConfirm' | 'orderFulfill' | 'orderFulfillmentCancel' | 'orderFulfillmentApprove' | 'orderFulfillmentUpdateTracking' | 'orderFulfillmentRefundProducts' | 'orderFulfillmentReturnProducts' | 'orderLinesCreate' | 'orderLineDelete' | 'orderLineUpdate' | 'orderDiscountAdd' | 'orderDiscountUpdate' | 'orderDiscountDelete' | 'orderLineDiscountUpdate' | 'orderLineDiscountRemove' | 'orderMarkAsPaid' | 'orderRefund' | 'orderUpdate' | 'orderUpdateShipping' | 'orderVoid' | 'orderBulkCancel' | 'deleteMetadata' | 'deletePrivateMetadata' | 'updateMetadata' | 'updatePrivateMetadata' | 'assignNavigation' | 'menuCreate' | 'menuDelete' | 'menuBulkDelete' | 'menuUpdate' | 'menuItemCreate' | 'menuItemDelete' | 'menuItemBulkDelete' | 'menuItemUpdate' | 'menuItemTranslate' | 'menuItemMove' | 'invoiceRequest' | 'invoiceRequestDelete' | 'invoiceCreate' | 'invoiceDelete' | 'invoiceUpdate' | 'invoiceSendNotification' | 'giftCardActivate' | 'giftCardCreate' | 'giftCardDelete' | 'giftCardDeactivate' | 'giftCardUpdate' | 'giftCardResend' | 'giftCardAddNote' | 'giftCardBulkCreate' | 'giftCardBulkDelete' | 'giftCardBulkActivate' | 'giftCardBulkDeactivate' | 'pluginUpdate' | 'externalNotificationTrigger' | 'saleCreate' | 'saleDelete' | 'saleBulkDelete' | 'saleUpdate' | 'saleCataloguesAdd' | 'saleCataloguesRemove' | 'saleTranslate' | 'saleChannelListingUpdate' | 'voucherCreate' | 'voucherDelete' | 'voucherBulkDelete' | 'voucherUpdate' | 'voucherCataloguesAdd' | 'voucherCataloguesRemove' | 'voucherTranslate' | 'voucherChannelListingUpdate' | 'exportProducts' | 'exportGiftCards' | 'fileUpload' | 'checkoutAddPromoCode' | 'checkoutBillingAddressUpdate' | 'checkoutComplete' | 'checkoutCreate' | 'checkoutCustomerAttach' | 'checkoutCustomerDetach' | 'checkoutEmailUpdate' | 'checkoutLineDelete' | 'checkoutLinesDelete' | 'checkoutLinesAdd' | 'checkoutLinesUpdate' | 'checkoutRemovePromoCode' | 'checkoutPaymentCreate' | 'checkoutShippingAddressUpdate' | 'checkoutShippingMethodUpdate' | 'checkoutDeliveryMethodUpdate' | 'checkoutLanguageCodeUpdate' | 'orderCreateFromCheckout' | 'channelCreate' | 'channelUpdate' | 'channelDelete' | 'channelActivate' | 'channelDeactivate' | 'channelReorderWarehouses' | 'attributeCreate' | 'attributeDelete' | 'attributeUpdate' | 'attributeTranslate' | 'attributeBulkDelete' | 'attributeValueBulkDelete' | 'attributeValueCreate' | 'attributeValueDelete' | 'attributeValueUpdate' | 'attributeValueTranslate' | 'attributeReorderValues' | 'appCreate' | 'appUpdate' | 'appDelete' | 'appTokenCreate' | 'appTokenDelete' | 'appTokenVerify' | 'appInstall' | 'appRetryInstall' | 'appDeleteFailedInstallation' | 'appFetchManifest' | 'appActivate' | 'appDeactivate' | 'tokenCreate' | 'tokenRefresh' | 'tokenVerify' | 'tokensDeactivateAll' | 'externalAuthenticationUrl' | 'externalObtainAccessTokens' | 'externalRefresh' | 'externalLogout' | 'externalVerify' | 'requestPasswordReset' | 'confirmAccount' | 'setPassword' | 'passwordChange' | 'requestEmailChange' | 'confirmEmailChange' | 'accountAddressCreate' | 'accountAddressUpdate' | 'accountAddressDelete' | 'accountSetDefaultAddress' | 'accountRegister' | 'accountUpdate' | 'accountRequestDeletion' | 'accountDelete' | 'addressCreate' | 'addressUpdate' | 'addressDelete' | 'addressSetDefault' | 'customerCreate' | 'customerUpdate' | 'customerDelete' | 'customerBulkDelete' | 'staffCreate' | 'staffUpdate' | 'staffDelete' | 'staffBulkDelete' | 'userAvatarUpdate' | 'userAvatarDelete' | 'userBulkSetActive' | 'permissionGroupCreate' | 'permissionGroupUpdate' | 'permissionGroupDelete' | MutationKeySpecifier)[];
+export type MutationKeySpecifier = ('webhookCreate' | 'webhookDelete' | 'webhookUpdate' | 'eventDeliveryRetry' | 'webhookDryRun' | 'webhookTrigger' | 'createWarehouse' | 'updateWarehouse' | 'deleteWarehouse' | 'assignWarehouseShippingZone' | 'unassignWarehouseShippingZone' | 'taxClassCreate' | 'taxClassDelete' | 'taxClassUpdate' | 'taxConfigurationUpdate' | 'taxCountryConfigurationUpdate' | 'taxCountryConfigurationDelete' | 'taxExemptionManage' | 'staffNotificationRecipientCreate' | 'staffNotificationRecipientUpdate' | 'staffNotificationRecipientDelete' | 'shopDomainUpdate' | 'shopSettingsUpdate' | 'shopFetchTaxRates' | 'shopSettingsTranslate' | 'shopAddressUpdate' | 'orderSettingsUpdate' | 'giftCardSettingsUpdate' | 'shippingMethodChannelListingUpdate' | 'shippingPriceCreate' | 'shippingPriceDelete' | 'shippingPriceBulkDelete' | 'shippingPriceUpdate' | 'shippingPriceTranslate' | 'shippingPriceExcludeProducts' | 'shippingPriceRemoveProductFromExclude' | 'shippingZoneCreate' | 'shippingZoneDelete' | 'shippingZoneBulkDelete' | 'shippingZoneUpdate' | 'productAttributeAssign' | 'productAttributeAssignmentUpdate' | 'productAttributeUnassign' | 'categoryCreate' | 'categoryDelete' | 'categoryBulkDelete' | 'categoryUpdate' | 'categoryTranslate' | 'collectionAddProducts' | 'collectionCreate' | 'collectionDelete' | 'collectionReorderProducts' | 'collectionBulkDelete' | 'collectionRemoveProducts' | 'collectionUpdate' | 'collectionTranslate' | 'collectionChannelListingUpdate' | 'productCreate' | 'productDelete' | 'productBulkDelete' | 'productUpdate' | 'productTranslate' | 'productChannelListingUpdate' | 'productMediaCreate' | 'productVariantReorder' | 'productMediaDelete' | 'productMediaBulkDelete' | 'productMediaReorder' | 'productMediaUpdate' | 'productTypeCreate' | 'productTypeDelete' | 'productTypeBulkDelete' | 'productTypeUpdate' | 'productTypeReorderAttributes' | 'productReorderAttributeValues' | 'digitalContentCreate' | 'digitalContentDelete' | 'digitalContentUpdate' | 'digitalContentUrlCreate' | 'productVariantCreate' | 'productVariantDelete' | 'productVariantBulkCreate' | 'productVariantBulkUpdate' | 'productVariantBulkDelete' | 'productVariantStocksCreate' | 'productVariantStocksDelete' | 'productVariantStocksUpdate' | 'productVariantUpdate' | 'productVariantSetDefault' | 'productVariantTranslate' | 'productVariantChannelListingUpdate' | 'productVariantReorderAttributeValues' | 'productVariantPreorderDeactivate' | 'variantMediaAssign' | 'variantMediaUnassign' | 'paymentCapture' | 'paymentRefund' | 'paymentVoid' | 'paymentInitialize' | 'paymentCheckBalance' | 'transactionCreate' | 'transactionUpdate' | 'transactionRequestAction' | 'pageCreate' | 'pageDelete' | 'pageBulkDelete' | 'pageBulkPublish' | 'pageUpdate' | 'pageTranslate' | 'pageTypeCreate' | 'pageTypeUpdate' | 'pageTypeDelete' | 'pageTypeBulkDelete' | 'pageAttributeAssign' | 'pageAttributeUnassign' | 'pageTypeReorderAttributes' | 'pageReorderAttributeValues' | 'draftOrderComplete' | 'draftOrderCreate' | 'draftOrderDelete' | 'draftOrderBulkDelete' | 'draftOrderLinesBulkDelete' | 'draftOrderUpdate' | 'orderAddNote' | 'orderCancel' | 'orderCapture' | 'orderConfirm' | 'orderFulfill' | 'orderFulfillmentCancel' | 'orderFulfillmentApprove' | 'orderFulfillmentUpdateTracking' | 'orderFulfillmentRefundProducts' | 'orderFulfillmentReturnProducts' | 'orderLinesCreate' | 'orderLineDelete' | 'orderLineUpdate' | 'orderDiscountAdd' | 'orderDiscountUpdate' | 'orderDiscountDelete' | 'orderLineDiscountUpdate' | 'orderLineDiscountRemove' | 'orderMarkAsPaid' | 'orderRefund' | 'orderUpdate' | 'orderUpdateShipping' | 'orderVoid' | 'orderBulkCancel' | 'deleteMetadata' | 'deletePrivateMetadata' | 'updateMetadata' | 'updatePrivateMetadata' | 'assignNavigation' | 'menuCreate' | 'menuDelete' | 'menuBulkDelete' | 'menuUpdate' | 'menuItemCreate' | 'menuItemDelete' | 'menuItemBulkDelete' | 'menuItemUpdate' | 'menuItemTranslate' | 'menuItemMove' | 'invoiceRequest' | 'invoiceRequestDelete' | 'invoiceCreate' | 'invoiceDelete' | 'invoiceUpdate' | 'invoiceSendNotification' | 'giftCardActivate' | 'giftCardCreate' | 'giftCardDelete' | 'giftCardDeactivate' | 'giftCardUpdate' | 'giftCardResend' | 'giftCardAddNote' | 'giftCardBulkCreate' | 'giftCardBulkDelete' | 'giftCardBulkActivate' | 'giftCardBulkDeactivate' | 'pluginUpdate' | 'externalNotificationTrigger' | 'saleCreate' | 'saleDelete' | 'saleBulkDelete' | 'saleUpdate' | 'saleCataloguesAdd' | 'saleCataloguesRemove' | 'saleTranslate' | 'saleChannelListingUpdate' | 'voucherCreate' | 'voucherDelete' | 'voucherBulkDelete' | 'voucherUpdate' | 'voucherCataloguesAdd' | 'voucherCataloguesRemove' | 'voucherTranslate' | 'voucherChannelListingUpdate' | 'exportProducts' | 'exportGiftCards' | 'fileUpload' | 'checkoutAddPromoCode' | 'checkoutBillingAddressUpdate' | 'checkoutComplete' | 'checkoutCreate' | 'checkoutCustomerAttach' | 'checkoutCustomerDetach' | 'checkoutEmailUpdate' | 'checkoutLineDelete' | 'checkoutLinesDelete' | 'checkoutLinesAdd' | 'checkoutLinesUpdate' | 'checkoutRemovePromoCode' | 'checkoutPaymentCreate' | 'checkoutShippingAddressUpdate' | 'checkoutShippingMethodUpdate' | 'checkoutDeliveryMethodUpdate' | 'checkoutLanguageCodeUpdate' | 'orderCreateFromCheckout' | 'channelCreate' | 'channelUpdate' | 'channelDelete' | 'channelActivate' | 'channelDeactivate' | 'channelReorderWarehouses' | 'attributeCreate' | 'attributeDelete' | 'attributeUpdate' | 'attributeTranslate' | 'attributeBulkDelete' | 'attributeValueBulkDelete' | 'attributeValueCreate' | 'attributeValueDelete' | 'attributeValueUpdate' | 'attributeValueTranslate' | 'attributeReorderValues' | 'appCreate' | 'appUpdate' | 'appDelete' | 'appTokenCreate' | 'appTokenDelete' | 'appTokenVerify' | 'appInstall' | 'appRetryInstall' | 'appDeleteFailedInstallation' | 'appFetchManifest' | 'appActivate' | 'appDeactivate' | 'tokenCreate' | 'tokenRefresh' | 'tokenVerify' | 'tokensDeactivateAll' | 'externalAuthenticationUrl' | 'externalObtainAccessTokens' | 'externalRefresh' | 'externalLogout' | 'externalVerify' | 'requestPasswordReset' | 'confirmAccount' | 'setPassword' | 'passwordChange' | 'requestEmailChange' | 'confirmEmailChange' | 'accountAddressCreate' | 'accountAddressUpdate' | 'accountAddressDelete' | 'accountSetDefaultAddress' | 'accountRegister' | 'accountUpdate' | 'accountRequestDeletion' | 'accountDelete' | 'addressCreate' | 'addressUpdate' | 'addressDelete' | 'addressSetDefault' | 'customerCreate' | 'customerUpdate' | 'customerDelete' | 'customerBulkDelete' | 'staffCreate' | 'staffUpdate' | 'staffDelete' | 'staffBulkDelete' | 'userAvatarUpdate' | 'userAvatarDelete' | 'userBulkSetActive' | 'permissionGroupCreate' | 'permissionGroupUpdate' | 'permissionGroupDelete' | MutationKeySpecifier)[];
 export type MutationFieldPolicy = {
 	webhookCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	webhookDelete?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2341,7 +2333,6 @@ export type MutationFieldPolicy = {
 	taxCountryConfigurationUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	taxCountryConfigurationDelete?: FieldPolicy<any> | FieldReadFunction<any>,
 	taxExemptionManage?: FieldPolicy<any> | FieldReadFunction<any>,
-	stockBulkUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	staffNotificationRecipientCreate?: FieldPolicy<any> | FieldReadFunction<any>,
 	staffNotificationRecipientUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	staffNotificationRecipientDelete?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -4821,23 +4812,6 @@ export type StockFieldPolicy = {
 	quantityAllocated?: FieldPolicy<any> | FieldReadFunction<any>,
 	quantityReserved?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type StockBulkResultKeySpecifier = ('stock' | 'errors' | StockBulkResultKeySpecifier)[];
-export type StockBulkResultFieldPolicy = {
-	stock?: FieldPolicy<any> | FieldReadFunction<any>,
-	errors?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type StockBulkUpdateKeySpecifier = ('count' | 'results' | 'errors' | StockBulkUpdateKeySpecifier)[];
-export type StockBulkUpdateFieldPolicy = {
-	count?: FieldPolicy<any> | FieldReadFunction<any>,
-	results?: FieldPolicy<any> | FieldReadFunction<any>,
-	errors?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type StockBulkUpdateErrorKeySpecifier = ('field' | 'message' | 'code' | StockBulkUpdateErrorKeySpecifier)[];
-export type StockBulkUpdateErrorFieldPolicy = {
-	field?: FieldPolicy<any> | FieldReadFunction<any>,
-	message?: FieldPolicy<any> | FieldReadFunction<any>,
-	code?: FieldPolicy<any> | FieldReadFunction<any>
-};
 export type StockCountableConnectionKeySpecifier = ('pageInfo' | 'edges' | 'totalCount' | StockCountableConnectionKeySpecifier)[];
 export type StockCountableConnectionFieldPolicy = {
 	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -5804,10 +5778,6 @@ export type StrictTypedTypePolicies = {
 	AppManifestExtension?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AppManifestExtensionKeySpecifier | (() => undefined | AppManifestExtensionKeySpecifier),
 		fields?: AppManifestExtensionFieldPolicy,
-	},
-	AppManifestRequiredSaleorVersion?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | AppManifestRequiredSaleorVersionKeySpecifier | (() => undefined | AppManifestRequiredSaleorVersionKeySpecifier),
-		fields?: AppManifestRequiredSaleorVersionFieldPolicy,
 	},
 	AppManifestWebhook?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | AppManifestWebhookKeySpecifier | (() => undefined | AppManifestWebhookKeySpecifier),
@@ -7920,18 +7890,6 @@ export type StrictTypedTypePolicies = {
 	Stock?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | StockKeySpecifier | (() => undefined | StockKeySpecifier),
 		fields?: StockFieldPolicy,
-	},
-	StockBulkResult?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | StockBulkResultKeySpecifier | (() => undefined | StockBulkResultKeySpecifier),
-		fields?: StockBulkResultFieldPolicy,
-	},
-	StockBulkUpdate?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | StockBulkUpdateKeySpecifier | (() => undefined | StockBulkUpdateKeySpecifier),
-		fields?: StockBulkUpdateFieldPolicy,
-	},
-	StockBulkUpdateError?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | StockBulkUpdateErrorKeySpecifier | (() => undefined | StockBulkUpdateErrorKeySpecifier),
-		fields?: StockBulkUpdateErrorFieldPolicy,
 	},
 	StockCountableConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | StockCountableConnectionKeySpecifier | (() => undefined | StockCountableConnectionKeySpecifier),

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -81,7 +81,6 @@ export enum AccountErrorCode {
   PASSWORD_TOO_COMMON = 'PASSWORD_TOO_COMMON',
   PASSWORD_TOO_SHORT = 'PASSWORD_TOO_SHORT',
   PASSWORD_TOO_SIMILAR = 'PASSWORD_TOO_SIMILAR',
-  PASSWORD_RESET_ALREADY_REQUESTED = 'PASSWORD_RESET_ALREADY_REQUESTED',
   REQUIRED = 'REQUIRED',
   UNIQUE = 'UNIQUE',
   JWT_SIGNATURE_EXPIRED = 'JWT_SIGNATURE_EXPIRED',
@@ -186,8 +185,7 @@ export enum AppErrorCode {
   REQUIRED = 'REQUIRED',
   UNIQUE = 'UNIQUE',
   OUT_OF_SCOPE_APP = 'OUT_OF_SCOPE_APP',
-  OUT_OF_SCOPE_PERMISSION = 'OUT_OF_SCOPE_PERMISSION',
-  UNSUPPORTED_SALEOR_VERSION = 'UNSUPPORTED_SALEOR_VERSION'
+  OUT_OF_SCOPE_PERMISSION = 'OUT_OF_SCOPE_PERMISSION'
 }
 
 export type AppExtensionFilterInput = {
@@ -690,76 +688,10 @@ export type AttributeWhereInput = {
 export type BulkAttributeValueInput = {
   /** ID of the selected attribute. */
   id?: InputMaybe<Scalars['ID']>;
-  /** The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.This field will be removed in Saleor 4.0. */
+  /** The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created. */
   values?: InputMaybe<Array<Scalars['String']>>;
-  /**
-   * Attribute value ID.
-   *
-   * Added in Saleor 3.12.
-   */
-  dropdown?: InputMaybe<AttributeValueSelectableTypeInput>;
-  /**
-   * Attribute value ID.
-   *
-   * Added in Saleor 3.12.
-   */
-  swatch?: InputMaybe<AttributeValueSelectableTypeInput>;
-  /**
-   * List of attribute value IDs.
-   *
-   * Added in Saleor 3.12.
-   */
-  multiselect?: InputMaybe<Array<AttributeValueSelectableTypeInput>>;
-  /**
-   * Numeric value of an attribute.
-   *
-   * Added in Saleor 3.12.
-   */
-  numeric?: InputMaybe<Scalars['String']>;
-  /**
-   * URL of the file attribute. Every time, a new value is created.
-   *
-   * Added in Saleor 3.12.
-   */
-  file?: InputMaybe<Scalars['String']>;
-  /**
-   * File content type.
-   *
-   * Added in Saleor 3.12.
-   */
-  contentType?: InputMaybe<Scalars['String']>;
-  /**
-   * List of entity IDs that will be used as references.
-   *
-   * Added in Saleor 3.12.
-   */
-  references?: InputMaybe<Array<Scalars['ID']>>;
-  /**
-   * Text content in JSON format.
-   *
-   * Added in Saleor 3.12.
-   */
-  richText?: InputMaybe<Scalars['JSONString']>;
-  /**
-   * Plain text content.
-   *
-   * Added in Saleor 3.12.
-   */
-  plainText?: InputMaybe<Scalars['String']>;
   /** The boolean value of an attribute to resolve. If the passed value is non-existent, it will be created. */
   boolean?: InputMaybe<Scalars['Boolean']>;
-  /**
-   * Represents the date value of the attribute value.
-   *
-   * Added in Saleor 3.12.
-   */
-  date?: InputMaybe<Scalars['Date']>;
-  /**
-   * Represents the date/time value of the attribute value.
-   *
-   * Added in Saleor 3.12.
-   */
-  dateTime?: InputMaybe<Scalars['DateTime']>;
 };
 
 export type CardInput = {
@@ -4147,7 +4079,7 @@ export type ProductCreateInput = {
   /**
    * Tax rate for enabled tax gateway.
    *
-   * DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.
    */
   taxCode?: InputMaybe<Scalars['String']>;
   /** Search engine optimization fields. */
@@ -4299,7 +4231,7 @@ export type ProductInput = {
   /**
    * Tax rate for enabled tax gateway.
    *
-   * DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+   * DEPRECATED: this field will be removed in Saleor 4.0. Use tax classes to control the tax calculation for a product.
    */
   taxCode?: InputMaybe<Scalars['String']>;
   /** Search engine optimization fields. */
@@ -4474,7 +4406,7 @@ export type ProductTypeInput = {
   /**
    * Tax rate for enabled tax gateway.
    *
-   * DEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type. If taxCode is provided, Saleor will try to find a tax class with given code (codes are stored in metadata) and assign it. If no tax class is found, it would be created and assigned.
+   * DEPRECATED: this field will be removed in Saleor 4.0.. Use tax classes to control the tax calculation for a product type.
    */
   taxCode?: InputMaybe<Scalars['String']>;
   /** ID of a tax class to assign to this product type. All products of this product type would use this tax class, unless it's overridden in the `Product` type. */
@@ -5195,27 +5127,6 @@ export enum StockAvailability {
 }
 
 /** An enumeration. */
-export enum StockBulkUpdateErrorCode {
-  GRAPHQL_ERROR = 'GRAPHQL_ERROR',
-  INVALID = 'INVALID',
-  NOT_FOUND = 'NOT_FOUND',
-  REQUIRED = 'REQUIRED'
-}
-
-export type StockBulkUpdateInput = {
-  /** Variant ID. */
-  variantId?: InputMaybe<Scalars['ID']>;
-  /** Variant external reference. */
-  variantExternalReference?: InputMaybe<Scalars['String']>;
-  /** Warehouse ID. */
-  warehouseId?: InputMaybe<Scalars['ID']>;
-  /** Warehouse external reference. */
-  warehouseExternalReference?: InputMaybe<Scalars['String']>;
-  /** Quantity of items available for sell. */
-  quantity: Scalars['Int'];
-};
-
-/** An enumeration. */
 export enum StockErrorCode {
   ALREADY_EXISTS = 'ALREADY_EXISTS',
   GRAPHQL_ERROR = 'GRAPHQL_ERROR',
@@ -5406,8 +5317,6 @@ export enum TaxExemptionManageErrorCode {
 
 /** An enumeration. */
 export enum ThumbnailFormatEnum {
-  ORIGINAL = 'ORIGINAL',
-  AVIF = 'AVIF',
   WEBP = 'WEBP'
 }
 
@@ -6932,7 +6841,7 @@ export type AppQueryVariables = Exact<{
 }>;
 
 
-export type AppQuery = { __typename: 'Query', app: { __typename: 'App', aboutApp: string | null, author: string | null, dataPrivacy: string | null, dataPrivacyUrl: string | null, id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, configurationUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks: Array<{ __typename: 'Webhook', id: string, name: string, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null };
+export type AppQuery = { __typename: 'Query', app: { __typename: 'App', aboutApp: string | null, dataPrivacy: string | null, dataPrivacyUrl: string | null, id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, configurationUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks: Array<{ __typename: 'Webhook', id: string, name: string, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null };
 
 export type ExtensionListQueryVariables = Exact<{
   filter: AppExtensionFilterInput;


### PR DESCRIPTION
I want to merge this change because it reverts #3379 and unblocks `main` from being not releasable.

## What was changed?
* I've reverted all changes done in #3379 

## How to test it?

* I propose you take `https://v312.staging.saleor.cloud/graphql/` and see if it breaking current dashboard - if not we ready to merge this PR 😄 


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
