### PR TITLE
Fix throw error when no description data in product list datagrid

### DIFF
--- a/.changeset/heavy-dingos-sell.md
+++ b/.changeset/heavy-dingos-sell.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix throw error when there is not description data in product list datagrid

--- a/src/products/components/ProductListDatagrid/datagrid.test.ts
+++ b/src/products/components/ProductListDatagrid/datagrid.test.ts
@@ -1,0 +1,25 @@
+import { getDescriptionValue } from "./datagrid";
+
+describe("getDescriptionValue", () => {
+  it("should return description value", () => {
+    expect(
+      getDescriptionValue(
+        '{"time": 1634014163888, "blocks": [{"data": {"text": "description"}, "type": "paragraph"}], "version": "2.20.0"}',
+      ),
+    ).toBe("description");
+  });
+
+  it("should return empty string when no description data", () => {
+    expect(
+      getDescriptionValue('{"blocks": [{"data": {}, "type": "paragraph"}]}'),
+    ).toBe("");
+  });
+
+  it("should return empty string when description contains &nbsp", () => {
+    expect(
+      getDescriptionValue(
+        '{"time": 1637142885936, "blocks": [{"data": {"text": "&nbsp;"}, "type": "paragraph"}], "version": "2.20.0"}',
+      ),
+    ).toBe("");
+  });
+});

--- a/src/products/components/ProductListDatagrid/datagrid.ts
+++ b/src/products/components/ProductListDatagrid/datagrid.ts
@@ -277,21 +277,7 @@ function getDescriptionCellContent(
     return readonlyTextCell("");
   }
 
-  const parsed = JSON.parse(value);
-
-  if (parsed) {
-    const descriptionFirstParagraph = parsed.blocks.find(
-      block => block.type === "paragraph",
-    );
-
-    if (descriptionFirstParagraph) {
-      return readonlyTextCell(
-        (descriptionFirstParagraph.data?.text ?? "").replace("&nbsp;", ""),
-      );
-    }
-  }
-
-  return readonlyTextCell(value || "");
+  return readonlyTextCell(getDescriptionValue(value));
 }
 
 function getNameCellContent(
@@ -357,6 +343,22 @@ function getAttributeCellContent(
   }
 
   return readonlyTextCell("");
+}
+
+export function getDescriptionValue(value: string) {
+  const parsed = JSON.parse(value);
+
+  if (parsed) {
+    const descriptionFirstParagraph = parsed?.blocks.find(
+      block => block.type === "paragraph",
+    );
+
+    if (descriptionFirstParagraph) {
+      return (descriptionFirstParagraph.data?.text ?? "").replace("&nbsp;", "");
+    }
+  }
+
+  return "";
 }
 
 export function getColumnMetadata(column: string) {

--- a/src/products/components/ProductListDatagrid/datagrid.ts
+++ b/src/products/components/ProductListDatagrid/datagrid.ts
@@ -285,7 +285,9 @@ function getDescriptionCellContent(
     );
 
     if (descriptionFirstParagraph) {
-      return readonlyTextCell(descriptionFirstParagraph.data.text);
+      return readonlyTextCell(
+        (descriptionFirstParagraph.data?.text ?? "").replace("&nbsp;", ""),
+      );
     }
   }
 


### PR DESCRIPTION
This PR fix throw error when there is not data in description field in product list datagrid

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [x] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [x] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
