### PR TITLE
Fix: Use getApiUrl in DevModePanel utils instead of direct environment variable

### DIFF
--- a/.changeset/spotty-cheetahs-teach.md
+++ b/.changeset/spotty-cheetahs-teach.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+making the DevModePanel use the generic getApiUrl as well to allow the dynamic update in docker containers

--- a/src/components/DevModePanel/utils.test.ts
+++ b/src/components/DevModePanel/utils.test.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from "@dashboard/config";
 import { createGraphiQLFetcher, FetcherOpts } from "@graphiql/toolkit";
 import { createFetch } from "@saleor/sdk";
 
@@ -13,10 +14,12 @@ jest.mock("@saleor/sdk", () => ({
 
 jest.mock("@dashboard/config", () => ({
   ENABLED_SERVICE_NAME_HEADER: true,
+  getApiUrl: jest.fn(() => "http://test-api.com"),
 }));
 
 const mockCreateGraphiQLFetcher = createGraphiQLFetcher as jest.Mock;
 const authorizedFetch = createFetch as jest.Mock;
+const mockGetApiUrl = getApiUrl as jest.Mock;
 
 describe("getFetcher", () => {
   const mockApiUrl = "http://test-api.com";
@@ -25,6 +28,8 @@ describe("getFetcher", () => {
   beforeEach(() => {
     process.env.API_URL = mockApiUrl;
     originalFetch = global.fetch;
+    // Ensure getApiUrl returns the expected value in each test
+    mockGetApiUrl.mockReturnValue(mockApiUrl);
   });
 
   afterEach(() => {

--- a/src/components/DevModePanel/utils.ts
+++ b/src/components/DevModePanel/utils.ts
@@ -1,4 +1,4 @@
-import { ENABLED_SERVICE_NAME_HEADER } from "@dashboard/config";
+import { ENABLED_SERVICE_NAME_HEADER, getApiUrl } from "@dashboard/config";
 import { createGraphiQLFetcher, FetcherOpts } from "@graphiql/toolkit";
 import { createFetch } from "@saleor/sdk";
 
@@ -24,7 +24,7 @@ export const getFetcher = (opts: FetcherOpts) => {
   }
 
   return createGraphiQLFetcher({
-    url: process.env.API_URL as string,
+    url: getApiUrl(),
     fetch: httpFetch as typeof fetch,
     headers,
   });


### PR DESCRIPTION
## Scope of the change


## Description

This PR updates the `getFetcher` function in the DevModePanel component to use the `getApiUrl` function from the configuration module instead of directly accessing `process.env.API_URL`. This change improves consistency with the rest of the codebase and ensures the API URL is retrieved from the centralized configuration.

## Changes

- Modified `src/components/DevModePanel/utils.ts` to use `getApiUrl()` instead of `process.env.API_URL`
- Updated tests in [src/components/DevModePanel/utils.test.ts](cci:7://file:///Users/jannikzinkl/Documents/git/saleor-dashboard/src/components/DevModePanel/utils.test.ts:0:0-0:0) to properly mock the `getApiUrl` function

## Testing

All tests are passing, confirming that the functionality works as expected.

## Impact

This change ensures consistent API URL retrieval across the codebase and improves maintainability by using the configuration system instead of direct environment variable access. Especially useful for docker environments!!


closes #5535 
