### PR TITLE
Experimental filters: warning banner for legacy filter presets

### DIFF
--- a/.changeset/cuddly-glasses-move.md
+++ b/.changeset/cuddly-glasses-move.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Experimental filters: warning banner for legacy filter presets

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -8186,6 +8186,10 @@
     "context": "button",
     "string": "CANCEL END DATE"
   },
+  "vBykp8": {
+    "context": "Alert text",
+    "string": "You are using an old version of the filter presets. Update your presets to continue using filters."
+  },
   "vC8vyb": {
     "context": "enabled status option label",
     "string": "Enabled"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5949,6 +5949,10 @@
     "context": "product inventory, checkbox",
     "string": "Variant currently in preorder"
   },
+  "eIGXwJ": {
+    "context": "Alert text",
+    "string": "You are using an old version of filter presets. The following presets: {presetNames} must be updated to continue using filters"
+  },
   "eLJQSh": {
     "context": "column title gift card",
     "string": "Gift Card"
@@ -8185,10 +8189,6 @@
   "v9ILn/": {
     "context": "button",
     "string": "CANCEL END DATE"
-  },
-  "vBykp8": {
-    "context": "Alert text",
-    "string": "You are using an old version of the filter presets. Update your presets to continue using filters."
   },
   "vC8vyb": {
     "context": "enabled status option label",

--- a/src/components/AppLayout/ListFilters/ListFilters.tsx
+++ b/src/components/AppLayout/ListFilters/ListFilters.tsx
@@ -6,6 +6,7 @@ import React, { ReactNode } from "react";
 
 import { ExpressionFilters } from "./components/ExpressionFilters";
 import { FiltersSelect } from "./components/FiltersSelect";
+import { LegacyFiltersPresetsAlert } from "./components/LegacyFiltersPresetsAlert";
 import SearchInput from "./components/SearchInput";
 
 export interface ListFiltersProps<TKeys extends string = string>
@@ -34,6 +35,7 @@ export const ListFilters = <TFilterKeys extends string = string>({
 
   return (
     <>
+      {filtersEnabled && <LegacyFiltersPresetsAlert />}
       <Box
         display="grid"
         __gridTemplateColumns="auto 1fr"

--- a/src/components/AppLayout/ListFilters/components/LegacyFiltersPresetsAlert.tsx
+++ b/src/components/AppLayout/ListFilters/components/LegacyFiltersPresetsAlert.tsx
@@ -1,0 +1,38 @@
+import { TokenType } from "@dashboard/components/ConditionalFilter/ValueProvider/UrlToken";
+import { getStatusColor } from "@dashboard/misc";
+import { storageUtils } from "@dashboard/products/views/ProductList/filters";
+import { Box, Text } from "@saleor/macaw-ui/next";
+import React from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+export const LegacyFiltersPresetsAlert = () => {
+  const presets = storageUtils.getFilterTabs();
+  const { formatMessage } = useIntl();
+
+  const hasLegacyPresets = !presets.every(preset =>
+    preset.data.match(`[${Object.values(TokenType)}][0-9].`),
+  );
+
+  if (hasLegacyPresets) {
+    return (
+      <Box
+        __backgroundColor={getStatusColor("warning")}
+        paddingX={7}
+        paddingY={5}
+        marginBottom={5}
+      >
+        <Text>{formatMessage(messages.alertText)}</Text>
+      </Box>
+    );
+  }
+  return null;
+};
+
+const messages = defineMessages({
+  alertText: {
+    defaultMessage:
+      "You are using an old version of the filter presets. Update your presets to continue using filters.",
+    description: "Alert text",
+    id: "vBykp8",
+  },
+});

--- a/src/components/AppLayout/ListFilters/components/LegacyFiltersPresetsAlert.tsx
+++ b/src/components/AppLayout/ListFilters/components/LegacyFiltersPresetsAlert.tsx
@@ -9,11 +9,11 @@ export const LegacyFiltersPresetsAlert = () => {
   const presets = storageUtils.getFilterTabs();
   const { formatMessage } = useIntl();
 
-  const hasLegacyPresets = !presets.every(preset =>
-    preset.data.match(`[${Object.values(TokenType)}][0-9].`),
+  const legacyPresets = presets.filter(
+    preset => !preset.data.match(`[${Object.values(TokenType)}][0-9].`),
   );
 
-  if (hasLegacyPresets) {
+  if (legacyPresets.length > 0) {
     return (
       <Box
         __backgroundColor={getStatusColor("warning")}
@@ -21,7 +21,15 @@ export const LegacyFiltersPresetsAlert = () => {
         paddingY={5}
         marginBottom={5}
       >
-        <Text>{formatMessage(messages.alertText)}</Text>
+        <Text>
+          {formatMessage(messages.alertText, {
+            presetNames: (
+              <Text variant="bodyStrong">
+                {legacyPresets.map(p => p.name).join(", ")}
+              </Text>
+            ),
+          })}
+        </Text>
       </Box>
     );
   }
@@ -31,8 +39,8 @@ export const LegacyFiltersPresetsAlert = () => {
 const messages = defineMessages({
   alertText: {
     defaultMessage:
-      "You are using an old version of the filter presets. Update your presets to continue using filters.",
+      "You are using an old version of filter presets. The following presets: {presetNames} must be updated to continue using filters",
     description: "Alert text",
-    id: "vBykp8",
+    id: "eIGXwJ",
   },
 });

--- a/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
+++ b/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
@@ -32,6 +32,7 @@ export const useUrlValueProvider = (
   const { data, loading, fetchQueries } = initialState;
   const [value, setValue] = useState<FilterContainer>([]);
 
+  const activeTab = params.get("activeTab");
   params.delete("asc");
   params.delete("sort");
   params.delete("activeTab");
@@ -52,7 +53,10 @@ export const useUrlValueProvider = (
   const persist = (filterValue: FilterContainer) => {
     router.history.replace({
       pathname: router.location.pathname,
-      search: stringify(prepareStructure(filterValue)),
+      search: stringify({
+        ...prepareStructure(filterValue),
+        ...{ activeTab: activeTab || undefined },
+      }),
     });
     setValue(filterValue);
   };

--- a/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
+++ b/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
@@ -34,6 +34,7 @@ export const useUrlValueProvider = (
 
   params.delete("asc");
   params.delete("sort");
+  params.delete("activeTab");
 
   const tokenizedUrl = new TokenArray(params.toString());
   const fetchingParams = tokenizedUrl.getFetchingParams();
@@ -64,8 +65,8 @@ export const useUrlValueProvider = (
   };
 
   const isPersisted = (element: FilterElement) => {
-    return value.some(p => FilterElement.isCompatible(p) && p.equals(element))
-  }
+    return value.some(p => FilterElement.isCompatible(p) && p.equals(element));
+  };
 
   const count = value.filter(v => typeof v !== "string").length;
 

--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -191,6 +191,7 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
                 )}
               </Text>
             )}
+
             <TopNav.Menu
               dataTestId="menu"
               items={[

--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -191,7 +191,6 @@ export const ProductListPage: React.FC<ProductListPageProps> = props => {
                 )}
               </Text>
             )}
-
             <TopNav.Menu
               dataTestId="menu"
               items={[

--- a/src/products/index.tsx
+++ b/src/products/index.tsx
@@ -1,4 +1,5 @@
 import { ConditionalProductFilterProvider } from "@dashboard/components/ConditionalFilter/context";
+import { useFlag } from "@dashboard/featureFlags";
 import { sectionNames } from "@dashboard/intl";
 import { asSortParams } from "@dashboard/utils/sort";
 import { getArrayQueryParam } from "@dashboard/utils/urls";
@@ -6,7 +7,6 @@ import { parse as parseQs } from "qs";
 import React from "react";
 import { useIntl } from "react-intl";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
-import { useFlag } from "@dashboard/featureFlags";
 
 import { WindowTitle } from "../components/WindowTitle";
 import {

--- a/src/products/index.tsx
+++ b/src/products/index.tsx
@@ -6,6 +6,7 @@ import { parse as parseQs } from "qs";
 import React from "react";
 import { useIntl } from "react-intl";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
+import { useFlag } from "@dashboard/featureFlags";
 
 import { WindowTitle } from "../components/WindowTitle";
 import {
@@ -32,6 +33,8 @@ import ProductVariantCreateComponent from "./views/ProductVariantCreate";
 
 const ProductList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1)) as any;
+  const productListingPageFiltersFlag = useFlag("product_filters");
+
   const params: ProductListUrlQueryParams = asSortParams(
     {
       ...qs,
@@ -45,7 +48,11 @@ const ProductList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   );
 
   return (
-    <ConditionalProductFilterProvider locationSearch={location.search}>
+    <ConditionalProductFilterProvider
+      locationSearch={
+        productListingPageFiltersFlag.enabled ? location.search : ""
+      }
+    >
       <ProductListComponent params={params} />
     </ConditionalProductFilterProvider>
   );


### PR DESCRIPTION
This PR adds a warning banner when there are legacy filter presets and fixes small issues when there is an `activeTab` set in query params.

Ref: #3272 


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="1237" alt="image" src="https://github.com/saleor/saleor-dashboard/assets/9116238/a3d6b8a6-b4a9-48fb-84bc-e3be3e42ca61">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
