### PR TITLE
Fix background transparency in GraphiQL hints

### DIFF
--- a/src/components/GraphiQL/styles.ts
+++ b/src/components/GraphiQL/styles.ts
@@ -63,8 +63,6 @@ export const useDashboardTheme = () => {
     "--font-weight-regular": vars.fontWeight.bodyLarge,
     "--font-size-hint": vars.fontSize.bodyEmpLarge,
     "--font-size-inline-code": vars.fontSize.bodySmall,
-    "--color-base": vars.colors.background.plain,
-    "--alpha-background-light": 0,
   } as React.CSSProperties;
 
   return { rootStyle };

--- a/src/components/GraphiQL/styles.ts
+++ b/src/components/GraphiQL/styles.ts
@@ -26,6 +26,8 @@ export const useStyles = makeStyles(
   { name: "GraphiQL" },
 );
 
+const ComputedStyle = getComputedStyle(document.documentElement);
+
 export const useEditorStyles = () => {
   const pluginContext = usePluginContext();
 
@@ -55,6 +57,9 @@ export const useEditorStyles = () => {
 };
 
 export const useDashboardTheme = () => {
+  const color = ComputedStyle.getPropertyValue("--mu-colors-background-plain");
+  const match = color.match(/hsla\(([^)]+)\)/);
+
   const rootStyle = {
     "--font-size-body": vars.fontSize.bodyMedium,
     "--font-size-h2": vars.fontSize.headingLarge,
@@ -63,6 +68,7 @@ export const useDashboardTheme = () => {
     "--font-weight-regular": vars.fontWeight.bodyLarge,
     "--font-size-hint": vars.fontSize.bodyEmpLarge,
     "--font-size-inline-code": vars.fontSize.bodySmall,
+    "--color-base": match ? match[1] : color,
   } as React.CSSProperties;
 
   return { rootStyle };


### PR DESCRIPTION
Use `getComputeStyle` workaround to align the backgrounds of GraphiQL
& the dashboard itself.I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
