### PR TITLE
New AWS credentials for demo deployments

### DIFF
--- a/.github/workflows/deploy-demo-staging.yaml
+++ b/.github/workflows/deploy-demo-staging.yaml
@@ -53,14 +53,14 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_DASHBOARD_STAGING_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DASHBOARD_STAGING_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEMO_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEMO_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy
         run: |
           aws s3 sync build/dashboard s3://${{ secrets.AWS_DEMO_STAGING_DEPLOYMENT_BUCKET }}/dashboard/static/
           aws s3 cp build/dashboard/index.html s3://${{ secrets.AWS_DEMO_STAGING_DEPLOYMENT_BUCKET }}/dashboard/
-          for i in {1..3}; do aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DEMO_STAGING_CF_DIST_ID }} --paths "/dashboard*" && break || sleep 5; done
+          for i in {1..3}; do aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DEMO_STAGING_CDN_DISTRIBUTION }} --paths "/dashboard*" && break || sleep 5; done
       - name: Prepare Demo release pull request
         run: |
           export GITHUB_TOKEN=$( \

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -36,14 +36,14 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_DASHBOARD_PROD_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DASHBOARD_PROD_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEMO_PROD_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEMO_PROD_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy
         run: |
-          aws s3 sync build/dashboard s3://${{ secrets.AWS_DEMO_DEPLOYMENT_BUCKET }}/dashboard/static/
-          aws s3 cp build/dashboard/index.html s3://${{ secrets.AWS_DEMO_DEPLOYMENT_BUCKET }}/dashboard/
-          for i in {1..3}; do aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DEMO_CF_DIST_ID }} --paths "/dashboard*" && break || sleep 5; done
+          aws s3 sync build/dashboard s3://${{ secrets.AWS_DEMO_PROD_DEPLOYMENT_BUCKET }}/dashboard/static/
+          aws s3 cp build/dashboard/index.html s3://${{ secrets.AWS_DEMO_PROD_DEPLOYMENT_BUCKET }}/dashboard/
+          for i in {1..3}; do aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DEMO_PROD_CDN_DISTRIBUTION }} --paths "/dashboard*" && break || sleep 5; done
       - name: Notify Slack
         if: ${{ always() }}
         env:


### PR DESCRIPTION
Github secrets to be:
 * removed:
   * `AWS_DEMO_STAGING_CF_DIST_ID`
   * `AWS_DEMO_DEPLOYMENT_BUCKET`
   * `AWS_DEMO_CF_DIST_ID`
 * updated:
   * `AWS_DEMO_STAGING_DEPLOYMENT_BUCKET`
 * created:
   * `AWS_DEMO_STAGING_ACCESS_KEY_ID`
   * `AWS_DEMO_STAGING_SECRET_ACCESS_KEY`
   * `AWS_DASHBOARD_PROD_ACCESS_KEY_ID`
   * `AWS_DASHBOARD_PROD_SECRET_ACCESS_KEY`
   * `AWS_DEMO_STAGING_CDN_DISTRIBUTION`
   * `AWS_DEMO_PROD_DEPLOYMENT_BUCKET`
   * `AWS_DEMO_PROD_CDN_DISTRIBUTION`

Secrets will be passed to @andrzejewsky via 1pass.