### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/cypressTestsHelpers/getEnvironmentVariables.js
+++ b/.github/workflows/cypressTestsHelpers/getEnvironmentVariables.js
@@ -19,170 +19,19 @@ program
     );
     core.setOutput("IS_OLD_VERSION", isOldVersion);
 
-    if (!isPatchRelease(options.version) && options.project == "CORE") {
-      //If it's minor version, check services, to get one before current
-      //Then create environment with this service, and big db
-      const snapshotWithBigDB = "nqw0Qmbr";
-      const versionBefore = await getServiceWithVersionOneBeforeVersion(
-        options.version,
-        options.token,
-      );
-
-      const environmentKey = await createEnvironment(
-        options.version,
-        options.token,
-        versionBefore,
-        snapshotWithBigDB,
-      );
-
-      //Update environment to current version
-      await updateEnvironment(environmentKey, options.version, options.token);
-      const domain = await getDomainForUpdatedEnvironment(
-        environmentKey,
-        options.token,
-      );
-      core.setOutput("url", `https://${domain}/`);
-    } else {
-      core.setOutput(
-        "url",
-        `https://v${getFormattedVersion(
-          options.version,
-        )}.staging.saleor.cloud/`,
-      );
-    }
+    core.setOutput(
+      "url",
+      `https://v${getFormattedVersion(options.version)}.staging.saleor.cloud/`,
+    );
 
     const branch = await getBranch(options.repo_token, options.version);
     core.setOutput("branch", branch);
   })
   .parse();
 
-async function createEnvironment(version, token, versionBefore, snapshot) {
-  const response = await fetch(
-    `https://staging-cloud.saleor.io/api/organizations/saleor/environments/`,
-    {
-      method: "POST",
-      body: `{ 
-        "service": "${versionBefore}",
-        "project": "staging",
-        "name": "minor-release-test-${version}",
-        "domain_label": "minor-release-${version}",
-        "restore_from": "${snapshot}"
-      }`,
-      headers: {
-        Authorization: `Token ${token}`,
-        Accept: "application/json",
-        "Content-Type": "application/json;charset=UTF-8",
-      },
-    },
-  );
-  const responseInJson = await response.json();
-
-  if (!responseInJson.task_id)
-    throw new Error(
-      `Can't create environment- ${JSON.stringify(responseInJson)}`,
-    );
-  const throwErrorAfterTimeoutWhenCreatingEnv = setTimeout(function () {
-    throw new Error("Environment didn't crated after 20 minutes");
-  }, 1200000);
-  return await waitUntilTaskInProgress(
-    responseInJson.task_id,
-    token,
-    throwErrorAfterTimeoutWhenCreatingEnv,
-  ).then(() => {
-    clearTimeout(throwErrorAfterTimeoutWhenCreatingEnv);
-    return responseInJson.key;
-  });
-}
-
-async function updateEnvironment(environmentId, version, token) {
-  console.log(
-    `{ "service": "saleor-staging-v${getFormattedVersion(version)}" }`,
-  );
-  const response = await fetch(
-    `https://staging-cloud.saleor.io/api/organizations/saleor/environments/${environmentId}/upgrade/`,
-    {
-      method: "PUT",
-      body: `{ "service": "saleor-staging-v${getFormattedVersion(version)}" }`,
-      headers: {
-        Authorization: `Token ${token}`,
-        Accept: "application/json",
-        "Content-Type": "application/json;charset=UTF-8",
-      },
-    },
-  );
-  const responseInJson = await response.json();
-  if (!responseInJson.task_id)
-    throw new Error(
-      `Can't update environment- ${JSON.stringify(responseInJson)}`,
-    );
-  const throwErrorAfterTimeout = setTimeout(function () {
-    throw new Error("Environment didn't upgraded after 20 minutes");
-  }, 1200000);
-  await waitUntilTaskInProgress(
-    responseInJson.task_id,
-    token,
-    throwErrorAfterTimeout,
-  );
-  clearTimeout(throwErrorAfterTimeout);
-}
-
-async function waitUntilTaskInProgress(taskId, token) {
-  const response = await fetch(
-    `https://staging-cloud.saleor.io/api/service/task-status/${taskId}/`,
-    {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json;charset=UTF-8",
-      },
-    },
-  );
-  const responseInJson = await response.json();
-  console.log(`Job status - ${responseInJson.status}`);
-  if (
-    responseInJson.status == "PENDING" ||
-    responseInJson.status == "IN_PROGRESS"
-  ) {
-    await new Promise(resolve =>
-      setTimeout(function () {
-        resolve(waitUntilTaskInProgress(taskId, token));
-      }, 10000),
-    );
-  } else if (responseInJson.status == "SUCCEEDED") {
-    return responseInJson.status;
-  } else if (responseInJson.status !== "SUCCEEDED") {
-    console.log("error");
-
-    throw new Error(
-      `Job ended with status - ${responseInJson.status} - ${responseInJson.job_name}`,
-    );
-  }
-}
-
-function isPatchRelease(version) {
-  const regex = /\d+\.\d+\.[1-9]/;
-  return version.match(regex) ? true : false;
-}
-
 function getFormattedVersion(version) {
-  const regex = /^\d+\.\d+\./;
-  return version.match(regex)[0].replace(/\./g, "");
-}
-
-async function getDomainForUpdatedEnvironment(environmentId, token) {
-  const response = await fetch(
-    `https://staging-cloud.saleor.io/api/organizations/saleor/environments/${environmentId}`,
-    {
-      method: "GET",
-      json: true,
-      responseType: "json",
-      headers: {
-        Authorization: `Token ${token}`,
-      },
-    },
-  );
-  const responseInJson = await response.json();
-  return responseInJson.domain;
+  const regex = /^v{0,1}(\d+\.\d+\.)/;
+  return version.match(regex)[1].replace(/\./g, "");
 }
 
 async function checkIfOldVersion(version, token) {
@@ -211,7 +60,7 @@ async function getTheNewestVersion(token) {
 async function getServices(token) {
   // us-east-1
   const response = await fetch(
-    `https://staging-cloud.saleor.io/api/regions/us-east-1/services`,
+    `https://staging-cloud.saleor.io/platform/api/regions/us-east-1/services`,
     {
       method: "GET",
       headers: {
@@ -223,49 +72,6 @@ async function getServices(token) {
   );
   const responseInJson = await response.json();
   return responseInJson;
-}
-
-async function getServiceWithVersionOneBeforeVersion(version, token) {
-  const services = await getServices(token);
-  const sandboxServices = services.filter(
-    element => element.service_type === "SANDBOX",
-  );
-  const sortedServices = sortServicesByVersion(sandboxServices);
-  const currentService = sortedServices.find(service => {
-    return service.name === `saleor-staging-v${getFormattedVersion(version)}`;
-  });
-  const serviceBeforeCurrent =
-    sortedServices[sortedServices.indexOf(currentService) + 1];
-  console.log(`Selected ${serviceBeforeCurrent.name} service`);
-  return serviceBeforeCurrent.name;
-}
-
-function sortServicesByVersion(services) {
-  // This function is used to sort environments by their version
-  // It returns sorted list of services in descending order
-
-  return services.sort(function (a, b) {
-    //Convert version from string to array eg. from "3.5.7" to [3, 5, 7]
-    // Where 3 is main version, 5 is major version and 7 is patch version
-
-    const versionASplittedToArray = a.version.split(/\D/);
-    const versionBSplittedToArray = b.version.split(/\D/);
-    const mainVersionNumberA = versionASplittedToArray[0];
-    const mainVersionNumberB = versionBSplittedToArray[0];
-    const majorVersionNumberA = versionASplittedToArray[1];
-    const majorVersionNumberB = versionBSplittedToArray[1];
-    const patchVersionNumberA = versionASplittedToArray[2];
-    const patchVersionNumberB = versionBSplittedToArray[2];
-
-    //Compare two versions
-    if (mainVersionNumberA !== mainVersionNumberB) {
-      return mainVersionNumberB - mainVersionNumberA;
-    } else if (majorVersionNumberA !== majorVersionNumberB) {
-      return majorVersionNumberB - majorVersionNumberA;
-    } else if (patchVersionNumberA !== patchVersionNumberB) {
-      return patchVersionNumberB - patchVersionNumberA;
-    } else return 0;
-  });
 }
 
 async function getBranch(token, version) {

--- a/.github/workflows/cypressTestsHelpers/getEnvironmentVariables.js
+++ b/.github/workflows/cypressTestsHelpers/getEnvironmentVariables.js
@@ -30,8 +30,8 @@ program
   .parse();
 
 function getFormattedVersion(version) {
-  const regex = /^v{0,1}(\d+\.\d+\.)/;
-  return version.match(regex)[1].replace(/\./g, "");
+  const regex = /^\d+\.\d+\./;
+  return version.match(regex)[0].replace(/\./g, "");
 }
 
 async function checkIfOldVersion(version, token) {


### PR DESCRIPTION
There were two issues:
- ~~Github started to return version with "v" in the beginning of the string. Before we had "3.15.0" now we have"v3.15.0" so I had to fix regex in one place~~
- We had the functionality to create a new environment with big db for migration tests. For now, I removed it, it may come back in a different version after a discussion with qa team. For now, migrations are tested manually.
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets and [read good practices](../.changeset/README.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
