### PR TITLE
test - user should be able to delete saved preset

### DIFF
--- a/cypress/e2e/products/productsList/productPresets.js
+++ b/cypress/e2e/products/productsList/productPresets.js
@@ -7,11 +7,13 @@ import { LOCAL_STORAGE_KEYS, urlList } from "../../../fixtures/";
 import { ensureCanvasStatic } from "../../../support/customCommands/sharedElementsOperations/canvas";
 import {
   addPresetWithName,
+  clickDeletePresetButton,
   clickSavedPresetContain,
   clickShowSavedPresetsButton,
   clickUpdatePresetButton,
   confirmActivePresetName,
   confirmGridRowsContainsText,
+  hoverSavedPresetContain,
   searchItems,
 } from "../../../support/pages/catalog/presetsAndSearch";
 
@@ -61,6 +63,34 @@ describe("As a user I should be able to save selected filters with search querie
         expect(
           localStorage.getItem(LOCAL_STORAGE_KEYS.keys.productPresets),
         ).to.contains(`query=${searchQuery}%20${updatedSearchQuery.trim()}`);
+      });
+    },
+  );
+  it(
+    "should be able to delete preset. TC: SALEOR_2714",
+    { tags: ["@productsList", "@allEnv", "@stable"] },
+    () => {
+      const firstPreset = "bean";
+      const secondPreset = "hoodie";
+      window.localStorage.setItem(
+        LOCAL_STORAGE_KEYS.keys.productPresets,
+        `[{"data":"query=${firstPreset}","name":"${firstPreset}"},{"data":"query=${secondPreset}","name":"${secondPreset}"}]`,
+      );
+      cy.visit(urlList.products);
+      ensureCanvasStatic(PRODUCTS_LIST.dataGridTable);
+      clickShowSavedPresetsButton();
+      hoverSavedPresetContain(secondPreset);
+      clickDeletePresetButton();
+      cy.clickSubmitButton();
+      ensureCanvasStatic(PRODUCTS_LIST.dataGridTable).then(() => {
+        expect(
+          localStorage.getItem(LOCAL_STORAGE_KEYS.keys.productPresets),
+        ).to.contains(`query=${firstPreset}`);
+        expect(
+          localStorage.getItem(LOCAL_STORAGE_KEYS.keys.productPresets),
+        ).to.not.contains(`query=${secondPreset}`);
+        clickShowSavedPresetsButton();
+        cy.contains(firstPreset).should("be.visible");
       });
     },
   );

--- a/cypress/elements/shared/presetsAndSearch.js
+++ b/cypress/elements/shared/presetsAndSearch.js
@@ -3,6 +3,7 @@ export const PRESETS = {
   presetNameTextField: '[data-test-id="preset-name-text-field"]',
   savePresetNameButton: '[data-test-id="save-preset-button"]',
   activePresetName: '[data-test-id="show-saved-filters-button"]',
+  presetDeleteButton: '[data-test-id="preset-delete-button"]',
   savedPreset: '[data-test-id="preset"]',
   updatePresetButton: '[data-test-id="update-preset-button"]',
 };

--- a/cypress/support/pages/catalog/presetsAndSearch.js
+++ b/cypress/support/pages/catalog/presetsAndSearch.js
@@ -28,11 +28,17 @@ export function confirmGridRowsContainsText(name) {
 export function confirmActivePresetName(name) {
   return cy.get(PRESETS.activePresetName).should("contain.text", name);
 }
+export function clickDeletePresetButton() {
+  return cy.get(PRESETS.presetDeleteButton).click();
+}
 export function clickShowSavedPresetsButton() {
   cy.get(PRESETS.activePresetName).click();
 }
 export function clickSavedPresetContain(presetName) {
   cy.get(PRESETS.savedPreset).contains(presetName).click();
+}
+export function hoverSavedPresetContain(presetName) {
+  cy.get(PRESETS.savedPreset).contains(presetName).trigger("mouseover");
 }
 export function clickUpdatePresetButton() {
   cy.get(PRESETS.updatePresetButton).click();

--- a/src/components/FilterPresetsSelect/FilterPresetItem.tsx
+++ b/src/components/FilterPresetsSelect/FilterPresetItem.tsx
@@ -49,6 +49,7 @@ export const FilterPresetItem = ({
             alignItems="center"
           >
             <RemoveIcon
+              data-test-id="preset-delete-button"
               color={{
                 default: "iconNeutralSubdued",
                 hover: "iconNeutralPlain",


### PR DESCRIPTION
New test checking is it possible to delete saved preset on products list view
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [x] stable
2. [x] app
3. [x] attribute
4. [x] category
5. [x] collection
6. [x] customer
7. [x] giftCard
8. [x] homePage
9. [x] login
10. [x] menuNavigation
11. [x] navigation
12. [x] orders
13. [x] pages
14. [x] payments
15. [x] permissions
16. [x] plugins
17. [x] productType
18. [x] products
19. [x] sales
20. [x] shipping
21. [x] translations
22. [x] variants
23. [x] vouchers

CONTAINERS=8
