### PR TITLE
properly get API_URL in runtime for GraphiQL

### DIFF
--- a/.changeset/hot-maps-shop.md
+++ b/.changeset/hot-maps-shop.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix API_URL in GraphiQL playground to be set during runtime instead of build

--- a/src/components/DevModePanel/utils.test.ts
+++ b/src/components/DevModePanel/utils.test.ts
@@ -1,3 +1,4 @@
+import * as config from "@dashboard/config";
 import { createGraphiQLFetcher, FetcherOpts } from "@graphiql/toolkit";
 import { createFetch } from "@saleor/sdk";
 
@@ -13,6 +14,7 @@ jest.mock("@saleor/sdk", () => ({
 
 jest.mock("@dashboard/config", () => ({
   ENABLED_SERVICE_NAME_HEADER: true,
+  getApiUrl: jest.fn(),
 }));
 
 const mockCreateGraphiQLFetcher = createGraphiQLFetcher as jest.Mock;
@@ -23,7 +25,7 @@ describe("getFetcher", () => {
   let originalFetch: typeof fetch;
 
   beforeEach(() => {
-    process.env.API_URL = mockApiUrl;
+    jest.spyOn(config, "getApiUrl").mockImplementation(() => mockApiUrl);
     originalFetch = global.fetch;
   });
 

--- a/src/components/DevModePanel/utils.ts
+++ b/src/components/DevModePanel/utils.ts
@@ -1,4 +1,4 @@
-import { ENABLED_SERVICE_NAME_HEADER } from "@dashboard/config";
+import { ENABLED_SERVICE_NAME_HEADER, getApiUrl } from "@dashboard/config";
 import { createGraphiQLFetcher, FetcherOpts } from "@graphiql/toolkit";
 import { createFetch } from "@saleor/sdk";
 
@@ -24,7 +24,7 @@ export const getFetcher = (opts: FetcherOpts) => {
   }
 
   return createGraphiQLFetcher({
-    url: process.env.API_URL as string,
+    url: getApiUrl(),
     fetch: httpFetch as typeof fetch,
     headers,
   });


### PR DESCRIPTION
## Scope of the change
Changed API_URL in the graphQL fetcher for GraphiQL, it was previously set through `process.env.` which in turn was set during build time and not in runtime.
I looked at the code and saw that getApiUrl could be a good solution.

Haven't touched tests before, it passes but LMK if there's anything else I need to do there.

Related issue is #5338 from January.
<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
