### PR TITLE
Allow to manually override number of shards to use during manual re-runs

### DIFF
--- a/.changeset/giant-students-pull.md
+++ b/.changeset/giant-students-pull.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Allow to manually override number of shards to use during manual re-runs

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,6 +1,6 @@
 name: PR automation
 
-on: 
+on:
   pull_request:
   workflow_dispatch:
     inputs:
@@ -8,7 +8,7 @@ on:
         type: number
         description: 'Number of shards to use for parallel testing'
         required: false
-        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.run-tests.with.concurrency`.
+        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.with.concurrency`.
 
 concurrency:
   group: ${{ github.ref }}
@@ -26,6 +26,7 @@ jobs:
       BACKUP_ID: ${{ steps.cloud_variables.outputs.BACKUP_ID }}
       BACKUP_VER: ${{ steps.cloud_variables.outputs.BACKUP_VER }}
       BACKUP_NAME: ${{ steps.cloud_variables.outputs.BACKUP_NAME }}
+      SHARD_MATRIX: ${{ steps.generate-shard-matrix.outputs.SHARD_MATRIX }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +49,21 @@ jobs:
           POOL_NAME: ${{ steps.cloud_variables.outputs.POOL_NAME }}
           POOL_INSTANCE: ${{ steps.cloud_variables.outputs.POOL_INSTANCE }}
           BACKUP_ID: ${{ steps.cloud_variables.outputs.BACKUP_ID }}
+
+      - name: Generate shard matrix
+        id: generate-shard-matrix
+        with:
+          concurrency: ${{ inputs.shards || 4 }}
+        run: |
+          max_concurrency=4
+          if [ "$concurrency" -gt "$max_concurrency" ]; then
+            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead." >&2
+            concurrency=$max_concurrency
+          fi
+          shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
+          shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
+          shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
+          echo "matrix=$shard_matrix" >> "$GITHUB_OUTPUT"
 
   deploy-dashboard:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'
@@ -133,24 +149,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ steps.generate-shard-matrix.outputs.matrix }}
-    with:
-      concurrency: ${{ inputs.shards || 4 }}
+        shard: ${{ needs.initialize-cloud.outputs.SHARD_MATRIX }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Generate shard matrix 
-        id: generate-shard-matrix
-        run: |
-          max_concurrency=4
-          if [ "$concurrency" -gt "$max_concurrency" ]; then
-            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead." >&2
-            concurrency=$max_concurrency
-          fi
-          shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
-          shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
-          shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
-          echo "matrix=$shard_matrix" >> "$GITHUB_OUTPUT"
 
       - name: Run playwright tests
         uses: ./.github/actions/run-pw-tests

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,6 +1,14 @@
 name: PR automation
 
-on: [pull_request]
+on: 
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      shards:
+        type: number
+        description: 'Number of shards to use for parallel testing'
+        required: false
+        default: 4 # This is the default only for manually (re-)triggered runs, Default for runs triggered by pull requests is configured via jobs.run-tests.with.concurrency
 
 concurrency:
   group: ${{ github.ref }}
@@ -125,9 +133,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: ${{ steps.generate-shard-matrix.outputs.matrix }}
+    with:
+      concurrency: ${{ inputs.shards || 4 }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Generate shard matrix 
+        id: generate-shard-matrix
+        run: |
+          shard_matrix=$(seq -f "%g/$concurrency" 1 $concurrency | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
+          shard_matrix=$(echo $shard_matrix | sed 's/,/, /g') # add space after each comma
+          shard_matrix=$(echo $shard_matrix | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
+          echo "matrix=$shard_matrix" >> $GITHUB_OUTPUT
 
       - name: Run playwright tests
         uses: ./.github/actions/run-pw-tests

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -8,7 +8,7 @@ on:
         type: number
         description: 'Number of shards to use for parallel testing'
         required: false
-        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.with.CONCURRENCY`.
+        default: 2 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.env.CONCURRENCY`.
 
 concurrency:
   group: ${{ github.ref }}
@@ -53,7 +53,7 @@ jobs:
       - name: Generate shard matrix
         id: generate-shard-matrix
         env:
-          CONCURRENCY: ${{ inputs.shards || 4 }}
+          CONCURRENCY: ${{ inputs.shards || 2 }}
         run: |
           MAX_CONCURRENCY=4
           if [ "$CONCURRENCY" -gt "$MAX_CONCURRENCY" ]; then

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.with.CONCURRENCY`.
 
-CONCURRENCY:
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -8,7 +8,7 @@ on:
         type: number
         description: 'Number of shards to use for parallel testing'
         required: false
-        default: 4 # This is the default only for manually (re-)triggered runs, Default for runs triggered by pull requests is configured via jobs.run-tests.with.concurrency
+        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.run-tests.with.concurrency`.
 
 concurrency:
   group: ${{ github.ref }}
@@ -142,6 +142,11 @@ jobs:
       - name: Generate shard matrix 
         id: generate-shard-matrix
         run: |
+          max_concurrency=4
+          if [ "$concurrency" -gt "$max_concurrency" ]; then
+            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead."
+            concurrency=$max_concurrency
+          fi
           shard_matrix=$(seq -f "%g/$concurrency" 1 $concurrency | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
           shard_matrix=$(echo $shard_matrix | sed 's/,/, /g') # add space after each comma
           shard_matrix=$(echo $shard_matrix | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -64,8 +64,8 @@ jobs:
           for i in $(seq 1 "$CONCURRENCY"); do        # Loop through the numbers from 1 to $CONCURRENCY.
             shard_matrix+=("\"$i/$CONCURRENCY\"")     # For each number i, append a string in the format "${i}/${CONCURRENCY}" to the shard_matrix array.
           done
-          shard_matrix=$(IFS=,; echo "[${shard_matrix[*]}]") # Join the elements of the shard_matrix array with commas and wrap the result in square brackets to create a valid JSON array string.
-          echo "SHARD_MATRIX=$shard_matrix" >> "$GITHUB_OUTPUT"
+          shard_matrix=( $(IFS=,; echo "[${shard_matrix[*]}]") ) # Join the elements of the shard_matrix array with commas and wrap the result in square brackets to create a valid JSON array string.
+          echo "SHARD_MATRIX=${shard_matrix[0]}" >> "$GITHUB_OUTPUT"
 
   deploy-dashboard:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -147,10 +147,10 @@ jobs:
             echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead."
             concurrency=$max_concurrency
           fi
-          shard_matrix=$(seq -f "%g/$concurrency" 1 $concurrency | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
-          shard_matrix=$(echo $shard_matrix | sed 's/,/, /g') # add space after each comma
-          shard_matrix=$(echo $shard_matrix | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
-          echo "matrix=$shard_matrix" >> $GITHUB_OUTPUT
+          shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
+          shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
+          shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
+          echo "matrix=$shard_matrix" >> "$GITHUB_OUTPUT"
 
       - name: Run playwright tests
         uses: ./.github/actions/run-pw-tests

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           max_concurrency=4
           if [ "$concurrency" -gt "$max_concurrency" ]; then
-            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead."
+            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead." >&2
             concurrency=$max_concurrency
           fi
           shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -60,9 +60,11 @@ jobs:
             echo "[WARN] The requested number of shards ($CONCURRENCY) exceeds maximum allowed value ($MAX_CONCURRENCY). Using $MAX_CONCURRENCY shards instead." >&2
             CONCURRENCY=$MAX_CONCURRENCY
           fi
-          shard_matrix=$(seq -f "%g/$CONCURRENCY" 1 "$CONCURRENCY" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $CONCURRENCY)
-          shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
-          shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
+          shard_matrix=()                             # Initialize an empty array to store the shard values.
+          for i in $(seq 1 "$CONCURRENCY"); do        # Loop through the numbers from 1 to $CONCURRENCY.
+            shard_matrix+=("\"$i/$CONCURRENCY\"")     # For each number i, append a string in the format "${i}/${CONCURRENCY}" to the shard_matrix array.
+          done
+          shard_matrix=$(IFS=,; echo "[${shard_matrix[*]}]") # Join the elements of the shard_matrix array with commas and wrap the result in square brackets to create a valid JSON array string.
           echo "SHARD_MATRIX=$shard_matrix" >> "$GITHUB_OUTPUT"
 
   deploy-dashboard:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -8,9 +8,9 @@ on:
         type: number
         description: 'Number of shards to use for parallel testing'
         required: false
-        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.with.concurrency`.
+        default: 4 # This is the default only for manually (re-)triggered runs. Default for runs triggered by pull requests is configured via `jobs.initialize-cloud.generate-shard-matrix.with.CONCURRENCY`.
 
-concurrency:
+CONCURRENCY:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -52,15 +52,15 @@ jobs:
 
       - name: Generate shard matrix
         id: generate-shard-matrix
-        with:
-          concurrency: ${{ inputs.shards || 4 }}
+        env:
+          CONCURRENCY: ${{ inputs.shards || 4 }}
         run: |
-          max_concurrency=4
-          if [ "$concurrency" -gt "$max_concurrency" ]; then
-            echo "[WARN] The requested number of shards ($concurrency) exceeds maximum allowed value ($max_concurrency). Using $max_concurrency shards instead." >&2
-            concurrency=$max_concurrency
+          MAX_CONCURRENCY=4
+          if [ "$CONCURRENCY" -gt "$MAX_CONCURRENCY" ]; then
+            echo "[WARN] The requested number of shards ($CONCURRENCY) exceeds maximum allowed value ($MAX_CONCURRENCY). Using $MAX_CONCURRENCY shards instead." >&2
+            CONCURRENCY=$MAX_CONCURRENCY
           fi
-          shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
+          shard_matrix=$(seq -f "%g/$CONCURRENCY" 1 "$CONCURRENCY" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $CONCURRENCY)
           shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
           shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
           echo "SHARD_MATRIX=$shard_matrix" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -63,7 +63,7 @@ jobs:
           shard_matrix=$(seq -f "%g/$concurrency" 1 "$concurrency" | paste -d ',' -s) # generate comma separated string like "1/4,2/4,3/4,4/4" (ranging from 1 to $concurrency)
           shard_matrix=$(echo "$shard_matrix" | sed 's/,/, /g') # add space after each comma
           shard_matrix=$(echo "$shard_matrix" | sed 's/^/[/; s/$/]/') # wrap the comma-space separated string in square brackets
-          echo "matrix=$shard_matrix" >> "$GITHUB_OUTPUT"
+          echo "SHARD_MATRIX=$shard_matrix" >> "$GITHUB_OUTPUT"
 
   deploy-dashboard:
     if: github.event.pull_request.head.repo.full_name == 'saleor/saleor-dashboard'

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ needs.initialize-cloud.outputs.SHARD_MATRIX }}
+        shard: ${{ fromJson(needs.initialize-cloud.outputs.SHARD_MATRIX) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
* Related issue: https://linear.app/saleor/issue/MERX-327/[qa]-investigate-why-tests-fail-on-ci

* **Context**: I am troubleshooting the timeout issues that our playwright is experiencing, and I want to run the workflows with varying parallelism. I decided that opening single PR that will allow manual overrides is better than multiple PRs tweaking the value.

* ~~**What this PR aims to achieve**: it allows to override default parallelism (4) with any number, but I have added a failsafe to only allow up to 4 shards (to be tweaked) - if more than max is requested, we fall back to the max.~~

Edit:
* **What this PR aims to achieve**:
  * it configures new default number of shards used when triggered by PR - it was 4, it is now going to be 2.
  * it allows to override default parallelism with any number, but I have added a failsafe to only allow up to 4 shards (to be tweaked) - if more than max is requested, we fall back to the max.
