### PR TITLE
test - fix for transaction orders test - set local storage to hide nav…

### DIFF
--- a/cypress/e2e/orders/transactionsForOrders.js
+++ b/cypress/e2e/orders/transactionsForOrders.js
@@ -114,10 +114,12 @@ describe("Orders", () => {
   });
 
   beforeEach(() => {
-    cy.clearSessionData().loginUserViaRequest(
-      "auth",
-      ONE_PERMISSION_USERS.order,
-    );
+    cy.clearSessionData()
+      .loginUserViaRequest("auth", ONE_PERMISSION_USERS.order)
+      .then(() => {
+        // set notifiedAboutNavigator to make navigator banner gone from the start - banner was covering needed elements during test
+        window.localStorage.setItem("notifiedAboutNavigator", "true");
+      });
   });
 
   it(

--- a/cypress/support/pages/ordersTransactionUtils.js
+++ b/cypress/support/pages/ordersTransactionUtils.js
@@ -3,6 +3,7 @@ import {
   ORDER_GRANT_REFUND,
   ORDER_TRANSACTION_CREATE,
   ORDERS_SELECTORS,
+  SHARED_ELEMENTS,
 } from "../../elements";
 
 export function markAsPaidOrderWithRefNumber(transactionNumber) {
@@ -34,6 +35,8 @@ export function grantRefundAllProductsAndShippingWithReason(
   clickMaxQuantityButton();
   typeRefundReason(refundReason);
   clickRefundShippingCheckbox();
+  // this check makes sure no banner covers apply button which was making this action flaky
+  cy.get(SHARED_ELEMENTS.notificationMessage).should("not.exist");
   clickApplyRefundButton();
   cy.get(ORDER_GRANT_REFUND.refundAmountInput).should("contain.value", total);
   clickConfirmRefundButton();


### PR DESCRIPTION

I want to merge this change because...

fix for transaction orders test - set local storage to hide navigator banner

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
