### PR TITLE
Improve copy button on create token modal

### DIFF
--- a/.changeset/red-ladybugs-stare.md
+++ b/.changeset/red-ladybugs-stare.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added success indicator when token / headers in "Create token" modal in custom app details page are successfully copied to clipboard

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6690,6 +6690,9 @@
     "context": "WarehouseSettings no shipping zones assigned",
     "string": "This warehouse has no shipping zones assigned."
   },
+  "ce5Hp1": {
+    "string": "Failed to copy to clipboard"
+  },
   "cfQf0w": {
     "context": "button",
     "string": "Create Order"

--- a/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/TokenCreateDialog.tsx
+++ b/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/TokenCreateDialog.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Mono } from "./Mono";
+import { useClipboardCopy } from "./useClipboardCopy";
 
 export interface TokenCreateDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
@@ -21,10 +22,6 @@ export interface TokenCreateDialogProps {
 }
 
 type TokenCreateStep = "form" | "summary";
-
-function handleCopy(token: string) {
-  navigator.clipboard.writeText(token);
-}
 
 const tokenPaperStyles = {
   padding: 4,
@@ -40,6 +37,8 @@ const TokenCreateDialog: React.FC<TokenCreateDialogProps> = props => {
   const [step, setStep] = React.useState<TokenCreateStep>("form");
   const intl = useIntl();
   const headers = createHeadersString(token ?? "");
+  const { copyToClipboard: copyTokenToClipboard, copyState: tokenCopyState } = useClipboardCopy();
+  const { copyToClipboard: copyHeaderToClipboard, copyState: headerCopyState } = useClipboardCopy();
 
   React.useEffect(() => {
     if (token) {
@@ -102,17 +101,19 @@ const TokenCreateDialog: React.FC<TokenCreateDialogProps> = props => {
                       <Mono>{token}</Mono>
                     </Text>
 
-                    <Button
+                    <ConfirmButton
+                      noTransition
+                      transitionState={tokenCopyState}
                       variant="secondary"
                       marginTop={2}
-                      onClick={() => handleCopy(token ?? "")}
+                      onClick={() => copyTokenToClipboard(token ?? "")}
                     >
                       <FormattedMessage
                         id="HVFq//"
                         defaultMessage="Copy token"
                         description="button"
                       />
-                    </Button>
+                    </ConfirmButton>
                   </Box>
 
                   <Box {...tokenPaperStyles}>
@@ -131,13 +132,18 @@ const TokenCreateDialog: React.FC<TokenCreateDialogProps> = props => {
                       gap={2}
                       marginTop={2}
                     >
-                      <Button variant="secondary" onClick={() => handleCopy(headers)}>
+                      <ConfirmButton
+                        noTransition
+                        transitionState={headerCopyState}
+                        variant="secondary"
+                        onClick={() => copyHeaderToClipboard(headers)}
+                      >
                         <FormattedMessage
                           id="ZhqH8J"
                           defaultMessage="Copy headers"
                           description="button"
                         />
-                      </Button>
+                      </ConfirmButton>
                       <Button variant="secondary" onClick={openPlayground}>
                         <FormattedMessage
                           id="0KmZCN"

--- a/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/useClipboardCopy.ts
+++ b/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/useClipboardCopy.ts
@@ -1,0 +1,48 @@
+import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
+import useNotifier from "@dashboard/hooks/useNotifier";
+import { useEffect, useRef, useState } from "react";
+import { useIntl } from "react-intl";
+
+const BUTTON_INDIDCATOR_TIMEOUT = 2000;
+
+export const useClipboardCopy = () => {
+  const intl = useIntl();
+  const notify = useNotifier();
+  const [copyState, setCopyState] = useState<ConfirmButtonTransitionState>("default");
+  const timeoutRef = useRef<number>();
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  });
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .catch(() => {
+        setCopyState("error");
+        notify({
+          status: "error",
+          text: intl.formatMessage({
+            defaultMessage: "Failed to copy to clipboard",
+            id: "ce5Hp1",
+          }),
+        });
+
+        timeoutRef.current = window.setTimeout(() => {
+          setCopyState("default");
+        }, BUTTON_INDIDCATOR_TIMEOUT);
+      })
+      .then(() => {
+        setCopyState("success");
+        timeoutRef.current = window.setTimeout(() => {
+          setCopyState("default");
+        }, BUTTON_INDIDCATOR_TIMEOUT);
+      });
+  };
+
+  return { copyToClipboard, copyState };
+};


### PR DESCRIPTION
## Scope of the change

This PR adds success copy indicator to "Copy token" / "Copy headers" buttons in Create Token modal in custom app details page


https://github.com/user-attachments/assets/47c1c63f-f7cf-4e13-9988-f26ad3cd0771


