### PR TITLE
Test maintenance - draft orders, pagination, create page 

### DIFF
--- a/cypress/e2e/pages/pages.js
+++ b/cypress/e2e/pages/pages.js
@@ -3,23 +3,14 @@
 
 import faker from "faker";
 
-import {
-  BUTTON_SELECTORS,
-  PAGE_DETAILS_SELECTORS,
-} from "../../elements";
-import {
-  pageDetailsUrl,
-  urlList,
-} from "../../fixtures/urlList";
+import { BUTTON_SELECTORS, PAGE_DETAILS_SELECTORS } from "../../elements";
+import { pageDetailsUrl, urlList } from "../../fixtures/urlList";
 import {
   attributeRequests,
   pageRequests,
   pageTypeRequests,
 } from "../../support/api/requests";
-import {
-  pageDetailsPage,
-  pagesPage,
-} from "../../support/pages";
+import { pageDetailsPage, pagesPage } from "../../support/pages";
 
 describe("Tests for pages", () => {
   const startsWith = `Pages`;
@@ -65,7 +56,7 @@ describe("Tests for pages", () => {
       pagesPage.selectPageTypeOnIndex(0);
       cy.clickSubmitButton();
       cy.waitForRequestAndCheckIfNoErrors("@PageType");
-      pageDetailsPage.typePageName(pageName);
+      pageDetailsPage.typePageName(pageName).should("have.value", pageName);
       cy.get(PAGE_DETAILS_SELECTORS.isNotPublishedCheckbox).click();
       pagesPage.savePage().then(page => {
         pageRequests.getPage(page.id).then(page => {

--- a/cypress/e2e/products/productsList/pagination.js
+++ b/cypress/e2e/products/productsList/pagination.js
@@ -2,13 +2,9 @@
 /// <reference types="../../../support"/>
 
 import { PAGINATION } from "../../../elements";
-import {
-  PRODUCTS_LIST,
-} from "../../../elements/catalog/products/products-list";
+import { PRODUCTS_LIST } from "../../../elements/catalog/products/products-list";
 import { urlList } from "../../../fixtures/urlList";
-import {
-  ensureCanvasStatic,
-} from "../../../support/customCommands/sharedElementsOperations/canvas";
+import { ensureCanvasStatic } from "../../../support/customCommands/sharedElementsOperations/canvas";
 
 describe("As an admin I should be able to manage products table", () => {
   beforeEach(() => {
@@ -43,7 +39,9 @@ describe("As an admin I should be able to manage products table", () => {
         .get(PAGINATION.nextPagePaginationButton)
         .should("not.be.disabled");
       ensureCanvasStatic(PRODUCTS_LIST.dataGridTable).then(() => {
-        cy.assertCanvasRowsNumber(PRODUCTS_LIST.dataGridTable, 21);
+        cy.get(PRODUCTS_LIST.dataGridTable)
+          .find("tr")
+          .should("have.length.above", 10);
       });
     },
   );

--- a/cypress/support/api/requests/Order.js
+++ b/cypress/support/api/requests/Order.js
@@ -170,6 +170,38 @@ export function getOrder(orderId) {
   }`;
   return cy.sendRequestWithQuery(query).its("body.data.order");
 }
+export function getDraftOrdersList() {
+  const query = `query OrderDraftList{
+    draftOrders(first:100){
+      edges{
+        node{
+          id
+          number
+          errors{
+            message
+          }
+        }
+      }
+    }
+  }`;
+  return cy.sendRequestWithQuery(query).its("body.data.draftOrders");
+}
+export function getOrdersList() {
+  const query = `query OrderList{
+    orders(first:100){
+      edges{
+        node{
+          id
+          number
+          errors{
+            message
+          }
+        }
+      }
+    }
+  }`;
+  return cy.sendRequestWithQuery(query).its("body.data.orders");
+}
 
 export function fulfillOrder({ orderId, warehouse, quantity, linesId }) {
   const lines = linesId.reduce((lines, lineId) => {

--- a/cypress/support/api/requests/index.js
+++ b/cypress/support/api/requests/index.js
@@ -1,6 +1,12 @@
 export { createChannel, updateChannelOrderSettings } from "./Channels";
 export { createCustomer, deleteCustomersStartsWith } from "./Customer";
-export { createDraftOrder, getOrder, updateOrdersSettings } from "./Order";
+export {
+  createDraftOrder,
+  getDraftOrdersList,
+  getOrder,
+  getOrdersList,
+  updateOrdersSettings,
+} from "./Order";
 export { updateMetadata, updatePrivateMetadata } from "./Metadata";
 export { getProductMetadata } from "./storeFront/ProductDetails";
 export { activatePlugin, updatePlugin } from "./Plugins";

--- a/cypress/support/customCommands/sharedElementsOperations/selects.js
+++ b/cypress/support/customCommands/sharedElementsOperations/selects.js
@@ -1,4 +1,4 @@
-import { PAGINATION } from "../../../elements";
+import { DRAFT_ORDER_SELECTORS, PAGINATION } from "../../../elements";
 import { BUTTON_SELECTORS } from "../../../elements/shared/button-selectors";
 import {
   selectorWithDataValue,
@@ -22,6 +22,9 @@ Cypress.Commands.add("clickSubmitButton", () =>
 );
 Cypress.Commands.add("clickConfirmButton", () =>
   cy.get(BUTTON_SELECTORS.confirm).click(),
+);
+Cypress.Commands.add("clickFinalizeButton", () =>
+  cy.get(DRAFT_ORDER_SELECTORS.finalizeButton).click(),
 );
 Cypress.Commands.add("openColumnPicker", () =>
   cy.get(SHARED_ELEMENTS.openColumnPickerButton).click(),


### PR DESCRIPTION
According to statistics from automation reports, I selected the most flaky and time-consuming test to be fixed:

1. should create the not published page
2. should move draft order to orders
3. should be able go to the next page and back on product list

Ad.1 Added assertion as a delay since cypress works too fast
Ad.2 Removed redundant multiple visits on different URLs in favor of checking lists via API
Ad.3 Pagination was working but viewport does not always follow - change assertion to check is there are more than 10 records instead precise value

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
5. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
6. [ ] Your code works with the latest stable version of the core
7. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [x] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
8. [ ] giftCard
9. [ ] homePage
10. [ ] login
11. [ ] menuNavigation
12. [ ] navigation
13. [ ] orders
14. [ ] pages
15. [ ] payments
16. [ ] permissions
17. [ ] plugins
18. [ ] productType
19. [ ] products
20. [ ] sales
21. [ ] shipping
22. [ ] translations
23. [ ] variants
24. [ ] vouchers

CONTAINERS=6
