### PR TITLE
Add password argument for manual and release workflows (3.19)

### DIFF
--- a/.changeset/healthy-adults-jump.md
+++ b/.changeset/healthy-adults-jump.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Release and manually workflow use password argument on creating test reports

--- a/.github/workflows/run-test-manual.yml
+++ b/.github/workflows/run-test-manual.yml
@@ -146,6 +146,9 @@ jobs:
 
       - name: Merge playwright reports
         uses: ./.github/actions/merge-pw-reports
+        with:
+          PASSWORD_FOR_DECODING_ARTIFACT: ${{ secrets.TESTS_RESULT_PASSWORD }}
+          
 
       - name: complete testmo report
         uses: ./.github/actions/testmo/testmo-finish

--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -220,7 +220,9 @@ jobs:
 
       - name: Merge playwright reports
         uses: ./.github/actions/merge-pw-reports
-
+        with:
+          PASSWORD_FOR_DECODING_ARTIFACT: ${{ secrets.TESTS_RESULT_PASSWORD }}
+          
       - name: complete testmo report
         uses: ./.github/actions/testmo/testmo-finish
         with:


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->
After merging https://github.com/saleor/saleor-dashboard/pull/5419 
Complete report step failing since password argument is missing in 2 places: 
<img width="1772" alt="image" src="https://github.com/user-attachments/assets/a25ab4bb-bca4-43e0-b835-d4daa5fe4c6e" />

https://github.com/saleor/saleor-dashboard/actions/runs/13926002274
