### PR TITLE
test - new test for orders and draft orders column picker

### DIFF
--- a/cypress/e2e/orders/draftOrders.js
+++ b/cypress/e2e/orders/draftOrders.js
@@ -13,7 +13,11 @@ import {
   createCustomer,
   updateOrdersSettings,
 } from "../../support/api/requests/";
-import { createShipping, getDefaultChannel } from "../../support/api/utils/";
+import {
+  createShipping,
+  createUnconfirmedOrder,
+  getDefaultChannel,
+} from "../../support/api/utils/";
 import * as productsUtils from "../../support/api/utils/products/productsUtils";
 import { ensureCanvasStatic } from "../../support/customCommands/sharedElementsOperations/canvas";
 import {
@@ -24,10 +28,12 @@ import {
 describe("Draft orders", () => {
   const startsWith = "CyDraftOrders-";
   const randomName = startsWith + faker.datatype.number();
-
+  let customer;
   let defaultChannel;
   let warehouse;
   let address;
+  let variantsList;
+  let shippingMethod;
 
   before(() => {
     cy.clearSessionData().loginUserViaRequest();
@@ -46,19 +52,25 @@ describe("Draft orders", () => {
           randomName,
           addresses.plAddress,
           true,
-        );
+        ).then(customerResp => {
+          customer = customerResp.user;
+        });
         createShipping({
           channelId: defaultChannel.id,
           name: randomName,
           address: addresses.plAddress,
         });
       })
-      .then(({ warehouse: warehouseResp }) => {
-        warehouse = warehouseResp;
-        productsUtils.createTypeAttributeAndCategoryForProduct({
-          name: randomName,
-        });
-      })
+      .then(
+        ({ warehouse: warehouseResp, shippingMethod: shippingMethodResp }) => {
+          warehouse = warehouseResp;
+          shippingMethod = shippingMethodResp;
+
+          productsUtils.createTypeAttributeAndCategoryForProduct({
+            name: randomName,
+          });
+        },
+      )
       .then(
         ({
           productType: productTypeResp,
@@ -74,8 +86,11 @@ describe("Draft orders", () => {
             categoryId: categoryResp.id,
           });
         },
-        cy.checkIfDataAreNotNull({ defaultChannel, warehouse, address }),
-      );
+      )
+      .then(({ variantsList: variantsResp, product }) => {
+        variantsList = variantsResp;
+        cy.checkIfDataAreNotNull({ defaultChannel, warehouse, address });
+      });
   });
 
   beforeEach(() => {
@@ -113,6 +128,53 @@ describe("Draft orders", () => {
             cy.contains(draftOrderNumber).should("not.exist");
           });
         });
+    },
+  );
+
+  it(
+    "should be able to turn of all but one static columns on draft orders detail. TC: SALEOR_2135",
+    { tags: ["@orders", "@allEnv", "@stable"] },
+    () => {
+      let order;
+      createUnconfirmedOrder({
+        customerId: customer.id,
+        channelId: defaultChannel.id,
+        shippingMethod,
+        variantsList,
+        address,
+        warehouse: warehouse.id,
+      }).then(({ order: orderResp }) => {
+        order = orderResp;
+        cy.visit(urlList.orders + `${order.id}`);
+        cy.openColumnPicker();
+        cy.get(SHARED_ELEMENTS.staticColumnContainer)
+          .should("contain.text", "Product")
+          .should("contain.text", "SKU")
+          .should("contain.text", "Variant")
+          .should("contain.text", "Quantity")
+          .should("contain.text", "Price")
+          .should("contain.text", "Total");
+        // switching off all but one static columns
+        cy.get(SHARED_ELEMENTS.gridStaticSkuButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticVariantNameButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticQuantityButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticPriceButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticTotalButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticProductButton).should(
+          "have.attr",
+          "data-state",
+          "on",
+        );
+        cy.get(SHARED_ELEMENTS.dataGridTable)
+          .find("th")
+          // on draft first th is empty so length need to be 2
+          .should("have.length", 2)
+          .last()
+          .should("have.text", "Product");
+        //next line hides picker
+        cy.get(SHARED_ELEMENTS.pageHeader).click({ force: true });
+        cy.get(SHARED_ELEMENTS.dynamicColumnContainer).should("not.exist");
+      });
     },
   );
 });

--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -574,4 +574,47 @@ describe("Orders", () => {
       });
     },
   );
+  it(
+    "should be able to turn of all but one static columns on orders detail. TC: SALEOR_2136",
+    { tags: ["@orders", "@allEnv", "@stable"] },
+    () => {
+      let order;
+      createReadyToFulfillOrder({
+        customerId: customer.id,
+        channelId: defaultChannel.id,
+        shippingMethod,
+        variantsList,
+        address,
+      }).then(({ order: orderResp }) => {
+        order = orderResp;
+        cy.visit(urlList.orders + `${order.id}`);
+        cy.openColumnPicker();
+        cy.get(SHARED_ELEMENTS.staticColumnContainer)
+          .should("contain.text", "Product")
+          .should("contain.text", "SKU")
+          .should("contain.text", "Variant")
+          .should("contain.text", "Quantity")
+          .should("contain.text", "Price")
+          .should("contain.text", "Total");
+        // switching off all but one static columns
+        cy.get(SHARED_ELEMENTS.gridStaticSkuButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticVariantNameButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticQuantityButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticPriceButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticTotalButton).click();
+        cy.get(SHARED_ELEMENTS.gridStaticProductButton).should(
+          "have.attr",
+          "data-state",
+          "on",
+        );
+        cy.get(SHARED_ELEMENTS.dataGridTable)
+          .find("th")
+          .should("have.length", 1)
+          .should("have.text", "Product");
+        //next line hides picker
+        cy.get(SHARED_ELEMENTS.pageHeader).click({ force: true });
+        cy.get(SHARED_ELEMENTS.dynamicColumnContainer).should("not.exist");
+      });
+    },
+  );
 });

--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -575,7 +575,7 @@ describe("Orders", () => {
     },
   );
   it(
-    "should be able to turn of all but one static columns on orders detail. TC: SALEOR_2136",
+    "should be able to turn off all but one static columns on orders detail. TC: SALEOR_2136",
     { tags: ["@orders", "@allEnv", "@stable"] },
     () => {
       let order;

--- a/cypress/elements/shared/sharedElements.js
+++ b/cypress/elements/shared/sharedElements.js
@@ -15,11 +15,18 @@ export const SHARED_ELEMENTS = {
   activeStaticColumnOnGridButton: '[data-state="on"]',
   dynamicColumnSelector: '[data-test-id="dynamic-column"]',
   dynamicColumnNameSelector: '[data-test-id^="dynamic-column-name"]',
+  gridStaticSkuButton: '[data-test-id="stat-col-sku"]',
+  gridStaticVariantNameButton: '[data-test-id="stat-col-variantName"]',
+  gridStaticQuantityButton: '[data-test-id="stat-col-quantity"]',
+  gridStaticPriceButton: '[data-test-id="stat-col-price"]',
+  gridStaticTotalButton: '[data-test-id="stat-col-total"]',
+  gridStaticProductButton: '[data-test-id="stat-col-product"]',
   dynamicColumnSearchInput: '[data-test-id="search-columns"]',
   selectedDynamicColumnNameSelector: '[data-test-id^="column-name-"]',
   removeSelectedDynamicColumnButton:
     '[data-test-id^="remove-dynamic-col-button"]',
   dynamicColumnContainer: '[data-test-id="dynamic-col-container"]',
+  staticColumnContainer: '[data-test-id="static-col-container"]',
   paginationForwardOnColumnPicker: '[data-test-id="pagination-forward"]',
   paginationBackOnColumnPicker: '[data-test-id="pagination-back"]',
   notificationSuccess:

--- a/cypress/support/customCommands/sharedElementsOperations/selects.js
+++ b/cypress/support/customCommands/sharedElementsOperations/selects.js
@@ -23,6 +23,9 @@ Cypress.Commands.add("clickSubmitButton", () =>
 Cypress.Commands.add("clickConfirmButton", () =>
   cy.get(BUTTON_SELECTORS.confirm).click(),
 );
+Cypress.Commands.add("openColumnPicker", () =>
+  cy.get(SHARED_ELEMENTS.openColumnPickerButton).click(),
+);
 
 Cypress.Commands.add("createNewOption", (selectSelector, newOption) => {
   cy.get(selectSelector).type(newOption);


### PR DESCRIPTION
A new column picker was added to orders and draft orders. Added tests cover switching columns off and removing them from the grid table.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [x] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=3
