### PR TITLE
OrderLine metadata form: reset form on close

### DIFF
--- a/.changeset/yellow-cups-arrive.md
+++ b/.changeset/yellow-cups-arrive.md
@@ -1,0 +1,6 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed issue in OrderLine metadata form dialog: when closing dialog, form state was preserved even when opened for different OrderLine.
+Now form state will be cleared properly on dialog closure.

--- a/src/orders/components/OrderMetadataDialog/OrderMetadataDialog.tsx
+++ b/src/orders/components/OrderMetadataDialog/OrderMetadataDialog.tsx
@@ -7,7 +7,7 @@ import { buttonMessages } from "@dashboard/intl";
 import { useHasManageProductsPermission } from "@dashboard/orders/hooks/useHasManageProductsPermission";
 import { mapMetadataItemToInput } from "@dashboard/utils/maps";
 import { Box, Button, Divider, Text } from "@saleor/macaw-ui-next";
-import React from "react";
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
 
@@ -49,7 +49,13 @@ export const OrderMetadataDialog = ({
         },
   });
 
-  const { handleSubmit, control, getValues, formState, trigger } = formMethods;
+  const { handleSubmit, control, getValues, formState, trigger, reset } = formMethods;
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
 
   return (
     <DashboardModal open={open} onChange={onClose}>


### PR DESCRIPTION
## Scope of the change

This PR fixes an issue in OrderLine metadata form dialog, previously when the form was opened and some input values were added to the form, once it was closed, the input values remaing the same even opened for different OrderLine.
