### PR TITLE
fixing tests: 2505 2506 -  should update product to be visible or not in listings

### DIFF
--- a/cypress/e2e/products/manageProducts/visibleInListingsProducts.js
+++ b/cypress/e2e/products/manageProducts/visibleInListingsProducts.js
@@ -72,7 +72,8 @@ describe("Products displayed in listings", () => {
         .then(({ product: productResp }) => {
           const product = productResp;
           const productUrl = productDetailsUrl(product.id);
-          updateProductVisibleInListings(productUrl);
+          cy.visit(productUrl);
+          updateProductVisibleInListings();
           searchInShop(productName);
         })
         .then(resp => {
@@ -103,7 +104,8 @@ describe("Products displayed in listings", () => {
         .then(({ product: productResp }) => {
           const product = productResp;
           const productUrl = productDetailsUrl(product.id);
-          updateProductVisibleInListings(productUrl);
+          cy.visit(productUrl);
+          updateProductVisibleInListings();
 
           searchInShop(productName).then(resp => {
             const isProductVisible = isProductVisibleInSearchResult(

--- a/cypress/elements/channels/available-channels-form.js
+++ b/cypress/elements/channels/available-channels-form.js
@@ -5,6 +5,6 @@ export const AVAILABLE_CHANNELS_FORM = {
   availableForPurchaseRadioButtons: "[name*='isAvailableForPurchase']",
   radioButtonsValueTrue: "[value='true']",
   radioButtonsValueFalse: "[value='false']",
-  visibleInListingsButton: "[name*='visibleInListings']",
+  visibleInListingsButton: "[id*='visibleInListings']",
   availableChannel: "[data-test-id*='channel-availability-item']",
 };

--- a/cypress/support/pages/catalog/products/productDetailsPage.js
+++ b/cypress/support/pages/catalog/products/productDetailsPage.js
@@ -25,24 +25,24 @@ export function updateProductPublish(productUrl, isPublished) {
   updateProductManageInChannel(productUrl, publishedSelector);
 }
 
-export function updateProductVisibleInListings(productUrl) {
-  updateProductManageInChannel(
-    productUrl,
-    AVAILABLE_CHANNELS_FORM.visibleInListingsButton,
-  );
+export function updateProductVisibleInListings() {
+  updateProductManageInChannel(AVAILABLE_CHANNELS_FORM.visibleInListingsButton);
 }
 
-function updateProductManageInChannel(productUrl, manageSelector) {
-  cy.visit(productUrl)
-    .get(AVAILABLE_CHANNELS_FORM.assignedChannels)
+function updateProductManageInChannel(manageSelector) {
+  cy.get(AVAILABLE_CHANNELS_FORM.assignedChannels)
     .click()
     .get(manageSelector)
     .first()
+    .scrollIntoView()
     .click()
+    // cypress click is to fast - our app is nor ready to handle new event when click occurs - solution could be disabling save button until app is ready to handle new event
+    .wait(1000)
     .waitForProgressBarToNotBeVisible()
     .addAliasToGraphRequest("ProductChannelListingUpdate")
     .get(BUTTON_SELECTORS.confirm)
     .click()
+    .confirmationMessageShouldAppear()
     .wait("@ProductChannelListingUpdate");
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.13.0-dev",
+  "version": "3.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor-dashboard",
-      "version": "3.13.0-dev",
+      "version": "3.13.2",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.13.2",
+  "version": "3.13.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor-dashboard",
-      "version": "3.13.2",
+      "version": "3.13.0-dev",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
I want to merge this change because...

fixing tests: 2505 2506 -  should update product to be visible or not in listings

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [x] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=6
