### PR TITLE
Update navigation on Explore Extensions page

### DIFF
--- a/.changeset/loud-scissors-hear.md
+++ b/.changeset/loud-scissors-hear.md
@@ -1,5 +1,0 @@
----
-"saleor-dashboard": patch
----
-
-Added new navigation on Explore Extensions page with a button linking to pages for installing app from manifest and adding custom app.

--- a/.changeset/loud-scissors-hear.md
+++ b/.changeset/loud-scissors-hear.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added new navigation on Explore Extensions page with a button linking to pages for installing app from manifest and adding custom app.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1158,6 +1158,9 @@
     "context": "Refund status success",
     "string": "Success"
   },
+  "52lmfF": {
+    "string": "Add Extension"
+  },
   "54KYgS": {
     "context": "months after label",
     "string": "months after issue"

--- a/src/extensions/components/ExploreExtensionsActions.tsx
+++ b/src/extensions/components/ExploreExtensionsActions.tsx
@@ -1,13 +1,17 @@
 import { ButtonWithDropdown } from "@dashboard/components/ButtonWithDropdown";
 import Link from "@dashboard/components/Link";
 import { buttonLabels } from "@dashboard/extensions/messages";
+import useNavigator from "@dashboard/hooks/useNavigator";
 import { MISSING_APPS_TYPEFORM_URL } from "@dashboard/links";
 import { Button } from "@saleor/macaw-ui-next";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { ExtensionsUrls } from "../urls";
+
 export const ExploreExtensionsActions = () => {
   const intl = useIntl();
+  const navigate = useNavigator();
 
   return (
     <>
@@ -23,18 +27,14 @@ export const ExploreExtensionsActions = () => {
             label: intl.formatMessage(buttonLabels.installFromManifest),
             testId: "install-from-manifest",
             onSelect: () => {
-              // TODO: Implement click logic
-              // eslint-disable-next-line no-console
-              console.log("Navigate to install page");
+              navigate(ExtensionsUrls.installCustomExtensionUrl());
             },
           },
           {
             label: intl.formatMessage(buttonLabels.installManually),
             testId: "install-manually",
             onSelect: () => {
-              // TODO: Implement click logic
-              // eslint-disable-next-line no-console
-              console.log("Navigate to install page");
+              navigate(ExtensionsUrls.addCustomExtensionUrl());
             },
           },
         ]}

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -56,6 +56,10 @@ export const buttonLabels = defineMessages({
     defaultMessage: "Back",
     id: "cyR7Kh",
   },
+  addExtension: {
+    defaultMessage: "Add Extension",
+    id: "52lmfF",
+  },
 });
 
 export const infoMessages = defineMessages({

--- a/src/extensions/views/ExploreExtensions/ExploreExtensions.tsx
+++ b/src/extensions/views/ExploreExtensions/ExploreExtensions.tsx
@@ -1,15 +1,11 @@
-import { InstallWithManifestFormButton } from "@dashboard/apps/components/InstallWithManifestFormButton";
-import { AppUrls } from "@dashboard/apps/urls";
 import { TopNav } from "@dashboard/components/AppLayout";
 import SearchInput from "@dashboard/components/AppLayout/ListFilters/components/SearchInput";
-import { RequestExtensionsButton } from "@dashboard/extensions/components/RequestExtensionsButton";
-import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
-import useNavigator from "@dashboard/hooks/useNavigator";
 import { Box } from "@saleor/macaw-ui-next";
-import React, { useCallback } from "react";
+import React from "react";
 import { useIntl } from "react-intl";
 
 import { headerTitles, messages } from "../../messages";
+import { ExploreExtensionsActions } from "./components/ExploreExtensionsActions";
 import { ExtensionsList } from "./components/ExtensionsList";
 import { useExploreExtensions } from "./hooks/useExploreExtensions";
 import { useExtensionsFilter } from "./hooks/useExtenstionsFilter";
@@ -18,15 +14,6 @@ export const ExploreExtensions = () => {
   const intl = useIntl();
   const { extensions, loading, error } = useExploreExtensions();
   const { handleQueryChange, query, filteredExtensions } = useExtensionsFilter({ extensions });
-  const { hasManagedAppsPermission } = useHasManagedAppsPermission();
-  const navigate = useNavigator();
-
-  const navigateToAppInstallPage = useCallback(
-    (manifestUrl: string) => {
-      navigate(AppUrls.resolveAppInstallUrl(manifestUrl));
-    },
-    [navigate],
-  );
 
   if (error) {
     // We want to show the default error page when app store api does not work
@@ -36,12 +23,7 @@ export const ExploreExtensions = () => {
   return (
     <>
       <TopNav title={intl.formatMessage(headerTitles.exploreExtensions)}>
-        <Box display="flex" gap={4} alignItems="center">
-          <RequestExtensionsButton />
-          {hasManagedAppsPermission && (
-            <InstallWithManifestFormButton onSubmitted={navigateToAppInstallPage} />
-          )}
-        </Box>
+        <ExploreExtensionsActions />
       </TopNav>
       <Box paddingX={6}>
         <Box __width="370px" marginTop={8} marginBottom={12}>

--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
@@ -97,7 +97,7 @@ describe("ExploreExtensionsActions", () => {
     expect(screen.getByTestId("add-extension-button")).toBeInTheDocument();
   });
 
-  it("doesn't returned add extension dropwhen user doesn't have permission", () => {
+  it("doesn't render add extension dropdown user doesn't have permission", () => {
     // Arrange
     (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: false });
 
@@ -105,7 +105,7 @@ describe("ExploreExtensionsActions", () => {
     render(<ExploreExtensionsActions />);
 
     // Assert
-    expect(screen.getByTestId("add-extension-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("add-extension-button")).not.toBeInTheDocument();
   });
 
   it("navigates to install custom extension when selecting from dropdown", async () => {

--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
@@ -36,15 +36,6 @@ jest.mock("@dashboard/extensions/components/RequestExtensionsButton", () => ({
   ),
   CONST_TYPEFORM_URL: "https://example.com/typeform",
 }));
-
-jest.mock("@dashboard/apps/components/InstallWithManifestFormButton", () => ({
-  InstallWithManifestFormButton: ({ onSubmitted }) => (
-    <button data-test-id="add-app-from-manifest" onClick={() => onSubmitted("test-url")}>
-      Install from manifest
-    </button>
-  ),
-}));
-
 jest.mock("@dashboard/extensions/messages", () => ({
   buttonLabels: {
     addExtension: {

--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
@@ -1,4 +1,3 @@
-import { AppUrls } from "@dashboard/apps/urls";
 import { CONST_TYPEFORM_URL } from "@dashboard/extensions/components/RequestExtensionsButton";
 import { ExtensionsUrls } from "@dashboard/extensions/urls";
 import { useFlag } from "@dashboard/featureFlags";

--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.test.tsx
@@ -1,0 +1,137 @@
+import { AppUrls } from "@dashboard/apps/urls";
+import { CONST_TYPEFORM_URL } from "@dashboard/extensions/components/RequestExtensionsButton";
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { useFlag } from "@dashboard/featureFlags";
+import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
+import useNavigator from "@dashboard/hooks/useNavigator";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { ExploreExtensionsActions } from "./ExploreExtensionsActions";
+
+jest.mock("@dashboard/featureFlags", () => ({
+  useFlag: jest.fn(),
+}));
+
+jest.mock("@dashboard/hooks/useHasManagedAppsPermission", () => ({
+  useHasManagedAppsPermission: jest.fn(),
+}));
+
+jest.mock("@dashboard/hooks/useNavigator", () => jest.fn());
+
+jest.mock("react-intl", () => ({
+  FormattedMessage: ({ id, defaultMessage }: { defaultMessage: string; id: string }) =>
+    defaultMessage || id,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage }: { defaultMessage: string }) => defaultMessage,
+  }),
+  defineMessages: (messages: unknown) => messages,
+}));
+
+jest.mock("@dashboard/extensions/components/RequestExtensionsButton", () => ({
+  RequestExtensionsButton: () => (
+    <a href={CONST_TYPEFORM_URL} target="_blank" rel="noopener noreferrer">
+      Request integration
+    </a>
+  ),
+  CONST_TYPEFORM_URL: "https://example.com/typeform",
+}));
+
+jest.mock("@dashboard/apps/components/InstallWithManifestFormButton", () => ({
+  InstallWithManifestFormButton: ({ onSubmitted }) => (
+    <button data-test-id="add-app-from-manifest" onClick={() => onSubmitted("test-url")}>
+      Install from manifest
+    </button>
+  ),
+}));
+
+jest.mock("@dashboard/extensions/messages", () => ({
+  buttonLabels: {
+    addExtension: {
+      defaultMessage: "Add Extension",
+      id: "addExtension",
+    },
+    installFromManifest: {
+      defaultMessage: "Install from Manifest",
+      id: "installFromManifest",
+    },
+    installManually: {
+      defaultMessage: "Install Manually",
+      id: "installManually",
+    },
+  },
+}));
+
+describe("ExploreExtensionsActions", () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigator as jest.Mock).mockReturnValue(mockNavigate);
+    (useFlag as jest.Mock).mockReturnValue({ enabled: true });
+  });
+
+  it("always renders request extensions button", () => {
+    // Arrange
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: false });
+
+    // Act
+    render(<ExploreExtensionsActions />);
+
+    // Assert
+    const link = screen.getByRole("link", { name: "Request integration" });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", CONST_TYPEFORM_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders add extension dropdown when user has permission and extensions dev is enabled", () => {
+    // Arrange
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+
+    // Act
+    render(<ExploreExtensionsActions />);
+
+    // Assert
+    expect(screen.getByTestId("add-extension-button")).toBeInTheDocument();
+  });
+
+  it("doesn't returned add extension dropwhen user doesn't have permission", () => {
+    // Arrange
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: false });
+
+    // Act
+    render(<ExploreExtensionsActions />);
+
+    // Assert
+    expect(screen.getByTestId("add-extension-button")).not.toBeInTheDocument();
+  });
+
+  it("navigates to install custom extension when selecting from dropdown", async () => {
+    // Arrange
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+
+    // Act
+    render(<ExploreExtensionsActions />);
+    await userEvent.click(screen.getByTestId("add-extension-button"));
+    await userEvent.click(screen.getByTestId("install-custom-extension"));
+
+    // Assert
+    expect(mockNavigate).toHaveBeenCalledWith(ExtensionsUrls.installCustomExtensionUrl());
+  });
+
+  it("navigates to add custom extension when selecting from dropdown", async () => {
+    // Arrange
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+
+    // Act
+    render(<ExploreExtensionsActions />);
+    await userEvent.click(screen.getByTestId("add-extension-button"));
+    await userEvent.click(screen.getByTestId("add-custom-extension"));
+
+    // Assert
+    expect(mockNavigate).toHaveBeenCalledWith(ExtensionsUrls.addCustomExtensionUrl());
+  });
+});

--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.tsx
@@ -1,0 +1,65 @@
+import { InstallWithManifestFormButton } from "@dashboard/apps/components/InstallWithManifestFormButton";
+import { AppUrls } from "@dashboard/apps/urls";
+import { ButtonWithDropdown } from "@dashboard/components/ButtonWithDropdown";
+import { RequestExtensionsButton } from "@dashboard/extensions/components/RequestExtensionsButton";
+import { buttonLabels } from "@dashboard/extensions/messages";
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { useFlag } from "@dashboard/featureFlags";
+import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
+import useNavigator from "@dashboard/hooks/useNavigator";
+import { Box, PlusIcon } from "@saleor/macaw-ui-next";
+import React, { useCallback, useMemo } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export const ExploreExtensionsActions = () => {
+  const intl = useIntl();
+  const navigate = useNavigator();
+  const { enabled: isExtensionsDevEnabled } = useFlag("extensions_dev");
+  const { hasManagedAppsPermission } = useHasManagedAppsPermission();
+
+  const navigateToAppInstallPage = useCallback(
+    (manifestUrl: string) => {
+      navigate(AppUrls.resolveAppInstallUrl(manifestUrl));
+    },
+    [navigate],
+  );
+
+  const addExtensionOptions = useMemo(
+    () => [
+      {
+        label: intl.formatMessage(buttonLabels.installFromManifest),
+        testId: "install-custom-extension",
+        onSelect: () => navigate(ExtensionsUrls.installCustomExtensionUrl()),
+      },
+      {
+        label: intl.formatMessage(buttonLabels.installManually),
+        testId: "add-custom-extension",
+        onSelect: () => navigate(ExtensionsUrls.addCustomExtensionUrl()),
+      },
+    ],
+    [intl, navigate],
+  );
+
+  return (
+    <Box display="flex" gap={4} alignItems="center">
+      <RequestExtensionsButton />
+
+      {hasManagedAppsPermission && (
+        <>
+          {isExtensionsDevEnabled ? (
+            <ButtonWithDropdown
+              variant="primary"
+              icon={<PlusIcon />}
+              options={addExtensionOptions}
+              testId="add-extension-button"
+            >
+              <FormattedMessage {...buttonLabels.addExtension} />
+            </ButtonWithDropdown>
+          ) : (
+            <InstallWithManifestFormButton onSubmitted={navigateToAppInstallPage} />
+          )}
+        </>
+      )}
+    </Box>
+  );
+};


### PR DESCRIPTION
## Scope of the change

Added new navigation on Explore Extensions page with links to "Add custom extension" and "Install extensions from manifest"

![CleanShot 2025-05-07 at 17 46 02@2x](https://github.com/user-attachments/assets/06083d3c-cc5c-4b59-9bd3-4bf878af9f89)

> [!TIP]
> This change is behind a dev feature flag. Enable it with:
> ```
> localStorage.setItem('FF_extensions_dev', '{"enabled":true,"payload":"default"}')
> ```
