### PR TITLE
View all orders of anonymous customer

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2942,6 +2942,10 @@
   "J4E+jp": {
     "string": "Variant name"
   },
+  "J4NBVR": {
+    "context": "link",
+    "string": "View Orders"
+  },
   "J7mFhU": {
     "context": "currency code select",
     "string": "{code} - {countries}"

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -18,13 +18,13 @@ import {
 } from "@dashboard/graphql";
 import useStateFromProps from "@dashboard/hooks/useStateFromProps";
 import { buttonMessages } from "@dashboard/intl";
+import { orderListUrl } from "@dashboard/orders/urls";
 import { FetchMoreProps, RelayToFlat } from "@dashboard/types";
 import createSingleAutocompleteSelectHandler from "@dashboard/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { Card, CardContent, Typography } from "@material-ui/core";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { orderListUrl } from "@dashboard/orders/urls";
 import { customerUrl } from "../../../customers/urls";
 import { maybe } from "../../../misc";
 import { AddressTextError } from "./AddrssTextError";

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent, Typography } from "@material-ui/core";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { orderListUrl } from "@dashboard/orders/urls";
 import { customerUrl } from "../../../customers/urls";
 import { maybe } from "../../../misc";
 import { AddressTextError } from "./AddrssTextError";
@@ -168,7 +169,23 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
               <FormattedMessage id="Qovenh" defaultMessage="Anonymous user" />
             </Typography>
           ) : (
-            <Typography className={classes.userEmail}>{userEmail}</Typography>
+            <>
+              <Typography className={classes.userEmail}>{userEmail}</Typography>
+              <div>
+                <Link
+                  underline={false}
+                  href={orderListUrl({
+                    customer: userEmail,
+                  })}
+                >
+                  <FormattedMessage
+                    id="J4NBVR"
+                    defaultMessage="View Orders"
+                    description="link"
+                  />
+                </Link>
+              </div>
+            </>
           )
         ) : (
           <>


### PR DESCRIPTION
closes #3753 

On the order page there is now a link under the email to see all orders of an anonymous customer.

### Screenshots
Order page (before):
![image](https://github.com/saleor/saleor-dashboard/assets/40419916/2d94ea65-7fa8-4ee1-82e3-6f871d3bacd9)


Order page (after):
![image](https://github.com/saleor/saleor-dashboard/assets/40419916/58c9cec4-1c51-4055-b424-c6f9be8f7914)


View Orders page:
![image](https://github.com/saleor/saleor-dashboard/assets/40419916/51e26fb6-4ea9-4fa2-a238-f240985b51cd)



<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [X] This code contains UI changes
2. [X] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [X] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
7. [ ] shipping
8. [ ] customer
9. [ ] permissions
10. [ ] menuNavigation
11. [ ] pages
12. [ ] sales
13. [ ] vouchers
14. [ ] homePage
15. [ ] login
16. [ ] orders
17. [ ] products
18. [ ] app
19. [ ] plugins
20. [ ] translations
21. [ ] navigation
22. [ ] variants
23. [ ] payments

CONTAINERS=1
