### PR TITLE
fix: customer history UI

### DIFF
--- a/src/customers/components/CustomerStats/CustomerStats.tsx
+++ b/src/customers/components/CustomerStats/CustomerStats.tsx
@@ -1,25 +1,11 @@
-import CardTitle from "@dashboard/components/CardTitle";
+import { DashboardCard } from "@dashboard/components/Card";
 import { DateTime } from "@dashboard/components/Date";
-import { Hr } from "@dashboard/components/Hr";
 import RequirePermissions from "@dashboard/components/RequirePermissions";
 import Skeleton from "@dashboard/components/Skeleton";
 import { CustomerDetailsQuery, PermissionEnum } from "@dashboard/graphql";
-import { Card, CardContent, Typography } from "@material-ui/core";
-import { makeStyles } from "@saleor/macaw-ui";
+import { Divider, Text } from "@saleor/macaw-ui/next";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-
-const useStyles = makeStyles(
-  theme => ({
-    label: {
-      marginBottom: theme.spacing(1),
-    },
-    value: {
-      fontSize: 24,
-    },
-  }),
-  { name: "CustomerStats" },
-);
 
 export interface CustomerStatsProps {
   customer: CustomerDetailsQuery["user"];
@@ -27,43 +13,42 @@ export interface CustomerStatsProps {
 
 const CustomerStats: React.FC<CustomerStatsProps> = props => {
   const { customer } = props;
-  const classes = useStyles(props);
 
   const intl = useIntl();
 
   return (
-    <Card>
-      <CardTitle
-        title={intl.formatMessage({
+    <DashboardCard>
+      <DashboardCard.Title>
+        {intl.formatMessage({
           id: "e7Nyu7",
           defaultMessage: "Customer History",
           description: "section header",
         })}
-      />
-      <CardContent>
-        <Typography className={classes.label} variant="caption">
+      </DashboardCard.Title>
+      <DashboardCard.Content display="flex" flexDirection="column">
+        <Text variant="caption">
           <FormattedMessage id="FNAZoh" defaultMessage="Last login" />
-        </Typography>
+        </Text>
         {customer ? (
-          <Typography variant="h6" className={classes.value}>
+          <Text>
             {customer.lastLogin === null ? (
               "-"
             ) : (
               <DateTime date={customer.lastLogin} plain />
             )}
-          </Typography>
+          </Text>
         ) : (
           <Skeleton />
         )}
-      </CardContent>
+      </DashboardCard.Content>
       <RequirePermissions requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}>
-        <Hr />
-        <CardContent>
-          <Typography className={classes.label} variant="caption">
+        <Divider />
+        <DashboardCard.Content display="flex" flexDirection="column">
+          <Text variant="caption">
             <FormattedMessage id="HMD+ib" defaultMessage="Last order" />
-          </Typography>
+          </Text>
           {customer && customer.lastPlacedOrder ? (
-            <Typography variant="h6" className={classes.value}>
+            <Text>
               {customer.lastPlacedOrder.edges.length === 0 ? (
                 "-"
               ) : (
@@ -72,13 +57,13 @@ const CustomerStats: React.FC<CustomerStatsProps> = props => {
                   plain
                 />
               )}
-            </Typography>
+            </Text>
           ) : (
             <Skeleton />
           )}
-        </CardContent>
+        </DashboardCard.Content>
       </RequirePermissions>
-    </Card>
+    </DashboardCard>
   );
 };
 CustomerStats.displayName = "CustomerStats";


### PR DESCRIPTION
I want to merge this change because it fixes the customer history UI. I also removed old MacawUI code.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
| Before | After |
| ------- | ------- |
| ![CleanShot 2023-05-18 at 16 54 46@2x](https://github.com/saleor/saleor-dashboard/assets/9116238/3fd58d3f-0675-41aa-8ed2-d8a596d26826) | ![CleanShot 2023-05-18 at 16 54 08@2x](https://github.com/saleor/saleor-dashboard/assets/9116238/1c3f123a-9159-457d-a1c7-02dabf7279ee) |
  

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
