### PR TITLE
Allow apps to open popups

### DIFF
--- a/.changeset/four-dragons-remain.md
+++ b/.changeset/four-dragons-remain.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Allow apps to open popups

--- a/src/apps/components/AppFrame/AppIFrame.tsx
+++ b/src/apps/components/AppFrame/AppIFrame.tsx
@@ -41,7 +41,7 @@ const _AppIFrame = forwardRef<HTMLIFrameElement, AppIFrameProps>(
         onLoad={onLoad}
         onError={onError}
         className={className}
-        sandbox="allow-same-origin allow-forms allow-scripts"
+        sandbox="allow-same-origin allow-forms allow-scripts allow-popups allow-popups-to-escape-sandbox"
       />
     );
   },


### PR DESCRIPTION
## What type of PR is this?
- [ ] 💅 Refactor
- [X] 🌟 Feature
- [ ] 🔥 Bug Fix
- [ ] 🔩 Maintenance
- [ ] 🛠 Workflow CI/CD changes

## Related Issues or Documents
- closes #4837 

## Usage Instructions, Screenshots, Recordings
Allows apps to open popups. It can be used to print documents from an App

Example:
```
const blobUrl = URL.createObjectURL(blob);
window.open(blobUrl, '_blank');
```

## Have you written tests?
- [ ] Yes!
- [X] No... here is why: I have tested this on my instance


## [Optional] Description
Currently when an App tries to open popup, it is blocked by browser: `request was made in a sandboxed frame whose 'allow-popups' permission is not set`