### PR TITLE
Fix couple of eslint rules

### DIFF
--- a/.changeset/many-icons-flow.md
+++ b/.changeset/many-icons-flow.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix couple of eslint rules connected to display name and no-case declarations

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,16 +101,7 @@
     "array-callback-return": "off",
     "import/export": "off",
     "n/no-callback-literal": "off",
-    "no-case-declarations": "off",
-    "no-empty-pattern": "off",
-    "no-fallthrough": "off",
-    "no-new": "off",
-    "no-prototype-builtins": "off",
-    "no-unreachable": "off",
-    "no-useless-catch": "off",
-    "no-useless-escape": "off",
-    "prefer-promise-reject-errors": "off",
-    "react/display-name": "warn"
+    "no-case-declarations": "warn"
   },
   "ignorePatterns": ["node_modules/", "**/types/**/*", "type-policies.ts"]
 }

--- a/src/apps/components/AppDetailsPage/AppDetailsPage.test.tsx
+++ b/src/apps/components/AppDetailsPage/AppDetailsPage.test.tsx
@@ -6,6 +6,7 @@ import { appDetails } from "../../fixtures";
 import { AppDetailsPage } from "./AppDetailsPage";
 
 const mockHeader = jest.fn();
+// eslint-disable-next-line react/display-name
 jest.mock("./Header", () => props => {
   mockHeader(props);
   return <></>;

--- a/src/apps/components/AppFrame/AppIFrame.tsx
+++ b/src/apps/components/AppFrame/AppIFrame.tsx
@@ -48,6 +48,8 @@ const _AppIFrame = forwardRef<HTMLIFrameElement, AppIFrameProps>(
   },
 );
 
+_AppIFrame.displayName = "AppIFrame";
+
 export const AppIFrame = memo(_AppIFrame, (prev, next) =>
   isEqualWith(prev, next),
 );

--- a/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
+++ b/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
@@ -26,7 +26,12 @@ export const InstallWithManifestFormButton: React.FC<
     const form = new FormData(e.currentTarget);
     const inputValue = form.get("manifest-url") as string;
 
-    onSubmitted(inputValue);
+    try {
+      const parsedURL = new URL(inputValue);
+      onSubmitted(parsedURL.href);
+    } catch (e) {
+      console.error("Invalid URL from input. Should be validated by browser");
+    }
   };
 
   if (inputOpened) {

--- a/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
+++ b/src/apps/components/InstallWithManifestFormButton/InstallWithManifestFormButton.tsx
@@ -26,13 +26,7 @@ export const InstallWithManifestFormButton: React.FC<
     const form = new FormData(e.currentTarget);
     const inputValue = form.get("manifest-url") as string;
 
-    try {
-      new URL(inputValue);
-
-      onSubmitted(inputValue);
-    } catch (e) {
-      console.error("Invalid URL from input. Should be validated by browser");
-    }
+    onSubmitted(inputValue);
   };
 
   if (inputOpened) {

--- a/src/components/AppLayout/util.ts
+++ b/src/components/AppLayout/util.ts
@@ -10,7 +10,7 @@ export const extractQueryParams = (queryString: string) => {
     if (match) {
       const arrayKey = match[1];
 
-      if (!queryParams.hasOwnProperty.call(arrayKey)) {
+      if (!Object.prototype.hasOwnProperty.call(queryParams, arrayKey)) {
         queryParams[arrayKey] = [];
       }
 

--- a/src/components/AppLayout/util.ts
+++ b/src/components/AppLayout/util.ts
@@ -10,7 +10,7 @@ export const extractQueryParams = (queryString: string) => {
     if (match) {
       const arrayKey = match[1];
 
-      if (!queryParams.hasOwnProperty(arrayKey)) {
+      if (!queryParams.hasOwnProperty.call(arrayKey)) {
         queryParams[arrayKey] = [];
       }
 

--- a/src/components/Form/ExitFormDialog.test.tsx
+++ b/src/components/Form/ExitFormDialog.test.tsx
@@ -14,6 +14,7 @@ jest.mock("react-intl", () => ({
 jest.mock("@saleor/macaw-ui", () => ({
   useStyles: jest.fn(() => () => ({})),
   makeStyles: jest.fn(() => () => ({})),
+  // eslint-disable-next-line react/display-name
   DialogHeader: jest.fn(() => () => <></>),
 }));
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -18,6 +18,8 @@ const _IconButton: React.FC<any> = React.forwardRef(
   },
 );
 
+_IconButton.displayName = "IconButton";
+
 export const IconButton = _IconButton as <
   T extends React.ElementType = "button",
 >(

--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -83,3 +83,5 @@ export const Metadata: React.FC<MetadataProps> = memo(({ data, onChange }) => {
     </Box>
   );
 }, propsCompare);
+
+Metadata.displayName = "Metadata";

--- a/src/components/SeoForm/SeoForm.tsx
+++ b/src/components/SeoForm/SeoForm.tsx
@@ -20,7 +20,7 @@ enum SeoField {
   description = "seoDescription",
 }
 
-const SLUG_REGEX = /^[a-zA-Z0-9\-\_]+$/;
+const SLUG_REGEX = /^[a-zA-Z0-9\-_]+$/;
 const maxSlugLength = 255;
 const maxTitleLength = 70;
 const maxDescriptionLength = 300;

--- a/src/containers/BackgroundTasks/BackgroundTasksProvider.tsx
+++ b/src/containers/BackgroundTasks/BackgroundTasksProvider.tsx
@@ -28,29 +28,20 @@ export function useBackgroundTasks(
   React.useEffect(() => {
     const intervalId = setInterval(() => {
       const queue = async () => {
-        try {
-          await Promise.all(
-            tasks.current.map(async task => {
-              if (task.status === TaskStatus.PENDING) {
-                let status: TaskStatus;
+        await Promise.all(
+          tasks.current.map(async task => {
+            if (task.status === TaskStatus.PENDING) {
+              const status = await handleTask(task);
 
-                try {
-                  status = await handleTask(task);
-                } catch (error) {
-                  throw error;
-                }
-                if (status !== TaskStatus.PENDING) {
-                  const taskIndex = tasks.current.findIndex(
-                    t => t.id === task.id,
-                  );
-                  tasks.current[taskIndex].status = status;
-                }
+              if (status !== TaskStatus.PENDING) {
+                const taskIndex = tasks.current.findIndex(
+                  t => t.id === task.id,
+                );
+                tasks.current[taskIndex].status = status;
               }
-            }),
-          );
-        } catch (error) {
-          throw error;
-        }
+            }
+          }),
+        );
       };
 
       queue();

--- a/src/custom-apps/components/PermissionAlert/PermissionAlert.test.tsx
+++ b/src/custom-apps/components/PermissionAlert/PermissionAlert.test.tsx
@@ -23,6 +23,7 @@ jest.mock("@saleor/macaw-ui", () => ({
   useTheme: jest.fn(() => () => ({})),
   useStyles: jest.fn(() => () => ({})),
   makeStyles: jest.fn(() => () => ({})),
+  // eslint-disable-next-line react/display-name
   DialogHeader: jest.fn(() => () => <></>),
 }));
 

--- a/src/giftCards/index.tsx
+++ b/src/giftCards/index.tsx
@@ -41,7 +41,7 @@ const GiftCardList: React.FC<RouteComponentProps<any>> = () => {
   return <GiftCardListComponent params={params} />;
 };
 
-const Component: React.FC = ({}) => {
+const Component: React.FC = () => {
   const intl = useIntl();
 
   return (

--- a/src/icons/Attributes.tsx
+++ b/src/icons/Attributes.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Attributes = createSvgIcon(
+const AttributesIcons = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const Attributes = createSvgIcon(
   "Attributes",
 );
 
-export default (props: SvgIconProps) => (
-  <Attributes {...props} viewBox="0 0 32 32" />
-);
+export default function Attributes(props: SvgIconProps) {
+  return <AttributesIcons {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/Channels.tsx
+++ b/src/icons/Channels.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Channels = createSvgIcon(
+const ChannelsIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const Channels = createSvgIcon(
   "Channels",
 );
 
-export default (props: SvgIconProps) => (
-  <Channels {...props} viewBox="0 0 32 32" />
-);
+export default function Channels(props: SvgIconProps) {
+  return <ChannelsIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/Miscellaneous.tsx
+++ b/src/icons/Miscellaneous.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Miscellaneous = createSvgIcon(
+const MiscellaneousIcon = createSvgIcon(
   <>
     <path
       fillRule="evenodd"
@@ -31,6 +31,6 @@ const Miscellaneous = createSvgIcon(
   "Miscellaneous",
 );
 
-export default (props: SvgIconProps) => (
-  <Miscellaneous {...props} viewBox="0 0 24 24" fill="none" />
-);
+export default function Miscellaneous(props: SvgIconProps) {
+  return <MiscellaneousIcon {...props} viewBox="0 0 24 24" fill="none" />;
+}

--- a/src/icons/Navigation.tsx
+++ b/src/icons/Navigation.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Navigation = createSvgIcon(
+const NavigationIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const Navigation = createSvgIcon(
   "Navigation",
 );
 
-export default (props: SvgIconProps) => (
-  <Navigation {...props} viewBox="0 0 32 32" />
-);
+export default function Navigation(props: SvgIconProps) {
+  return <NavigationIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/PageTypes.tsx
+++ b/src/icons/PageTypes.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const PageTypes = createSvgIcon(
+const PageTypesIcons = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const PageTypes = createSvgIcon(
   "PageTypes",
 );
 
-export default (props: SvgIconProps) => (
-  <PageTypes {...props} viewBox="0 0 24 25" />
-);
+export default function PageTypes(props: SvgIconProps) {
+  return <PageTypesIcons {...props} viewBox="0 0 24 25" />;
+}

--- a/src/icons/PermissionGroups.tsx
+++ b/src/icons/PermissionGroups.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const PermissionGroups = createSvgIcon(
+const PermissionGroupsIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const PermissionGroups = createSvgIcon(
   "PermissionGroups",
 );
 
-export default (props: SvgIconProps) => (
-  <PermissionGroups {...props} viewBox="0 0 32 32" />
-);
+export default function PermissionGroups(props: SvgIconProps) {
+  return <PermissionGroupsIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/ProductTypes.tsx
+++ b/src/icons/ProductTypes.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const ProductTypes = createSvgIcon(
+const ProductTypesIcon = createSvgIcon(
   <>
     <path
       fillRule="evenodd"
@@ -13,6 +13,6 @@ const ProductTypes = createSvgIcon(
   "ProductTypes",
 );
 
-export default (props: SvgIconProps) => (
-  <ProductTypes {...props} viewBox="0 0 44 44" />
-);
+export default function ProductTypes(props: SvgIconProps) {
+  return <ProductTypesIcon {...props} viewBox="0 0 44 44" />;
+}

--- a/src/icons/ShippingMethods.tsx
+++ b/src/icons/ShippingMethods.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const ShippingMethods = createSvgIcon(
+const ShippingMethodsIcons = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const ShippingMethods = createSvgIcon(
   "ShippingMethods",
 );
 
-export default (props: SvgIconProps) => (
-  <ShippingMethods {...props} viewBox="0 0 32 32" />
-);
+export default function ShippingMethods(props: SvgIconProps) {
+  return <ShippingMethodsIcons {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/SiteSettings.tsx
+++ b/src/icons/SiteSettings.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const SiteSettings = createSvgIcon(
+const SiteSettingsIcon = createSvgIcon(
   <>
     <path
       fillRule="evenodd"
@@ -19,6 +19,6 @@ const SiteSettings = createSvgIcon(
   "SiteSettings",
 );
 
-export default (props: SvgIconProps) => (
-  <SiteSettings {...props} viewBox="0 0 32 32" />
-);
+export default function SiteSettings(props: SvgIconProps) {
+  return <SiteSettingsIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/StaffMembers.tsx
+++ b/src/icons/StaffMembers.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const StaffMembers = createSvgIcon(
+const StaffMembersIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const StaffMembers = createSvgIcon(
   "StaffMembers",
 );
 
-export default (props: SvgIconProps) => (
-  <StaffMembers {...props} viewBox="0 0 32 32" />
-);
+export default function StaffMembers(props: SvgIconProps) {
+  return <StaffMembersIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/Taxes.tsx
+++ b/src/icons/Taxes.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Taxes = createSvgIcon(
+const TaxesIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const Taxes = createSvgIcon(
   "Taxes",
 );
 
-export default (props: SvgIconProps) => (
-  <Taxes {...props} viewBox="0 0 32 32" />
-);
+export default function Taxes(props: SvgIconProps) {
+  return <TaxesIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/icons/Warehouses.tsx
+++ b/src/icons/Warehouses.tsx
@@ -1,7 +1,7 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
-const Warehouses = createSvgIcon(
+const WarehousesIcon = createSvgIcon(
   <path
     fillRule="evenodd"
     clipRule="evenodd"
@@ -11,6 +11,6 @@ const Warehouses = createSvgIcon(
   "Warehouses",
 );
 
-export default (props: SvgIconProps) => (
-  <Warehouses {...props} viewBox="0 0 32 32" />
-);
+export default function Warehouses(props: SvgIconProps) {
+  return <WarehousesIcon {...props} viewBox="0 0 32 32" />;
+}

--- a/src/navigation/views/MenuDetails/index.tsx
+++ b/src/navigation/views/MenuDetails/index.tsx
@@ -119,7 +119,6 @@ const MenuDetails: React.FC<MenuDetailsProps> = ({ id, params }) => {
 
       default:
         throw unknownTypeError;
-        break;
     }
   };
 

--- a/src/orders/components/OrderHistory/messages.ts
+++ b/src/orders/components/OrderHistory/messages.ts
@@ -100,6 +100,8 @@ export const getEventMessage = (
             defaultMessage: "Order refund information was sent to customer",
             description: "order history message",
           });
+        default:
+          return "";
       }
     case OrderEventsEnum.FULFILLMENT_CANCELED:
       return intl.formatMessage({

--- a/src/utils/handlers/multiFileUploadHandler.test.ts
+++ b/src/utils/handlers/multiFileUploadHandler.test.ts
@@ -48,7 +48,7 @@ describe("Multiple file upload handler", () => {
     const handle = createMultiFileUploadHandler((_, fileIndex) => {
       const promise = new Promise<void>((resolve, reject) => {
         if (fileIndex === 2) {
-          reject();
+          reject(new Error("mock error"));
         } else {
           resolve();
         }


### PR DESCRIPTION
This PR closes a couple of issues connected with eslint:
* #3915 
* Small fixes tracked inside: https://github.com/saleor/saleor-dashboard/issues/3860
	* prefer-promise-reject-errors
	* no-useless-escape
	* no-useless-catch
	* no-unreachable
	* no-prototype-builtins
	* no-new
	* no-fallthrough
	* no-empty-pattern
* #3916

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
