### PR TITLE
Fix voucher channel listing crash on adornment click

### DIFF
--- a/src/discounts/components/VoucherValue/VoucherValue.tsx
+++ b/src/discounts/components/VoucherValue/VoucherValue.tsx
@@ -6,7 +6,6 @@ import ResponsiveTable from "@dashboard/components/ResponsiveTable";
 import Skeleton from "@dashboard/components/Skeleton";
 import TableHead from "@dashboard/components/TableHead";
 import TableRowLink from "@dashboard/components/TableRowLink";
-import TextFieldWithChoice from "@dashboard/components/TextFieldWithChoice";
 import { ChannelInput } from "@dashboard/discounts/handlers";
 import { DiscountTypeEnum } from "@dashboard/discounts/types";
 import { DiscountErrorFragment } from "@dashboard/graphql";
@@ -20,6 +19,7 @@ import {
   TableCell,
   Typography,
 } from "@material-ui/core";
+import { Input, Text } from "@saleor/macaw-ui/next";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -99,22 +99,21 @@ const VoucherValue: React.FC<VoucherValueProps> = props => {
                   return (
                     <TableRowLink key={listing?.id || `skeleton-${index}`}>
                       <TableCell>
-                        <Typography>{listing?.name || <Skeleton />}</Typography>
+                        <Text>{listing?.name || <Skeleton />}</Text>
                       </TableCell>
                       <TableCell className={classes.colPrice}>
                         {listing ? (
-                          <TextFieldWithChoice
+                          <Input
                             disabled={disabled}
                             error={!!error?.length}
-                            ChoiceProps={{
-                              label:
-                                data.discountType ===
+                            endAdornment={
+                              <Text variant="caption">
+                                {data.discountType ===
                                 DiscountTypeEnum.VALUE_FIXED
                                   ? listing.currency
-                                  : "%",
-                              name: "discountType" as keyof FormData,
-                              values: null,
-                            }}
+                                  : "%"}
+                              </Text>
+                            }
                             helperText={
                               error
                                 ? getDiscountErrorMessage(
@@ -135,10 +134,6 @@ const VoucherValue: React.FC<VoucherValueProps> = props => {
                             })}
                             value={listing.discountValue || ""}
                             type="number"
-                            fullWidth
-                            inputProps={{
-                              min: 0,
-                            }}
                           />
                         ) : (
                           <Skeleton />

--- a/src/discounts/components/VoucherValue/styles.ts
+++ b/src/discounts/components/VoucherValue/styles.ts
@@ -9,6 +9,8 @@ export const useStyles = makeStyles(
     },
     colPrice: {
       minWidth: 300,
+      paddingTop: 12,
+      paddingBottom: 12,
     },
     colType: {
       fontSize: 14,


### PR DESCRIPTION
This PR migrates channel listing inputs on voucher details view, solving the problem described in #3735.

### Screenshots

![image](https://github.com/saleor/saleor-dashboard/assets/41952692/5c8664b9-9fa4-4b2c-bb83-0c8ea05809f0)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core


### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
