### PR TITLE
Fix extensions warning icon

### DIFF
--- a/src/apps/components/AppAlerts/AlertExclamationIcon.tsx
+++ b/src/apps/components/AppAlerts/AlertExclamationIcon.tsx
@@ -15,7 +15,7 @@ export const AlertExclamationIcon = () => {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      {isHovered ? <ExclamationIconFilled /> : <ExclamationIcon />}
+      {isHovered ? <ExclamationIconFilled /> : <ExclamationIcon width="17px" height="17px" />}
     </Box>
   );
 };


### PR DESCRIPTION
## Scope of the change
Warning icon in extensions menu item no has same name when hover and without hover

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
