### PR TITLE
Display hash commit instead of version on main.

### DIFF
--- a/.changeset/grumpy-eagles-live.md
+++ b/.changeset/grumpy-eagles-live.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Set custom version within the workflow of deployments from main

--- a/.github/workflows/deploy-master-staging.yaml
+++ b/.github/workflows/deploy-master-staging.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set custom version
         run: |
           HASH=$(git rev-parse --short HEAD)
-          CURRENT_VERSION=$(cat package.json | jq .version)
+          CURRENT_VERSION=$(jq -r .version package.json)
           echo "CUSTOM_VERSION=${CURRENT_VERSION}-${HASH}" >> $GITHUB_ENV
 
       - name: Setup Node

--- a/.github/workflows/deploy-master-staging.yaml
+++ b/.github/workflows/deploy-master-staging.yaml
@@ -23,9 +23,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set custom version
         run: |
-          set -x
-          hash=$(git rev-parse --short HEAD)
-          echo "CUSTOM_VERSION=dev-${hash}" >> $GITHUB_ENV
+          HASH=$(git rev-parse --short HEAD)
+          CURRENT_VERSION=$(cat package.json | jq .version)
+          echo "CUSTOM_VERSION=${CURRENT_VERSION}-${HASH}" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy-master-staging.yaml
+++ b/.github/workflows/deploy-master-staging.yaml
@@ -21,6 +21,11 @@ jobs:
       IS_CLOUD_INSTANCE: true
     steps:
       - uses: actions/checkout@v2
+      - name: Set custom version
+        run: |
+          set -x
+          hash=$(git rev-parse --short HEAD)
+          echo "CUSTOM_VERSION=dev-${hash}" >> $GITHUB_ENV
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
We want to see commit hash instead of version within the dashboard on the deployment that comes from main. 


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
