### PR TITLE
Fix double mutation when non staff user logs in

### DIFF
--- a/src/auth/hooks/useAuthParameters.ts
+++ b/src/auth/hooks/useAuthParameters.ts
@@ -11,7 +11,8 @@ export const useAuthParameters = () => {
   );
 
   return {
-    requestedExternalPluginId,
+    requestedExternalPluginId:
+      requestedExternalPluginId === "null" ? null : requestedExternalPluginId,
     fallbackUri: fallbackUri === "null" || !fallbackUri ? "/" : fallbackUri,
     isCallbackPath: location.pathname.includes(loginCallbackPath),
     setRequestedExternalPluginId,

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -181,9 +181,12 @@ export function useAuthProvider({
   };
 
   const handleExternalLogin = async (
-    pluginId: string,
+    pluginId: string | undefined,
     input: ExternalLoginInput,
   ) => {
+    if (!pluginId) {
+      return;
+    }
     try {
       const result = await getExternalAccessToken({
         pluginId,

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -23,12 +23,15 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     requestLoginByExternalPlugin,
     loginByExternalPlugin,
     authenticating,
+    authenticated,
     errors,
   } = useUser();
   const {
     data: externalAuthentications,
     loading: externalAuthenticationsLoading,
-  } = useAvailableExternalAuthenticationsQuery();
+  } = useAvailableExternalAuthenticationsQuery({
+    skip: authenticating || authenticated,
+  });
 
   const {
     fallbackUri,
@@ -63,15 +66,13 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
   };
 
   const handleExternalAuthentication = async (code: string, state: string) => {
-    const result = await loginByExternalPlugin(requestedExternalPluginId, {
+    await loginByExternalPlugin(requestedExternalPluginId, {
       code,
       state,
     });
     setRequestedExternalPluginId(null);
-    if (result && !result?.errors?.length) {
-      navigate(fallbackUri);
-      setFallbackUri(null);
-    }
+    navigate(fallbackUri);
+    setFallbackUri(null);
   };
 
   useEffect(() => {

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -1,4 +1,4 @@
-import { useAvailableExternalAuthenticationsQuery } from "@dashboard/graphql";
+import { useAvailableExternalAuthenticationsLazyQuery } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { getAppMountUriForRedirect } from "@dashboard/utils/urls";
 import React, { useEffect } from "react";
@@ -23,16 +23,12 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     requestLoginByExternalPlugin,
     loginByExternalPlugin,
     authenticating,
-    authenticated,
     errors,
   } = useUser();
-  const {
-    data: externalAuthentications,
-    loading: externalAuthenticationsLoading,
-  } = useAvailableExternalAuthenticationsQuery({
-    skip: authenticating || authenticated,
-  });
-
+  const [
+    queryExternalAuthentications,
+    { data: externalAuthentications, loading: externalAuthenticationsLoading },
+  ] = useAvailableExternalAuthenticationsLazyQuery();
   const {
     fallbackUri,
     requestedExternalPluginId,
@@ -74,6 +70,15 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     navigate(fallbackUri);
     setFallbackUri(null);
   };
+
+  useEffect(() => {
+    const { code, state } = params;
+    const externalAuthParamsExist = code && state && isCallbackPath;
+
+    if (!externalAuthParamsExist) {
+      queryExternalAuthentications();
+    }
+  }, [isCallbackPath, params, queryExternalAuthentications]);
 
   useEffect(() => {
     const { code, state } = params;


### PR DESCRIPTION
Fixes #3554.
I want to merge this change because it fixes an error when non-staff user logs in via OpenID. 

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
