### PR TITLE
Show plugins in explore extensions when dev ff is enabled

### DIFF
--- a/src/extensions/views/ExploreExtensions/hooks/useExploreExtensions.test.ts
+++ b/src/extensions/views/ExploreExtensions/hooks/useExploreExtensions.test.ts
@@ -15,6 +15,10 @@ jest.mock("@dashboard/graphql", () => ({
     },
   })),
 }));
+jest.mock("@dashboard/featureFlags", () => ({
+  ...jest.requireActual("@dashboard/featureFlags"),
+  useFlag: jest.fn(() => ({ enabled: true })),
+}));
 
 const mockedAppStoreExtensions = {
   payments: {

--- a/src/extensions/views/ExploreExtensions/hooks/useExploreExtensions.test.ts
+++ b/src/extensions/views/ExploreExtensions/hooks/useExploreExtensions.test.ts
@@ -16,7 +16,7 @@ jest.mock("@dashboard/graphql", () => ({
   })),
 }));
 jest.mock("@dashboard/featureFlags", () => ({
-  ...jest.requireActual("@dashboard/featureFlags"),
+  ...(jest.requireActual("@dashboard/featureFlags") as object),
   useFlag: jest.fn(() => ({ enabled: true })),
 }));
 


### PR DESCRIPTION
Show all extensions when dev feature flag is enabled

> [!TIP]
> To enable use this command in console:
> ```
> localStorage.setItem('FF_extensions_dev', '{"enabled":true,"payload":"default"}')
> ```

## Screenshots

![CleanShot 2025-05-22 at 16 15 47@2x](https://github.com/user-attachments/assets/75aec323-9909-47c3-a9a6-8856172e25c7)
