### PR TITLE
Fix image scaling

### DIFF
--- a/.changeset/pretty-pianos-rush.md
+++ b/.changeset/pretty-pianos-rush.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed scaling issues for small images in OrderLine metadata dialog - now small images will scale to fit entire reserved space, just like other places in Salero Dashboard. Previously such images remained at their default size in px.

--- a/src/orders/components/OrderMetadataDialog/OrderLineDetails/VariantThumbnail.tsx
+++ b/src/orders/components/OrderMetadataDialog/OrderLineDetails/VariantThumbnail.tsx
@@ -19,12 +19,14 @@ export const VariantThumbnail = ({
       justifyContent="center"
       height={20}
       width={20}
+      __padding="2px"
       borderRadius={4}
       borderStyle="solid"
       borderWidth={1}
       borderColor="default1"
+      overflow="hidden"
     >
-      <img src={src} alt="" />
+      <Box as="img" width="100%" height="100%" objectFit="contain" src={src} alt="" />
     </Box>
   );
 };


### PR DESCRIPTION
## Scope of the change

This PR xixed scaling issues for small images in OrderLine metadata dialog - now small images will scale to fit entire reserved space, just like other places in Salero Dashboard. Previously such images remained at their default size in px. It also added padding just like Product Details page images display.

## Screenshots

**Before**:
![Screenshot 2025-03-06 at 15 34 55](https://github.com/user-attachments/assets/08b457d4-90a7-42b6-8dc9-029db707ff27)


**After**:

![CleanShot 2025-03-06 at 16 43 11@2x](https://github.com/user-attachments/assets/af8eaa92-d65a-4062-94ad-d55903c75252)
![CleanShot 2025-03-06 at 16 43 06@2x](https://github.com/user-attachments/assets/73e9f1ed-fff5-4750-9740-682eb76e0465)
![CleanShot 2025-03-06 at 16 42 59@2x](https://github.com/user-attachments/assets/b39693b7-bfbb-4c09-9200-f421c20e5ad8)
