### PR TITLE
Handle re-login in sidebar apps alerts

### DIFF
--- a/.changeset/nasty-pumpkins-jump.md
+++ b/.changeset/nasty-pumpkins-jump.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+The apps alert in the sidebar now will show up again after user logs in again.

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -27,6 +27,7 @@ import {
   UserContextError,
 } from "../types";
 import { displayDemoMessage } from "../utils";
+import { usePersistLoginDate } from "./usePersistLoginDate";
 
 export interface UseAuthProviderOpts {
   intl: IntlShape;
@@ -36,6 +37,7 @@ export interface UseAuthProviderOpts {
 type AuthErrorCodes = `${AccountErrorCode}`;
 
 export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderOpts): UserContext {
+  const { setLastLoginDate } = usePersistLoginDate();
   const { login, getExternalAuthUrl, getExternalAccessToken, logout } = useAuth();
   const navigate = useNavigator();
   const { authenticated, authenticating, user } = useAuthState();
@@ -129,6 +131,8 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         includeDetails: false,
       });
 
+      setLastLoginDate(new Date().toISOString());
+
       const errorList = result.data?.tokenCreate?.errors?.map(
         ({ code }) => code,
         // SDK is deprecated and has outdated types - we need to use ones from Dashboard
@@ -196,6 +200,8 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         pluginId,
         input: JSON.stringify(input),
       });
+
+      setLastLoginDate(new Date().toISOString());
 
       if (isEmpty(result.data?.externalObtainAccessTokens?.user?.userPermissions)) {
         setErrors(["noPermissionsError"]);

--- a/src/auth/hooks/usePersistLoginDate.ts
+++ b/src/auth/hooks/usePersistLoginDate.ts
@@ -1,0 +1,12 @@
+import useLocalStorage from "@dashboard/hooks/useLocalStorage";
+
+const key = "login_date";
+
+export const usePersistLoginDate = () => {
+  const [lastLoginDate, setLastLoginDate] = useLocalStorage<string | null>(key, null);
+
+  return {
+    lastLoginDate,
+    setLastLoginDate,
+  };
+};


### PR DESCRIPTION
## Scope of the change

- shows alert again after user logs in again to Dashboard
<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->
