### PR TITLE
Fix search extensions input

### DIFF
--- a/.changeset/tiny-trees-hope.md
+++ b/.changeset/tiny-trees-hope.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Improved search element across dashboard: now clicking on search icon or near the search border will focus the input.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2423,9 +2423,6 @@
     "context": "table header column",
     "string": "Country name"
   },
-  "D66hpd": {
-    "string": "Search extensions..."
-  },
   "D8nsBc": {
     "context": "no warehouses info",
     "string": "There are no warehouses set up for your store. To add stock quantity to the variant please <a>configure a warehouse</a>"
@@ -8772,6 +8769,9 @@
   "qMB6d2": {
     "context": "weight",
     "string": "to {value} {unit}"
+  },
+  "qMEm+l": {
+    "string": "Search Extensions..."
   },
   "qNcoRY": {
     "context": "notes about customer header",

--- a/src/components/AppLayout/ListFilters/components/SearchInput.tsx
+++ b/src/components/AppLayout/ListFilters/components/SearchInput.tsx
@@ -4,38 +4,19 @@ import {
   Box,
   SearchInput as MacawSearchInput,
   SearchInputProps as MacawSearchInputProps,
-  sprinkles,
 } from "@saleor/macaw-ui-next";
 import React from "react";
 
 export interface SearchInputProps extends SearchPageProps {
   placeholder: string;
   size?: MacawSearchInputProps["size"];
-  withBorder?: boolean;
 }
 
 const SearchInput: React.FC<SearchInputProps> = props => {
-  const { initialSearch, onSearchChange, placeholder, withBorder, size = "small" } = props;
+  const { initialSearch, onSearchChange, placeholder, size = "small" } = props;
   const [search, setSearch] = React.useState(initialSearch);
 
   React.useEffect(() => setSearch(initialSearch), [initialSearch]);
-
-  const className = withBorder
-    ? sprinkles({
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderColor: {
-          default: "default1",
-          hover: "default1Hovered",
-          focusWithin: "accent1",
-        },
-        backgroundColor: {
-          default: "transparent",
-          hover: "transparent",
-          focusWithin: "transparent",
-        },
-      })
-    : "";
 
   return (
     <Debounce debounceFn={onSearchChange} time={500}>
@@ -50,7 +31,6 @@ const SearchInput: React.FC<SearchInputProps> = props => {
         return (
           <Box as="label" display="flex" alignItems="center" width="100%">
             <MacawSearchInput
-              className={className}
               size={size}
               value={search}
               onChange={handleSearchChange}

--- a/src/components/AppLayout/ListFilters/components/SearchInput.tsx
+++ b/src/components/AppLayout/ListFilters/components/SearchInput.tsx
@@ -48,7 +48,7 @@ const SearchInput: React.FC<SearchInputProps> = props => {
         };
 
         return (
-          <Box display="flex" alignItems="center" width="100%">
+          <Box as="label" display="flex" alignItems="center" width="100%">
             <MacawSearchInput
               className={className}
               size={size}

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -168,8 +168,8 @@ export const notifyMessages = defineMessages({
 
 export const messages = defineMessages({
   searchPlaceholder: {
-    defaultMessage: "Search extensions...",
-    id: "D66hpd",
+    defaultMessage: "Search Extensions...",
+    id: "qMEm+l",
   },
   installed: {
     defaultMessage: "Installed",

--- a/src/extensions/views/ExploreExtensions/ExploreExtensions.tsx
+++ b/src/extensions/views/ExploreExtensions/ExploreExtensions.tsx
@@ -26,9 +26,8 @@ export const ExploreExtensions = () => {
         <ExploreExtensionsActions />
       </TopNav>
       <Box paddingX={6}>
-        <Box __width="370px" marginTop={8} marginBottom={12}>
+        <Box __width="370px" marginTop={12} marginBottom={7}>
           <SearchInput
-            withBorder
             size="medium"
             initialSearch={query}
             placeholder={intl.formatMessage(messages.searchPlaceholder)}

--- a/src/extensions/views/InstalledExtensions/InstalledExtensions.test.tsx
+++ b/src/extensions/views/InstalledExtensions/InstalledExtensions.test.tsx
@@ -109,7 +109,7 @@ describe("InstalledExtensions", () => {
     const mockHandleQueryChange = jest.fn();
     // Initial render with all extensions
     const { rerender } = render(<InstalledExtensions {...defaultProps} />);
-    const searchInput = screen.getByPlaceholderText("Search extensions...");
+    const searchInput = screen.getByPlaceholderText("Search Extensions...");
 
     // Act: Simulate typing search query
     fireEvent.change(searchInput, { target: { value: "Test App" } });

--- a/src/extensions/views/InstalledExtensions/InstalledExtensions.tsx
+++ b/src/extensions/views/InstalledExtensions/InstalledExtensions.tsx
@@ -69,9 +69,8 @@ export const InstalledExtensions = ({ params }: InstalledExtensionsProps) => {
         </Box>
       </TopNav>
       <Box paddingX={6}>
-        <Box __width="370px" marginY={12}>
+        <Box __width="370px" marginTop={12} marginBottom={7}>
           <SearchInput
-            withBorder
             size="medium"
             initialSearch={query}
             placeholder={intl.formatMessage(messages.searchPlaceholder)}

--- a/src/extensions/views/InstalledExtensions/InstalledExtensions.tsx
+++ b/src/extensions/views/InstalledExtensions/InstalledExtensions.tsx
@@ -69,7 +69,7 @@ export const InstalledExtensions = ({ params }: InstalledExtensionsProps) => {
         </Box>
       </TopNav>
       <Box paddingX={6}>
-        <Box __width="370px" marginTop={8} marginBottom={12}>
+        <Box __width="370px" marginY={12}>
           <SearchInput
             withBorder
             size="medium"


### PR DESCRIPTION
This PR fixes search input globally to be wrapped with `<label>`, this fixes issue where user clicking outside of narrow `<input>` element (e.g. on search icon, near border) would not trigger focus.

It also unifies search look across extensions views, to remove border and fix margins to make it look more like other views:

**Explore extensions**

![CleanShot 2025-05-26 at 11 44 25@2x](https://github.com/user-attachments/assets/7278b52b-eb50-44ea-9d76-5b15dd4b3137)


**Installed extensions**

![CleanShot 2025-05-26 at 11 44 20@2x](https://github.com/user-attachments/assets/fc28b576-d2f8-4bb8-97b8-1f927ec01ec5)
