### PR TITLE
Add e2e for should be able to switch to products tile view SALEOR_2610

### DIFF
--- a/cypress/e2e/products/productsList/productsView.js
+++ b/cypress/e2e/products/productsList/productsView.js
@@ -1,0 +1,22 @@
+/// <reference types="cypress"/>
+/// <reference types="../../../support"/>
+
+import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
+import { urlList } from "../../../fixtures/urlList";
+
+describe("As an user I should be able switch between product views", () => {
+  beforeEach(() => {
+    cy.clearSessionData().loginUserViaRequest();
+    cy.visit(urlList.products);
+  });
+
+  it(
+    "should be able to switch to products image view TC: SALEOR_2610",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      cy.get(PRODUCTS_LIST.tileViewButton).click();
+      cy.get(PRODUCTS_LIST.tileProductsView).should("be.visible");
+      cy.get(PRODUCTS_LIST.dataGridTable).should("not.exist");
+    },
+  );
+});

--- a/cypress/elements/catalog/products/products-list.js
+++ b/cypress/elements/catalog/products/products-list.js
@@ -50,4 +50,7 @@ export const PRODUCTS_LIST = {
   },
   resultsOnPageSelect: "[data-test-id='PaginationRowNumberSelect']",
   rowNumberOption: "[data-test-id='rowNumberOption']",
+  tileViewButton: '[data-test-id="tileViewButton"]',
+  datagridViewButton: '[data-test-id="datagridViewButton"]',
+  tileProductsView: '[data-test-id="tileView"]',
 };

--- a/src/products/components/ProductListTiles/ProductListTiles.tsx
+++ b/src/products/components/ProductListTiles/ProductListTiles.tsx
@@ -43,6 +43,7 @@ export const ProductListTiles: React.FC<ProductListTilesProps> = ({
           gap={9}
           padding={9}
           __paddingTop={`calc(${vars.space[9]} - ${vars.space[5]}`}
+          data-test-id="tileView"
         >
           {products.map(product => (
             <ProductTile

--- a/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
+++ b/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
@@ -18,10 +18,14 @@ export const ProductListViewSwitch = ({
       setProductListViewType(value as ProductListViewType);
     }}
   >
-    <Switch.Item id="datagrid" value="datagrid">
+    <Switch.Item
+      id="datagrid"
+      value="datagrid"
+      data-test-id="datagridViewButton"
+    >
       <ViewListIcon size="medium" />
     </Switch.Item>
-    <Switch.Item id="tile" value="tile">
+    <Switch.Item id="tile" value="tile" data-test-id="tileViewButton">
       <ViewTilesIcon size="medium" />
     </Switch.Item>
   </Switch>


### PR DESCRIPTION
I want to merge this change because it adds new e2e 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
