### PR TITLE
Add caching policies for extensions list

### DIFF
--- a/.changeset/light-fireants-wave.md
+++ b/.changeset/light-fireants-wave.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Now navigating to the installed extension, shows the list instantly, this means list is being cached while fetching happens in the background.

--- a/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
+++ b/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
@@ -63,11 +63,13 @@ export const useInstalledExtensions = () => {
     variables: {
       first: 100,
       filter: {
+        isActive: true,
         type: AppTypeEnum.THIRDPARTY,
       },
       canFetchAppEvents: hasManagedAppsPermission,
     },
   });
+
   const eventDeliveries = mapEdgesToItems(eventDeliveriesData?.apps) ?? [];
   const eventDeliveriesMap = new Map(eventDeliveries.map(app => [app.id, app]));
 

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -77,6 +77,9 @@ export const apolloClient = new ApolloClient({
           },
         },
       },
+      App: {
+        keyFields: false,
+      },
     } as TypedTypePolicies,
   }),
   link,


### PR DESCRIPTION
Now extensions list is loaded only once; when navigating across the pages, going back to the list shows it instantly while in the background everything is being fetched.

Changes
- disabling normalisation for a single app, now each app is cached individual, this prevents affecting by the other queries that are using app fetching from wiping up each other
- when fetching event delivers, there is no need to fetch all of them, we only are interested in active apps
