### PR TITLE
Removing community live update baner

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -17,7 +17,11 @@
     "devDependencies": "error"
   },
   "vite": false,
-  "ignore": ["playwright/**", "**/*.js"],
+  "ignore": [
+    "playwright/**",
+    "**/*.js",
+    "src/welcomePage/WelcomePageTilesContainer/tileData.tsx"
+  ],
   "ignoreDependencies": [
     "@graphql-codegen/typescript-apollo-client-helpers",
     "@graphql-codegen/typescript-operations",

--- a/src/welcomePage/WelcomePageTilesContainer/WelcomePageTilesContainer.tsx
+++ b/src/welcomePage/WelcomePageTilesContainer/WelcomePageTilesContainer.tsx
@@ -3,7 +3,7 @@ import { Box } from "@saleor/macaw-ui-next";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { CommunityLiveUpdate, getTilesData } from "./tileData";
+import { getTilesData } from "./tileData";
 import { WelcomePageInfoTile } from "./WelcomePageInfoTile";
 
 export const WelcomePageTilesContainer = () => {
@@ -25,7 +25,6 @@ export const WelcomePageTilesContainer = () => {
       gap={6}
       marginTop={7}
     >
-      <CommunityLiveUpdate onTileButtonClick={handleTileButtonClick} />
       {tiles.map(tile => (
         <WelcomePageInfoTile key={tile.id} {...tile} />
       ))}


### PR DESCRIPTION
## Scope of the change

- Removing banner right after the update meeting
- Keeping component for further similar events
