### PR TITLE
Experimental filters: additional empty values & full support for ranges

### DIFF
--- a/.changeset/tricky-olives-jog.md
+++ b/.changeset/tricky-olives-jog.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Experimental filters: additional empty values & full support for ranges

--- a/src/components/ConditionalFilter/FilterElement/ConditionSelected.ts
+++ b/src/components/ConditionalFilter/FilterElement/ConditionSelected.ts
@@ -1,6 +1,6 @@
 import { getDefaultByControlName } from "../controlsType";
 import { ConditionItem } from "./ConditionOptions";
-import { ConditionValue } from "./ConditionValue";
+import { ConditionValue, isItemOptionArray, isTuple } from "./ConditionValue";
 
 export class ConditionSelected {
   private constructor(
@@ -11,7 +11,11 @@ export class ConditionSelected {
   ) {}
 
   public isEmpty() {
-    return this.value === ""
+    return (
+      this.value === "" ||
+      (isItemOptionArray(this.value) && this.value.length === 0) ||
+      (isTuple(this.value) && this.value.includes(""))
+    );
   }
 
   public static empty() {

--- a/src/components/ConditionalFilter/constants.ts
+++ b/src/components/ConditionalFilter/constants.ts
@@ -92,8 +92,14 @@ export const ATTRIBUTE_INPUT_TYPE_CONDITIONS = {
     { type: "number", label: "greater", value: "input-3" },
     { type: "number.range", label: "between", value: "input-4" },
   ],
-  DATE_TIME: [{ type: "date", label: "is", value: "input-1" }],
-  DATE: [{ type: "date", label: "is", value: "input-1" }],
+  DATE_TIME: [
+    { type: "datetime", label: "is", value: "input-1" },
+    { type: "datetime.range", label: "between", value: "input-4" },
+  ],
+  DATE: [
+    { type: "date", label: "is", value: "input-1" },
+    { type: "date.range", label: "between", value: "input-4" },
+  ],
   SWATCH: [{ type: "multiselect", label: "in", value: "input-2" }],
 };
 

--- a/src/components/ConditionalFilter/controlsType.ts
+++ b/src/components/ConditionalFilter/controlsType.ts
@@ -7,6 +7,10 @@ export const CONTROL_DEFAULTS = {
   multiselect: [] as ConditionValue,
   select: "",
   combobox: "",
+  date: "",
+  datetime: "",
+  "date.range": ["", ""] as [string, string],
+  "datetime.range": ["", ""] as [string, string],
 };
 
 export const getDefaultByControlName = (name: string): ConditionValue =>

--- a/src/components/ConditionalFilter/queryVariables.ts
+++ b/src/components/ConditionalFilter/queryVariables.ts
@@ -8,6 +8,7 @@ import {
 import { FilterContainer } from "./FilterElement";
 import { ConditionSelected } from "./FilterElement/ConditionSelected";
 import {
+  ConditionValue,
   isItemOption,
   isItemOptionArray,
   isTuple,
@@ -58,13 +59,27 @@ const createStaticQueryPart = (
   return value;
 };
 
+const getRangeQueryPartByType = (value: [string, string], type: string) => {
+  const [lte, gte] = value;
+
+  switch (type) {
+    case "datetime.range":
+      return { dateTime: { lte, gte } };
+    case "date.range":
+      return { date: { lte, gte } };
+    case "number.range":
+    default:
+      return { valuesRange: { lte: parseFloat(lte), gte: parseFloat(gte) } };
+  }
+};
+
 const createAttributeQueryPart = (
   attributeSlug: string,
   selected: ConditionSelected,
 ): AttributeInput => {
   if (!selected.conditionValue) return { slug: attributeSlug };
 
-  const { label } = selected.conditionValue;
+  const { label, type } = selected.conditionValue;
   const { value } = selected;
 
   if (label === "lower" && typeof value === "string") {
@@ -76,10 +91,9 @@ const createAttributeQueryPart = (
   }
 
   if (isTuple(value) && label === "between") {
-    const [lte, gte] = value;
     return {
       slug: attributeSlug,
-      valuesRange: { lte: parseFloat(lte), gte: parseFloat(gte) },
+      ...getRangeQueryPartByType(value, type),
     };
   }
 

--- a/src/components/ConditionalFilter/queryVariables.ts
+++ b/src/components/ConditionalFilter/queryVariables.ts
@@ -8,7 +8,6 @@ import {
 import { FilterContainer } from "./FilterElement";
 import { ConditionSelected } from "./FilterElement/ConditionSelected";
 import {
-  ConditionValue,
   isItemOption,
   isItemOptionArray,
   isTuple,


### PR DESCRIPTION
This PR fixes:
* add additional empty values for `datetime` & `date`
* additional `isEmpty` conditions for ranges and arrays
* sending proper values as ranges - API requires different values for numeric/date/datetime

ref: #3272 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](/.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
