### PR TITLE
Improve tracking number and warehouse alignment in order view

### DIFF
--- a/.changeset/happy-singers-sip.md
+++ b/.changeset/happy-singers-sip.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Warehouse and tracking number in fulfilled order section are now displayed in two separate lines improving readability.

--- a/src/orders/components/OrderFulfilledProductsCard/ExtraInfoLines.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/ExtraInfoLines.tsx
@@ -1,6 +1,6 @@
 import { FulfillmentStatus, OrderDetailsFragment } from "@dashboard/graphql";
 import { getStringOrPlaceholder } from "@dashboard/misc";
-import { Box, Text } from "@saleor/macaw-ui-next";
+import { Box, Paragraph, Text } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -23,8 +23,14 @@ const ExtraInfoLines: React.FC<ExtraInfoLinesProps> = ({ fulfillment }) => {
   const { warehouse, trackingNumber, status } = fulfillment;
 
   return (
-    <Box paddingY={4} borderColor="default1" borderBottomStyle={"solid"} borderBottomWidth={1}>
-      <Text color="default2" fontSize={3}>
+    <Box
+      paddingY={4}
+      paddingX={6}
+      borderColor="default1"
+      borderBottomStyle={"solid"}
+      borderBottomWidth={1}
+    >
+      <Paragraph color="default2" fontSize={3}>
         {warehouse && (
           <>
             {intl.formatMessage(
@@ -43,8 +49,8 @@ const ExtraInfoLines: React.FC<ExtraInfoLinesProps> = ({ fulfillment }) => {
             </Text>
           </>
         )}
-      </Text>
-      <Text color="default2" fontSize={3}>
+      </Paragraph>
+      <Paragraph color="default2" fontSize={3}>
         {trackingNumber && (
           <FormattedMessage
             {...extraInfoMessages.tracking}
@@ -62,7 +68,7 @@ const ExtraInfoLines: React.FC<ExtraInfoLinesProps> = ({ fulfillment }) => {
             }}
           />
         )}
-      </Text>
+      </Paragraph>
     </Box>
   );
 };


### PR DESCRIPTION
## Scope of the change

This PR improves tracking number and warehouse alignment in order view. They are now in two separate lines improving readability. It adds padding to their container to match the rest of the view.

Before:
![image](https://github.com/user-attachments/assets/490e9906-abf0-4daa-aa22-22708aa2448f)


After:
![CleanShot 2025-04-01 at 11 50 26](https://github.com/user-attachments/assets/6bc6c6f7-a7dd-416c-b355-ab69890b3288)


<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
