### PR TITLE
Fix wrong feature flag used to hide navigation items

### DIFF
--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -253,7 +253,7 @@ export const ConfigurationSection: React.FC = () => {
   };
   const user = useUser();
   const intl = useIntl();
-  const { enabled: isExtensionsEnabled } = useFlag("extensions");
+  const { enabled: isExtensionsEnabled } = useFlag("extensions_dev");
 
   return (
     <>


### PR DESCRIPTION
## Scope of the change

Fixed confgiuration for webhooks and plugins hidden when extensions are enabled (dev ff should be used instead)
