### PR TITLE
Prevent page reload on login page

### DIFF
--- a/.changeset/slimy-points-begin.md
+++ b/.changeset/slimy-points-begin.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Login page now doesn't reload after submitting the login form. This means that email and password input remain filled after unsuccessful login attempt.

--- a/src/auth/components/LoginPage/LoginPage.test.tsx
+++ b/src/auth/components/LoginPage/LoginPage.test.tsx
@@ -1,14 +1,17 @@
+import { AvailableExternalAuthenticationsQuery } from "@dashboard/graphql";
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 
 import LoginPage from "./LoginPage";
+
+type AuthType = AvailableExternalAuthenticationsQuery["shop"]["availableExternalAuthentications"];
 
 const mockExternalAuth = {
   id: "cloud",
   name: "Cloud",
-};
+  __typename: "ExternalAuthentication",
+} as AuthType[0];
 
 const defaultProps = {
   errors: [],
@@ -54,7 +57,7 @@ describe("LoginPage", () => {
       const twoAuths = [
         { id: "oidc", name: "OIDC" },
         { id: "cloud", name: "Cloud" },
-      ];
+      ] as AuthType;
 
       // Act
       render(<LoginPage {...defaultProps} externalAuthentications={twoAuths} />);

--- a/src/auth/components/LoginPage/LoginPage.test.tsx
+++ b/src/auth/components/LoginPage/LoginPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import LoginPage from "./LoginPage";
+
+const mockExternalAuth = {
+  id: "cloud",
+  name: "Cloud",
+};
+
+const defaultProps = {
+  errors: [],
+  disabled: false,
+  loading: false,
+  externalAuthentications: [mockExternalAuth],
+  onExternalAuthentication: jest.fn(),
+  onSubmit: jest.fn(),
+};
+
+jest.mock("react-intl", () => ({
+  useIntl: jest.fn(() => ({
+    formatMessage: jest.fn(x => x.defaultMessage),
+  })),
+  defineMessages: (x: unknown) => x,
+  FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <>{defaultMessage}</>,
+}));
+
+jest.mock("react-router-dom", () => ({
+  MemoryRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("LoginPage", () => {
+  describe("External Authentication", () => {
+    it("sets optimisticLoaderAuthId when clicking external auth button", async () => {
+      // Arrange & Act
+      render(<LoginPage {...defaultProps} />);
+
+      const authButton = screen.getByRole("button", { name: "Cloud" });
+
+      userEvent.click(authButton);
+
+      // Assert
+      await waitFor(() => {
+        expect(authButton).toHaveAttribute("data-test-state", "loading");
+        expect(defaultProps.onExternalAuthentication).toHaveBeenCalledWith(mockExternalAuth.id);
+      });
+    });
+
+    it("shows loader only for clicked authentication method", async () => {
+      // Arrange
+      const twoAuths = [
+        { id: "oidc", name: "OIDC" },
+        { id: "cloud", name: "Cloud" },
+      ];
+
+      // Act
+      render(<LoginPage {...defaultProps} externalAuthentications={twoAuths} />);
+
+      const oidcButton = screen.getByRole("button", { name: "OIDC" });
+      const cloudButton = screen.getByRole("button", { name: "Cloud" });
+
+      userEvent.click(oidcButton);
+
+      // Assert
+      await waitFor(() => {
+        expect(cloudButton).not.toHaveAttribute("data-test-state", "loading");
+        expect(oidcButton).toHaveAttribute("data-test-state", "loading");
+      });
+    });
+  });
+});

--- a/src/auth/components/LoginPage/LoginPage.tsx
+++ b/src/auth/components/LoginPage/LoginPage.tsx
@@ -7,7 +7,7 @@ import { SubmitPromise } from "@dashboard/hooks/useForm";
 import { commonMessages } from "@dashboard/intl";
 import { EyeIcon } from "@saleor/macaw-ui";
 import { Box, Button, Divider, Input, Text } from "@saleor/macaw-ui-next";
-import React from "react";
+import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
@@ -35,7 +35,8 @@ const LoginPage: React.FC<LoginCardProps> = props => {
   } = props;
   const classes = useStyles(props);
   const intl = useIntl();
-  const [showPassword, setShowPassword] = React.useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [optimisticLoaderAuthId, setOptimisticLoaderAuthId] = useState<null | string>(null);
 
   return (
     <LoginForm onSubmit={onSubmit}>
@@ -138,15 +139,21 @@ const LoginPage: React.FC<LoginCardProps> = props => {
           {externalAuthentications.map(externalAuthentication => (
             <React.Fragment key={externalAuthentication.id}>
               <FormSpacer />
-              <Button
+              <ButtonWithLoader
                 width="100%"
                 variant="secondary"
-                onClick={() => onExternalAuthentication(externalAuthentication.id)}
+                onClick={() => {
+                  onExternalAuthentication(externalAuthentication.id);
+                  setOptimisticLoaderAuthId(externalAuthentication.id);
+                }}
                 data-test-id="external-authentication"
                 disabled={disabled}
+                transitionState={
+                  optimisticLoaderAuthId === externalAuthentication.id ? "loading" : "default"
+                }
               >
                 {externalAuthentication.name}
-              </Button>
+              </ButtonWithLoader>
             </React.Fragment>
           ))}
         </Box>

--- a/src/auth/components/LoginPage/LoginPage.tsx
+++ b/src/auth/components/LoginPage/LoginPage.tsx
@@ -1,12 +1,12 @@
 import { UserContextError } from "@dashboard/auth/types";
 import { passwordResetUrl } from "@dashboard/auth/urls";
+import { ButtonWithLoader } from "@dashboard/components/ButtonWithLoader/ButtonWithLoader";
 import { FormSpacer } from "@dashboard/components/FormSpacer";
 import { AvailableExternalAuthenticationsQuery } from "@dashboard/graphql";
 import { SubmitPromise } from "@dashboard/hooks/useForm";
 import { commonMessages } from "@dashboard/intl";
-import { CircularProgress, Divider, TextField } from "@material-ui/core";
-import { EyeIcon, IconButton } from "@saleor/macaw-ui";
-import { Box, Button, Text } from "@saleor/macaw-ui-next";
+import { EyeIcon } from "@saleor/macaw-ui";
+import { Box, Button, Divider, Input, Text } from "@saleor/macaw-ui-next";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
@@ -37,17 +37,9 @@ const LoginPage: React.FC<LoginCardProps> = props => {
   const intl = useIntl();
   const [showPassword, setShowPassword] = React.useState(false);
 
-  if (loading) {
-    return (
-      <div className={classes.loading}>
-        <CircularProgress size={128} />
-      </div>
-    );
-  }
-
   return (
     <LoginForm onSubmit={onSubmit}>
-      {({ change: handleChange, data, submit }) => (
+      {({ change: handleChange, data }) => (
         <Box display="flex" flexDirection="column" alignItems="flex-start" width="100%">
           <Text size={6} fontWeight="bold" lineHeight={3} marginBottom={4}>
             <FormattedMessage id="vzgZ3U" defaultMessage="Sign In" description="card header" />
@@ -62,27 +54,26 @@ const LoginPage: React.FC<LoginCardProps> = props => {
               key={error}
               data-test-id="login-error-message"
             >
-              <Text color="warning1">{getErrorMessage(error, intl)}</Text>
+              <Text color="critical2">{getErrorMessage(error, intl)}</Text>
             </Box>
           ))}
-          <TextField
+          <Input
             autoFocus
-            fullWidth
-            autoComplete="username"
+            width="100%"
+            autoComplete="email"
             label={intl.formatMessage(commonMessages.email)}
             name="email"
             onChange={handleChange}
             value={data.email}
-            inputProps={{
-              "data-test-id": "email",
-              spellCheck: false,
-            }}
+            data-test-id="email"
+            spellCheck={false}
             disabled={disabled}
+            required
           />
           <FormSpacer />
           <div className={classes.passwordWrapper}>
-            <TextField
-              fullWidth
+            <Input
+              width="100%"
               autoComplete="password"
               label={intl.formatMessage({
                 id: "5sg7KC",
@@ -92,48 +83,43 @@ const LoginPage: React.FC<LoginCardProps> = props => {
               onChange={handleChange}
               type={showPassword ? "text" : "password"}
               value={data.password}
-              inputProps={{
-                "data-test-id": "password",
-                spellCheck: false,
-              }}
+              data-test-id="password"
+              spellCheck={false}
               disabled={disabled}
+              required
             />
             {/* Not using endAdornment as it looks weird with autocomplete */}
-            <IconButton
-              className={classes.showPasswordBtn}
-              variant="ghost"
-              hoverOutline={false}
+            <Button
+              icon={<EyeIcon />}
               onMouseDown={() => setShowPassword(true)}
               onMouseUp={() => setShowPassword(false)}
-            >
-              <EyeIcon />
-            </IconButton>
-          </div>
-          <Text
-            // @ts-expect-error - to fix in macaw-ui
-            as={Link}
-            className={classes.link}
-            to={passwordResetUrl}
-            fontSize={3}
-            data-test-id="reset-password-link"
-          >
-            <FormattedMessage
-              id="3tbL7x"
-              defaultMessage="Forgot password?"
-              description="description"
+              variant="tertiary"
+              position="absolute"
+              __top={10}
+              __right={10}
             />
-          </Text>
+          </div>
+          <Link to={passwordResetUrl}>
+            <Text className={classes.link} fontSize={3} data-test-id="reset-password-link">
+              <FormattedMessage
+                id="3tbL7x"
+                defaultMessage="Forgot password?"
+                description="description"
+              />
+            </Text>
+          </Link>
+
           <div className={classes.buttonContainer}>
-            <Button
+            <ButtonWithLoader
               width="100%"
               disabled={disabled}
               variant="primary"
-              onClick={submit}
               type="submit"
+              transitionState={loading ? "loading" : "default"}
               data-test-id="submit"
             >
               <FormattedMessage id="AubJ/S" defaultMessage="Sign in" description="button" />
-            </Button>
+            </ButtonWithLoader>
           </div>
           {externalAuthentications.length > 0 && (
             <>

--- a/src/auth/components/LoginPage/LoginPage.tsx
+++ b/src/auth/components/LoginPage/LoginPage.tsx
@@ -63,6 +63,7 @@ const LoginPage: React.FC<LoginCardProps> = props => {
             width="100%"
             autoComplete="email"
             label={intl.formatMessage(commonMessages.email)}
+            id="email"
             name="email"
             onChange={handleChange}
             value={data.email}
@@ -72,34 +73,32 @@ const LoginPage: React.FC<LoginCardProps> = props => {
             required
           />
           <FormSpacer />
-          <div className={classes.passwordWrapper}>
-            <Input
-              width="100%"
-              autoComplete="password"
-              label={intl.formatMessage({
-                id: "5sg7KC",
-                defaultMessage: "Password",
-              })}
-              name="password"
-              onChange={handleChange}
-              type={showPassword ? "text" : "password"}
-              value={data.password}
-              data-test-id="password"
-              spellCheck={false}
-              disabled={disabled}
-              required
-            />
-            {/* Not using endAdornment as it looks weird with autocomplete */}
-            <Button
-              icon={<EyeIcon />}
-              onMouseDown={() => setShowPassword(true)}
-              onMouseUp={() => setShowPassword(false)}
-              variant="tertiary"
-              position="absolute"
-              __top={10}
-              __right={10}
-            />
-          </div>
+          <Input
+            width="100%"
+            label={intl.formatMessage({
+              id: "5sg7KC",
+              defaultMessage: "Password",
+            })}
+            id="password"
+            name="password"
+            autoComplete="current-password"
+            onChange={handleChange}
+            type={showPassword ? "text" : "password"}
+            value={data.password}
+            data-test-id="password"
+            spellCheck={false}
+            disabled={disabled}
+            endAdornment={
+              <Button
+                icon={<EyeIcon />}
+                onMouseDown={() => setShowPassword(true)}
+                onMouseUp={() => setShowPassword(false)}
+                variant="tertiary"
+                type="button"
+              />
+            }
+            required
+          />
           <Link to={passwordResetUrl}>
             <Text className={classes.link} fontSize={3} data-test-id="reset-password-link">
               <FormattedMessage

--- a/src/auth/components/LoginPage/form.tsx
+++ b/src/auth/components/LoginPage/form.tsx
@@ -12,6 +12,7 @@ export interface UseLoginFormResult {
   change: FormChange;
   data: LoginFormData;
   submit: () => SubmitPromise;
+  reset: () => void;
 }
 
 export interface LoginFormProps {
@@ -32,12 +33,13 @@ const getLoginFormData = () => {
 
 function useLoginForm(onSubmit: (data: LoginFormData) => SubmitPromise): UseLoginFormResult {
   const form = useForm(getLoginFormData());
-  const { change, data } = form;
+  const { change, data, reset } = form;
   const handleFormSubmit = useHandleFormSubmit({ onSubmit });
   const submit = async () => handleFormSubmit(data);
 
   return {
     change,
+    reset,
     data,
     submit,
   };
@@ -48,6 +50,8 @@ const LoginForm: React.FC<LoginFormProps> = ({ children, onSubmit }) => {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     await props.submit();
+
+    props.reset(); // clear fields after submit
   };
 
   return <form onSubmit={handleSubmit}>{children(props)}</form>;

--- a/src/auth/components/LoginPage/form.tsx
+++ b/src/auth/components/LoginPage/form.tsx
@@ -45,10 +45,9 @@ function useLoginForm(onSubmit: (data: LoginFormData) => SubmitPromise): UseLogi
 
 const LoginForm: React.FC<LoginFormProps> = ({ children, onSubmit }) => {
   const props = useLoginForm(onSubmit);
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    // Cypress tests blow up without it
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    props.submit();
+    await props.submit();
   };
 
   return <form onSubmit={handleSubmit}>{children(props)}</form>;

--- a/src/auth/components/LoginPage/messages.ts
+++ b/src/auth/components/LoginPage/messages.ts
@@ -43,5 +43,9 @@ export function getErrorMessage(err: UserContextError, intl: IntlShape): string 
       return intl.formatMessage(errorMessages.noPermissionsError);
     case "loginAttemptDelay":
       return intl.formatMessage(errorMessages.loginAttemptDelay);
+    case "invalidCredentials":
+      return intl.formatMessage(errorMessages.loginError);
+    default:
+      return intl.formatMessage(errorMessages.unknownLoginError);
   }
 }

--- a/src/auth/components/styles.ts
+++ b/src/auth/components/styles.ts
@@ -27,10 +27,6 @@ const useStyles = makeStyles(
     loginButton: {
       width: "100%",
     },
-    passwordWrapper: {
-      position: "relative",
-      width: "100%",
-    },
   }),
   { name: "Login" },
 );

--- a/src/auth/components/styles.ts
+++ b/src/auth/components/styles.ts
@@ -31,11 +31,6 @@ const useStyles = makeStyles(
       position: "relative",
       width: "100%",
     },
-    showPasswordBtn: {
-      position: "absolute",
-      top: 6,
-      right: 8,
-    },
   }),
   { name: "Login" },
 );

--- a/src/auth/hooks/useAuthProvider.test.ts
+++ b/src/auth/hooks/useAuthProvider.test.ts
@@ -1,0 +1,219 @@
+import { ApolloError } from "@apollo/client";
+import { AccountErrorCode } from "@dashboard/graphql";
+import { useAuth, useAuthState } from "@saleor/sdk";
+import { waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import { useAuthProvider } from "./useAuthProvider";
+
+// Mock dependencies
+jest.mock("@saleor/sdk");
+
+const useAuthStateMock = {
+  authenticated: false,
+  authenticating: false,
+  user: null,
+};
+
+const mockLogin = jest.fn();
+
+jest.mock("@dashboard/utils/credentialsManagement", () => ({
+  login: jest.fn(),
+  saveCredentials: jest.fn(),
+  isSupported: true,
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock("@dashboard/hooks/useNavigator", () => () => mockNavigate);
+
+const mockNotify = jest.fn();
+const mockIntl = {
+  formatMessage: jest.fn(message => message.defaultMessage),
+};
+const mockApolloClient = {
+  clearStore: jest.fn(),
+};
+
+jest.mock("react-intl", () => ({
+  useIntl: jest.fn(() => ({
+    formatMessage: jest.fn(x => x.defaultMessage),
+  })),
+  defineMessages: jest.fn(x => x),
+}));
+
+jest.mock("@dashboard/graphql", () => {
+  const actualModule = jest.requireActual("@dashboard/graphql");
+
+  return {
+    __esModule: true,
+    ...actualModule,
+    useUserDetailsQuery: jest.fn(() => ({
+      data: undefined,
+    })),
+  };
+});
+
+(useAuthState as jest.Mock).mockReturnValue(useAuthStateMock);
+(useAuth as jest.Mock).mockReturnValue({
+  login: mockLogin,
+});
+describe("useAuthProvider", () => {
+  describe("handleLogin", () => {
+    it("should handle successful login", async () => {
+      // Arrange
+      mockLogin.mockResolvedValueOnce({
+        data: {
+          tokenCreate: {
+            errors: [],
+            user: {
+              email: "admin@example.com",
+              userPermissions: ["MANAGE_ORDERS"],
+              isStaff: true,
+            },
+          },
+        },
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("admin@example.com", "password");
+      });
+
+      // Assert
+      waitFor(() => {
+        expect(mockLogin).toBeCalledtimes(1);
+        expect(mockLogin).toHaveBeenCalledWith({
+          email: "admin@example.com",
+          password: "password",
+          includeDetails: false,
+        });
+      });
+    });
+
+    it("should handle login with no permissions", async () => {
+      // Arrange
+      mockLogin.mockResolvedValueOnce({
+        data: {
+          tokenCreate: {
+            errors: [],
+            user: {
+              email: "user@example.com",
+              userPermissions: [],
+              isStaff: false,
+            },
+          },
+        },
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("user@example.com", "password");
+      });
+
+      // Assert
+      waitFor(() => {
+        expect(result.current.errors).toContain("noPermissionsError");
+      });
+    });
+
+    it("should handle invalid credentials error", async () => {
+      // Arrange
+      mockLogin.mockResolvedValueOnce({
+        data: {
+          tokenCreate: {
+            errors: [{ code: AccountErrorCode.INVALID_CREDENTIALS }],
+            user: null,
+          },
+        },
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("wrong@example.com", "wrongpass");
+      });
+
+      // Assert
+      waitFor(() => {
+        expect(result.current.errors).toContain("invalidCredentials");
+      });
+    });
+
+    it("should handle login attempt delayed error", async () => {
+      // Arrange
+      mockLogin.mockResolvedValueOnce({
+        data: {
+          tokenCreate: {
+            errors: [{ code: AccountErrorCode.LOGIN_ATTEMPT_DELAYED }],
+            user: null,
+          },
+        },
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("test@example.com", "password");
+      });
+
+      // Assert
+      expect(result.current.errors).toContain("loginAttemptDelay");
+    });
+
+    it("should handle Apollo error", async () => {
+      // Arrange
+      mockLogin.mockRejectedValueOnce(
+        new ApolloError({
+          networkError: new Error("Network error"),
+        }),
+      );
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("test@example.com", "password");
+      });
+
+      // Assert
+      expect(result.current.errors).toContain("unknownLoginError");
+    });
+  });
+});

--- a/src/auth/hooks/useAuthProvider.test.ts
+++ b/src/auth/hooks/useAuthProvider.test.ts
@@ -215,5 +215,33 @@ describe("useAuthProvider", () => {
       // Assert
       expect(result.current.errors).toContain("unknownLoginError");
     });
+
+    it("should handle other login errors", async () => {
+      // Arrange
+      mockLogin.mockResolvedValueOnce({
+        data: {
+          tokenCreate: {
+            errors: [{ code: AccountErrorCode.ACCOUNT_NOT_CONFIRMED }],
+            user: null,
+          },
+        },
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useAuthProvider({
+          intl: mockIntl as any,
+          notify: mockNotify,
+          apolloClient: mockApolloClient as any,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.login!("test@example.com", "password");
+      });
+
+      // Assert
+      expect(result.current.errors).toContain("loginError");
+    });
   });
 });

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -152,8 +152,6 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         saveCredentials(result.data!.tokenCreate!.user!, password);
       } else {
         const userContextErrorList: UserContextError[] = [];
-        // While login page can show multiple errors, "loginError" doesn't match "attemptDelay"
-        // and should be shown when no other error is present
 
         errorList?.forEach(error => {
           switch (error) {

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -142,12 +142,14 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         await handleLogout();
       }
 
-      if (result && !errorList?.length) {
+      const hasUser = !!result.data?.tokenCreate?.user;
+
+      if (hasUser && !errorList?.length) {
         if (DEMO_MODE) {
           displayDemoMessage(intl, notify);
         }
 
-        saveCredentials(result.data?.tokenCreate?.user!, password);
+        saveCredentials(result.data!.tokenCreate!.user!, password);
       } else {
         const userContextErrorList: UserContextError[] = [];
         // While login page can show multiple errors, "loginError" doesn't match "attemptDelay"

--- a/src/auth/hooks/useAuthProvider.ts
+++ b/src/auth/hooks/useAuthProvider.ts
@@ -40,7 +40,7 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
   const navigate = useNavigator();
   const { authenticated, authenticating, user } = useAuthState();
   const [requestedExternalPluginId] = useLocalStorage("requestedExternalPluginId", null);
-  const [isAuthRequestRunning, setIsAuthRequestRunning] = useState(false);
+  const [isCredentialsLogin, setIsCredentialsLogin] = useState(false);
   const [errors, setErrors] = useState<UserContextError[]>([]);
   const permitCredentialsAPI = useRef(true);
 
@@ -116,12 +116,12 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
   };
 
   const handleLogin = async (email: string, password: string) => {
-    if (isAuthRequestRunning) {
+    if (isCredentialsLogin) {
       return;
     }
 
     try {
-      setIsAuthRequestRunning(true);
+      setIsCredentialsLogin(true);
 
       const result = await login({
         email,
@@ -134,7 +134,10 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         // SDK is deprecated and has outdated types - we need to use ones from Dashboard
       ) as AuthErrorCodes[];
 
-      if (isEmpty(result.data?.tokenCreate?.user?.userPermissions)) {
+      const userLoggedInButHasNoPermissions =
+        result.data?.tokenCreate?.user && isEmpty(result.data?.tokenCreate?.user?.userPermissions);
+
+      if (userLoggedInButHasNoPermissions) {
         setErrors(["noPermissionsError"]);
         await handleLogout();
       }
@@ -146,13 +149,25 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
 
         saveCredentials(result.data?.tokenCreate?.user!, password);
       } else {
+        const userContextErrorList: UserContextError[] = [];
         // While login page can show multiple errors, "loginError" doesn't match "attemptDelay"
         // and should be shown when no other error is present
-        if (errorList?.includes(AccountErrorCode.LOGIN_ATTEMPT_DELAYED)) {
-          setErrors(["loginAttemptDelay"]);
-        } else {
-          setErrors(["loginError"]);
-        }
+
+        errorList?.forEach(error => {
+          switch (error) {
+            case AccountErrorCode.LOGIN_ATTEMPT_DELAYED:
+              userContextErrorList.push("loginAttemptDelay");
+              break;
+            case AccountErrorCode.INVALID_CREDENTIALS:
+              userContextErrorList.push("invalidCredentials");
+              break;
+            default:
+              userContextErrorList.push("loginError");
+              break;
+          }
+        });
+
+        setErrors(userContextErrorList);
       }
 
       await logoutNonStaffUser(result.data?.tokenCreate!);
@@ -165,7 +180,7 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
         setErrors(["unknownLoginError"]);
       }
     } finally {
-      setIsAuthRequestRunning(false);
+      setIsCredentialsLogin(false);
     }
   };
   const handleRequestExternalLogin = async (pluginId: string, input: RequestExternalLoginInput) => {
@@ -239,6 +254,7 @@ export function useAuthProvider({ intl, notify, apolloClient }: UseAuthProviderO
     loginByExternalPlugin: handleExternalLogin,
     logout: handleLogout,
     authenticating: authenticating && !errors.length,
+    isCredentialsLogin,
     authenticated: authenticated && !!user?.isStaff && !errors.length,
     user: userDetails.data?.me,
     refetchUser: userDetails.refetch,

--- a/src/auth/hooks/useAuthRedirection.ts
+++ b/src/auth/hooks/useAuthRedirection.ts
@@ -13,7 +13,8 @@ export const useAuthRedirection = () => {
   const router = useRouter();
   const params = new URLSearchParams(router.location.search);
   const shouldRedirect = params.has(PLUGIN_ID_PARAM);
-  const { authenticated, authenticating, requestLoginByExternalPlugin } = useUser();
+  const { authenticated, authenticating, requestLoginByExternalPlugin, isCredentialsLogin } =
+    useUser();
   const { setRequestedExternalPluginId } = useAuthParameters();
   const pluginId = params.get(PLUGIN_ID_PARAM);
   const handleAuthentication = async () => {
@@ -42,6 +43,6 @@ export const useAuthRedirection = () => {
 
   return {
     authenticated,
-    authenticating: authenticating || shouldRedirect,
+    authenticating: (authenticating || shouldRedirect) && !isCredentialsLogin, // Prevent redirecting when user is logging in with credentials
   };
 };

--- a/src/auth/index.tsx
+++ b/src/auth/index.tsx
@@ -29,6 +29,7 @@ export const UserContext = React.createContext<Context>({
   logout: undefined,
   requestLoginByExternalPlugin: undefined,
   authenticating: false,
+  isCredentialsLogin: false,
   authenticated: false,
   errors: [],
   refetchUser: undefined,

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -22,6 +22,7 @@ export const UserContextError = {
   externalLoginError: "externalLoginError",
   loginAttemptDelay: "loginAttemptDelay",
   unknownLoginError: "unknownLoginError",
+  invalidCredentials: "invalidCredentials",
 } as const;
 
 export type UserContextError = (typeof UserContextError)[keyof typeof UserContextError];
@@ -39,6 +40,7 @@ export interface UserContext {
   ) => Promise<GetExternalAuthUrlData | undefined>;
   user?: UserFragment | null;
   authenticating: boolean;
+  isCredentialsLogin: boolean;
   authenticated: boolean;
   errors: UserContextError[];
   refetchUser?: () => Promise<ApolloQueryResult<UserDetailsQuery>>;


### PR DESCRIPTION
## Scope of the change

* Removes overlay loading animation
* Removes doubled submit fn execution
* Prevents overlay loading animation **during credentials login**
* Adds loading animation to "Login" button
* Prevents user from submitting empty Email and Password fields
* Fixes an issue where any Saleor login error have been overridden by permission error
* Properly handles incorrect credentials error (after so many years 😅)
* Adds loading animation to cloud login button
* Cleans form after submit

**BEFORE**:

https://github.com/user-attachments/assets/a694d05f-13c3-4910-8922-96b60adb92e9



**AFTER**:


https://github.com/user-attachments/assets/2c906f54-23b5-4706-b276-03500d0dbe3d





<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->
