### PR TITLE
Always set trusted origin when preparing instance

### DIFF
--- a/.github/actions/prepare-instance/action.yml
+++ b/.github/actions/prepare-instance/action.yml
@@ -76,7 +76,8 @@ runs:
 
     - name: Add client origins
       shell: bash
-      if: ${{!contains(inputs.BASE_URL, inputs.POOL_INSTANCE) && !steps.instance_check.outputs.INSTANCE_KEY }} # Add base url as a trusted origins if we're using deployed dashboard in repo (saleor.rocks)
+      # Add base url as a trusted origins if we're using deployed dashboard in repo (saleor.rocks)
+      if: ${{ !contains(inputs.BASE_URL, inputs.POOL_INSTANCE) }}
       env:
         POOL_NAME: ${{ inputs.POOL_NAME }}
         BASE_URL: ${{ inputs.BASE_URL }}


### PR DESCRIPTION
## Scope of the change

This PR improves our deployment workflow by always setting trusted origin even if instance already exists

Previously if workflow was cancelled (e.g. new push) then trusted origin was not set (it was part of separate step in action) and thus some e2e tests were failing due to missing trusted origin.
