### PR TITLE
Inform about app replacements of plugins in plugins page

### DIFF
--- a/.changeset/eight-wombats-do.md
+++ b/.changeset/eight-wombats-do.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Added information in Plugins Page about the App Store. Now plugins page informs that Apps will replace plugins in the future. Also every plugin that is "active" will display an inline message to visit the App Store for the app replacement

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3507,6 +3507,9 @@
     "context": "dialog header",
     "string": "Cancel Orders"
   },
+  "NL6mvR": {
+    "string": "Visit App Store to replace with the App"
+  },
   "NLNonj": {
     "context": "send to channel select label",
     "string": "Send to channel"
@@ -8667,6 +8670,9 @@
   "ycrTBX": {
     "context": "table header channel col label",
     "string": "Channel"
+  },
+  "yfhLcv": {
+    "string": "We are working on replacing plugins with apps. Read more about"
   },
   "yhv3HX": {
     "context": "voucher requirements, header",

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,7 +1,8 @@
 import { Typography } from "@material-ui/core";
 import { TypographyProps } from "@material-ui/core/Typography";
 import { makeStyles } from "@saleor/macaw-ui";
-import React from "react";
+import { Text, TextProps } from "@saleor/macaw-ui/next";
+import React, { HTMLAttributes } from "react";
 
 const useStyles = makeStyles(
   {
@@ -18,6 +19,9 @@ interface ExternalLinkProps extends React.HTMLProps<HTMLAnchorElement> {
   typographyProps?: TypographyProps;
 }
 
+/**
+ * @deprecated use ExternalLinkNext
+ */
 const ExternalLink: React.FC<ExternalLinkProps> = props => {
   const { className, children, href, typographyProps, target, rel, ...rest } =
     props;
@@ -42,3 +46,18 @@ const ExternalLink: React.FC<ExternalLinkProps> = props => {
 };
 ExternalLink.displayName = "ExternalLink";
 export default ExternalLink;
+
+export const ExternalLinkNext = (
+  props: TextProps & Omit<HTMLAttributes<HTMLAnchorElement>, "children">,
+) => {
+  const opensNewTab = props.target === "_blank";
+
+  return (
+    <Text
+      {...props}
+      as="a"
+      rel={props.rel ?? opensNewTab ? "noopener noreferer" : ""}
+      textDecoration="none"
+    />
+  );
+};

--- a/src/plugins/components/PluginsList/PluginsList.tsx
+++ b/src/plugins/components/PluginsList/PluginsList.tsx
@@ -5,13 +5,20 @@ import TableRowLink from "@dashboard/components/TableRowLink";
 import { PluginBaseFragment } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { renderCollection } from "@dashboard/misc";
+import { getPluginsWithAppReplacementsIds } from "@dashboard/plugins/plugins-with-app-replacements";
 import { PluginListUrlSortField, pluginUrl } from "@dashboard/plugins/urls";
 import { ListProps, SortPage } from "@dashboard/types";
-import { TableBody, TableCell, TableFooter } from "@material-ui/core";
+import {
+  TableBody,
+  TableCell,
+  TableFooter,
+  Typography,
+} from "@material-ui/core";
 import { EditIcon, makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
+import { pluginsMiscMessages } from "./messages";
 import PluginChannelAvailabilityCell from "./PluginChannelAvailabilityCell";
 import PluginChannelConfigurationCell from "./PluginChannelConfigurationCell";
 import PluginListTableHead from "./PluginListTableHead";
@@ -24,6 +31,10 @@ export const useStyles = makeStyles(
   }),
   { name: "PluginsList" },
 );
+
+const pluginsWithAppReplacements = getPluginsWithAppReplacementsIds();
+const hasAppReplacement = (pluginId: string) =>
+  pluginsWithAppReplacements.includes(pluginId);
 
 export interface PluginListProps
   extends ListProps,
@@ -56,8 +67,16 @@ const PluginList: React.FC<PluginListProps> = props => {
       <TableBody>
         {renderCollection(
           plugins,
-          plugin =>
-            plugin ? (
+          plugin => {
+            const hasReplacement = plugin && hasAppReplacement(plugin.id);
+            const activeChannelConfigurations =
+              plugin?.channelConfigurations?.filter(c => c.active);
+            const isActive =
+              plugin?.globalConfiguration?.active ||
+              (activeChannelConfigurations &&
+                activeChannelConfigurations.length > 0);
+
+            return plugin ? (
               <TableRowLink
                 data-test-id="plugin"
                 hover={!!plugin}
@@ -67,7 +86,16 @@ const PluginList: React.FC<PluginListProps> = props => {
                 onClick={() => plugin && navigate(pluginUrl(plugin.id))}
                 key={plugin ? plugin.id : "skeleton"}
               >
-                <TableCell colSpan={5}>{plugin.name}</TableCell>
+                <TableCell colSpan={5}>
+                  <Typography>{plugin.name}</Typography>
+                  {hasReplacement && isActive && (
+                    <Typography variant="caption" color="error">
+                      {intl.formatMessage(
+                        pluginsMiscMessages.appReplacementMessage,
+                      )}
+                    </Typography>
+                  )}
+                </TableCell>
                 <PluginChannelConfigurationCell plugin={plugin} />
                 <PluginChannelAvailabilityCell plugin={plugin} />
                 <TableCell align="right">
@@ -80,7 +108,8 @@ const PluginList: React.FC<PluginListProps> = props => {
                   <Skeleton />
                 </TableCell>
               </TableRowLink>
-            ),
+            );
+          },
           () => (
             <TableRowLink>
               <TableCell colSpan={totalColSpan}>

--- a/src/plugins/components/PluginsList/messages.ts
+++ b/src/plugins/components/PluginsList/messages.ts
@@ -75,3 +75,10 @@ export const pluginStatusMessages = defineMessages({
     description: "status label deactivated",
   },
 });
+
+export const pluginsMiscMessages = defineMessages({
+  appReplacementMessage: {
+    defaultMessage: "Visit App Store to replace with the App",
+    id: 'NL6mvR',
+  },
+});

--- a/src/plugins/components/PluginsListPage/PluginsListPage.tsx
+++ b/src/plugins/components/PluginsListPage/PluginsListPage.tsx
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
+import ExternalLink from "@dashboard/components/ExternalLink";
 import FilterBar from "@dashboard/components/FilterBar";
 import { ListPageLayout } from "@dashboard/components/Layouts";
 import { configurationMenuUrl } from "@dashboard/configuration";
@@ -12,7 +13,8 @@ import {
   SortPage,
   TabPageProps,
 } from "@dashboard/types";
-import { Card } from "@material-ui/core";
+import { Card, Typography } from "@material-ui/core";
+import Alert from "@material-ui/lab/Alert";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -22,7 +24,10 @@ import {
   PluginFilterKeys,
   PluginListFilterOpts,
 } from "./filters";
-import { pluginsFilterErrorMessages } from "./messages";
+import {
+  pluginsFilterErrorMessages,
+  pluginsListPageMessages,
+} from "./messages";
 
 export interface PluginsListPageProps
   extends PageListProps,
@@ -56,6 +61,20 @@ const PluginsListPage: React.FC<PluginsListPageProps> = ({
         title={intl.formatMessage(sectionNames.plugins)}
       />
       <Card>
+        <div>
+          <Alert severity="warning" title="Warning">
+            <Typography variant="body1">
+              {intl.formatMessage(pluginsListPageMessages.appStoreWarning)}{" "}
+              <ExternalLink
+                target="blank"
+                typographyProps={{ display: "inline" }}
+                href="https://docs.saleor.io/docs/3.x/developer/app-store/overview"
+              >
+                Saleor App Store.
+              </ExternalLink>
+            </Typography>
+          </Alert>
+        </div>
         <FilterBar
           errorMessages={pluginsFilterErrorMessages}
           currentTab={currentTab}

--- a/src/plugins/components/PluginsListPage/PluginsListPage.tsx
+++ b/src/plugins/components/PluginsListPage/PluginsListPage.tsx
@@ -1,11 +1,12 @@
 // @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
-import ExternalLink from "@dashboard/components/ExternalLink";
+import { ExternalLinkNext } from "@dashboard/components/ExternalLink";
 import FilterBar from "@dashboard/components/FilterBar";
 import { ListPageLayout } from "@dashboard/components/Layouts";
 import { configurationMenuUrl } from "@dashboard/configuration";
 import { PluginBaseFragment } from "@dashboard/graphql";
 import { sectionNames } from "@dashboard/intl";
+import { getStatusColor } from "@dashboard/misc";
 import { PluginListUrlSortField } from "@dashboard/plugins/urls";
 import {
   FilterPageProps,
@@ -13,8 +14,8 @@ import {
   SortPage,
   TabPageProps,
 } from "@dashboard/types";
-import { Card, Typography } from "@material-ui/core";
-import Alert from "@material-ui/lab/Alert";
+import { Card } from "@material-ui/core";
+import { Box, Text } from "@saleor/macaw-ui/next";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -62,18 +63,25 @@ const PluginsListPage: React.FC<PluginsListPageProps> = ({
       />
       <Card>
         <div>
-          <Alert severity="warning" title="Warning">
-            <Typography variant="body1">
+          <Box
+            paddingX={7}
+            paddingY={5}
+            marginBottom={5}
+            __backgroundColor={getStatusColor("warning")}
+          >
+            <Text variant="heading" as="h2">
+              {intl.formatMessage(pluginsListPageMessages.warningHeadline)}
+            </Text>
+            <Text variant="body">
               {intl.formatMessage(pluginsListPageMessages.appStoreWarning)}{" "}
-              <ExternalLink
-                target="blank"
-                typographyProps={{ display: "inline" }}
+              <ExternalLinkNext
+                target="_blank"
                 href="https://docs.saleor.io/docs/3.x/developer/app-store/overview"
               >
                 Saleor App Store.
-              </ExternalLink>
-            </Typography>
-          </Alert>
+              </ExternalLinkNext>
+            </Text>
+          </Box>
         </div>
         <FilterBar
           errorMessages={pluginsFilterErrorMessages}

--- a/src/plugins/components/PluginsListPage/messages.ts
+++ b/src/plugins/components/PluginsListPage/messages.ts
@@ -19,4 +19,8 @@ export const pluginsListPageMessages = defineMessages({
       "We are working on replacing plugins with apps. Read more about",
     id: "yfhLcv",
   },
+  warningHeadline: {
+    defaultMessage: "Warning",
+    id: "3SVI5p",
+  },
 });

--- a/src/plugins/components/PluginsListPage/messages.ts
+++ b/src/plugins/components/PluginsListPage/messages.ts
@@ -12,3 +12,11 @@ export const pluginsFilterErrorMessages = defineMessages({
     description: "plugin filters error messages channels",
   },
 });
+
+export const pluginsListPageMessages = defineMessages({
+  appStoreWarning: {
+    defaultMessage:
+      "We are working on replacing plugins with apps. Read more about",
+    id: "yfhLcv",
+  },
+});

--- a/src/plugins/plugins-with-app-replacements.ts
+++ b/src/plugins/plugins-with-app-replacements.ts
@@ -1,0 +1,20 @@
+/**
+ * Provides a static list of plugins IDs that are already re-implemented
+ * as apps and available in the App Store.
+ *
+ * In the future they will be officially deprecated, but now called "with app replacements"
+ *
+ * Ids are part of plugins query
+ * https://docs.saleor.io/docs/3.x/api-reference/miscellaneous/queries/plugins
+ */
+export const getPluginsWithAppReplacementsIds = () => {
+  return [
+    "mirumee.payments.adyen",
+    "mirumee.taxes.avalara",
+    "mirumee.invoicing",
+    "mirumee.notifications.sendgrid_email",
+    "saleor.payments.stripe",
+    "mirumee.payments.stripe",
+    "mirumee.notifications.user_email",
+  ];
+};


### PR DESCRIPTION
closes https://github.com/saleor/apps/issues/71

This issue is a step towards marking plugins as deprecated. Plugins are not yet officially deprecated, but we can already encourage users to look at apps instead of using plugin

### Screenshots

![Zrzut ekranu 2023-08-3 o 11 11 20](https://github.com/saleor/saleor-dashboard/assets/9268745/5731606a-7269-4046-974e-8c5a0f6564aa)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
