### PR TITLE
add github actions for announcing releases and help-wanted issues

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,17 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Announce to Discord
+        uses: SethCohen/github-releases-to-discord@6ac5abea42b8cbac14316970819a8a535aab08ea # v1.16.2
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          color: "15105570"
+          content: "New Saleor Dashboard release!"

--- a/.github/workflows/help-wanted-issues-to-discord.yml
+++ b/.github/workflows/help-wanted-issues-to-discord.yml
@@ -1,0 +1,24 @@
+name: Notify Discord on Help Wanted Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    if: github.event.label.name == 'help wanted'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: appleboy/discord-action@6047e1fe519c24dbf2865cf0557f20f51f075b3e # v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_GFI_WEBHOOK_URL }}
+          message: |
+            🎉 New Issue Labeled with "Help Wanted" in Saleor Dashboard
+
+            **Issue Details:**
+            - Title: ${{ github.event.issue.title }}
+            - Number: #${{ github.event.issue.number }}
+            - URL: ${{ github.event.issue.html_url }}
+
+            Please take a look and help if you can! 🙏


### PR DESCRIPTION
## Scope of the change

We want to announce releases and post issues labeled with "help wanted" to Discord, the same way as we do in saleor/saleor.