### PR TITLE
fixed products presest and draft orders

### DIFF
--- a/cypress/e2e/orders/orders.js
+++ b/cypress/e2e/orders/orders.js
@@ -9,7 +9,11 @@ import {
   ORDERS_SELECTORS,
   SHARED_ELEMENTS,
 } from "../../elements/";
-import { MESSAGES, ONE_PERMISSION_USERS, urlList } from "../../fixtures";
+import {
+  MESSAGES,
+  ONE_PERMISSION_USERS,
+  urlList,
+} from "../../fixtures";
 import {
   createCustomer,
   getOrder,
@@ -28,6 +32,9 @@ import {
   productsUtils,
   updateTaxConfigurationForChannel,
 } from "../../support/api/utils/";
+import {
+  ensureCanvasStatic,
+} from "../../support/customCommands/sharedElementsOperations/canvas";
 import {
   addNewProductToOrder,
   addPrivateMetadataFieldFulfillmentOrder,
@@ -308,7 +315,7 @@ describe("Orders", () => {
         address,
       }).then(unconfirmedOrderResponse => {
         cy.visit(urlList.orders + `${unconfirmedOrderResponse.order.id}`);
-
+        ensureCanvasStatic(SHARED_ELEMENTS.dataGridTable);
         changeQuantityOfProducts();
 
         cy.get(ORDERS_SELECTORS.orderSummarySubtotalPriceRow).should(

--- a/cypress/e2e/products/productsList/productPresets.js
+++ b/cypress/e2e/products/productsList/productPresets.js
@@ -1,10 +1,20 @@
 /// <reference types="cypress"/>
 /// <reference types="../../../support"/>
 
-import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
-import { SEARCH } from "../../../elements/shared";
-import { LOCAL_STORAGE_KEYS, urlList } from "../../../fixtures/";
-import { ensureCanvasStatic } from "../../../support/customCommands/sharedElementsOperations/canvas";
+import {
+  PRODUCTS_LIST,
+} from "../../../elements/catalog/products/products-list";
+import {
+  PRESETS,
+  SEARCH,
+} from "../../../elements/shared";
+import {
+  LOCAL_STORAGE_KEYS,
+  urlList,
+} from "../../../fixtures/";
+import {
+  ensureCanvasStatic,
+} from "../../../support/customCommands/sharedElementsOperations/canvas";
 import {
   addPresetWithName,
   clickDeletePresetButton,
@@ -90,7 +100,7 @@ describe("As a user I should be able to save selected filters with search querie
           localStorage.getItem(LOCAL_STORAGE_KEYS.keys.productPresets),
         ).to.not.contains(`query=${secondPreset}`);
         clickShowSavedPresetsButton();
-        cy.contains(firstPreset).should("be.visible");
+        cy.get(PRESETS.savedPreset).contains(firstPreset).should("be.visible");
       });
     },
   );

--- a/cypress/support/pages/ordersOperations.js
+++ b/cypress/support/pages/ordersOperations.js
@@ -37,7 +37,7 @@ export function changeQuantityOfProducts() {
   cy.get(ORDERS_SELECTORS.dataGridTable).should("be.visible");
   cy.get(ORDERS_SELECTORS.quantityCellFirstRowOrderDetails)
     .click({ force: true })
-    .wait(200)
+    .should("have.attr", "aria-selected", "true")
     .click({ force: true })
     .wait(1000);
   cy.get(ORDERS_SELECTORS.gridClip)


### PR DESCRIPTION
fixed products preset last assertion(could not found element) and changing the quantity of product on draft orders (the clip was not interactive fast enough)

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [x] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
