### PR TITLE
Add timeouts ensures that the workflow will automatically terminate jobs that are taking too long

### DIFF
--- a/.changeset/perfect-feet-sneeze.md
+++ b/.changeset/perfect-feet-sneeze.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Implementing timeouts ensures the workflow automatically terminates jobs taking too long, improving resource utilization and avoiding potential workflow hangs.

--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -37,13 +37,14 @@ on:
       TESTS_CONCLUSION:
         value: ${{ jobs.tests-complete.outputs.TESTS_CONCLUSION }}
         description: conclusion of tests
-      RUN_URL: 
+      RUN_URL:
         value: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         description: Url to job run
-        
+
 jobs:
   add-check-and-prepare-instance:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       VERSION: ${{inputs.VERSION}}
       CUSTOM_VERSION: ${{inputs.CUSTOM_VERSION}}
@@ -130,9 +131,10 @@ jobs:
     if: needs.add-check-and-prepare-instance.outputs.FRAMEWORK == '"cypress"'
     needs: add-check-and-prepare-instance
     runs-on: ubuntu-22.04
-    container: 
+    timeout-minutes: 30
+    container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
-      options: --user 1001  
+      options: --user 1001
     strategy:
       fail-fast: false
       matrix:
@@ -172,7 +174,7 @@ jobs:
           mailpitUrl: ${{ secrets.CYPRESS_MAILPITURL }}
           stripeSecretKey: ${{ secrets.STRIPE_SECRET_KEY }}
           stripePublicKey: ${{ secrets.STRIPE_PUBLIC_KEY }}
-          cypressGrepTags:  ${{steps.set-tag-for-tests.outputs.result}}
+          cypressGrepTags: ${{steps.set-tag-for-tests.outputs.result}}
           split: ${{ strategy.job-total }}
           splitIndex: ${{ strategy.job-index }}
           commitInfoMessage: All tests triggered via ${{ github.event_name}} on ${{ steps.get-env-uri.outputs.ENV_URI }}
@@ -189,6 +191,7 @@ jobs:
   run-pw-tests:
     runs-on: ubuntu-22.04
     needs: "add-check-and-prepare-instance"
+    timeout-minutes: 30
     if: needs.add-check-and-prepare-instance.outputs.FRAMEWORK == '"playwright"'
     strategy:
       fail-fast: false
@@ -211,7 +214,7 @@ jobs:
           MAILPITURL: ${{ secrets.MAILPITURL }}
           URL_TO_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PW_WORKERS: ${{ vars.PW_WORKERS }}
-          PW_RETRIES: ${{ vars.PW_RETRIES }} 
+          PW_RETRIES: ${{ vars.PW_RETRIES }}
           PROJECT: "e2e apps-e2e"
 
       - name: submit-results-to-testmo
@@ -227,6 +230,7 @@ jobs:
       !cancelled() && always()
     needs: ["add-check-and-prepare-instance", "run-cy-tests", "run-pw-tests"]
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     outputs:
       TESTS_CONCLUSION: "${{ steps.send-slack-message.outputs.status }}"
     steps:
@@ -274,7 +278,7 @@ jobs:
           --environment "$ENVIRONMENT" \
           --url_to_action "$URL_TO_ACTION" \
           --ref_name "$REF_NAME" \
-          --additional_title "$ADDITIONAL_TITLE" 
+          --additional_title "$ADDITIONAL_TITLE"
 
       - id: update-check
         if: always() && ${{ needs.add-check-and-prepare-instance.outputs.CHECK_ID }}


### PR DESCRIPTION
This PR introduces timeouts for jobs in the GitHub Actions workflow to ensure jobs are automatically stopped if they exceed a reasonable runtime. This helps to prevent long-running or hanging jobs from consuming resources unnecessarily.

<!--
  First of all, thank your for the contribution! We appreciate all incoming pull requests! 🥳

  Before submitting your pull request, please ensure you've done the following:

    📖 Read contribution guide: https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md
    🤓 Your pull request is small enough (otherwise please create smaller chunks)
    👀 You have added proper test coverage
    👜 The pull request's title is readable and meaningful
    📜 You have added changeset file
    📄 If you add/update some copy, they are extracted: run npm run extract-messages
  
  🧵 NOTE: Tests.
    Tests are MANDATORY, please follow these scenarios:
    👉🏼 when you are fixing a bug, test should cover regression you fix
    👉🏼 when you develop new feature, test should cover at least user stories steps (it can be tested by rendering component that implements given feature)
    👉🏼 Please do not implement e2e tests by yourself, we try to limit them for the favor of integration (RTL) ones or units.
    

  🧵 NOTE: Changesets.
    Each pull request requires changeset file, that you can add by running command: npm run change:add. The prompt will ask you to pick a type of change:
    👉🏼 patch - any fix, typo change, CI change, tiny visuals, basically any change that can be seamlessly portable to previous releases
    👉🏼 minor - new features, ui changes, everything that will be includes in the upcoming minor release.
-->

## What type of PR is this?
- [ ] 💅 Refactor
- [ ] 🌟 Feature
- [ ] 🔥 Bug Fix
- [ ] 🔩 Maintenance
- [x] 🛠 Workflow CI/CD changes

## Related Issues or Documents
<!--
  🔑 In this section please attach any resources that are related
  such as: other issues, other pull requests, docs link etc.
  
  If your pull request is closing some issue, use the close clause:
    closes #123 - github will automatically link related by by its number
-->

- closes #

## Usage Instructions, Screenshots, Recordings
<!--
  🔑 Attach here anything that is needed for maintainers:
  - if it's a bug, attach steps to reproduce (unless they are already attached with linked issue)
  - any instructions of usage
  - screenshots or videos if applicable
-->

## Have you written tests?
- [ ] Yes!
- [ ] No... here is why: _Writing tests are mandatory, please replace this text with why test are not included in this PR_


## [Optional] Description
Implementing timeouts ensures that the workflow will automatically terminate jobs that are taking too long, improving resource utilization and avoiding potential workflow hangs.

<!--
  🔑 Put here any additional information regarding change you make. Any additional context, description of what was done.
-->