### PR TITLE
Fix: custom app details page not loading when user doesn't have manage_apps permissions

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1948,6 +1948,9 @@
     "context": "order refund subtitle",
     "string": "Refunded items can't be fulfilled"
   },
+  "ALe+of": {
+    "string": "You don't have permission to manage webhooks. Contact your administrator for access."
+  },
   "AOI4LW": {
     "context": "navigator placeholder",
     "string": "Search in Catalog"
@@ -6847,6 +6850,10 @@
     "context": "Transaction title",
     "string": "Gift card (**** {code})"
   },
+  "e5gJ9u": {
+    "context": "tooltip for disabled buttons",
+    "string": "You don't have permission to manage apps"
+  },
   "e7Nyu7": {
     "context": "section header",
     "string": "Customer History"
@@ -8121,6 +8128,9 @@
   },
   "m19JfL": {
     "string": "View and update your plugins and their settings."
+  },
+  "m2Jb3P": {
+    "string": "You don't have permission to manage authentication tokens. Contact your administrator for access."
   },
   "m6IBe5": {
     "context": "invoice number prefix",

--- a/src/extensions/index.tsx
+++ b/src/extensions/index.tsx
@@ -193,15 +193,17 @@ export const ExtensionsSection = () => {
           )}
         />
 
-        <Route
+        <SectionRoute
           exact
           path={ExtensionsPaths.resolveAddCustomExtensionWebhook(":appId")}
           component={AddCustomExtensionWebhookView}
+          permissions={[PermissionEnum.MANAGE_APPS]}
         />
-        <Route
+        <SectionRoute
           exact
           path={ExtensionsPaths.resolveEditCustomExtensionWebhook(":appId", ":id")}
           component={EditCustomExtensionWebhookView}
+          permissions={[PermissionEnum.MANAGE_APPS]}
         />
         <Route component={NotFound} />
       </Switch>

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -364,4 +364,9 @@ export const appMessages = defineMessages({
     defaultMessage: "App deactivated",
     description: "snackbar text",
   },
+  missingManageAppsPermission: {
+    defaultMessage: "You don't have permission to manage apps",
+    id: "e5gJ9u",
+    description: "tooltip for disabled buttons",
+  },
 });

--- a/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
+++ b/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
@@ -19,6 +19,7 @@ import {
   useWebhookDeleteMutation,
   WebhookDeleteMutation,
 } from "@dashboard/graphql";
+import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import useNotifier from "@dashboard/hooks/useNotifier";
 import useShop from "@dashboard/hooks/useShop";
@@ -57,6 +58,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
   const notify = useNotifier();
   const intl = useIntl();
   const shop = useShop();
+  const { hasManagedAppsPermission } = useHasManagedAppsPermission();
 
   useEffect(() => onTokenClose, []);
 
@@ -66,7 +68,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
   >(navigate, params => ExtensionsUrls.editCustomExtensionUrl(id, params), params);
   const { data, loading, refetch } = useAppQuery({
     displayLoader: true,
-    variables: { id, hasManagedAppsPermission: true },
+    variables: { id, hasManagedAppsPermission },
   });
   const [activateApp, activateAppResult] = useAppActivateMutation({
     onCompleted: data => {
@@ -80,7 +82,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
         refetch();
         closeModal();
       } else {
-        errors.forEach(error =>
+        errors?.forEach(error =>
           notify({
             status: "error",
             text: getAppInstallErrorMessage(error, intl),
@@ -93,7 +95,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
     onCompleted: data => {
       const errors = data?.appDeactivate?.errors;
 
-      if (errors.length === 0) {
+      if (errors?.length === 0) {
         notify({
           status: "success",
           text: intl.formatMessage(appMessages.appDeactivated),
@@ -101,7 +103,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
         refetch();
         closeModal();
       } else {
-        errors.forEach(error =>
+        errors?.forEach(error =>
           notify({
             status: "error",
             text: getAppInstallErrorMessage(error, intl),
@@ -111,7 +113,7 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
     },
   });
   const onWebhookDelete = (data: WebhookDeleteMutation) => {
-    if (data.webhookDelete.errors.length === 0) {
+    if (data?.webhookDelete?.errors?.length === 0) {
       notify({
         status: "success",
         text: intl.formatMessage(commonMessages.savedChanges),
@@ -141,12 +143,12 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
   };
   const customApp = data?.app;
   const onTokenCreate = (data: AppTokenCreateMutation) => {
-    if (data?.appTokenCreate?.errors.length === 0) {
+    if (data?.appTokenCreate?.errors?.length === 0) {
       refetch();
     }
   };
   const onTokenDelete = (data: AppTokenDeleteMutation) => {
-    if (data?.appTokenDelete?.errors.length === 0) {
+    if (data?.appTokenDelete?.errors?.length === 0) {
       notify({
         status: "success",
         text: intl.formatMessage(commonMessages.savedChanges),
@@ -171,9 +173,10 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
           id,
           input: {
             name: data.name,
-            permissions: data.hasFullAccess
-              ? shop.permissions.map(permission => permission.code)
-              : data.permissions,
+            permissions:
+              data.hasFullAccess && shop?.permissions
+                ? shop.permissions.map(permission => permission.code)
+                : data.permissions,
           },
         },
       }),
@@ -205,6 +208,11 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
     return <NotFoundPage backHref={ExtensionsUrls.resolveInstalledExtensionsUrl()} />;
   }
 
+  // Show loading state if data isn't available yet
+  if (loading && !data) {
+    return null; // Or some loading indicator
+  }
+
   return (
     <>
       <WindowTitle title={getStringOrPlaceholder(customApp?.name)} />
@@ -230,16 +238,17 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
         }
         onAppActivateOpen={() => openModal("app-activate")}
         onAppDeactivateOpen={() => openModal("app-deactivate")}
-        permissions={shop?.permissions}
+        permissions={shop?.permissions || []}
         app={data?.app}
         saveButtonBarState={updateAppOpts.status}
+        hasManagedAppsPermission={hasManagedAppsPermission}
       />
       <TokenCreateDialog
         confirmButtonState={createTokenOpts.status}
         onClose={closeModal}
         onCreate={handleTokenCreate}
         open={params.action === "create-token"}
-        token={createTokenOpts.data?.appTokenCreate.authToken}
+        token={createTokenOpts.data?.appTokenCreate?.authToken || ""}
       />
       <TokenDeleteDialog
         confirmButtonState={deleteTokenOpts.status}
@@ -252,21 +261,21 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
       />
       <WebhookDeleteDialog
         confirmButtonState={webhookDeleteOpts.status}
-        name={data?.app?.webhooks.find(webhook => webhook.id === params.id)?.name}
+        name={data?.app?.webhooks?.find(webhook => webhook.id === params.id)?.name || ""}
         onClose={closeModal}
         onConfirm={handleRemoveWebhookConfirm}
         open={params.action === "remove-webhook"}
       />
       <AppActivateDialog
         confirmButtonState={activateAppResult.status}
-        name={data?.app.name}
+        name={data?.app?.name || ""}
         onClose={closeModal}
         onConfirm={handleActivateConfirm}
         open={params.action === "app-activate"}
       />
       <AppDeactivateDialog
         confirmButtonState={deactivateAppResult.status}
-        name={data?.app.name}
+        name={data?.app?.name || ""}
         onClose={closeModal}
         onConfirm={handleDeactivateConfirm}
         thirdParty={false}

--- a/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
+++ b/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
@@ -208,11 +208,6 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
     return <NotFoundPage backHref={ExtensionsUrls.resolveInstalledExtensionsUrl()} />;
   }
 
-  // Show loading state if data isn't available yet
-  if (loading && !data) {
-    return null; // Or some loading indicator
-  }
-
   return (
     <>
       <WindowTitle title={getStringOrPlaceholder(customApp?.name)} />

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
@@ -7,6 +7,7 @@ import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButto
 import Form from "@dashboard/components/Form";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { Savebar } from "@dashboard/components/Savebar";
+import { appMessages } from "@dashboard/extensions/messages";
 import { ExtensionsUrls } from "@dashboard/extensions/urls";
 import {
   AppErrorFragment,
@@ -82,12 +83,6 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
   const webhooks = app?.webhooks || [];
   const formErrors = getFormErrors(["permissions"], errors || []);
   const permissionsError = getAppErrorMessage(formErrors.permissions, intl);
-
-  const noPermissionText = intl.formatMessage({
-    id: "e5gJ9u",
-    defaultMessage: "You don't have permission to manage apps",
-    description: "tooltip for disabled buttons",
-  });
 
   // Ensure all values have safe fallbacks
   const initialForm: CustomExtensionDetailsPageFormData = {
@@ -195,7 +190,7 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
               {!hasManagedAppsPermission && (
                 <Tooltip.Content>
                   <Tooltip.Arrow />
-                  {noPermissionText}
+                  {appMessages.missingManageAppsPermission}
                 </Tooltip.Content>
               )}
             </Tooltip>
@@ -218,7 +213,7 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
               {!hasManagedAppsPermission && (
                 <Tooltip.Content>
                   <Tooltip.Arrow />
-                  {noPermissionText}
+                  {appMessages.missingManageAppsPermission}
                 </Tooltip.Content>
               )}
             </Tooltip>

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
@@ -106,30 +106,30 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
       {({ data, change, submit, isSaveDisabled }) => (
         <DetailPageLayout>
           <TopNav href={ExtensionsUrls.resolveInstalledExtensionsUrl()} title={app?.name || ""}>
-            <Tooltip>
-              <Tooltip.Trigger>
-                <Button
-                  variant="secondary"
-                  className={classes.activateButton}
-                  disableFocusRipple
-                  onClick={data.isActive ? onAppDeactivateOpen : onAppActivateOpen}
-                  disabled={disabled || !hasManagedAppsPermission}
-                >
-                  <SVG src={activateIcon} />
-                  {data?.isActive ? (
-                    <FormattedMessage id="whTEcF" defaultMessage="Deactivate" description="link" />
-                  ) : (
-                    <FormattedMessage id="P5twxk" defaultMessage="Activate" description="link" />
-                  )}
-                </Button>
-              </Tooltip.Trigger>
-              {!hasManagedAppsPermission && (
-                <Tooltip.Content>
-                  <Tooltip.Arrow />
-                  {noPermissionText}
-                </Tooltip.Content>
-              )}
-            </Tooltip>
+            {hasManagedAppsPermission && (
+              <Tooltip>
+                <Tooltip.Trigger>
+                  <Button
+                    variant="secondary"
+                    className={classes.activateButton}
+                    disableFocusRipple
+                    onClick={data.isActive ? onAppDeactivateOpen : onAppActivateOpen}
+                    disabled={disabled}
+                  >
+                    <SVG src={activateIcon} />
+                    {data?.isActive ? (
+                      <FormattedMessage
+                        id="whTEcF"
+                        defaultMessage="Deactivate"
+                        description="link"
+                      />
+                    ) : (
+                      <FormattedMessage id="P5twxk" defaultMessage="Activate" description="link" />
+                    )}
+                  </Button>
+                </Tooltip.Trigger>
+              </Tooltip>
+            )}
           </TopNav>
           <DetailPageLayout.Content>
             {token && (

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/CustomExtensionTokens.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/CustomExtensionTokens.tsx
@@ -7,7 +7,7 @@ import { AppUpdateMutation } from "@dashboard/graphql";
 import { renderCollection } from "@dashboard/misc";
 import { TableBody, TableCell, TableHead } from "@material-ui/core";
 import { DeleteIcon, IconButton } from "@saleor/macaw-ui";
-import { Skeleton } from "@saleor/macaw-ui-next";
+import { Skeleton, Text } from "@saleor/macaw-ui-next";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -17,11 +17,13 @@ export interface CustomAppTokensProps {
   tokens: AppUpdateMutation["appUpdate"]["app"]["tokens"] | null;
   onCreate: () => void;
   onDelete: (id: string) => void;
+  hasManagedAppsPermission: boolean;
 }
 
 const numberOfColumns = 3;
+
 const CustomExtensionTokens: React.FC<CustomAppTokensProps> = props => {
-  const { tokens, onCreate, onDelete } = props;
+  const { tokens, onCreate, onDelete, hasManagedAppsPermission } = props;
   const classes = useStyles(props);
   const intl = useIntl();
 
@@ -36,62 +38,82 @@ const CustomExtensionTokens: React.FC<CustomAppTokensProps> = props => {
           })}
         </DashboardCard.Title>
         <DashboardCard.Toolbar>
-          <Button variant="secondary" onClick={onCreate} data-test-id="create-token">
-            <FormattedMessage id="RMB6fU" defaultMessage="Create Token" description="button" />
-          </Button>
+          {hasManagedAppsPermission && (
+            <Button variant="secondary" onClick={onCreate} data-test-id="create-token">
+              <FormattedMessage id="RMB6fU" defaultMessage="Create Token" description="button" />
+            </Button>
+          )}
         </DashboardCard.Toolbar>
       </DashboardCard.Header>
 
       <DashboardCard.Content paddingX={0}>
         <ResponsiveTable>
-          <TableHead>
-            <TableRowLink>
-              <TableCell className={classes.colNote}>
-                <FormattedMessage id="0DRBjg" defaultMessage="Token Note" />
-              </TableCell>
-              <TableCell className={classes.colKey}>
-                <FormattedMessage
-                  id="MAsLIT"
-                  defaultMessage="Key"
-                  description="custom app token key"
-                />
-              </TableCell>
-              <TableCell className={classes.colActions}>
-                <FormattedMessage
-                  id="VHuzgq"
-                  defaultMessage="Actions"
-                  description="table actions"
-                />
-              </TableCell>
-            </TableRowLink>
-          </TableHead>
+          {hasManagedAppsPermission && (
+            <TableHead>
+              <TableRowLink>
+                <TableCell className={classes.colNote}>
+                  <FormattedMessage id="0DRBjg" defaultMessage="Token Note" />
+                </TableCell>
+                <TableCell className={classes.colKey}>
+                  <FormattedMessage
+                    id="MAsLIT"
+                    defaultMessage="Key"
+                    description="custom app token key"
+                  />
+                </TableCell>
+                <TableCell className={classes.colActions}>
+                  <FormattedMessage
+                    id="VHuzgq"
+                    defaultMessage="Actions"
+                    description="table actions"
+                  />
+                </TableCell>
+              </TableRowLink>
+            </TableHead>
+          )}
           <TableBody>
-            {renderCollection(
-              tokens,
-              token => (
-                <TableRowLink key={token ? token.id : "skeleton"}>
-                  <TableCell className={classes.colNote}>{token?.name || <Skeleton />}</TableCell>
-                  <TableCell className={classes.colKey}>
-                    {token?.authToken ? `**** ${token.authToken}` : <Skeleton />}
-                  </TableCell>
-                  <TableCell className={classes.colActions}>
-                    <IconButton
-                      variant="secondary"
-                      color="primary"
-                      onClick={() => onDelete(token.id)}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </TableCell>
-                </TableRowLink>
-              ),
-              () => (
-                <TableRowLink>
-                  <TableCell colSpan={numberOfColumns}>
-                    <FormattedMessage id="bsP4f3" defaultMessage="No tokens found" />
-                  </TableCell>
-                </TableRowLink>
-              ),
+            {hasManagedAppsPermission ? (
+              renderCollection(
+                tokens,
+                token => (
+                  <TableRowLink key={token ? token.id : "skeleton"}>
+                    <TableCell className={classes.colNote}>{token?.name || <Skeleton />}</TableCell>
+                    <TableCell className={classes.colKey}>
+                      {token?.authToken ? `**** ${token.authToken}` : <Skeleton />}
+                    </TableCell>
+                    <TableCell className={classes.colActions}>
+                      {hasManagedAppsPermission && (
+                        <IconButton
+                          variant="secondary"
+                          color="primary"
+                          onClick={() => onDelete(token.id)}
+                          data-test-id={`delete-token-${token.id}`}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      )}
+                    </TableCell>
+                  </TableRowLink>
+                ),
+                () => (
+                  <TableRowLink>
+                    <TableCell colSpan={numberOfColumns}>
+                      <FormattedMessage id="bsP4f3" defaultMessage="No tokens found" />
+                    </TableCell>
+                  </TableRowLink>
+                ),
+              )
+            ) : (
+              <TableRowLink>
+                <TableCell colSpan={numberOfColumns}>
+                  <Text color="default2">
+                    <FormattedMessage
+                      id="m2Jb3P"
+                      defaultMessage="You don't have permission to manage authentication tokens. Contact your administrator for access."
+                    />
+                  </Text>
+                </TableCell>
+              </TableRowLink>
             )}
           </TableBody>
         </ResponsiveTable>

--- a/src/extensions/views/EditCustomExtension/components/WebhooksList/WebhooksList.tsx
+++ b/src/extensions/views/EditCustomExtension/components/WebhooksList/WebhooksList.tsx
@@ -117,7 +117,7 @@ export const WebhooksList: React.FC<WebhooksListProps> = ({
                             onClick={
                               webhook ? stopPropagation(() => onRemove(webhook.id)) : undefined
                             }
-                            data-test-id={`delete-webhook-${webhook.id}`}
+                            data-test-id={`delete-webhook-${webhook?.id}`}
                           >
                             <DeleteIcon />
                           </IconButton>

--- a/src/extensions/views/EditCustomExtension/components/WebhooksList/WebhooksList.tsx
+++ b/src/extensions/views/EditCustomExtension/components/WebhooksList/WebhooksList.tsx
@@ -13,7 +13,7 @@ import { commonMessages, commonStatusMessages, sectionNames } from "@dashboard/i
 import { renderCollection, stopPropagation } from "@dashboard/misc";
 import { TableBody, TableCell, TableHead } from "@material-ui/core";
 import { DeleteIcon, IconButton } from "@saleor/macaw-ui";
-import { Skeleton } from "@saleor/macaw-ui-next";
+import { Skeleton, Text } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -25,13 +25,19 @@ export interface WebhooksListProps {
   webhooks: WebhookFragment[];
   onRemove: (id: string) => void;
   createHref?: string;
+  hasManagedAppsPermission: boolean;
 }
 
-export const WebhooksList: React.FC<WebhooksListProps> = ({ webhooks, createHref, onRemove }) => {
+export const WebhooksList: React.FC<WebhooksListProps> = ({
+  webhooks,
+  createHref,
+  onRemove,
+  hasManagedAppsPermission,
+}) => {
   const intl = useIntl();
   const classes = useStyles();
   const navigate = useNavigator();
-  const numberOfColumns = webhooks?.length === 0 ? 2 : 3;
+  const numberOfColumns = hasManagedAppsPermission ? 3 : 1;
 
   const handleCreateWebhook = () => {
     if (!createHref) return;
@@ -46,7 +52,7 @@ export const WebhooksList: React.FC<WebhooksListProps> = ({ webhooks, createHref
           {intl.formatMessage(sectionNames.webhooksAndEvents)}
         </DashboardCard.Title>
         <DashboardCard.Toolbar>
-          {!!createHref && (
+          {!!createHref && hasManagedAppsPermission && (
             <Button variant="secondary" onClick={handleCreateWebhook} data-test-id="create-webhook">
               <FormattedMessage {...messages.createWebhook} />
             </Button>
@@ -55,70 +61,90 @@ export const WebhooksList: React.FC<WebhooksListProps> = ({ webhooks, createHref
       </DashboardCard.Header>
       <DashboardCard.Content paddingX={0}>
         <ResponsiveTable className={classes.table}>
-          <TableHead>
-            <TableRowLink>
-              <TableCellHeader>{intl.formatMessage(commonMessages.name)}</TableCellHeader>
-              <TableCellHeader>{intl.formatMessage(commonMessages.status)}</TableCellHeader>
-              <TableCell className={clsx(classes.colAction, classes.colRight)}>
-                <FormattedMessage {...messages.action} />
-              </TableCell>
-            </TableRowLink>
-          </TableHead>
+          {hasManagedAppsPermission && (
+            <TableHead>
+              <TableRowLink>
+                <TableCellHeader>{intl.formatMessage(commonMessages.name)}</TableCellHeader>
+                <TableCellHeader>{intl.formatMessage(commonMessages.status)}</TableCellHeader>
+                <TableCell className={clsx(classes.colAction, classes.colRight)}>
+                  <FormattedMessage {...messages.action} />
+                </TableCell>
+              </TableRowLink>
+            </TableHead>
+          )}
           <TableBody>
-            {renderCollection(
-              webhooks,
-              webhook => (
-                <TableRowLink
-                  hover={!!webhook}
-                  className={webhook ? classes.tableRow : undefined}
-                  href={webhook && CustomAppUrls.resolveWebhookUrl(webhook.app.id, webhook.id)}
-                  key={webhook ? webhook.id : "skeleton"}
-                >
-                  <TableCell
-                    className={clsx(classes.colName, {
-                      [classes.colNameUnnamed]: isUnnamed(webhook),
-                    })}
+            {hasManagedAppsPermission ? (
+              renderCollection(
+                webhooks,
+                webhook => (
+                  <TableRowLink
+                    hover={!!webhook}
+                    className={webhook ? classes.tableRow : undefined}
+                    href={webhook && CustomAppUrls.resolveWebhookUrl(webhook.app.id, webhook.id)}
+                    key={webhook ? webhook.id : "skeleton"}
                   >
-                    {isUnnamed(webhook) ? (
-                      <FormattedMessage {...messages.unnamedWebhook} />
-                    ) : (
-                      webhook?.name || <Skeleton />
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    {webhook ? (
-                      <Pill
-                        label={
-                          webhook.isActive
-                            ? intl.formatMessage(commonStatusMessages.active)
-                            : intl.formatMessage(commonStatusMessages.notActive)
-                        }
-                        color={webhook.isActive ? "success" : "error"}
-                      />
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell>
-                  <TableCell className={clsx(classes.colAction, classes.colRight)}>
-                    <TableButtonWrapper>
-                      <IconButton
-                        variant="secondary"
-                        color="primary"
-                        onClick={webhook ? stopPropagation(() => onRemove(webhook.id)) : undefined}
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    </TableButtonWrapper>
-                  </TableCell>
-                </TableRowLink>
-              ),
-              () => (
-                <TableRowLink>
-                  <TableCell colSpan={numberOfColumns}>
-                    {intl.formatMessage(messages.noWebhooks)}
-                  </TableCell>
-                </TableRowLink>
-              ),
+                    <TableCell
+                      className={clsx(classes.colName, {
+                        [classes.colNameUnnamed]: isUnnamed(webhook),
+                      })}
+                    >
+                      {isUnnamed(webhook) ? (
+                        <FormattedMessage {...messages.unnamedWebhook} />
+                      ) : (
+                        webhook?.name || <Skeleton />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {webhook ? (
+                        <Pill
+                          label={
+                            webhook.isActive
+                              ? intl.formatMessage(commonStatusMessages.active)
+                              : intl.formatMessage(commonStatusMessages.notActive)
+                          }
+                          color={webhook.isActive ? "success" : "error"}
+                        />
+                      ) : (
+                        <Skeleton />
+                      )}
+                    </TableCell>
+                    <TableCell className={clsx(classes.colAction, classes.colRight)}>
+                      {hasManagedAppsPermission && (
+                        <TableButtonWrapper>
+                          <IconButton
+                            variant="secondary"
+                            color="primary"
+                            onClick={
+                              webhook ? stopPropagation(() => onRemove(webhook.id)) : undefined
+                            }
+                            data-test-id={`delete-webhook-${webhook.id}`}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </TableButtonWrapper>
+                      )}
+                    </TableCell>
+                  </TableRowLink>
+                ),
+                () => (
+                  <TableRowLink>
+                    <TableCell colSpan={numberOfColumns}>
+                      {intl.formatMessage(messages.noWebhooks)}
+                    </TableCell>
+                  </TableRowLink>
+                ),
+              )
+            ) : (
+              <TableRowLink>
+                <TableCell colSpan={numberOfColumns}>
+                  <Text color="default2">
+                    <FormattedMessage
+                      id="ALe+of"
+                      defaultMessage="You don't have permission to manage webhooks. Contact your administrator for access."
+                    />
+                  </Text>
+                </TableCell>
+              </TableRowLink>
             )}
           </TableBody>
         </ResponsiveTable>


### PR DESCRIPTION
## Description

Fixed custom app views when user doesn't have `MANAGE_APPS` permissions:
- details view now loads
  - tokens and webhook & events are hidden with message
  - activate / deactivate button is hidden
  - save button is disabled, with tooltip
  - permission checkboxes are disabled
- view and edit app webhooks are hidden from users that don't have permission and return 404

## Screenshots
![CleanShot 2025-05-13 at 11 33 45@2x](https://github.com/user-attachments/assets/97e24d35-5354-4c09-9329-6a2f3c8268cf)
![CleanShot 2025-05-13 at 11 33 52@2x](https://github.com/user-attachments/assets/462408d1-8c1e-4ac0-a96e-8ddea9ed69b2)
