### PR TITLE
test for opening products from order grid

### DIFF
--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -40,6 +40,7 @@ import {
   expandPrivateFulfillmentMetadata,
   expandPublicFulfillmentMetadata,
   finalizeDraftOrder,
+  openVariantDetailsOptions,
   selectChannelInPicker,
   updatePrivateMetadataFieldFulfillmentOrder,
   updatePublicMetadataFieldFulfillmentOrder,
@@ -56,6 +57,7 @@ describe("Orders", () => {
   let variantsList;
   let address;
   let taxClass;
+  let productDetails;
 
   const shippingPrice = 2;
   const variantPrice = 1;
@@ -124,7 +126,8 @@ describe("Orders", () => {
           });
         },
       )
-      .then(({ variantsList: variantsResp }) => {
+      .then(({ variantsList: variantsResp, product }) => {
+        productDetails = product;
         variantsList = variantsResp;
         cy.checkIfDataAreNotNull({
           customer,
@@ -515,6 +518,59 @@ describe("Orders", () => {
               });
           });
         });
+      });
+    },
+  );
+  it(
+    "should open product details from order details - unconfirmed order. TC: SALEOR_2133",
+    { tags: ["@orders", "@allEnv", "@stable"] },
+    () => {
+      createUnconfirmedOrder({
+        customerId: customer.id,
+        channelId: defaultChannel.id,
+        shippingMethod,
+        variantsList,
+        address,
+      }).then(unconfirmedOrderResponse => {
+        cy.visit(urlList.orders + `${unconfirmedOrderResponse.order.id}`);
+        openVariantDetailsOptions();
+        cy.get(ORDERS_SELECTORS.openProductDetailsButton).then(
+          openProductInNewTabButton => {
+            cy.wrap(openProductInNewTabButton)
+              .invoke("attr", "target")
+              .should("eq", "_blank");
+            cy.wrap(openProductInNewTabButton)
+              .invoke("attr", "href")
+              .should("contain", productDetails.id.replace("=", ""));
+          },
+        );
+      });
+    },
+  );
+  it(
+    "should open product details from order details - confirmed order. TC: 2134",
+    { tags: ["@orders", "@allEnv", "@stable"] },
+    () => {
+      let order;
+      createReadyToFulfillOrder({
+        customerId: customer.id,
+        channelId: defaultChannel.id,
+        shippingMethod,
+        variantsList,
+        address,
+      }).then(({ order: orderResp }) => {
+        order = orderResp;
+        cy.visit(urlList.orders + `${order.id}`);
+        cy.get(ORDERS_SELECTORS.rowActionButton)
+          .find("a")
+          .then(openProductInNewTabButton => {
+            cy.wrap(openProductInNewTabButton)
+              .invoke("attr", "target")
+              .should("eq", "_blank");
+            cy.wrap(openProductInNewTabButton)
+              .invoke("attr", "href")
+              .should("contain", productDetails.id.replace("=", ""));
+          });
       });
     },
   );

--- a/cypress/elements/orders/orders-selectors.js
+++ b/cypress/elements/orders/orders-selectors.js
@@ -10,6 +10,7 @@ export const ORDERS_SELECTORS = {
   refundButton: '[data-test-id="refund-button"]',
   fulfillMenuButton: '[data-test-id="fulfill-menu"]',
   priceCellFirstRowOrderDetails: "[id='glide-cell-5-0']",
+  productNameOrderDetailsRow: "'[id='glide-cell-0-0']'",
   productNameSecondRowOrderDetails: "[id='glide-cell-1-1']",
   quantityCellFirstRowOrderDetails: "[id='glide-cell-4-0']",
   gridClip: "[class='clip-region']",
@@ -24,6 +25,8 @@ export const ORDERS_SELECTORS = {
   grantRefundButton: '[data-test-id="grantRefundButton"]',
   transactionReferenceInput: '[data-test-id="transaction-reference-input"]',
   orderTransactionsList: '[data-test-id="orderTransactionsList"]',
+  openProductDetailsButton: '[data-test-id="open-product-details"]',
+  rowActionButton: '[data-test-id="row-action-button"]',
   captureManualTransactionButton:
     '[data-test-id="captureManualTransactionButton"]',
 };

--- a/cypress/support/pages/index.js
+++ b/cypress/support/pages/index.js
@@ -18,6 +18,7 @@ export {
   applyFixedLineDiscountForProduct,
   changeQuantityOfProducts,
   deleteProductFromGridTableOnIndex,
+  openVariantDetailsOptions,
 } from "./ordersOperations";
 export { expectWelcomeMessageIncludes } from "./homePage";
 export { getDisplayedSelectors } from "./permissionsPage";

--- a/cypress/support/pages/ordersOperations.js
+++ b/cypress/support/pages/ordersOperations.js
@@ -60,6 +60,11 @@ export function deleteProductFromGridTableOnIndex(trIndex = 0) {
     .click()
     .wait("@OrderLineDelete");
 }
+
+export function openVariantDetailsOptions(variantIndex = 1) {
+  return cy.get(BUTTON_SELECTORS.showMoreButton).eq(variantIndex).click();
+}
+
 export function addNewProductToOrder(productIndex = 0, variantIndex = 0) {
   cy.get(DRAFT_ORDER_SELECTORS.addProducts).click();
   return cy

--- a/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
@@ -65,6 +65,7 @@ export const OrderDraftDetailsDatagrid = ({
         Icon: (
           <Link
             to={productUrl(lines[index]?.variant.product.id)}
+            data-test-id="open-product-details"
             target="_blank"
             className={sprinkles({
               display: "flex",


### PR DESCRIPTION
Add tests for open product detail from confirmed and unconfirmed order
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core


### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
