### PR TITLE
Fix breaking Manage App screen when app is disabled

### DIFF
--- a/src/apps/components/AppDetailsPage/AppDetailsPage.tsx
+++ b/src/apps/components/AppDetailsPage/AppDetailsPage.tsx
@@ -21,22 +21,31 @@ export const AppDetailsPage: React.FC<AppDetailsPageProps> = ({
   onAppActivateOpen,
   onAppDeactivateOpen,
   onAppDeleteOpen,
-}) => (
-  <>
-    <Header
-      data={data}
-      onAppActivateOpen={onAppActivateOpen}
-      onAppDeactivateOpen={onAppDeactivateOpen}
-      onAppDeleteOpen={onAppDeleteOpen}
-    />
-    <AboutCard aboutApp={data?.aboutApp} loading={loading} />
-    <CardSpacer />
-    <PermissionsCard permissions={data?.permissions} loading={loading} />
-    <CardSpacer />
-    <DataPrivacyCard dataPrivacyUrl={data?.dataPrivacyUrl} loading={loading} />
-    <CardSpacer />
-  </>
-);
+}) => {
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <>
+      <Header
+        data={data}
+        onAppActivateOpen={onAppActivateOpen}
+        onAppDeactivateOpen={onAppDeactivateOpen}
+        onAppDeleteOpen={onAppDeleteOpen}
+      />
+      <AboutCard aboutApp={data?.aboutApp} loading={loading} />
+      <CardSpacer />
+      <PermissionsCard permissions={data?.permissions} loading={loading} />
+      <CardSpacer />
+      <DataPrivacyCard
+        dataPrivacyUrl={data?.dataPrivacyUrl}
+        loading={loading}
+      />
+      <CardSpacer />
+    </>
+  );
+};
 
 AppDetailsPage.displayName = "AppDetailsPage";
 export default AppDetailsPage;

--- a/src/apps/components/AppDetailsPage/Header.tsx
+++ b/src/apps/components/AppDetailsPage/Header.tsx
@@ -33,6 +33,10 @@ const Header: React.FC<HeaderProps> = ({
       : AppUrls.resolveAppListUrl();
   };
 
+  if (!data) {
+    return null;
+  }
+
   return (
     <>
       <AppPageNav
@@ -47,7 +51,7 @@ const Header: React.FC<HeaderProps> = ({
       />
 
       <HeaderOptions
-        data={data}
+        isActive={data.isActive}
         onAppActivateOpen={onAppActivateOpen}
         onAppDeactivateOpen={onAppDeactivateOpen}
         onAppDeleteOpen={onAppDeleteOpen}

--- a/src/apps/components/AppDetailsPage/HeaderOptions.tsx
+++ b/src/apps/components/AppDetailsPage/HeaderOptions.tsx
@@ -1,5 +1,3 @@
-import Skeleton from "@dashboard/components/Skeleton";
-import { AppQuery } from "@dashboard/graphql";
 import { buttonMessages } from "@dashboard/intl";
 import { ButtonBase } from "@material-ui/core";
 import { Box } from "@saleor/macaw-ui/next";
@@ -12,28 +10,19 @@ import deleteIcon from "../../../../assets/images/delete.svg";
 import { useStyles } from "./styles";
 
 interface HeaderOptionsProps {
-  data: AppQuery["app"];
+  isActive: boolean;
   onAppActivateOpen: () => void;
   onAppDeactivateOpen: () => void;
   onAppDeleteOpen: () => void;
 }
 
 const HeaderOptions: React.FC<HeaderOptionsProps> = ({
-  data,
+  isActive,
   onAppActivateOpen,
   onAppDeactivateOpen,
   onAppDeleteOpen,
 }) => {
   const classes = useStyles();
-
-  if (!data) {
-    return (
-      <Box marginX={7}>
-        <Skeleton />
-        <div className={classes.hr} />
-      </Box>
-    );
-  }
 
   return (
     <Box marginX={7}>
@@ -41,10 +30,10 @@ const HeaderOptions: React.FC<HeaderOptionsProps> = ({
         <ButtonBase
           className={classes.headerLinkContainer}
           disableRipple
-          onClick={data.isActive ? onAppDeactivateOpen : onAppActivateOpen}
+          onClick={isActive ? onAppDeactivateOpen : onAppActivateOpen}
         >
           <SVG src={activateIcon} />
-          {data?.isActive ? (
+          {isActive ? (
             <FormattedMessage {...buttonMessages.deactivate} />
           ) : (
             <FormattedMessage {...buttonMessages.activate} />


### PR DESCRIPTION
Fixed problem that app was trying to access `data.name` but `data` was initially null

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core


### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
