### PR TITLE
Add presets tests for products list view

### DIFF
--- a/cypress/e2e/products/productsList/productPresets.js
+++ b/cypress/e2e/products/productsList/productPresets.js
@@ -1,0 +1,37 @@
+/// <reference types="cypress"/>
+/// <reference types="../../../support"/>
+
+import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
+import { urlList } from "../../../fixtures/urlList";
+import { ensureCanvasStatic } from "../../../support/customCommands/sharedElementsOperations/canvas";
+import {
+  addPresetWithName,
+  confirmActivePresetName,
+  confirmGridRowsContainsText,
+  searchItems,
+} from "../../../support/pages/catalog/presetsAndSearch";
+
+describe("As a user I should be able to save selected filters with search queries under the given name", () => {
+  beforeEach(() => {
+    cy.clearSessionData().loginUserViaRequest();
+    cy.visit(urlList.products);
+  });
+
+  it(
+    "should be able to add preset. TC: SALEOR_3802",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      ensureCanvasStatic(PRODUCTS_LIST.dataGridTable).then(() => {
+        cy.assertCanvasRowsNumber(PRODUCTS_LIST.dataGridTable, 21);
+      });
+      const presetName = "hoodie";
+
+      searchItems(presetName);
+      addPresetWithName(presetName);
+      ensureCanvasStatic(PRODUCTS_LIST.dataGridTable).then(() => {
+        confirmGridRowsContainsText(presetName);
+        confirmActivePresetName(presetName);
+      });
+    },
+  );
+});

--- a/cypress/elements/shared/index.js
+++ b/cypress/elements/shared/index.js
@@ -1,5 +1,12 @@
 import { ADDRESS_SELECTORS } from "./addressForm";
 import { BUTTON_SELECTORS } from "./button-selectors";
+import { PRESETS, SEARCH } from "./presetsAndSearch";
 import { SHARED_ELEMENTS } from "./sharedElements";
 
-export { ADDRESS_SELECTORS, BUTTON_SELECTORS, SHARED_ELEMENTS };
+export {
+  ADDRESS_SELECTORS,
+  BUTTON_SELECTORS,
+  PRESETS,
+  SEARCH,
+  SHARED_ELEMENTS,
+};

--- a/cypress/elements/shared/presetsAndSearch.js
+++ b/cypress/elements/shared/presetsAndSearch.js
@@ -1,0 +1,9 @@
+export const PRESETS = {
+  addPresetButton: "[data-test-id='add-preset-button']",
+  presetNameTextField: '[data-test-id="preset-name-text-field"]',
+  savePresetNameButton: '[data-test-id="save-preset-button"]',
+  activePresetName: '[data-test-id="show-saved-filters-button"]',
+};
+export const SEARCH = {
+  searchInput: "[data-test-id='search-input']",
+};

--- a/cypress/support/pages/catalog/presetsAndSearch.js
+++ b/cypress/support/pages/catalog/presetsAndSearch.js
@@ -1,0 +1,30 @@
+import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
+import { PRESETS, SEARCH } from "../../../elements/shared";
+
+export function searchItems(name) {
+  return cy
+    .addAliasToGraphRequest("ProductList")
+    .get(SEARCH.searchInput)
+    .type(name)
+    .wait("@ProductList");
+}
+export function addPresetWithName(name) {
+  return cy
+    .get(PRESETS.addPresetButton)
+    .click()
+    .get(PRESETS.presetNameTextField)
+    .type(name)
+    .get(PRESETS.savePresetNameButton)
+    .click()
+    .wait("@ProductList");
+}
+export function confirmGridRowsContainsText(name) {
+  return cy
+    .get(PRODUCTS_LIST.dataGridTable)
+    .find("tbody")
+    .find("tr")
+    .should("contain.text", name);
+}
+export function confirmActivePresetName(name) {
+  return cy.get(PRESETS.activePresetName).should("contain.text", name);
+}

--- a/src/components/AppLayout/ListFilters/components/SearchInput.tsx
+++ b/src/components/AppLayout/ListFilters/components/SearchInput.tsx
@@ -29,6 +29,7 @@ const SearchInput: React.FC<SearchInputProps> = props => {
               value={search}
               onChange={handleSearchChange}
               placeholder={placeholder}
+              data-test-id="search-input"
             />
           </Box>
         );

--- a/src/components/FilterPresetsSelect/FilterPresetsSelect.tsx
+++ b/src/components/FilterPresetsSelect/FilterPresetsSelect.tsx
@@ -174,6 +174,7 @@ export const FilterPresetsSelect = ({
       {renderDropdown()}
       {showUpdateButton && (
         <Button
+          data-test-id="update-preset-button"
           className={sprinkles({
             marginLeft: 6,
           })}
@@ -188,6 +189,7 @@ export const FilterPresetsSelect = ({
         <Tooltip>
           <Tooltip.Trigger>
             <Button
+              data-test-id="add-preset-button"
               className={sprinkles({
                 marginLeft: 6,
               })}

--- a/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
+++ b/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
@@ -71,16 +71,18 @@ const SaveFilterTabDialog: React.FC<SaveFilterTabDialogProps> = ({
                 value={data.name}
                 onChange={change}
                 error={errors}
+                data-test-id="preset-name-text-field"
                 helperText={errors ? "This field is required" : null}
               />
             </DialogContent>
             <DialogActions>
-              <BackButton onClick={onClose}>
+              <BackButton onClick={onClose} data-test-id="cancel-preset-button">
                 <FormattedMessage {...buttonMessages.cancel} />
               </BackButton>
               <ConfirmButton
                 transitionState={confirmButtonState}
                 onClick={submit}
+                data-test-id="save-preset-button"
               >
                 <FormattedMessage {...buttonMessages.save} />
               </ConfirmButton>


### PR DESCRIPTION
I want to merge this change because...

It adds happy path test for creating presets of products search

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
