### PR TITLE
Skip test for clearing translation

### DIFF
--- a/.changeset/mighty-boxes-lie.md
+++ b/.changeset/mighty-boxes-lie.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Skipped the e2e test for translation cleanup due to an occasional error with editorJS that cannot be reproduce manually.

--- a/playwright/tests/translations.spec.ts
+++ b/playwright/tests/translations.spec.ts
@@ -57,7 +57,7 @@ test("TC: SALEOR_122 Should be able to edit translation  @e2e @translations", as
   await translationsPage.waitForDOMToFullyLoad();
   await expect(translationsPage.page.getByText(newDescription)).toBeVisible();
 });
-test("TC: SALEOR_123 Should be able to clear translation  @e2e @translations", async () => {
+test.skip("TC: SALEOR_123 Should be able to clear translation  @e2e @translations", async () => {
   const description =
     "Letnia kolekcja Saleor obejmuje gamę produktów, które cieszą się popularnością na rynku.Sklep demonstracyjny na każdą porę roku.Saleor uchwycił słońce open source, e-commerce.";
 


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

I'm skipping e2e "SALEOR_123 Should be able to clear translation" This test started to fail occasionally on main and 3.20 with error this._editorJS.save is not a function. It's not possible to trigger it manually
https://linear.app/saleor/issue/BCK-1431/clear-translation-fail-with-this-editorjssave-is-not-a-function

