### PR TITLE
Add clarity to cancel order dialog #4336

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1605,6 +1605,14 @@
     "context": "cancel button",
     "string": "Cancel order"
   },
+  "8fI5PB": {
+    "context": "confirm button",
+    "string": "Cancel order"
+  },
+  "CswOOG": {
+    "context": "cancel button",
+    "string": "Keep order"
+  },
   "9eC0MZ": {
     "context": "collection",
     "string": "Hidden"
@@ -3842,9 +3850,9 @@
     "context": "sum of all manual refunds for transaction",
     "string": "Manual refund"
   },
-  "PRXpBm": {
+  "dCpZEE": { 
     "context": "dialog header",
-    "string": "Cancel Order"
+    "string": "Cancel Order {orderNumber}"
   },
   "PTW56s": {
     "context": "alert",
@@ -4761,8 +4769,8 @@
     "context": "fulfill button label",
     "string": "Fulfill anyway"
   },
-  "VSztEE": {
-    "string": "Cancelling this order will release unfulfilled stocks, so they can be bought by other customers. <b>Order will not be refunded when cancelling order - You need to do it manually.</b> Are you sure you want to cancel this order?"
+  "uGS10l": {
+    "string": "Cancelling this order will release unfulfilled stocks, so they can be bought by other customers. <b>Important:</b> Refunds need to be issued <b>manually</b> after order cancelation. Are you sure you want to cancel this order?"
   },
   "VTITVe": {
     "context": "section header",

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -403,6 +403,14 @@ export const buttonMessages = defineMessages({
     id: "rbrahO",
     defaultMessage: "Close",
   },
+  cancelOrder: {
+    id: "8fI5PB",
+    defaultMessage: "Cancel order",
+  },
+  keepOrder: {
+    id: "CswOOG",
+    defaultMessage: "Keep order",
+  },
 });
 
 export const sectionNames = defineMessages({

--- a/src/orders/components/OrderCancelDialog/OrderCancelDialog.tsx
+++ b/src/orders/components/OrderCancelDialog/OrderCancelDialog.tsx
@@ -44,16 +44,19 @@ const OrderCancelDialog: React.FC<OrderCancelDialogProps> = props => {
     <Dialog onClose={onClose} open={open} maxWidth="sm">
       <DialogTitle disableTypography>
         <FormattedMessage
-          id="PRXpBm"
-          defaultMessage="Cancel Order"
+          id="dCpZEE"
+          defaultMessage="Cancel Order {orderNumber}"
           description="dialog header"
+          values={{
+            orderNumber,
+          }}
         />
       </DialogTitle>
       <DialogContent>
         <DialogContentText key="cancel">
           <FormattedMessage
-            id="VSztEE"
-            defaultMessage="Cancelling this order will release unfulfilled stocks, so they can be bought by other customers. <b>Order will not be refunded when cancelling order - You need to do it manually.</b> Are you sure you want to cancel this order?"
+            id="uGS10l"
+            defaultMessage="Cancelling this order will release unfulfilled stocks, so they can be bought by other customers. <b>Important:</b> Refunds need to be issued <b>manually</b> after order cancelation. Are you sure you want to cancel this order?"
             values={{
               b: (...chunks) => <b>{chunks}</b>,
               orderNumber,
@@ -72,13 +75,15 @@ const OrderCancelDialog: React.FC<OrderCancelDialogProps> = props => {
         )}
       </DialogContent>
       <DialogActions>
-        <BackButton onClick={onClose} />
+        <BackButton onClick={onClose}>
+          <FormattedMessage {...buttonMessages.keepOrder} />
+        </BackButton>
         <ConfirmButton
           onClick={onSubmit}
           transitionState={confirmButtonState}
           type="submit"
         >
-          <FormattedMessage {...buttonMessages.accept} />
+          <FormattedMessage {...buttonMessages.cancelOrder} />
         </ConfirmButton>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
closes #4336 

### Screenshots

UI before changes
![issue](https://github.com/saleor/saleor-dashboard/assets/73781042/110658d1-175e-437b-94ba-5110afa9b4fb)

UI after changes
![ui after](https://github.com/saleor/saleor-dashboard/assets/73781042/17890aa0-bb7c-495c-9f82-285dc3471119)

### Pull Request Checklist

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [x] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [x] Your code works with the latest stable version of the core
6. [ ] I added changesets file (instructions in [contribution guide](https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
