### PR TITLE
Fix close menu panel when click on account settings

### DIFF
--- a/src/components/Sidebar/user/Controls.tsx
+++ b/src/components/Sidebar/user/Controls.tsx
@@ -1,4 +1,5 @@
 import { useUser } from "@dashboard/auth";
+import useNavigator from "@dashboard/hooks/useNavigator";
 import { staffMemberDetailsUrl } from "@dashboard/staff/urls";
 import { useTheme } from "@dashboard/theme";
 import { useTheme as useLegacyTheme } from "@saleor/macaw-ui";
@@ -8,12 +9,10 @@ import {
   Dropdown,
   List,
   MoreOptionsIcon,
-  sprinkles,
   Text,
 } from "@saleor/macaw-ui/next";
 import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
-import { Link } from "react-router-dom";
 
 import { ThemeSwitcher } from "./ThemeSwitcher";
 
@@ -48,6 +47,11 @@ export const useLegacyThemeHandler = () => {
 export const UserControls = () => {
   const { user, logout } = useUser();
   const { changeTheme, theme } = useLegacyThemeHandler();
+  const navigate = useNavigator();
+
+  const goToAccountSettings = () => {
+    navigate(staffMemberDetailsUrl(user.id));
+  };
 
   return (
     <Dropdown>
@@ -69,24 +73,16 @@ export const UserControls = () => {
           >
             <Dropdown.Item>
               <List.Item
-                borderRadius={4}
                 data-test-id="account-settings-button"
+                {...listItemStyles}
+                onClick={goToAccountSettings}
               >
-                <Link
-                  to={staffMemberDetailsUrl(user?.id)}
-                  className={sprinkles({
-                    display: "block",
-                    width: "100%",
-                    ...listItemStyles,
-                  })}
-                >
-                  <Text>
-                    <FormattedMessage
-                      id="NQgbYA"
-                      defaultMessage="Account Settings"
-                    />
-                  </Text>
-                </Link>
+                <Text>
+                  <FormattedMessage
+                    id="NQgbYA"
+                    defaultMessage="Account Settings"
+                  />
+                </Text>
               </List.Item>
             </Dropdown.Item>
             <Dropdown.Item>


### PR DESCRIPTION
closes https://github.com/saleor/saleor-dashboard/issues/3675

React-router-dom Link component doesn't cooperate well with Radix Dropdown so I have to use navigate and onClick.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core


### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
