### PR TITLE
Rollback saleor-sdk to 0.4.5

### DIFF
--- a/cypress/support/customCommands/user/index.js
+++ b/cypress/support/customCommands/user/index.js
@@ -44,8 +44,8 @@ Cypress.Commands.add(
   }`;
     return cy.sendRequestWithQuery(mutation, null).then(resp => {
       window.localStorage.setItem(
-        "_saleorRefreshToken",
-        resp.body.data.tokenCreate.refreshToken,
+        "_saleorCSRFToken",
+        resp.body.data.tokenCreate.csrfToken,
       );
       window.sessionStorage.setItem(
         authorization,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@material-ui/styles": "^4.11.4",
         "@reach/auto-id": "^0.16.0",
         "@saleor/macaw-ui": "^0.8.0-pre.68",
-        "@saleor/sdk": "^0.4.6",
+        "@saleor/sdk": "0.4.5",
         "@sentry/react": "^6.0.0",
         "@types/faker": "^5.1.6",
         "@uiw/react-color-hue": "0.0.34",
@@ -8019,9 +8019,9 @@
       }
     },
     "node_modules/@saleor/sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.6.tgz",
-      "integrity": "sha512-k3efAoq/L6EiPIPdB2ZTP0XEIyzYiGl5sDhqUHwRGQ2Mk3zNT1BmNVCU1jJmBJot3490tyo4qG4sU768TfFPnQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.5.tgz",
+      "integrity": "sha512-ABryBWpk+mXb9zzrNO+5P+F1UBoFrhV7VEFUSMvYzXPuDDseS07JlOctRB1G3nOF+1y+8pxKGWoJSpACODlq8w==",
       "dependencies": {
         "cross-fetch": "^3.1.4",
         "jwt-decode": "^3.1.2"
@@ -43177,9 +43177,9 @@
       }
     },
     "@saleor/sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.6.tgz",
-      "integrity": "sha512-k3efAoq/L6EiPIPdB2ZTP0XEIyzYiGl5sDhqUHwRGQ2Mk3zNT1BmNVCU1jJmBJot3490tyo4qG4sU768TfFPnQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@saleor/sdk/-/sdk-0.4.5.tgz",
+      "integrity": "sha512-ABryBWpk+mXb9zzrNO+5P+F1UBoFrhV7VEFUSMvYzXPuDDseS07JlOctRB1G3nOF+1y+8pxKGWoJSpACODlq8w==",
       "requires": {
         "cross-fetch": "^3.1.4",
         "jwt-decode": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@material-ui/styles": "^4.11.4",
     "@reach/auto-id": "^0.16.0",
     "@saleor/macaw-ui": "^0.8.0-pre.68",
-    "@saleor/sdk": "^0.4.6",
+    "@saleor/sdk": "0.4.5",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",
     "@uiw/react-color-hue": "0.0.34",


### PR DESCRIPTION
I want to merge this change because it rolls back [#583](https://github.com/saleor/saleor-dashboard/pull/3426)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
