### PR TITLE
Enable disabled app row to be clicked and nav to details

### DIFF
--- a/src/apps/components/AppDetailsPage/Header.tsx
+++ b/src/apps/components/AppDetailsPage/Header.tsx
@@ -19,15 +19,25 @@ const Header: React.FC<HeaderProps> = ({
   onAppDeactivateOpen,
   onAppDeleteOpen,
 }) => {
-  /**
-   * App is null with first render so fallback with HTML-safe fallback
-   */
-  const backButtonTarget = data?.id ? AppUrls.resolveAppUrl(data.id) : "#";
+  const getBackButtonUrl = () => {
+    /**
+     * App is null with first render so fallback with HTML-safe fallback
+     */
+    if (!data?.id) {
+      return "#";
+    }
+
+    const isAppActive = data.isActive;
+
+    return isAppActive
+      ? AppUrls.resolveAppUrl(data.id)
+      : AppUrls.resolveAppListUrl();
+  };
 
   return (
     <>
       <TopNav
-        href={backButtonTarget}
+        href={getBackButtonUrl()}
         title={
           <>
             {data?.name} {!data?.isActive && <DeactivatedText />}

--- a/src/apps/components/InstalledAppListRow/InstalledAppListRow.tsx
+++ b/src/apps/components/InstalledAppListRow/InstalledAppListRow.tsx
@@ -1,6 +1,6 @@
 import { appsMessages } from "@dashboard/apps/messages";
 import { InstalledApp } from "@dashboard/apps/types";
-import { AppUrls } from "@dashboard/apps/urls";
+import { AppPaths, AppUrls } from "@dashboard/apps/urls";
 import { isAppInTunnel } from "@dashboard/apps/utils";
 import Link from "@dashboard/components/Link";
 import { Box, Chip, List, sprinkles, Text } from "@saleor/macaw-ui/next";
@@ -19,13 +19,20 @@ export const InstalledAppListRow: React.FC<InstalledApp> = props => {
 
   const location = useLocation();
 
+  /**
+   * Active app will redirect to app iframe, but disabled app is likely not going to work - so iframe is blocked.
+   * Link will point to app "manage" screen where app can be enabled or uninstalled
+   */
+  const appUrl = app.isActive
+    ? AppUrls.resolveAppUrl(app.id)
+    : AppPaths.resolveAppDetailsPath(app.id);
+
   return (
     <Link
-      href={AppUrls.resolveAppUrl(app.id)}
+      href={appUrl}
       state={{ from: location.pathname }}
       className={sprinkles({ display: "contents" })}
       inline={false}
-      disabled={!app.isActive}
     >
       <List.Item
         padding={4}
@@ -40,7 +47,7 @@ export const InstalledAppListRow: React.FC<InstalledApp> = props => {
           default: !app.isActive ? "surfaceNeutralSubdued" : undefined,
           hover: "surfaceNeutralSubdued",
         }}
-        cursor={app.isActive ? "pointer" : "not-allowed"}
+        cursor={"pointer"}
       >
         <Box
           gap={2}


### PR DESCRIPTION
closes https://github.com/saleor/saleor-dashboard/issues/3716

1. Disabled app row is now clickable
2. Disabled row redirects to app's "manage" page where it can be enabled
3. Enabled rows works as before


AC:

GIVEN
App is installed 
AND
App is disabled

WHEN
User clicks on the disabled app in `/apps` page

THEN
User gets redirected to "Manage App Page" where "Enable App" button is enabled

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
5. [ ] All visible strings are translated with proper context including data-formatting
6. [ ] Attributes `data-test-id` are added for new elements
7. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
8. [ ] Your code works with the latest stable version of the core


### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
9. [ ] productType
10. [ ] shipping
11. [ ] customer
12. [ ] permissions
13. [ ] menuNavigation
14. [ ] pages
15. [ ] sales
16. [ ] vouchers
17. [ ] homePage
18. [ ] login
19. [ ] orders
20. [ ] products
21. [ ] app
22. [ ] plugins
23. [ ] translations
24. [ ] navigation
25. [ ] variants
26. [ ] payments

CONTAINERS=1
