### PR TITLE
Remove arrow in app page

### DIFF
--- a/.changeset/wet-penguins-fail.md
+++ b/.changeset/wet-penguins-fail.md
@@ -1,0 +1,10 @@
+---
+"saleor-dashboard": minor
+---
+
+Removed "go back" arrow in App view, where app is mounted. 
+
+This arrow caused a confusion between Dashboard navigation and App internal navigation. 
+Now, to go back to the Apps List, the side navigation must be used. 
+
+The "Manage App" view was not changed - arrow is still displayed to navigate back to the App Page.

--- a/src/apps/components/AppPage/AppPage.tsx
+++ b/src/apps/components/AppPage/AppPage.tsx
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { AppUrls } from "@dashboard/apps/urls";
 import {
   borderHeight,
   topBarHeight,
@@ -39,7 +38,6 @@ export const AppPage: React.FC<AppPageProps> = ({
   return (
     <DetailPageLayout gridTemplateColumns={1} withSavebar={false}>
       <AppPageNav
-        goBackUrl={AppUrls.resolveAppListUrl()}
         appId={data?.id}
         name={data?.name}
         supportUrl={data?.supportUrl}

--- a/src/apps/components/AppPage/AppPageNav.tsx
+++ b/src/apps/components/AppPage/AppPageNav.tsx
@@ -14,7 +14,10 @@ interface AppPageNavProps {
   author?: string | undefined | null;
   appId: string;
   appLogoUrl?: string | undefined | null;
-  goBackUrl: string;
+  /**
+   * Render a back arrow only if an URL is provided.
+   */
+  goBackUrl?: string;
   /**
    * Temporary prop, so the header can be composed with buttons instead hard coding them.
    * Component is used on Manage App page too, so the button should be hidden there
@@ -56,9 +59,9 @@ export const AppPageNav: React.FC<AppPageNavProps> = ({
         justifyContent="space-between"
         width="100%"
       >
-        <Box display="flex" gap={4} alignItems="center">
-          <TopNavLink to={goBackUrl} variant="tertiary" />
-          <Box display="flex" gap={2} alignItems="center">
+        <Box display="flex" gap={2} alignItems="center">
+          {goBackUrl && <TopNavLink to={goBackUrl} variant="tertiary" />}
+          <Box display="flex" gap={4} alignItems="center">
             <AppAvatar size={8} logo={logo} />
             <Box display="flex" flexDirection="column">
               <Text variant="heading">{name}</Text>

--- a/src/components/AppLayout/TopNav/TopNavLink.tsx
+++ b/src/components/AppLayout/TopNav/TopNavLink.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, Button, sprinkles } from "@saleor/macaw-ui/next";
+import { ArrowLeftIcon, Button } from "@saleor/macaw-ui/next";
 import React from "react";
 import { Link } from "react-router-dom";
 
@@ -6,7 +6,7 @@ export const TopNavLink: React.FC<{
   to: string;
   variant?: "secondary" | "tertiary";
 }> = ({ to, variant = "secondary" }) => (
-  <Link to={to} className={sprinkles({ marginRight: 2 })}>
+  <Link to={to}>
     <Button
       icon={<ArrowLeftIcon />}
       variant={variant}

--- a/src/components/AppLayout/TopNav/TopNavLink.tsx
+++ b/src/components/AppLayout/TopNav/TopNavLink.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, Button } from "@saleor/macaw-ui/next";
+import { ArrowLeftIcon, Button, sprinkles } from "@saleor/macaw-ui/next";
 import React from "react";
 import { Link } from "react-router-dom";
 
@@ -6,7 +6,7 @@ export const TopNavLink: React.FC<{
   to: string;
   variant?: "secondary" | "tertiary";
 }> = ({ to, variant = "secondary" }) => (
-  <Link to={to}>
+  <Link to={to} className={sprinkles({ marginRight: 2 })}>
     <Button
       icon={<ArrowLeftIcon />}
       variant={variant}


### PR DESCRIPTION
This PR removes confusing arrow (back button) in the App Page (where app is mounted). It causes confusion between Dashboard navigation and App navigation.

Now, to go back to the app list (which was the target of removed button), user has to click "Apps" on the left hand side navigation.

In the "manage app" view, arrow was not removed. Its a nested view which can navigate back to the app view.

### Screenshots

![Zrzut ekranu 2023-08-8 o 15 43 57](https://github.com/saleor/saleor-dashboard/assets/9268745/b9b713e3-cde2-4e43-b3bd-5f3064228fc8)
![Zrzut ekranu 2023-08-8 o 15 43 52](https://github.com/saleor/saleor-dashboard/assets/9268745/de98c893-5c7b-45f5-b520-13e07368f70f)




<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
