### PR TITLE
Add name of applied voucher to order details

### DIFF
--- a/.changeset/chatty-years-nail.md
+++ b/.changeset/chatty-years-nail.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Order details page now displays the name of the applied voucher.

--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 API_URL=https://demo.saleor.io/graphql/
 APP_MOUNT_URI=/
 APPS_MARKETPLACE_API_URL=https://apps.saleor.io/api/v2/saleor-apps
-LOCALE_CODE="EN" 
+LOCALE_CODE="EN"
 DEMO_MODE=false
 
 MAILPITURL=xxxx #For playwright

--- a/src/orders/messages.ts
+++ b/src/orders/messages.ts
@@ -26,14 +26,19 @@ export const orderDiscountTypeLabelMessages = defineMessages({
     description: "staff added type order discount",
   },
   voucher: {
-    id: "sEjRyz",
-    defaultMessage: "Voucher",
+    id: "l4o0ar",
+    defaultMessage: "Voucher: {voucherName}",
     description: "voucher type order discount",
   },
   promotion: {
     id: "TBdxTP",
     defaultMessage: "Promotion",
     description: "promotion type order discount",
+  },
+  sale: {
+    id: "a/JR9Y",
+    defaultMessage: "Sale",
+    description: "sale type order discount",
   },
 });
 

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -2754,7 +2754,7 @@ describe("Merge repeated order lines of fulfillment lines", () => {
     ).toBe(2);
   });
 });
-describe("Get discount type lable", () => {
+describe("Get discount type label", () => {
   it("should return Staff added for manual discount", () => {
     // Arrange
     const discount = {
@@ -2790,15 +2790,38 @@ describe("Get discount type lable", () => {
     // Assert
     expect(result).toBe("-");
   });
-  it("should return voucher when voucher discount type", () => {
+  it("should return voucher name formatting when voucher discount type", () => {
     // Arrange
     const discount = {
       type: OrderDiscountType.VOUCHER,
+      name: "Big sale",
     } as OrderDiscountFragment;
     // Act
     const result = getDiscountTypeLabel(discount, intlMock);
 
     // Assert
-    expect(result).toBe("Voucher");
+    expect(result).toContain("Voucher:");
+  });
+  it("should return Sale discount for sale discount type", () => {
+    // Arrange
+    const discount = {
+      type: OrderDiscountType.SALE,
+    } as OrderDiscountFragment;
+    // Act
+    const result = getDiscountTypeLabel(discount, intlMock);
+
+    // Assert
+    expect(result).toBe("Sale");
+  });
+  it("should return Promotion when promotion discount type", () => {
+    // Arrange
+    const discount = {
+      type: OrderDiscountType.PROMOTION,
+    } as OrderDiscountFragment;
+    // Act
+    const result = getDiscountTypeLabel(discount, intlMock);
+
+    // Assert
+    expect(result).toBe("Promotion");
   });
 });

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -468,7 +468,15 @@ export const getDiscountTypeLabel = (discount: OrderDiscountFragment, intl: Intl
       return intl.formatMessage(orderDiscountTypeLabelMessages.staffAdded);
     case OrderDiscountType.ORDER_PROMOTION:
       return getDiscountNameLabel(discount.name);
-    default:
-      return intl.formatMessage(orderDiscountTypeLabelMessages.voucher);
+    case OrderDiscountType.VOUCHER:
+      return intl.formatMessage(orderDiscountTypeLabelMessages.voucher, {
+        voucherName: discount.name,
+      });
+
+    case OrderDiscountType.PROMOTION:
+      return intl.formatMessage(orderDiscountTypeLabelMessages.promotion);
+
+    case OrderDiscountType.SALE:
+      return intl.formatMessage(orderDiscountTypeLabelMessages.sale);
   }
 };


### PR DESCRIPTION
## What type of PR is this?
- [ ] 💅 Refactor
- [X] 🌟 Feature
- [ ] 🔥 Bug Fix
- [ ] 🔩 Maintenance
- [ ] 🛠 Workflow CI/CD changes

## Related Issues or Documents
- closes [MERX-516](https://linear.app/saleor/issue/MERX-516/display-what-voucher-was-applied-in-the-order)

## Usage Instructions, Screenshots, Recordings
<img width="656" alt="image" src="https://github.com/user-attachments/assets/504f7b3e-1268-496d-805a-21614d0a08e3">


## Have you written tests?
- [X] Yes!

## [Optional] Description
I also fixed a little detail in the `.env.template` based on a solution from @Droniu. Without the fix, my dashboard was a wall of errors