### PR TITLE
Fix case when there is no fallback uri within the local storage

### DIFF
--- a/src/auth/hooks/useAuthParameters.ts
+++ b/src/auth/hooks/useAuthParameters.ts
@@ -12,7 +12,7 @@ export const useAuthParameters = () => {
 
   return {
     requestedExternalPluginId,
-    fallbackUri: fallbackUri === "null" ? "/" : fallbackUri,
+    fallbackUri: fallbackUri === "null" || !fallbackUri ? "/" : fallbackUri,
     isCallbackPath: location.pathname.includes(loginCallbackPath),
     setRequestedExternalPluginId,
     setFallbackUri,


### PR DESCRIPTION
Steps to reproduce:
1. Log out from dashbaord
2. Remove `externalLoginFallbackUri` from the local storage
3. Trigger login via external plugin by authentication link
4. After redirections, 404 page pops up


**Expected**: We should land on the dashboard home normally

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
6. [ ] Attributes `[data-test-id]` are added for new elements
7. [ ] Changes are mentioned in the changelog
8. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
9. [ ] productType
10. [ ] shipping
11. [ ] customer
12. [ ] permissions
13. [ ] menuNavigation
14. [ ] pages
15. [ ] sales
16. [ ] vouchers
17. [ ] homePage
18. [ ] login
19. [ ] orders
20. [ ] products
21. [ ] app
22. [ ] plugins
23. [ ] translations
24. [ ] navigation
25. [ ] variants
26. [ ] payments

CONTAINERS=1
