### PR TITLE
Fix extensions page not loading when user doesn't have MANAGE_APPS permission

### DIFF
--- a/src/extensions/views/InstalledExtensions/hooks/useActiveAppsInstallations.ts
+++ b/src/extensions/views/InstalledExtensions/hooks/useActiveAppsInstallations.ts
@@ -80,7 +80,7 @@ export const useActiveAppsInstallations = ({
     });
 
   /**
-   * Check if there has occured by any reason untracked installation with status PENDING and add it to activeInstallations.
+   * Check if there has occurred by any reason untracked installation with status PENDING and add it to activeInstallations.
    */
   useEffect(
     () =>

--- a/src/extensions/views/InstalledExtensions/hooks/usePendingInstallation.tsx
+++ b/src/extensions/views/InstalledExtensions/hooks/usePendingInstallation.tsx
@@ -1,5 +1,6 @@
 import { InstalledExtension } from "@dashboard/extensions/types";
 import { JobStatusEnum, useAppsInstallationsQuery } from "@dashboard/graphql";
+import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
 import { fuzzySearch } from "@dashboard/misc";
 import React, { useEffect, useState } from "react";
 
@@ -23,9 +24,14 @@ export const usePendingInstallation = ({
   onFailedInstallationRemove,
   searchQuery,
 }: UsePendingInstallationProps) => {
-  const [initialLoading, setInitialLoading] = useState(true);
+  const { hasManagedAppsPermission } = useHasManagedAppsPermission();
+
+  // Don't display loading when user doesn't have permissions
+  // we don't fetch installations in that case
+  const [initialLoading, setInitialLoading] = useState(hasManagedAppsPermission);
   const { data, loading, refetch } = useAppsInstallationsQuery({
     displayLoader: true,
+    skip: !hasManagedAppsPermission,
   });
   const { installedNotify, removeInProgressAppNotify, errorNotify } = useInstallationNotify();
 


### PR DESCRIPTION
## Scope of the change

This PR fixes new extensions page not loading when user didn't have `MANAGE_APPS` permissions
