### PR TITLE
Delete single and bulk delete variants tests

### DIFF
--- a/.changeset/cuddly-crabs-lick.md
+++ b/.changeset/cuddly-crabs-lick.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Delete single and bulk delete variants tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? "blob" : "html",
-  timeout: process.env.CI ? 60000 : 10000,
+  timeout: process.env.CI ? 60000 : 20000,
   // webServer: {
   //   command: "npm run dev",
   //   url: "http://localhost:9000/",

--- a/playwright/data/e2eTestData.ts
+++ b/playwright/data/e2eTestData.ts
@@ -26,6 +26,17 @@ export const PRODUCTS = {
     id: "UHJvZHVjdDo3MzM%3D",
     info: "Product that contains single variant",
   },
+  singleVariantDeleteProduct: {
+    productId: "UHJvZHVjdDo3Njc%3D",
+    variantId: "UHJvZHVjdFZhcmlhbnQ6MTIzNg%3D%3D",
+    productName: "beer with variant to be deleted",
+    info: "Delete variant via it details page product",
+  },
+  multipleVariantsBulkDeleteProduct: {
+    productId: "UHJvZHVjdDo3NjY%3D",
+    productName: "juice with variant to be deleted",
+    info: "Delete multiple variants via grid product page",
+  },
   productWithVariantWhichWillBeUpdated: {
     id: "UHJvZHVjdDo3NjU%3D",
     name: "product with variant which will be updated",

--- a/playwright/pages/basePage.ts
+++ b/playwright/pages/basePage.ts
@@ -8,6 +8,7 @@ export class BasePage {
   constructor(
     page: Page,
     readonly pageHeader = page.getByTestId("page-header"),
+    readonly bulkDeleteGridRowsButton = page.getByTestId("bulk-delete-button"),
     readonly gridCanvas = page.locator('[data-testid="data-grid-canvas"]'),
     readonly gridInput = page
       .locator('[class="clip-region"]')
@@ -42,17 +43,26 @@ export class BasePage {
   async clickFilterButton() {
     await this.filterButton.click();
   }
+  async clickBulkDeleteGridRowsButton() {
+    await this.bulkDeleteGridRowsButton.click();
+  }
 
   async typeInSearchOnListView(searchItem: string) {
     await this.searchInputListView.fill(searchItem);
   }
   async clickNextPageButton() {
     await this.nextPagePaginationButton.click();
-    await expect(this.errorBanner).not.toBeVisible();
+    await expect(
+      this.errorBanner,
+      "No error banner should be visible",
+    ).not.toBeVisible();
   }
   async clickPreviousPageButton() {
     await this.previousPagePaginationButton.click();
-    await expect(this.errorBanner).not.toBeVisible();
+    await expect(
+      this.errorBanner,
+      "No error banner should be visible",
+    ).not.toBeVisible();
   }
   async clickNumbersOfRowsButton() {
     await this.rowNumberButton.click();
@@ -66,17 +76,26 @@ export class BasePage {
     await this.successBanner
       .locator(`text=${msg}`)
       .waitFor({ state: "visible", timeout: 10000 });
-    await expect(this.errorBanner).not.toBeVisible();
+    await expect(
+      this.errorBanner,
+      "No error banner should be visible",
+    ).not.toBeVisible();
   }
   async expectSuccessBanner() {
     await this.successBanner
       .first()
       .waitFor({ state: "visible", timeout: 15000 });
-    await expect(this.errorBanner).not.toBeVisible();
+    await expect(
+      this.errorBanner,
+      "No error banner should be visible",
+    ).not.toBeVisible();
   }
   async expectInfoBanner() {
     await this.infoBanner.first().waitFor({ state: "visible", timeout: 15000 });
-    await expect(this.errorBanner).not.toBeVisible();
+    await expect(
+      this.errorBanner,
+      "No error banner should be visible",
+    ).not.toBeVisible();
   }
 
   async getRandomInt(max: number) {

--- a/playwright/pages/dialogs/deleteVariantDialog.ts
+++ b/playwright/pages/dialogs/deleteVariantDialog.ts
@@ -1,0 +1,12 @@
+import type { Page } from "@playwright/test";
+
+export class DeleteVariantDialog {
+  constructor(
+    page: Page,
+    readonly deleteVariantButton = page.getByTestId("delete-variant-button"),
+  ) {}
+
+  async clickDeleteVariantButton() {
+    await this.deleteVariantButton.click();
+  }
+}

--- a/playwright/pages/productPage.ts
+++ b/playwright/pages/productPage.ts
@@ -63,6 +63,7 @@ export class ProductPage {
     readonly saveUploadUrlButton = page.getByTestId("upload-url-button"),
     readonly editVariantButton = page.getByTestId("row-action-button"),
     readonly productUpdateFormSection = page.getByTestId("product-update-form"),
+    readonly noVariantsText = page.getByTestId("empty-data-grid-text"),
     readonly firstCategoryItem = page.locator("#downshift-0-item-0"),
     readonly visibleRadioBtn = page.locator("[name='isPublished']"),
     readonly channelAvailabilityItem = page.locator(

--- a/playwright/pages/variantsPage.ts
+++ b/playwright/pages/variantsPage.ts
@@ -1,8 +1,9 @@
 import { URL_LIST } from "@data/url";
+import { ChannelSelectDialog } from "@dialogs/channelSelectDialog";
+import { DeleteVariantDialog } from "@dialogs/deleteVariantDialog";
 import type { Page } from "@playwright/test";
 
 import { BasePage } from "./basePage";
-import { ChannelSelectDialog } from "./dialogs/channelSelectDialog";
 import { MetadataSeoPage } from "./pageElements/metadataSeoPage";
 
 export class VariantsPage {
@@ -10,6 +11,7 @@ export class VariantsPage {
   channelSelectDialog: ChannelSelectDialog;
   metadataSeoPage: MetadataSeoPage;
   basePage: BasePage;
+  deleteVariantDialog: DeleteVariantDialog;
 
   constructor(
     page: Page,
@@ -22,6 +24,7 @@ export class VariantsPage {
     readonly addWarehouseButton = page.getByTestId("add-warehouse"),
     readonly chooseMediaButton = page.getByTestId("choose-media-button"),
     readonly addVariantButton = page.getByTestId("button-add-variant"),
+    readonly deleteVariantButton = page.getByTestId("button-bar-delete"),
     readonly warehouseOption = page.getByRole("menuitem"),
     readonly saveButton = page.getByTestId("button-bar-confirm"),
     readonly stockInput = page.getByTestId("stock-input"),
@@ -44,6 +47,7 @@ export class VariantsPage {
     this.basePage = new BasePage(page);
     this.metadataSeoPage = new MetadataSeoPage(page);
     this.channelSelectDialog = new ChannelSelectDialog(page);
+    this.deleteVariantDialog = new DeleteVariantDialog(page);
   }
 
   async typeVariantName(variantName = "XXL beverage") {
@@ -81,6 +85,9 @@ export class VariantsPage {
 
   async clickMageChannelsButton() {
     await this.manageChannels.click();
+  }
+  async clickDeleteVariantButton() {
+    await this.deleteVariantButton.click();
   }
   async clickChooseMediaButton() {
     await this.chooseMediaButton.click();

--- a/playwright/tests/product.spec.ts
+++ b/playwright/tests/product.spec.ts
@@ -8,12 +8,21 @@ import { expect, test } from "@playwright/test";
 
 test.use({ storageState: "playwright/.auth/admin.json" });
 
-test("TC: SALEOR_3 Create basic product with variants @e2e @product", async ({
-  page,
-}) => {
-  const productCreateDialog = new ProductCreateDialog(page);
-  const productPage = new ProductPage(page);
+let productPage: ProductPage;
+let productCreateDialog: ProductCreateDialog;
+let variantsPage: VariantsPage;
+let basePage: BasePage;
+let mailpitService: MailpitService;
 
+test.beforeEach(({ page, request }) => {
+  productPage = new ProductPage(page);
+  productCreateDialog = new ProductCreateDialog(page);
+  variantsPage = new VariantsPage(page);
+  basePage = new BasePage(page);
+  mailpitService = new MailpitService(request);
+});
+
+test("TC: SALEOR_3 Create basic product with variants @e2e @product", async () => {
   await productPage.gotoProductListPage();
   await productPage.clickCreateProductButton();
   await productCreateDialog.selectProductTypeWithVariants();
@@ -26,11 +35,7 @@ test("TC: SALEOR_3 Create basic product with variants @e2e @product", async ({
   await productPage.clickSaveButton();
   await productPage.expectSuccessBanner();
 });
-test("TC: SALEOR_5 Create basic - single product type - product without variants @e2e @product", async ({
-  page,
-}) => {
-  const productPage = new ProductPage(page);
-
+test("TC: SALEOR_5 Create basic - single product type - product without variants @e2e @product", async () => {
   await productPage.gotoCreateProductPage(PRODUCTS.singleProductType.id);
   await productPage.selectOneChannelAsAvailableWhenMoreSelected();
   await productPage.typeNameDescAndRating();
@@ -48,8 +53,6 @@ test("TC: SALEOR_26 Create basic info variant - via edit variant page @e2e @prod
   page,
 }) => {
   const variantName = `TC: SALEOR_26 - variant name - ${new Date().toISOString()}`;
-  const productPage = new ProductPage(page);
-  const variantsPage = new VariantsPage(page);
 
   await productPage.gotoExistingProductPage(PRODUCTS.productWithOneVariant.id);
   await productPage.clickFirstEditVariantButton();
@@ -67,14 +70,11 @@ test("TC: SALEOR_26 Create basic info variant - via edit variant page @e2e @prod
     variantsPage.variantsList.locator(variantsPage.variantsNames, {
       hasText: variantName,
     }),
+    `New variant name: ${variantName} should be visible on the list`,
   ).toBeVisible();
 });
-test("TC: SALEOR_27 Create full info variant - via edit variant page @e2e @product", async ({
-  page,
-}) => {
+test("TC: SALEOR_27 Create full info variant - via edit variant page @e2e @product", async () => {
   const variantName = `TC: SALEOR_27 - variant name - ${new Date().toISOString()}`;
-  const productPage = new ProductPage(page);
-  const variantsPage = new VariantsPage(page);
 
   await productPage.gotoExistingProductPage(PRODUCTS.productWithOneVariant.id);
   await productPage.clickFirstEditVariantButton();
@@ -96,6 +96,7 @@ test("TC: SALEOR_27 Create full info variant - via edit variant page @e2e @produ
     variantsPage.variantsList.locator(variantsPage.variantsNames, {
       hasText: variantName,
     }),
+    `New variant name: ${variantName} should be visible on the list`,
   ).toBeVisible();
   await variantsPage.selectWarehouse();
   await variantsPage.typeQuantityInStock();
@@ -103,11 +104,7 @@ test("TC: SALEOR_27 Create full info variant - via edit variant page @e2e @produ
   await variantsPage.expectSuccessBanner();
 });
 
-test("TC: SALEOR_44 As an admin I should be able to delete a several products @basic-regression @product @e2e", async ({
-  page,
-}) => {
-  const basePage = new BasePage(page);
-  const productPage = new ProductPage(page);
+test("TC: SALEOR_44 As an admin I should be able to delete a several products @basic-regression @product @e2e", async () => {
   await productPage.gotoProductListPage();
 
   await basePage.checkListRowsBasedOnContainingText(
@@ -121,31 +118,26 @@ test("TC: SALEOR_44 As an admin I should be able to delete a several products @b
     await basePage.findRowIndexBasedOnText(
       PRODUCTS.productsToBeBulkDeleted.names,
     ),
+    `Given products: ${PRODUCTS.productsToBeBulkDeleted.names} should be deleted from the list`,
   ).toEqual([]);
 });
 
-test("TC: SALEOR_45 As an admin I should be able to delete a single products @basic-regression @product @e2e", async ({
-  page,
-}) => {
-  const basePage = new BasePage(page);
-  const productPage = new ProductPage(page);
-
+test("TC: SALEOR_45 As an admin I should be able to delete a single products @basic-regression @product @e2e", async () => {
   await productPage.gotoExistingProductPage(
     PRODUCTS.productWithOneVariantToBeDeletedFromDetails.id,
   );
   await productPage.clickDeleteProductButton();
   await productPage.deleteProductDialog.clickDeleteButton();
   await await basePage.expectSuccessBannerMessage("Product Removed");
-  await expect(basePage.gridCanvas.locator("table")).not.toContainText(
+  await expect(
+    basePage.gridCanvas.locator("table"),
+    `Given product: ${PRODUCTS.productWithOneVariantToBeDeletedFromDetails.name} should be deleted from the list`,
+  ).not.toContainText(
     PRODUCTS.productWithOneVariantToBeDeletedFromDetails.name,
   );
 });
-test("TC: SALEOR_46 As an admin, I should be able to update a product by uploading media, assigning channels, assigning tax, and adding a new variant   @basic-regression @product @e2e", async ({
-  page,
-}) => {
+test("TC: SALEOR_46 As an admin, I should be able to update a product by uploading media, assigning channels, assigning tax, and adding a new variant   @basic-regression @product @e2e", async () => {
   const newVariantName = "variant 2";
-  const productPage = new ProductPage(page);
-
   await productPage.gotoExistingProductPage(
     PRODUCTS.singleProductTypeToBeUpdated.id,
   );
@@ -169,24 +161,25 @@ test("TC: SALEOR_46 As an admin, I should be able to update a product by uploadi
   const postSaveTax = await productPage.rightSideDetailsPage.taxInput
     .locator("input")
     .inputValue();
-  await expect(preSaveTax).toEqual(postSaveTax);
+  await expect(
+    preSaveTax,
+    "Pre save tax name should be equal as the one after save",
+  ).toEqual(postSaveTax);
   await productPage.basePage.gridCanvas
     .getByText(newVariantName)
     .waitFor({ state: "attached" });
-  await expect(productPage.productAvailableInChannelsText).toContainText(
-    "In 1 out of 7 channels",
-  );
-  expect(await productPage.productImage.count()).toEqual(1);
+  await expect(
+    productPage.productAvailableInChannelsText,
+    "Label copy shows 1 out of 7 channels ",
+  ).toContainText("In 1 out of 7 channels");
+  expect(
+    await productPage.productImage.count(),
+    "Newly added single image should be present",
+  ).toEqual(1);
 });
 
 // blocked by bug https://github.com/saleor/saleor-dashboard/issues/4368
-test.skip("TC: SALEOR_56 As an admin, I should be able to export products from single channel as CSV file @basic-regression @product @e2e", async ({
-  page,
-  request,
-}) => {
-  const productPage = new ProductPage(page);
-  const mailpitService = new MailpitService(request);
-
+test.skip("TC: SALEOR_56 As an admin, I should be able to export products from single channel as CSV file @basic-regression @product @e2e", async () => {
   await productPage.gotoProductListPage();
   await productPage.clickCogShowMoreButtonButton();
   await productPage.clickExportButton();
@@ -202,10 +195,7 @@ test.skip("TC: SALEOR_56 As an admin, I should be able to export products from s
   );
 });
 
-test("TC: SALEOR_57 As an admin, I should be able to search products on list view @basic-regression @product @e2e", async ({
-  page,
-}) => {
-  const productPage = new ProductPage(page);
+test("TC: SALEOR_57 As an admin, I should be able to search products on list view @basic-regression @product @e2e", async () => {
   await productPage.gotoProductListPage();
   await productPage.basePage.typeInSearchOnListView(
     PRODUCTS.productToAddVariants.name,
@@ -216,13 +206,11 @@ test("TC: SALEOR_57 As an admin, I should be able to search products on list vie
   ]);
   expect(
     await productPage.basePage.gridCanvas.locator("table tbody tr").count(),
+    "There should be only one product visible on list",
   ).toEqual(1);
 });
 
-test("TC: SALEOR_58 As an admin I should be able use pagination on product list view @basic-regression @product @e2e", async ({
-  page,
-}) => {
-  const productPage = new ProductPage(page);
+test("TC: SALEOR_58 As an admin I should be able use pagination on product list view @basic-regression @product @e2e", async () => {
   await productPage.gotoProductListPage();
   await productPage.basePage.waitForGrid();
   const firstPageProductName = await productPage.basePage.getGridCellText(0, 0);
@@ -251,10 +239,7 @@ test("TC: SALEOR_58 As an admin I should be able use pagination on product list 
   ).toContainText(firstPageProductName);
 });
 
-test("TC: SALEOR_59 As an admin I should be able to filter products by channel on product list view @basic-regression @product @e2e", async ({
-  page,
-}) => {
-  const productPage = new ProductPage(page);
+test("TC: SALEOR_59 As an admin I should be able to filter products by channel on product list view @basic-regression @product @e2e", async () => {
   await productPage.gotoProductListPage();
   await productPage.basePage.waitForGrid();
 
@@ -277,14 +262,11 @@ test("TC: SALEOR_59 As an admin I should be able to filter products by channel o
     `Product: ${PRODUCTS.productAvailableOnlyInPlnChannel.name} should be visible on grid table`,
   ).toContainText(PRODUCTS.productAvailableOnlyInPlnChannel.name);
 });
-test("TC: SALEOR_60 As an admin I should be able update existing variant @basic-regression @product @e2e", async ({
-  page,
-}) => {
+
+test("TC: SALEOR_60 As an admin I should be able update existing variant @basic-regression @product @e2e", async () => {
   const variantName = `TC: SALEOR_60 - variant name - ${new Date().toISOString()}`;
   const sku = `SALEOR_60-sku-${new Date().toISOString()}`;
 
-  const productPage = new ProductPage(page);
-  const variantsPage = new VariantsPage(page);
   await variantsPage.gotoExistingVariantPage(
     PRODUCTS.productWithVariantWhichWillBeUpdated.id,
     PRODUCTS.productWithVariantWhichWillBeUpdated.variantId,
@@ -300,19 +282,58 @@ test("TC: SALEOR_60 As an admin I should be able update existing variant @basic-
   await variantsPage.typeSellingPriceInChannel("USD", "120");
   await variantsPage.typeCostPriceInChannel("USD", "100");
   await variantsPage.typeSku(sku);
+  await variantsPage.selectWarehouse("Africa");
+  await variantsPage.typeQuantityInStock("Africa", "5000");
   await variantsPage.clickSaveVariantButton();
-
   await variantsPage.expectSuccessBanner();
   await expect(
     variantsPage.variantsList.locator(variantsPage.variantsNames, {
       hasText: variantName,
     }),
+    `Updated name: ${variantName} should be visible on list`,
   ).toBeVisible();
-
-  await variantsPage.selectWarehouse("Africa");
-  await variantsPage.typeQuantityInStock("Africa", "5000");
-  await variantsPage.clickSaveVariantButton();
-
-  await variantsPage.expectSuccessBanner();
   await productPage.productImage.waitFor({ state: "visible" });
+});
+test("TC: SALEOR_61 As an admin I should be able to delete existing variant @basic-regression @product @e2e", async () => {
+  await variantsPage.gotoExistingVariantPage(
+    PRODUCTS.singleVariantDeleteProduct.productId,
+    PRODUCTS.singleVariantDeleteProduct.variantId,
+  );
+
+  await variantsPage.clickDeleteVariantButton();
+  await variantsPage.deleteVariantDialog.clickDeleteVariantButton();
+
+  await productPage.expectSuccessBanner();
+  await expect(
+    productPage.noVariantsText,
+    "Message about how to add new variant should be visible in place of list of variants",
+  ).toBeVisible();
+  await expect(
+    productPage.productNameInput,
+    "Deleting last variant from variant details page should redirect to product page",
+  ).toHaveText(PRODUCTS.singleVariantDeleteProduct.productName);
+});
+
+test("TC: SALEOR_62 As an admin I should be able to bulk delete existing variants @basic-regression @product @e2e", async () => {
+  await productPage.gotoExistingProductPage(
+    PRODUCTS.multipleVariantsBulkDeleteProduct.productId,
+  );
+
+  await productPage.basePage.waitForGrid();
+  await productPage.basePage.gridCanvas.scrollIntoViewIfNeeded();
+  // there should be 3 variants present and checked in next steps
+  await productPage.basePage.clickGridCell(0, 0);
+  await productPage.basePage.clickGridCell(0, 1);
+  await productPage.basePage.clickGridCell(0, 2);
+  await productPage.basePage.clickBulkDeleteGridRowsButton();
+  await expect(
+    productPage.noVariantsText,
+    "Message about how to add new variant should be visible in place of list of variants",
+  ).toBeVisible();
+  await productPage.clickSaveButton();
+  await productPage.expectSuccessBanner();
+  await expect(
+    productPage.noVariantsText,
+    "Message about how to add new variant should be visible in place of list of variants",
+  ).toBeVisible();
 });

--- a/playwright/tests/product.spec.ts
+++ b/playwright/tests/product.spec.ts
@@ -309,9 +309,9 @@ test("TC: SALEOR_61 As an admin I should be able to delete existing variant @bas
     "Message about how to add new variant should be visible in place of list of variants",
   ).toBeVisible();
   await expect(
-    productPage.productNameInput,
+    productPage.page.url(),
     "Deleting last variant from variant details page should redirect to product page",
-  ).toHaveText(PRODUCTS.singleVariantDeleteProduct.productName);
+  ).toContain(PRODUCTS.singleVariantDeleteProduct.productId);
 });
 
 test("TC: SALEOR_62 As an admin I should be able to bulk delete existing variants @basic-regression @product @e2e", async () => {

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -588,7 +588,9 @@ export const Datagrid: React.FC<DatagridProps> = ({
             </>
           ) : (
             <Box padding={6} textAlign="center">
-              <Text size="small">{emptyText}</Text>
+              <Text data-test-id="empty-data-grid-text" size="small">
+                {emptyText}
+              </Text>
             </Box>
           )}
         </CardContent>

--- a/src/products/components/ProductVariantDeleteDialog/ProductVariantDeleteDialog.tsx
+++ b/src/products/components/ProductVariantDeleteDialog/ProductVariantDeleteDialog.tsx
@@ -70,6 +70,7 @@ const ProductVariantDeleteDialog: React.FC<
           transitionState={confirmButtonState}
           className={classes.deleteButton}
           onClick={onConfirm}
+          data-test-id="delete-variant-button"
         >
           <FormattedMessage
             id="rbkmfG"

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -1,3 +1,4 @@
+// import { isLimitReached } from "@dashboard/utils/limits";
 import { ChannelData } from "@dashboard/channels/utils";
 import { ColumnPicker } from "@dashboard/components/Datagrid/ColumnPicker/ColumnPicker";
 import { useColumns } from "@dashboard/components/Datagrid/ColumnPicker/useColumns";
@@ -20,7 +21,6 @@ import { ProductVariantListError } from "@dashboard/products/views/ProductUpdate
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { Item } from "@glideapps/glide-data-grid";
 import { Button } from "@saleor/macaw-ui";
-// import { isLimitReached } from "@dashboard/utils/limits";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -211,7 +211,11 @@ export const ProductVariants: React.FC<ProductVariantsProps> = ({
       ]}
       rows={variants?.length ?? 0}
       selectionActions={(indexes, { removeRows }) => (
-        <Button variant="tertiary" onClick={() => removeRows(indexes)}>
+        <Button
+          data-test-id="bulk-delete-button"
+          variant="tertiary"
+          onClick={() => removeRows(indexes)}
+        >
           <FormattedMessage {...buttonMessages.delete} />
         </Button>
       )}


### PR DESCRIPTION
closes #4550 

- Contains also better `expect` copy for all expects in Product tests
- Moved initialization of pages to before each - tests body polishing 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets file (instructions in [contribution guide](https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
