### PR TITLE
testmo checks fails on community pull requests

### DIFF
--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -211,7 +211,7 @@ jobs:
 
   cypress-run-selected:
     runs-on: ubuntu-22.04
-    needs: [prepare-tests, deploy, testmo-report-preparation]
+    needs: [prepare-tests, deploy]
     container: cypress/browsers:node18.12.0-chrome106-ff106
     strategy:
       fail-fast: false

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -171,8 +171,10 @@ jobs:
           echo ${{steps.get_tags.outputs.result}}
 
   testmo-report-preparation:
+    env:
+      TESTMO_URL: ${{ secrets.TESTMO_URL }}
     needs: prepare-tests
-    if: ${{ secrets.TESTMO_URL }}
+    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -201,6 +203,8 @@ jobs:
 
   cypress-run-selected:
     runs-on: ubuntu-22.04
+    env:
+      TESTMO_URL: ${{ secrets.TESTMO_URL }}
     needs:
       [
         prepare-tests,
@@ -270,7 +274,7 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
-        if: ${{ secrets.TESTMO_URL }}
+        if: ${{ env.TESTMO_URL }}
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \
@@ -282,8 +286,10 @@ jobs:
           TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
+    env:
+      TESTMO_URL: ${{ secrets.TESTMO_URL }}
     needs: [testmo-report-preparation, cypress-run-selected]
-    if: ${{ secrets.TESTMO_URL }}
+    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           TESTMO_URL: ${{ secrets.TESTMO_URL }}
         if: "${{ env.TESTMO_URL != '' }}"
-        run: echo "::set-output name=defined::true"
+        run: echo "::set-output name=defined::false"
   deploy:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -171,7 +171,10 @@ jobs:
           echo ${{steps.get_tags.outputs.result}}
 
   testmo-report-preparation:
+    env:
+      TESTMO_URL: ${{ secrets.TESTMO_URL }}
     needs: prepare-tests
+    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -275,9 +275,7 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected, deploy]
-    if: |
-      needs.testmo-report-preparation.result == 'success' || 
-           needs.testmo-report-preparation.result == 'failed'
+    if: ${{ success() && failure() }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           TESTMO_URL: ${{ secrets.TESTMO_URL }}
         if: "${{ env.TESTMO_URL != '' }}"
-        run: echo "::set-output name=defined::false"
+        run: echo "::set-output name=defined::true"
   deploy:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -172,7 +172,7 @@ jobs:
 
   testmo-report-preparation:
     needs: prepare-tests
-    if: ${{ env.TESTMO_URL }}
+    if: ${{ secrets.TESTMO_URL }}
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -270,7 +270,7 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
-        if: ${{ env.TESTMO_URL }}
+        if: ${{ secrets.TESTMO_URL }}
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \
@@ -283,7 +283,7 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected]
-    if: ${{ env.TESTMO_URL }}
+    if: ${{ secrets.TESTMO_URL }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -172,6 +172,7 @@ jobs:
 
   testmo-report-preparation:
     needs: prepare-tests
+    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -269,6 +270,7 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
+        if: ${{ env.TESTMO_URL }}
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \
@@ -281,7 +283,7 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected]
-    if: always()
+    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -3,6 +3,16 @@ name: TEST-ENV-DEPLOYMENT
 
 on: [pull_request]
 jobs:
+  check-secret:
+    runs-on: ubuntu-22.04
+    outputs:
+      testmo-url: ${{ steps.testmo-url.outputs.defined }}
+    steps:
+      - id: testmo-url
+        env:
+          TESTMO_URL: ${{ secrets.TESTMO_URL }}
+        if: "${{ env.TESTMO_URL != '' }}"
+        run: echo "::set-output name=defined::true"
   deploy:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'
     runs-on: ubuntu-22.04
@@ -171,10 +181,8 @@ jobs:
           echo ${{steps.get_tags.outputs.result}}
 
   testmo-report-preparation:
-    env:
-      TESTMO_URL: ${{ secrets.TESTMO_URL }}
-    needs: prepare-tests
-    if: ${{ env.TESTMO_URL }}
+    needs: [check-secret, prepare-tests]
+    if: needs.check-secret.outputs.testmo-url == 'true'
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -277,9 +285,9 @@ jobs:
           TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
-    needs: [testmo-report-preparation, cypress-run-selected]
+    needs: [testmo-report-preparation, cypress-run-selected, check-secret]
     if: |
-      always() && !contains(needs.*.result, 'skipped')
+      always() && !contains(needs.*.result, 'skipped') && needs.check-secret.outputs.testmo-url == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -201,7 +201,7 @@ jobs:
 
   cypress-run-selected:
     runs-on: ubuntu-22.04
-    needs: [prepare-tests, deploy]
+    needs: [prepare-tests, deploy, testmo-report-preparation]
     container: cypress/browsers:node18.12.0-chrome106-ff106
     strategy:
       fail-fast: false

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -275,7 +275,8 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected, deploy]
-    if: ${{ success() && failure() }}
+    if: |
+      needs.cypress-run-selected.result == 'success' || needs.cypress-run-selected.result == 'failure'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -276,7 +276,7 @@ jobs:
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected, deploy]
     if: |
-      needs.cypress-run-selected.result == 'success' || needs.cypress-run-selected.result == 'failure'
+      (needs.cypress-run-selected.result == 'success' || needs.cypress-run-selected.result == 'failure')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -274,6 +274,7 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
+        if: needs.check-secret.outputs.testmo-url == 'true'
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -171,10 +171,7 @@ jobs:
           echo ${{steps.get_tags.outputs.result}}
 
   testmo-report-preparation:
-    env:
-      TESTMO_URL: ${{ secrets.TESTMO_URL }}
     needs: prepare-tests
-    if: ${{ env.TESTMO_URL }}
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -203,15 +200,7 @@ jobs:
 
   cypress-run-selected:
     runs-on: ubuntu-22.04
-    env:
-      TESTMO_URL: ${{ secrets.TESTMO_URL }}
-    needs:
-      [
-        prepare-tests,
-        deploy,
-        testmo-report-preparation,
-        testmo-report-preparation,
-      ]
+    needs: [prepare-tests, deploy, testmo-report-preparation]
     container: cypress/browsers:node18.12.0-chrome106-ff106
     strategy:
       fail-fast: false
@@ -274,7 +263,6 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
-        if: ${{ env.TESTMO_URL }}
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \
@@ -286,10 +274,10 @@ jobs:
           TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
-    env:
-      TESTMO_URL: ${{ secrets.TESTMO_URL }}
-    needs: [testmo-report-preparation, cypress-run-selected]
-    if: ${{ env.TESTMO_URL }}
+    needs: [testmo-report-preparation, cypress-run-selected, deploy]
+    if: |
+      needs.testmo-report-preparation.result == 'success' || 
+           needs.testmo-report-preparation.result == 'failed'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -274,7 +274,7 @@ jobs:
           TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
-    needs: [testmo-report-preparation, cypress-run-selected, deploy]
+    needs: [testmo-report-preparation, cypress-run-selected]
     if: needs.cypress-run-selected.result != 'skipped'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -275,8 +275,7 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected, deploy]
-    if: |
-      (needs.cypress-run-selected.result == 'success' || needs.cypress-run-selected.result == 'failure')
+    if: needs.cypress-run-selected.result != 'skipped'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -3,16 +3,6 @@ name: TEST-ENV-DEPLOYMENT
 
 on: [pull_request]
 jobs:
-  check-secret:
-    runs-on: ubuntu-22.04
-    outputs:
-      testmo-url: ${{ steps.testmo-url.outputs.defined }}
-    steps:
-      - id: testmo-url
-        env:
-          TESTMO_URL: ${{ secrets.TESTMO_URL }}
-        if: "${{ env.TESTMO_URL != '' }}"
-        run: echo "::set-output name=defined::true"
   deploy:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'
     runs-on: ubuntu-22.04
@@ -181,8 +171,8 @@ jobs:
           echo ${{steps.get_tags.outputs.result}}
 
   testmo-report-preparation:
-    needs: [check-secret, prepare-tests]
-    if: needs.check-secret.outputs.testmo-url == 'true'
+    needs: prepare-tests
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-22.04
     outputs:
       testmo-run-id: ${{ steps.run-tests.outputs.TESTMO_RUN_ID }}
@@ -274,7 +264,7 @@ jobs:
         working-directory: .github/workflows
         run: npm ci
       - name: Testmo threads submit
-        if: needs.check-secret.outputs.testmo-url == 'true'
+        if: github.event.pull_request.head.repo.fork == false
         working-directory: .github/workflows
         run: |
           npx testmo automation:run:submit-thread \
@@ -286,9 +276,9 @@ jobs:
           TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
-    needs: [testmo-report-preparation, cypress-run-selected, check-secret]
+    needs: [testmo-report-preparation, cypress-run-selected]
     if: |
-      always() && !contains(needs.*.result, 'skipped') && needs.check-secret.outputs.testmo-url == 'true'
+      always() && !contains(needs.*.result, 'skipped') && !contains(needs.*.result, 'cancelled') && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -275,7 +275,8 @@ jobs:
           TESTMO_RUN_ID: ${{ needs.testmo-report-preparation.outputs.testmo-run-id }}
   test-complete:
     needs: [testmo-report-preparation, cypress-run-selected]
-    if: needs.cypress-run-selected.result != 'skipped'
+    if: |
+      always() && !contains(needs.*.result, 'skipped')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
PR from the community has no access to secrets, making testmo steps fail. I added the condition to trigger testmo only if the secret is available.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
