### PR TITLE
:ribbon: Add if statement to the merge reports :ribbon:

### DIFF
--- a/.changeset/khaki-camels-double.md
+++ b/.changeset/khaki-camels-double.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Adds conditional logic to the Merge Playwright Reports workflow, ensuring that the merge and upload steps are only triggered when the pull request has the run pw-e2e label applied.

--- a/.github/actions/merge-pw-reports/action.yml
+++ b/.github/actions/merge-pw-reports/action.yml
@@ -13,19 +13,16 @@ runs:
       run: npm ci
 
     - name: Download blob reports from GitHub Actions Artifacts
-      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       uses: actions/download-artifact@v3
       with:
         name: all-blob-reports
         path: all-blob-reports
 
     - name: Merge into HTML Report
-      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       shell: bash
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
-      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       uses: actions/upload-artifact@v3
       with:
         name: html-report--attempt-${{ github.run_attempt }}

--- a/.github/actions/merge-pw-reports/action.yml
+++ b/.github/actions/merge-pw-reports/action.yml
@@ -13,16 +13,19 @@ runs:
       run: npm ci
 
     - name: Download blob reports from GitHub Actions Artifacts
+      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       uses: actions/download-artifact@v3
       with:
         name: all-blob-reports
         path: all-blob-reports
 
     - name: Merge into HTML Report
+      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       shell: bash
       run: npx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
+      if: contains(github.event.pull_request.labels.*.name, 'run pw-e2e')
       uses: actions/upload-artifact@v3
       with:
         name: html-report--attempt-${{ github.run_attempt }}

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -176,7 +176,7 @@ jobs:
           PW_RETRIES: ${{ vars.PW_RETRIES }}
 
   merge-reports:
-    if: "!cancelled()"
+    if: "!cancelled() && contains(github.event.pull_request.labels.*.name, 'run pw-e2e')"
 
     needs: run-tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
  First of all, thank your for the contribution! We appreciate all incoming pull requests! 🥳

  Before submitting your pull request, please ensure you've done the following:

    📖 Read contribution guide: https://github.com/saleor/saleor-dashboard/blob/main/.github/CONTRIBUTING.md
    🤓 Your pull request is small enough (otherwise please create smaller chunks)
    👀 You have added proper test coverage
    👜 The pull request's title is readable and meaningful
    📜 You have added changeset file
    📄 If you add/update some copy, they are extracted: run npm run extract-messages
  
  🧵 NOTE: Tests.
    Tests are MANDATORY, please follow these scenarios:
    👉🏼 when you are fixing a bug, test should cover regression you fix
    👉🏼 when you develop new feature, test should cover at least user stories steps (it can be tested by rendering component that implements given feature)
    👉🏼 Please do not implement e2e tests by yourself, we try to limit them for the favor of integration (RTL) ones or units.
    

  🧵 NOTE: Changesets.
    Each pull request requires changeset file, that you can add by running command: npm run change:add. The prompt will ask you to pick a type of change:
    👉🏼 patch - any fix, typo change, CI change, tiny visuals, basically any change that can be seamlessly portable to previous releases
    👉🏼 minor - new features, ui changes, everything that will be includes in the upcoming minor release.
-->

## What type of PR is this?
- [ ] 💅 Refactor
- [ ] 🌟 Feature
- [ ] 🔥 Bug Fix
- [ ] 🔩 Maintenance
- [x] 🛠 Workflow CI/CD changes

## Related Issues or Documents
<!--
  🔑 In this section please attach any resources that are related
  such as: other issues, other pull requests, docs link etc.
  
  If your pull request is closing some issue, use the close clause:
    closes #123 - github will automatically link related by by its number
-->

- closes # https://linear.app/saleor/issue/MERX-1015/failing-workflow-without-e2e-tag

## Usage Instructions, Screenshots, Recordings
This changeset adds conditional logic to the Merge Playwright Reports workflow, ensuring that the merge and upload steps are only triggered when the pull request has the run pw-e2e label applied. This prevents unnecessary failures when no end-to-end tests are run.

Key Changes:
- Added if condition to check for the run pw-e2e label before running the steps to download, merge, and upload Playwright test reports.
- Prevents the merge reports job from running when no E2E tests have been executed.
<!--
  🔑 Attach here anything that is needed for maintainers:
  - if it's a bug, attach steps to reproduce (unless they are already attached with linked issue)
  - any instructions of usage
  - screenshots or videos if applicable
-->

## Have you written tests?
- [ ] Yes!
- [ ] No... here is why: _Writing tests are mandatory, please replace this text with why test are not included in this PR_


## [Optional] Description
<!--
  🔑 Put here any additional information regarding change you make. Any additional context, description of what was done.
-->