### PR TITLE
Fix iframe reloaded on each theme change

### DIFF
--- a/src/apps/components/AppFrame/AppIFrame.tsx
+++ b/src/apps/components/AppFrame/AppIFrame.tsx
@@ -45,12 +45,6 @@ const _AppIFrame = forwardRef<HTMLIFrameElement, AppIFrameProps>(
   },
 );
 
-export const AppIFrame = memo(_AppIFrame, (prev, next) => {
-  const res = isEqualWith(prev, next, (prevVal, nextVal) => {
-    // don't compare functions
-    if (typeof prevVal === "function" && typeof nextVal === "function") {
-      return true;
-    }
-  });
-  return res;
-});
+export const AppIFrame = memo(_AppIFrame, (prev, next) =>
+  isEqualWith(prev, next),
+);

--- a/src/apps/components/AppFrame/AppIFrame.tsx
+++ b/src/apps/components/AppFrame/AppIFrame.tsx
@@ -1,0 +1,56 @@
+import { AppDetailsUrlQueryParams, AppUrls } from "@dashboard/apps/urls";
+import { ThemeType } from "@saleor/app-sdk/app-bridge";
+import { useTheme } from "@saleor/macaw-ui";
+import isEqualWith from "lodash/isEqualWith";
+import React, { forwardRef, memo, useEffect, useRef } from "react";
+
+interface AppIFrameProps {
+  appId: string;
+  src: string;
+  featureFlags: Record<string, string>;
+  params: AppDetailsUrlQueryParams;
+  onLoad: () => void;
+  onError: () => void;
+  className: string;
+}
+
+const _AppIFrame = forwardRef<HTMLIFrameElement, AppIFrameProps>(
+  ({ appId, src, featureFlags, params, onLoad, onError, className }, ref) => {
+    const themeRef = useRef<ThemeType>();
+    const { themeType } = useTheme();
+
+    // Ignore updates to themeType - iframe will be notified via events
+    // Otherwise this will cause reload of entire iframe
+    useEffect(() => {
+      themeRef.current = themeType;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const iframeSrc = AppUrls.resolveAppIframeUrl(appId, src, {
+      ...params,
+      featureFlags,
+      theme: themeRef.current,
+    });
+
+    return (
+      <iframe
+        ref={ref}
+        src={iframeSrc}
+        onLoad={onLoad}
+        onError={onError}
+        className={className}
+        sandbox="allow-same-origin allow-forms allow-scripts"
+      />
+    );
+  },
+);
+
+export const AppIFrame = memo(_AppIFrame, (prev, next) => {
+  const res = isEqualWith(prev, next, (prevVal, nextVal) => {
+    // don't compare functions
+    if (typeof prevVal === "function" && typeof nextVal === "function") {
+      return true;
+    }
+  });
+  return res;
+});


### PR DESCRIPTION
I want to merge this change because it fixes an issue when changing Dashboard's theme: it caused app's iframe to reload, even though the theme in app changed correctly (thanks to AppBridge - postMessage)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:

https://user-images.githubusercontent.com/4144459/231511102-477719ae-5d8b-471b-9e8f-64cdd4826337.mp4

After:

https://user-images.githubusercontent.com/4144459/231511341-fb8d1125-2de3-46ae-bbb7-d84d2ff43e01.mp4

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
