### PR TITLE
Fix empty page in /extensions

### DIFF
--- a/.changeset/quiet-icons-dress.md
+++ b/.changeset/quiet-icons-dress.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added "Not found" page when navigating to non-existing route in `/extensions/*`. Previously a blank page was displayed.

--- a/src/extensions/index.tsx
+++ b/src/extensions/index.tsx
@@ -8,6 +8,7 @@ import { InstalledExtensions } from "@dashboard/extensions/views/InstalledExtens
 import { useFlag } from "@dashboard/featureFlags";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { sectionNames } from "@dashboard/intl";
+import NotFound from "@dashboard/NotFound";
 import { parse as parseQs } from "qs";
 import React from "react";
 import { useIntl } from "react-intl";
@@ -50,6 +51,7 @@ export const ExtensionsSection = () => {
           path={ExtensionsPaths.installedExtensions}
           component={InstalledExtensionsView}
         />
+        <Route component={NotFound} />
       </Switch>
     </>
   );


### PR DESCRIPTION
## Scope of the change

Improved navigation in `/extensions`: when there's no page matching route now a "Not found" page will be displayed, previously it was a blank page.
