### PR TITLE
Move condional filters UI to dashboard

### DIFF
--- a/.changeset/stale-guests-sort.md
+++ b/.changeset/stale-guests-sort.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Move condional filters UI to dashboard

--- a/src/components/ConditionalFilter/FiltersArea.tsx
+++ b/src/components/ConditionalFilter/FiltersArea.tsx
@@ -1,15 +1,11 @@
-import {
-  _ExperimentalFilters,
-  Box,
-  FilterEvent,
-  Row,
-} from "@saleor/macaw-ui/next";
+import { Box, FilterEvent, Row } from "@saleor/macaw-ui/next";
 import React, { FC } from "react";
 
 import { useConditionalFilterContext } from "./context";
 import { FilterContainer } from "./FilterElement";
 import { LeftOperand } from "./LeftOperandsProvider";
 import { useFiltersAreaTranslations } from "./messages";
+import { Filters } from "./UI";
 import { useFilterContainer } from "./useFilterContainer";
 import { useTranslate } from "./useTranslate";
 import { ErrorEntry } from "./Validation";
@@ -80,35 +76,32 @@ export const FiltersArea: FC<FiltersAreaProps> = ({
   };
 
   return (
-    <_ExperimentalFilters
+    <Filters
       leftOptions={translateOperandOptions(leftOperandsProvider.operands)}
       value={translateSelectedOperands(value) as Array<string | Row>}
       onChange={handleStateChange}
       error={errors}
       locale={translations.locale}
     >
-      <_ExperimentalFilters.Footer>
-        <_ExperimentalFilters.AddRowButton
+      <Filters.Footer>
+        <Filters.AddRowButton
           variant="tertiary"
           disabled={value.length > MAX_VALUE_ITEMS}
         >
           {translations.addFilter}
-        </_ExperimentalFilters.AddRowButton>
+        </Filters.AddRowButton>
         <Box display="flex" gap={3}>
-          <_ExperimentalFilters.ClearButton
-            onClick={onCancel}
-            variant="tertiary"
-          >
+          <Filters.ClearButton onClick={onCancel} variant="tertiary">
             {translations.clearFilters}
-          </_ExperimentalFilters.ClearButton>
-          <_ExperimentalFilters.ConfirmButton
+          </Filters.ClearButton>
+          <Filters.ConfirmButton
             onClick={() => onConfirm(value)}
             disabled={hasEmptyRows}
           >
             {translations.saveFilters}
-          </_ExperimentalFilters.ConfirmButton>
+          </Filters.ConfirmButton>
         </Box>
-      </_ExperimentalFilters.Footer>
-    </_ExperimentalFilters>
+      </Filters.Footer>
+    </Filters>
   );
 };

--- a/src/components/ConditionalFilter/UI/EventEmitter.ts
+++ b/src/components/ConditionalFilter/UI/EventEmitter.ts
@@ -1,0 +1,191 @@
+import { RangeValue } from "@saleor/macaw-ui/next";
+
+import {
+  ConditionBlurData,
+  ConditionChangeData,
+  ConditionFocusData,
+  LeftOperatorBlurData,
+  LeftOperatorChangeData,
+  LeftOperatorFocusData,
+  LeftOperatorInputValueChangeData,
+  LeftOperatorOption,
+  RightOperatorBlurData,
+  RightOperatorChangeData,
+  RightOperatorFocusData,
+  RightOperatorInputValueChangeData,
+  RightOperatorOption,
+  RowAddData,
+  RowRemoveData,
+} from "./types";
+
+export class FilterEventEmitter extends EventTarget {
+  type = "filterChange";
+
+  addRow() {
+    this.dispatchEvent(
+      new CustomEvent<RowAddData>(this.type, {
+        detail: {
+          type: "row.add",
+          rowType: "1",
+        },
+      }),
+    );
+  }
+
+  removeRow(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<RowRemoveData>(this.type, {
+        detail: {
+          type: "row.remove",
+          path: `${index}`,
+          index,
+        },
+      }),
+    );
+  }
+
+  changeLeftOperator(
+    index: number,
+    value: LeftOperatorOption,
+    rowType: string | undefined,
+  ) {
+    this.dispatchEvent(
+      new CustomEvent<LeftOperatorChangeData>(this.type, {
+        detail: {
+          type: "leftOperator.onChange",
+          path: `${index}`,
+          value,
+          rowType: rowType ?? "",
+          index,
+        },
+      }),
+    );
+  }
+
+  focusLeftOperator(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<LeftOperatorFocusData>(this.type, {
+        detail: {
+          type: "leftOperator.onFocus",
+          path: `${index}`,
+          index,
+        },
+      }),
+    );
+  }
+
+  blurLeftOperator(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<LeftOperatorBlurData>(this.type, {
+        detail: {
+          type: "leftOperator.onBlur",
+          path: `${index}`,
+          index,
+        },
+      }),
+    );
+  }
+
+  inputChangeLeftOperator(index: number, value: string) {
+    this.dispatchEvent(
+      new CustomEvent<LeftOperatorInputValueChangeData>(this.type, {
+        detail: {
+          type: "leftOperator.onInputValueChange",
+          path: `${index}`,
+          value,
+          index,
+        },
+      }),
+    );
+  }
+
+  changeCondition(index: number, value: ConditionChangeData["value"]) {
+    this.dispatchEvent(
+      new CustomEvent<ConditionChangeData>(this.type, {
+        detail: {
+          type: "condition.onChange",
+          path: `${index}.condition.selected`,
+          value,
+          index,
+        },
+      }),
+    );
+  }
+
+  focusCondition(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<ConditionFocusData>(this.type, {
+        detail: {
+          type: "condition.onFocus",
+          path: `${index}.condition.selected`,
+          index,
+        },
+      }),
+    );
+  }
+
+  blurCondition(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<ConditionBlurData>(this.type, {
+        detail: {
+          type: "condition.onBlur",
+          path: `${index}.condition.selected`,
+          index,
+        },
+      }),
+    );
+  }
+
+  changeRightOperator(
+    index: number,
+    value: string | RightOperatorOption[] | RightOperatorOption | RangeValue,
+  ) {
+    this.dispatchEvent(
+      new CustomEvent<RightOperatorChangeData>(this.type, {
+        detail: {
+          type: "rightOperator.onChange",
+          path: `${index}.condition.selected.value`,
+          value,
+          index,
+        },
+      }),
+    );
+  }
+
+  focusRightOperator(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<RightOperatorFocusData>(this.type, {
+        detail: {
+          type: "rightOperator.onFocus",
+          path: `${index}.condition.selected.value`,
+          index,
+        },
+      }),
+    );
+  }
+
+  blurRightOperator(index: number) {
+    this.dispatchEvent(
+      new CustomEvent<RightOperatorBlurData>(this.type, {
+        detail: {
+          type: "rightOperator.onBlur",
+          path: `${index}.condition.selected.value`,
+          index,
+        },
+      }),
+    );
+  }
+
+  inputChangeRightOperator(index: number, value: string) {
+    this.dispatchEvent(
+      new CustomEvent<RightOperatorInputValueChangeData>(this.type, {
+        detail: {
+          type: "rightOperator.onInputValueChange",
+          path: `${index}.condition.selected.value`,
+          index,
+          value,
+        },
+      }),
+    );
+  }
+}

--- a/src/components/ConditionalFilter/UI/Filters.tsx
+++ b/src/components/ConditionalFilter/UI/Filters.tsx
@@ -1,0 +1,54 @@
+import { Box, Text } from "@saleor/macaw-ui/next";
+import React from "react";
+
+import { ExperimentalFiltersProps } from ".";
+import { createErrorLookup, getErrorByRowIndex } from "./errors";
+import { FilterEventEmitter } from "./EventEmitter";
+import { RowComponent } from "./Row";
+
+type FiltersProps = Pick<
+  ExperimentalFiltersProps,
+  "value" | "leftOptions" | "error"
+> & {
+  emitter: FilterEventEmitter;
+  locale: Record<string, string>;
+};
+
+export const Filters = ({
+  value,
+  leftOptions,
+  emitter,
+  locale,
+  error,
+}: FiltersProps) => {
+  const errorsByRowIndex = createErrorLookup(error);
+
+  return (
+    <Box
+      display="grid"
+      __gridTemplateColumns="repeat(2, auto)"
+      alignItems="start"
+      columnGap={2}
+      rowGap={3}
+      alignSelf="start"
+    >
+      <Text paddingTop={1.5}>{locale.WHERE}</Text>
+      {value.map((item, idx) =>
+        typeof item === "string" ? (
+          <Text key={idx} paddingTop={1.5}>
+            {locale[item]}
+          </Text>
+        ) : (
+          <RowComponent
+            item={item}
+            index={idx}
+            key={`filterRow-${idx}`}
+            leftOptions={leftOptions}
+            emitter={emitter}
+            error={getErrorByRowIndex(errorsByRowIndex, idx)}
+          />
+        ),
+      )}
+    </Box>
+  );
+};

--- a/src/components/ConditionalFilter/UI/Footer.tsx
+++ b/src/components/ConditionalFilter/UI/Footer.tsx
@@ -1,0 +1,40 @@
+import { Box, Button, ButtonProps, PropsWithBox } from "@saleor/macaw-ui/next";
+import React from "react";
+
+import { useFilterContext } from "./context";
+
+export const Footer = ({ children, ...props }: PropsWithBox<unknown>) => (
+  <Box display="flex" justifyContent="space-between" paddingTop={1} {...props}>
+    {children}
+  </Box>
+);
+
+export const AddRowButton = ({ children, ...props }: ButtonProps) => {
+  const { emitter } = useFilterContext();
+
+  return (
+    <Button onClick={() => emitter.addRow()} variant="secondary" {...props}>
+      {children}
+    </Button>
+  );
+};
+
+export const ClearButton = ({ children, ...props }: ButtonProps) => {
+  const { actionButtonsDisabled } = useFilterContext();
+
+  return (
+    <Button variant="secondary" disabled={actionButtonsDisabled} {...props}>
+      {children}
+    </Button>
+  );
+};
+
+export const ConfirmButton = ({ children, ...props }: ButtonProps) => {
+  const { actionButtonsDisabled } = useFilterContext();
+
+  return (
+    <Button variant="primary" disabled={actionButtonsDisabled} {...props}>
+      {children}
+    </Button>
+  );
+};

--- a/src/components/ConditionalFilter/UI/NoValue.tsx
+++ b/src/components/ConditionalFilter/UI/NoValue.tsx
@@ -1,0 +1,10 @@
+import { Box, Text } from "@saleor/macaw-ui/next";
+import React from "react";
+
+export const NoValue = ({ locale }: { locale: Record<string, string> }) => {
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center">
+      <Text>{locale.noValueText}</Text>
+    </Box>
+  );
+};

--- a/src/components/ConditionalFilter/UI/RangeInputWrapper.tsx
+++ b/src/components/ConditionalFilter/UI/RangeInputWrapper.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@saleor/macaw-ui/next";
+import React from "react";
+
+export const RangeInputWrapper = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return (
+    <Box display="flex" gap={0.5} alignItems="center" flexWrap="wrap">
+      {children}
+    </Box>
+  );
+};

--- a/src/components/ConditionalFilter/UI/RightOperator.tsx
+++ b/src/components/ConditionalFilter/UI/RightOperator.tsx
@@ -1,0 +1,237 @@
+import {
+  DynamicCombobox,
+  DynamicMultiselect,
+  Input,
+  RangeInput,
+  Select,
+} from "@saleor/macaw-ui/next";
+import React from "react";
+
+import { FilterEventEmitter } from "./EventEmitter";
+import {
+  isCombobox,
+  isDate,
+  isDateRange,
+  isDateTime,
+  isDateTimeRange,
+  isMultiselect,
+  isNumberInput,
+  isNumberRange,
+  isSelect,
+  isTextInput,
+} from "./operators";
+import { RangeInputWrapper } from "./RangeInputWrapper";
+import { SelectedOperator } from "./types";
+
+interface RightOperatorProps {
+  index: number;
+  selected: SelectedOperator;
+  emitter: FilterEventEmitter;
+  error: boolean;
+  helperText: string;
+  disabled: boolean;
+}
+
+export const RightOperator = ({
+  index,
+  selected,
+  emitter,
+  error,
+  disabled,
+  helperText,
+}: RightOperatorProps) => {
+  if (isTextInput(selected)) {
+    return (
+      <Input
+        value={selected.value}
+        onChange={e => {
+          emitter.changeRightOperator(index, e.target.value);
+        }}
+        onFocus={() => {
+          emitter.focusRightOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurRightOperator(index);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isNumberInput(selected)) {
+    return (
+      <Input
+        type="number"
+        value={selected.value}
+        onChange={e => {
+          emitter.changeRightOperator(index, e.target.value);
+        }}
+        onFocus={() => {
+          emitter.focusRightOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurRightOperator(index);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isMultiselect(selected)) {
+    return (
+      <DynamicMultiselect
+        value={selected.value}
+        options={selected.options ?? []}
+        loading={selected.loading}
+        onChange={value => emitter.changeRightOperator(index, value)}
+        onInputValueChange={value => {
+          emitter.inputChangeRightOperator(index, value);
+        }}
+        onFocus={() => {
+          emitter.focusRightOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurRightOperator(index);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isCombobox(selected)) {
+    return (
+      <DynamicCombobox
+        value={selected.value}
+        options={selected.options ?? []}
+        loading={selected.loading}
+        onChange={value => {
+          if (!value) return;
+          emitter.changeRightOperator(index, value);
+        }}
+        onInputValueChange={value =>
+          emitter.inputChangeRightOperator(index, value)
+        }
+        onFocus={() => {
+          emitter.focusRightOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurRightOperator(index);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isSelect(selected)) {
+    return (
+      <Select
+        value={selected.value}
+        options={selected.options ?? []}
+        onChange={value => emitter.changeRightOperator(index, value)}
+        onFocus={() => {
+          emitter.focusRightOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurRightOperator(index);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isNumberRange(selected)) {
+    return (
+      <RangeInputWrapper>
+        <RangeInput
+          value={selected.value}
+          onChange={value => {
+            emitter.changeRightOperator(index, value);
+          }}
+          type="number"
+          error={!!error}
+          helperText={helperText}
+          disabled={disabled}
+          width="100%"
+        />
+      </RangeInputWrapper>
+    );
+  }
+
+  if (isDate(selected)) {
+    return (
+      <Input
+        type="date"
+        value={selected.value}
+        onChange={e => {
+          emitter.changeRightOperator(index, e.target.value);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isDateTime(selected)) {
+    return (
+      <Input
+        type="datetime-local"
+        value={selected.value}
+        onChange={e => {
+          emitter.changeRightOperator(index, e.target.value);
+        }}
+        error={error}
+        helperText={helperText}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (isDateRange(selected)) {
+    return (
+      <RangeInputWrapper>
+        <RangeInput
+          value={selected.value}
+          onChange={value => {
+            emitter.changeRightOperator(index, value);
+          }}
+          type="date"
+          error={!!error}
+          helperText={helperText}
+          disabled={disabled}
+          width="100%"
+        />
+      </RangeInputWrapper>
+    );
+  }
+
+  if (isDateTimeRange(selected)) {
+    return (
+      <RangeInputWrapper>
+        <RangeInput
+          value={selected.value}
+          onChange={value => {
+            emitter.changeRightOperator(index, value);
+          }}
+          type="datetime-local"
+          error={!!error}
+          helperText={helperText}
+          disabled={disabled}
+          width="100%"
+        />
+      </RangeInputWrapper>
+    );
+  }
+
+  return <Input disabled value={selected.value} />;
+};

--- a/src/components/ConditionalFilter/UI/Root.tsx
+++ b/src/components/ConditionalFilter/UI/Root.tsx
@@ -1,0 +1,57 @@
+import { Box, Divider } from "@saleor/macaw-ui/next";
+import React, { ReactNode } from "react";
+
+import { FilterContext } from "./context";
+import { Filters } from "./Filters";
+import { NoValue } from "./NoValue";
+import type { Error, FilterEvent, LeftOperatorOption, Row } from "./types";
+import { useEventEmitter } from "./useEvents";
+
+export interface ExperimentalFiltersProps {
+  value: Array<Row | string>;
+  leftOptions: LeftOperatorOption[];
+  children?: ReactNode;
+  onChange?: (event: FilterEvent["detail"]) => void;
+  locale?: Record<string, string>;
+  error?: Error[];
+}
+
+export const Root = ({
+  value,
+  onChange,
+  leftOptions,
+  children,
+  locale = {
+    WHERE: "Where",
+    AND: "and",
+    OR: "or",
+    noValueText: "Click button below to start filtering",
+  },
+  error,
+}: ExperimentalFiltersProps) => {
+  const { emitter } = useEventEmitter({
+    onChange,
+  });
+
+  return (
+    <FilterContext.Provider
+      value={{ emitter, actionButtonsDisabled: value.length === 0 }}
+    >
+      <Box height="100%" display="grid" __gridTemplateRows="1fr">
+        {value.length > 0 ? (
+          <Filters
+            value={value}
+            leftOptions={leftOptions}
+            emitter={emitter}
+            locale={locale}
+            error={error}
+          />
+        ) : (
+          <NoValue locale={locale} />
+        )}
+        <Divider />
+        {children}
+      </Box>
+    </FilterContext.Provider>
+  );
+};

--- a/src/components/ConditionalFilter/UI/Row.tsx
+++ b/src/components/ConditionalFilter/UI/Row.tsx
@@ -1,0 +1,103 @@
+import {
+  Box,
+  Button,
+  DynamicCombobox,
+  RemoveIcon,
+  Select,
+} from "@saleor/macaw-ui/next";
+import React from "react";
+
+import { getItemConstraint } from "./constrains";
+import { ErrorLookup } from "./errors";
+import { FilterEventEmitter } from "./EventEmitter";
+import { RightOperator } from "./RightOperator";
+import { ExperimentalFiltersProps } from "./Root";
+import { Row } from "./types";
+
+interface RowProps {
+  item: Row;
+  index: number;
+  leftOptions: ExperimentalFiltersProps["leftOptions"];
+  emitter: FilterEventEmitter;
+  error: ErrorLookup[number];
+}
+
+export const RowComponent = ({
+  item,
+  index,
+  leftOptions,
+  emitter,
+  error,
+}: RowProps) => {
+  const constrain = getItemConstraint(item.constraint);
+
+  return (
+    <Box
+      display="grid"
+      gap={0.5}
+      __gridTemplateColumns="200px 120px 200px auto"
+      placeItems="center"
+      alignItems="start"
+    >
+      <DynamicCombobox
+        value={item.value}
+        options={leftOptions}
+        loading={item.loading}
+        onChange={value => {
+          if (!value) return;
+
+          emitter.changeLeftOperator(
+            index,
+            value,
+            leftOptions.find(option => option.value === value.value)?.type,
+          );
+        }}
+        onInputValueChange={value => {
+          emitter.inputChangeLeftOperator(index, value);
+        }}
+        onFocus={() => {
+          emitter.focusLeftOperator(index);
+        }}
+        onBlur={() => {
+          emitter.blurLeftOperator(index);
+        }}
+        error={error.left.show}
+        helperText={error.left.text}
+        disabled={constrain.disableLeftOperator}
+      />
+
+      <Select
+        value={item.condition.selected.conditionValue}
+        options={item.condition.options}
+        disabled={constrain.disableCondition}
+        onChange={value => {
+          emitter.changeCondition(index, value);
+        }}
+        onFocus={() => {
+          emitter.focusCondition(index);
+        }}
+        onBlur={() => {
+          emitter.blurCondition(index);
+        }}
+        error={error.condition.show}
+        helperText={error.condition.text}
+      />
+
+      <RightOperator
+        selected={item.condition?.selected}
+        index={index}
+        emitter={emitter}
+        error={error.right.show}
+        helperText={error.right.text}
+        disabled={constrain.disableRightOperator}
+      />
+
+      <Button
+        variant="tertiary"
+        icon={<RemoveIcon />}
+        onClick={() => emitter.removeRow(index)}
+        disabled={constrain.disableRemoveButton}
+      />
+    </Box>
+  );
+};

--- a/src/components/ConditionalFilter/UI/constrains.ts
+++ b/src/components/ConditionalFilter/UI/constrains.ts
@@ -1,0 +1,8 @@
+import { Row } from "./types";
+
+export const getItemConstraint = (constraint: Row["constraint"]) => ({
+  disableRemoveButton: !constraint?.removable,
+  disableLeftOperator: constraint?.disabled?.includes("left") ?? false,
+  disableCondition: constraint?.disabled?.includes("condition") ?? false,
+  disableRightOperator: constraint?.disabled?.includes("right") ?? false,
+});

--- a/src/components/ConditionalFilter/UI/context.ts
+++ b/src/components/ConditionalFilter/UI/context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+import { FilterEventEmitter } from "./EventEmitter";
+
+interface Context {
+  emitter: FilterEventEmitter;
+  actionButtonsDisabled: boolean;
+}
+
+export const FilterContext = createContext<Context | undefined>(undefined);
+
+export const useFilterContext = () => {
+  const context = useContext(FilterContext);
+
+  if (!context) {
+    throw new Error(
+      "Filter context must be used within FilterContext.Provider",
+    );
+  }
+
+  return context;
+};

--- a/src/components/ConditionalFilter/UI/errors.ts
+++ b/src/components/ConditionalFilter/UI/errors.ts
@@ -1,0 +1,65 @@
+import { Error } from "./types";
+
+export type ErrorLookup = Record<
+  number,
+  {
+    left: {
+      text: string;
+      show: boolean;
+    };
+    right: {
+      text: string;
+      show: boolean;
+    };
+    condition: {
+      text: string;
+      show: boolean;
+    };
+  }
+>;
+
+export const createErrorLookup = (errors: Error[] | undefined): ErrorLookup => {
+  const entries = errors?.map(error => [
+    error.row,
+    {
+      left: {
+        text: error.leftText ?? "",
+        show: !!error.leftText,
+      },
+      right: {
+        text: error.rightText ?? "",
+        show: !!error.rightText,
+      },
+      condition: {
+        text: error.conditionText ?? "",
+        show: !!error.conditionText,
+      },
+    },
+  ]);
+
+  return entries ? Object.fromEntries(entries) : {};
+};
+
+export const getErrorByRowIndex = (
+  errorLookup: ErrorLookup,
+  rowIndex: number,
+) => {
+  const possibleError = errorLookup[rowIndex];
+
+  return (
+    possibleError ?? {
+      left: {
+        text: "",
+        show: false,
+      },
+      right: {
+        text: "",
+        show: false,
+      },
+      condition: {
+        text: "",
+        show: false,
+      },
+    }
+  );
+};

--- a/src/components/ConditionalFilter/UI/index.ts
+++ b/src/components/ConditionalFilter/UI/index.ts
@@ -1,0 +1,20 @@
+import { AddRowButton, ClearButton, ConfirmButton, Footer } from "./Footer";
+import { Root } from "./Root";
+
+export type { ExperimentalFiltersProps } from "./Root";
+export type {
+  ConditionOption,
+  Error,
+  FilterEvent,
+  LeftOperatorOption,
+  RightOperatorOption,
+  Row,
+  SelectedOperator,
+} from "./types";
+
+export const Filters = Object.assign(Root, {
+  AddRowButton,
+  ConfirmButton,
+  ClearButton,
+  Footer,
+});

--- a/src/components/ConditionalFilter/UI/operators.ts
+++ b/src/components/ConditionalFilter/UI/operators.ts
@@ -1,0 +1,47 @@
+import {
+  ComboboxOperator,
+  DateOperator,
+  DateTimeOperator,
+  InputOperator,
+  MultiselectOperator,
+  NumberRangeOperator,
+  SelectedOperator,
+  SelectOperator,
+} from "./types";
+
+export const isTextInput = (value: SelectedOperator): value is InputOperator =>
+  value.conditionValue?.type === "text";
+
+export const isNumberInput = (
+  value: SelectedOperator,
+): value is InputOperator => value.conditionValue?.type === "number";
+
+export const isMultiselect = (
+  value: SelectedOperator,
+): value is MultiselectOperator => value.conditionValue?.type === "multiselect";
+
+export const isCombobox = (
+  value: SelectedOperator,
+): value is ComboboxOperator => value.conditionValue?.type === "combobox";
+
+export const isSelect = (value: SelectedOperator): value is SelectOperator =>
+  value.conditionValue?.type === "select";
+
+export const isNumberRange = (
+  value: SelectedOperator,
+): value is NumberRangeOperator =>
+  value.conditionValue?.type === "number.range";
+
+export const isDate = (value: SelectedOperator): value is DateOperator =>
+  value.conditionValue?.type === "date";
+
+export const isDateTime = (
+  value: SelectedOperator,
+): value is DateTimeOperator => value.conditionValue?.type === "datetime";
+
+export const isDateRange = (value: SelectedOperator): value is DateOperator =>
+  value.conditionValue?.type === "date.range";
+
+export const isDateTimeRange = (
+  value: SelectedOperator,
+): value is DateTimeOperator => value.conditionValue?.type === "datetime.range";

--- a/src/components/ConditionalFilter/UI/types.ts
+++ b/src/components/ConditionalFilter/UI/types.ts
@@ -1,0 +1,211 @@
+import { Option, RangeValue } from "@saleor/macaw-ui/next";
+
+export type DisabledScope = "left" | "right" | "condition";
+
+export type RightOperatorOption = Option & {
+  slug: string;
+};
+
+export type LeftOperatorOption = Option & {
+  type: string;
+};
+
+export type ConditionOption<T extends string> = Option & {
+  type: T;
+};
+
+export interface Error {
+  row: number;
+  leftText?: string;
+  conditionText?: string;
+  rightText?: string;
+}
+
+type ConditionOptionTypes = ConditionOption<
+  | "text"
+  | "number"
+  | "multiselect"
+  | "combobox"
+  | "select"
+  | "number.range"
+  | "date"
+  | "datetime"
+  | "date.range"
+  | "datetime.range"
+>;
+
+export interface Row {
+  value: { label: string; value: string; type: string } | null;
+  loading?: boolean;
+  constraint?: {
+    dependsOn: string[];
+    disabled?: DisabledScope[];
+    removable?: boolean;
+  };
+  condition: {
+    loading?: boolean;
+    options: ConditionOptionTypes[];
+    selected: SelectedOperator;
+  };
+}
+
+export type SelectedOperator =
+  | InputOperator
+  | MultiselectOperator
+  | ComboboxOperator
+  | SelectOperator
+  | NumberRangeOperator
+  | DateOperator
+  | DateTimeOperator
+  | DateRangeOperator
+  | DateTimeRangeOperator;
+
+export interface InputOperator {
+  value: string;
+  conditionValue: ConditionOption<"text" | "number"> | null;
+}
+
+export interface MultiselectOperator {
+  value: RightOperatorOption[];
+  conditionValue: ConditionOption<"multiselect"> | null;
+  options: RightOperatorOption[];
+  loading?: boolean;
+}
+
+export interface ComboboxOperator {
+  value: RightOperatorOption;
+  conditionValue: ConditionOption<"combobox"> | null;
+  options: RightOperatorOption[];
+  loading?: boolean;
+}
+
+export interface SelectOperator {
+  value: RightOperatorOption;
+  conditionValue: ConditionOption<"select"> | null;
+  options: RightOperatorOption[];
+}
+
+export interface NumberRangeOperator {
+  value: RangeValue;
+  conditionValue: ConditionOption<"number.range"> | null;
+}
+
+export interface DateOperator {
+  value: string;
+  conditionValue: ConditionOption<"date"> | null;
+}
+
+export interface DateTimeOperator {
+  value: string;
+  conditionValue: ConditionOption<"datetime"> | null;
+}
+
+export interface DateRangeOperator {
+  value: RangeValue;
+  conditionValue: ConditionOption<"date.range"> | null;
+}
+
+export interface DateTimeRangeOperator {
+  value: RangeValue;
+  conditionValue: ConditionOption<"datetime.range"> | null;
+}
+
+export interface FilterEvent extends Event {
+  detail?:
+    | RowAddData
+    | RowRemoveData
+    | LeftOperatorChangeData
+    | LeftOperatorFocusData
+    | LeftOperatorBlurData
+    | LeftOperatorInputValueChangeData
+    | ConditionChangeData
+    | ConditionFocusData
+    | ConditionBlurData
+    | RightOperatorChangeData
+    | RightOperatorFocusData
+    | RightOperatorBlurData
+    | RightOperatorInputValueChangeData;
+}
+
+export interface RowAddData {
+  type: "row.add";
+  rowType: string;
+}
+
+export interface RowRemoveData {
+  type: "row.remove";
+  path: `${number}`;
+  index: number;
+}
+
+export interface LeftOperatorChangeData {
+  type: "leftOperator.onChange";
+  path: `${number}`;
+  index: number;
+  value: LeftOperatorOption;
+  rowType: string;
+}
+
+export interface LeftOperatorFocusData {
+  type: "leftOperator.onFocus";
+  path: `${number}`;
+  index: number;
+}
+
+export interface LeftOperatorBlurData {
+  type: "leftOperator.onBlur";
+  path: `${number}`;
+  index: number;
+}
+
+export interface LeftOperatorInputValueChangeData {
+  type: "leftOperator.onInputValueChange";
+  path: `${number}`;
+  index: number;
+  value: string;
+}
+
+export interface ConditionChangeData {
+  type: "condition.onChange";
+  path: `${number}.condition.selected`;
+  index: number;
+  value: ConditionOptionTypes;
+}
+
+export interface ConditionFocusData {
+  type: "condition.onFocus";
+  path: `${number}.condition.selected`;
+  index: number;
+}
+
+export interface ConditionBlurData {
+  type: "condition.onBlur";
+  path: `${number}.condition.selected`;
+  index: number;
+}
+
+export interface RightOperatorChangeData {
+  type: "rightOperator.onChange";
+  path: `${number}.condition.selected.value`;
+  index: number;
+  value: string | RightOperatorOption[] | RightOperatorOption | RangeValue;
+}
+
+export interface RightOperatorFocusData {
+  type: "rightOperator.onFocus";
+  path: `${number}.condition.selected.value`;
+  index: number;
+}
+
+export interface RightOperatorBlurData {
+  type: "rightOperator.onBlur";
+  path: `${number}.condition.selected.value`;
+  index: number;
+}
+
+export interface RightOperatorInputValueChangeData {
+  type: "rightOperator.onInputValueChange";
+  path: `${number}.condition.selected.value`;
+  index: number;
+  value: string;
+}

--- a/src/components/ConditionalFilter/UI/useEvents.tsx
+++ b/src/components/ConditionalFilter/UI/useEvents.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+import { FilterEventEmitter } from "./EventEmitter";
+import { FilterEvent } from "./types";
+
+interface UseEventsProps {
+  onChange?: (event: FilterEvent["detail"]) => void;
+}
+
+const emitter = new FilterEventEmitter();
+
+export const useEventEmitter = ({ onChange }: UseEventsProps) => {
+  useEffect(() => {
+    const handleChange = (event: FilterEvent) => {
+      onChange?.(event.detail);
+    };
+
+    emitter.addEventListener(emitter.type, handleChange);
+
+    return () => {
+      emitter.removeEventListener(emitter.type, handleChange);
+    };
+  }, [onChange]);
+
+  return {
+    emitter,
+  };
+};


### PR DESCRIPTION
This PR moves conditional filters UI to dashboard.

closes #...

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets file (instructions in [contribution guide](https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
