### PR TITLE
Add rowHeight prop to Datagrid component

### DIFF
--- a/.changeset/curly-pears-end.md
+++ b/.changeset/curly-pears-end.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Add rowHeight prop to Datagrid component

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -105,6 +105,7 @@ export interface DatagridProps {
   columnSelect?: DataEditorProps["columnSelect"];
   showEmptyDatagrid?: boolean;
   rowAnchor?: (item: Item) => string;
+  rowHeight?: number | ((index: number) => number);
   actionButtonPosition?: "left" | "right";
   recentlyAddedColumn?: string; // Enables scroll to recently added column
 }
@@ -139,6 +140,7 @@ export const Datagrid: React.FC<DatagridProps> = ({
   onRowSelectionChange,
   actionButtonPosition = "left",
   recentlyAddedColumn,
+  rowHeight = cellHeight,
   ...datagridProps
 }): ReactElement => {
   const classes = useStyles({ actionButtonPosition });
@@ -523,7 +525,7 @@ export const Datagrid: React.FC<DatagridProps> = ({
                   onItemHovered={handleRowHover}
                   getRowThemeOverride={handleGetThemeOverride}
                   gridSelection={selection}
-                  rowHeight={cellHeight}
+                  rowHeight={rowHeight}
                   headerHeight={cellHeight}
                   ref={editor}
                   onPaste


### PR DESCRIPTION
This PR adds the `rowHeight` prop to the Datagrid component.

1. Keeps the default `cellHeight` value if prop not provided
2. This allows for setting a dynamic row height if needed (See example in screenshots)

### Screenshots
**Before**
<img width="1149" alt="Screenshot 2023-07-08 at 3 51 45 PM" src="https://github.com/saleor/saleor-dashboard/assets/4250593/2b74ca42-bea7-401f-a23e-2d2932746170">

**After**
This is an example of using the `rowHeight` prop to set a dynamic height based on product description length.
(_Not implemented in this PR_)

<img width="1155" alt="Screenshot 2023-07-08 at 3 41 30 PM" src="https://github.com/saleor/saleor-dashboard/assets/4250593/0f16866b-1dcf-47c0-b462-43d100cc5dd2">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
4. [ ] All visible strings are translated with proper context including data-formatting
5. [ ] Attributes `data-test-id` are added for new elements
6. [x] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
7. [x] Your code works with the latest stable version of the core
8. [x] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] giftCard
3. [ ] category
4. [ ] collection
5. [ ] attribute
6. [ ] productType
9. [ ] shipping
10. [ ] customer
11. [ ] permissions
12. [ ] menuNavigation
13. [ ] pages
14. [ ] sales
15. [ ] vouchers
16. [ ] homePage
17. [ ] login
18. [ ] orders
19. [ ] products
20. [ ] app
21. [ ] plugins
22. [ ] translations
23. [ ] navigation
24. [ ] variants
25. [ ] payments

CONTAINERS=1
