### PR TITLE
Change assertion text within channels checkbox in e2e tests

### DIFF
--- a/.changeset/fast-badgers-wink.md
+++ b/.changeset/fast-badgers-wink.md
@@ -2,4 +2,4 @@
 "saleor-dashboard": minor
 ---
 
-fix copy availability
+Change assertion text within channels checkbox in e2e tests

--- a/.changeset/fast-badgers-wink.md
+++ b/.changeset/fast-badgers-wink.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+fix copy availability

--- a/playwright/data/copy.ts
+++ b/playwright/data/copy.ts
@@ -1,3 +1,3 @@
 export const AVAILABILITY = {
-  in1OutOf7Channels: "In 1 out of 7 channels",
+  in1OutOf: "In 1 out of",
 };

--- a/playwright/tests/discountAndVouchers.spec.ts
+++ b/playwright/tests/discountAndVouchers.spec.ts
@@ -84,7 +84,7 @@ test("TC: SALEOR_85 Create voucher with manual code and percentage discount @vou
     `Given codes: ${code} should have status Active displayed on grid`,
   ).toEqual(1);
   await vouchersPage.page
-    .getByText(AVAILABILITY.in1OutOf7Channels)
+    .getByText(AVAILABILITY.in1OutOf)
     .waitFor({ state: "visible" });
 });
 

--- a/playwright/tests/product.spec.ts
+++ b/playwright/tests/product.spec.ts
@@ -169,7 +169,7 @@ test("TC: SALEOR_46 As an admin, I should be able to update a product by uploadi
   await expect(
     productPage.productAvailableInChannelsText,
     "Label copy shows 1 out of 7 channels ",
-  ).toContainText(AVAILABILITY.in1OutOf7Channels);
+  ).toContainText(AVAILABILITY.in1OutOf);
   expect(
     await productPage.productImage.count(),
     "Newly added single image should be present",


### PR DESCRIPTION
Copy for assertion was to detailed - contained number of channels in DB. 
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `data-test-id` are added for new elements
4. [ ] The changes are tested in Chrome/Firefox/Safari browsers and in light/dark mode
5. [ ] Your code works with the latest stable version of the core
6. [ ] I added changesets file (instructions in [contribution guide](https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md)

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://automation-dashboard.staging.saleor.cloud/graphql/
APPS_MARKETPLACE_API_URI=https://apps.staging.saleor.io/api/v2/saleor-apps

### Do you want to run more stable tests?

To run all tests, just select the stable checkbox. To speed up tests, increase the number of containers. Tests will be re-run only when the "run e2e" label is added.

1. [ ] stable
2. [ ] app
3. [ ] attribute
4. [ ] category
5. [ ] collection
6. [ ] customer
7. [ ] giftCard
8. [ ] homePage
9. [ ] login
10. [ ] menuNavigation
11. [ ] navigation
12. [ ] orders
13. [ ] pages
14. [ ] payments
15. [ ] permissions
16. [ ] plugins
17. [ ] productType
18. [ ] products
19. [ ] sales
20. [ ] shipping
21. [ ] translations
22. [ ] variants
23. [ ] vouchers

CONTAINERS=2
