### PR TITLE
Align the background colors

### DIFF
--- a/src/components/GraphiQL/styles.ts
+++ b/src/components/GraphiQL/styles.ts
@@ -3,8 +3,8 @@ import {
   usePluginContext,
   useTheme as useGraphiQLTheme,
 } from "@graphiql/react";
-import { makeStyles, useTheme } from "@saleor/macaw-ui";
-import { vars } from "@saleor/macaw-ui/next";
+import { makeStyles } from "@saleor/macaw-ui";
+import { useTheme, vars } from "@saleor/macaw-ui/next";
 import { useEffect } from "react";
 
 export const useStyles = makeStyles(
@@ -55,6 +55,14 @@ export const useEditorStyles = () => {
 };
 
 export const useDashboardTheme = () => {
+  const {
+    themeValues: {
+      colors: { background },
+    },
+  } = useTheme();
+
+  const match = background.plain.match(/hsla\(([^)]+)\)/);
+
   const rootStyle = {
     "--font-size-body": vars.fontSize.bodyMedium,
     "--font-size-h2": vars.fontSize.headingLarge,
@@ -63,6 +71,7 @@ export const useDashboardTheme = () => {
     "--font-weight-regular": vars.fontWeight.bodyLarge,
     "--font-size-hint": vars.fontSize.bodyEmpLarge,
     "--font-size-inline-code": vars.fontSize.bodySmall,
+    "--color-base": match ? match[1] : background.plain,
   } as React.CSSProperties;
 
   return { rootStyle };
@@ -70,12 +79,9 @@ export const useDashboardTheme = () => {
 
 export const useGraphiQLThemeSwitcher = () => {
   const theme = useTheme();
-  const { theme: graphiqlTheme, setTheme: setGraphiqlTheme } =
-    useGraphiQLTheme();
+  const { setTheme: setGraphiQLTheme } = useGraphiQLTheme();
 
   useEffect(() => {
-    if (theme.themeType !== graphiqlTheme) {
-      setGraphiqlTheme(theme.themeType);
-    }
+    setGraphiQLTheme(theme.theme === "defaultDark" ? "dark" : "light");
   });
 };

--- a/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.test.tsx
+++ b/src/custom-apps/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.test.tsx
@@ -1,10 +1,9 @@
-import "@testing-library/jest-dom";
-
 import {
   WebhookEventTypeAsyncEnum,
   WebhookEventTypeSyncEnum,
 } from "@dashboard/graphql";
 import { Fetcher } from "@graphiql/toolkit";
+import { ThemeProvider } from "@saleor/macaw-ui/next";
 import { ApolloMockedProvider } from "@test/ApolloMockedProvider";
 import { render, screen } from "@testing-library/react";
 import React from "react";
@@ -21,13 +20,6 @@ jest.mock("react-intl", () => ({
     formatMessage: jest.fn(x => x.defaultMessage),
   })),
   defineMessages: jest.fn(x => x),
-}));
-
-jest.mock("@saleor/macaw-ui", () => ({
-  useTheme: jest.fn(() => () => ({})),
-  useStyles: jest.fn(() => () => ({})),
-  makeStyles: jest.fn(() => () => ({})),
-  DialogHeader: jest.fn(() => () => <></>),
 }));
 
 beforeEach(() => {
@@ -54,7 +46,9 @@ describe("WebhookSubscriptionQuery", () => {
     // Act
     render(
       <ApolloMockedProvider>
-        <WebhookSubscriptionQuery {...props} />
+        <ThemeProvider>
+          <WebhookSubscriptionQuery {...props} />
+        </ThemeProvider>
       </ApolloMockedProvider>,
     );
 


### PR DESCRIPTION
I want to merge this change because it aligns the backgrounds of GraphiQL & the dashboard itself using the `getComputeStyle` workaround.

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before | After
--- | ---
<img width="1322" alt="CleanShot 2023-04-06 at 12 58 50@2x" src="https://user-images.githubusercontent.com/200613/230357837-9fcda7bc-2ae4-4b1f-91f1-8b2e400b1bcc.png"> | <img width="1322" alt="CleanShot 2023-04-06 at 12 56 54@2x" src="https://user-images.githubusercontent.com/200613/230357458-cc063266-401e-48a6-b3ab-c5187f053464.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
