### PR TITLE
Fix cypress tests for plugins 3.11

### DIFF
--- a/cypress/e2e/configuration/plugins/plugins.js
+++ b/cypress/e2e/configuration/plugins/plugins.js
@@ -98,7 +98,7 @@ describe("As an admin I want to manage plugins", () => {
         .confirmationMessageShouldDisappear();
       requestPasswordReset(Cypress.env("USER_NAME"), defaultChannel.slug);
       getMailWithResetPasswordLink(Cypress.env("USER_NAME"), adminName)
-        .its("0.Content.Headers.Subject.0")
+        .its("Subject")
         .should("contains", adminName);
     },
   );

--- a/cypress/support/api/utils/users.js
+++ b/cypress/support/api/utils/users.js
@@ -110,7 +110,7 @@ export function getMailWithResetPasswordLink(email, subject, i = 0) {
           cy.wait(3000);
           getMailWithResetPasswordLink(serverStoredEmail, subject, i + 1);
         } else {
-          cy.wrap(resetPasswordMails);
+          cy.wrap(resetPasswordMails).mpLatest().mpGetMailDetails();
         }
       });
     }
@@ -144,7 +144,7 @@ export function getMailWithGiftCardExportWithAttachment(
   if (i > 5) {
     throw new Error(`There is no email Gift Card export for user ${email}`);
   }
-  return cy.mpGetMailsByRecipient(email).should(mails => {
+  return cy.mpGetMailsByRecipient(email).then(mails => {
     if (!mails.length) {
       cy.wait(3000);
       getMailWithGiftCardExportWithAttachment(
@@ -166,8 +166,8 @@ export function getMailWithGiftCardExportWithAttachment(
         } else {
           cy.wrap(mailsWithSubject)
             .mpLatest()
-            .should("not.eq", undefined)
-            .mpGetMailDetails();
+            .mpGetMailDetails()
+            .should("not.eq", undefined);
         }
       });
     }

--- a/cypress/support/customCommands/basicOperations/mailpit.js
+++ b/cypress/support/customCommands/basicOperations/mailpit.js
@@ -12,7 +12,7 @@ Cypress.Commands.add("mpGetAllMails", (fromLast = 60000) =>
   cy
     .request({
       method: "GET",
-      url: mhApiUrl("/v1/messages?limit=9999"),
+      url: mhApiUrl("/v1/messages?limit=100"),
     })
     .then(response => {
       // by default get mails received in last 60000ms


### PR DESCRIPTION
I want to merge this change because It's cherry-picked from - https://github.com/saleor/saleor-dashboard/pull/3637

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
