### PR TITLE
Sort webhooks in App details by latest attempt 

### DIFF
--- a/.changeset/fifty-beds-watch.md
+++ b/.changeset/fifty-beds-watch.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Webhooks in app details section now are sorted based on which attempt is latest

--- a/src/apps/components/AppWebhooksDisplay/utils.test.ts
+++ b/src/apps/components/AppWebhooksDisplay/utils.test.ts
@@ -122,4 +122,139 @@ describe("sortWebhooksByFailedDeliveries", () => {
     // Assert
     expect(result[0].name).toBe("non-empty");
   });
+
+  it("should sort by attempt date when available", () => {
+    const webhookWithAttempt = {
+      name: "with-attempt",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [
+                  {
+                    node: {
+                      id: "id",
+                      response: "response",
+                      status: EventDeliveryStatusEnum.FAILED,
+                      responseStatusCode: 500,
+                      createdAt: "2024-03-18T10:00:00Z",
+                      __typename: "EventDeliveryAttempt",
+                    },
+                    __typename: "EventDeliveryAttemptCountableEdge",
+                  },
+                ],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-17T10:00:00Z",
+              id: "delivery-1",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "1",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const webhookWithoutAttempt = {
+      name: "without-attempt",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-19T10:00:00Z",
+              id: "delivery-2",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "2",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const webhooks = [webhookWithAttempt, webhookWithoutAttempt];
+
+    // Act
+    const result = webhooks.sort(sortWebhooksByDeliveries);
+
+    // Assert
+    expect(result[0].name).toBe("without-attempt");
+    expect(result[1].name).toBe("with-attempt");
+  });
+
+  it("should fallback to delivery date when no attempt is present", () => {
+    // Arrange
+    const olderDelivery = {
+      name: "older",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-17T10:00:00Z",
+              id: "delivery-1",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "1",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const newerDelivery = {
+      name: "newer",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-18T10:00:00Z",
+              id: "delivery-2",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "2",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const webhooks = [olderDelivery, newerDelivery];
+
+    // Act
+    const result = webhooks.sort(sortWebhooksByDeliveries);
+
+    // Assert
+    expect(result[0].name).toBe("newer");
+    expect(result[1].name).toBe("older");
+  });
 });

--- a/src/apps/components/AppWebhooksDisplay/utils.test.ts
+++ b/src/apps/components/AppWebhooksDisplay/utils.test.ts
@@ -123,6 +123,91 @@ describe("sortWebhooksByFailedDeliveries", () => {
     expect(result[0].name).toBe("non-empty");
   });
 
+  it("should sort by attempt dates", () => {
+    const webhookWithAttempt = {
+      name: "with-attempt",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [
+                  {
+                    node: {
+                      id: "id",
+                      response: "response",
+                      status: EventDeliveryStatusEnum.FAILED,
+                      responseStatusCode: 500,
+                      createdAt: "2024-03-18T10:00:00Z",
+                      __typename: "EventDeliveryAttempt",
+                    },
+                    __typename: "EventDeliveryAttemptCountableEdge",
+                  },
+                ],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-17T10:00:00Z",
+              id: "delivery-1",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "1",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const webhookWithoutAttempt = {
+      name: "with-newer-attempt",
+      eventDeliveries: {
+        edges: [
+          {
+            node: {
+              attempts: {
+                edges: [
+                  {
+                    node: {
+                      id: "id-two",
+                      response: "response",
+                      status: EventDeliveryStatusEnum.FAILED,
+                      responseStatusCode: 500,
+                      createdAt: "2024-03-19T11:00:00Z",
+                      __typename: "EventDeliveryAttempt",
+                    },
+                    __typename: "EventDeliveryAttemptCountableEdge",
+                  },
+                ],
+                __typename: "EventDeliveryAttemptCountableConnection",
+              },
+              createdAt: "2024-03-19T10:00:00Z",
+              id: "delivery-2",
+              eventType: WebhookEventTypeEnum.ORDER_CONFIRMED,
+              status: EventDeliveryStatusEnum.FAILED,
+              __typename: "EventDelivery",
+            },
+            __typename: "EventDeliveryCountableEdge",
+          },
+        ],
+        __typename: "EventDeliveryCountableConnection",
+      },
+      id: "2",
+      ...DEFAULT_WEBHOOK,
+    } as Webhook;
+
+    const webhooks = [webhookWithAttempt, webhookWithoutAttempt];
+
+    // Act
+    const result = webhooks.sort(sortWebhooksByDeliveries);
+
+    // Assert
+    expect(result[0].name).toBe("with-newer-attempt");
+    expect(result[1].name).toBe("with-attempt");
+  });
+
   it("should sort by attempt date when available", () => {
     const webhookWithAttempt = {
       name: "with-attempt",

--- a/src/apps/components/AppWebhooksDisplay/utils.ts
+++ b/src/apps/components/AppWebhooksDisplay/utils.ts
@@ -2,15 +2,19 @@ import { AppWebhookDeliveriesQuery } from "@dashboard/graphql";
 
 export type Webhook = NonNullable<NonNullable<AppWebhookDeliveriesQuery["app"]>["webhooks"]>[0];
 
-export const sortWebhooksByDeliveries = (a: Webhook, b: Webhook) => {
-  const getLatestDate = (webhook: Webhook) => {
-    const attemptDate =
-      webhook.eventDeliveries?.edges?.[0]?.node?.attempts?.edges?.[0]?.node?.createdAt;
-    const deliveryDate = webhook.eventDeliveries?.edges?.[0]?.node?.createdAt;
+const getLatestDate = (webhook: Webhook): string | undefined => {
+  const attemptDate: string | undefined =
+    webhook.eventDeliveries?.edges?.[0]?.node?.attempts?.edges?.[0]?.node?.createdAt;
+  const deliveryDate: string | undefined = webhook.eventDeliveries?.edges?.[0]?.node?.createdAt;
 
-    return attemptDate || deliveryDate;
-  };
+  if (attemptDate && deliveryDate) {
+    return attemptDate > deliveryDate ? attemptDate : deliveryDate;
+  }
 
+  return attemptDate || deliveryDate;
+};
+
+export const sortWebhooksByDeliveries = (a: Webhook, b: Webhook): number => {
   const dateA = getLatestDate(a);
   const dateB = getLatestDate(b);
 

--- a/src/apps/components/AppWebhooksDisplay/utils.ts
+++ b/src/apps/components/AppWebhooksDisplay/utils.ts
@@ -3,9 +3,25 @@ import { AppWebhookDeliveriesQuery } from "@dashboard/graphql";
 export type Webhook = NonNullable<NonNullable<AppWebhookDeliveriesQuery["app"]>["webhooks"]>[0];
 
 export const sortWebhooksByDeliveries = (a: Webhook, b: Webhook) => {
-  const deliveriesA = a.eventDeliveries?.edges?.length ?? 0;
-  const deliveriesB = b.eventDeliveries?.edges?.length ?? 0;
+  const getLatestDate = (webhook: Webhook) => {
+    const attemptDate =
+      webhook.eventDeliveries?.edges?.[0]?.node?.attempts?.edges?.[0]?.node?.createdAt;
+    const deliveryDate = webhook.eventDeliveries?.edges?.[0]?.node?.createdAt;
+
+    return attemptDate || deliveryDate;
+  };
+
+  const dateA = getLatestDate(a);
+  const dateB = getLatestDate(b);
+
+  if (!dateA && !dateB) {
+    return 0;
+  }
+
+  if (!dateA) return 1;
+
+  if (!dateB) return -1;
 
   // desc
-  return deliveriesB - deliveriesA;
+  return new Date(dateB).getTime() - new Date(dateA).getTime();
 };


### PR DESCRIPTION
## Scope of the change

* sort webhooks in app details by latest attempts or event deliveries so that the latest fail shows up on top

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->
