### PR TITLE
Update link to docs for specific app install errors

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1905,6 +1905,10 @@
     "context": "no products placeholder",
     "string": "No products are available matching query in the channel assigned to this order."
   },
+  "9pGRfy": {
+    "context": "Add custom extension error link to Saleor Docs",
+    "string": "Learn more about this error"
+  },
   "9pLPLn": {
     "context": "refund amounts were unsettled",
     "string": "Unsettled"

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -1,17 +1,38 @@
+import { AppErrorCode } from "@dashboard/graphql";
 import { defineMessages } from "react-intl";
 
-const DOCS_MANIFEST_COMMON_ERRORS_URL =
-  "https://docs.saleor.io/docs/next/developer/extending/apps/manifest";
+export const getSpecificManifestErrorDocLink = (errorCode?: AppErrorCode): string => {
+  const BASE_URL =
+    "https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes";
 
-// Placeholder for specific error documentation links
-// For now, all errors point to the same general manifest errors page.
-// TODO: Update with specific URLs once available.
-export const getSpecificManifestErrorDocLink = (_errorCode?: string): string => {
-  // We'll add this when we add page with specific error code messages
-  // if (errorCode === "INVALID_PERMISSION") {
-  //   return "https://docs.saleor.io/docs/next/developer/extending/apps/manifest#invalid-permission";
-  // }
-  return DOCS_MANIFEST_COMMON_ERRORS_URL;
+  if (!errorCode) {
+    return BASE_URL;
+  }
+
+  const hashMap: Record<AppErrorCode, string> = {
+    [AppErrorCode.INVALID_URL_FORMAT]: "#apperrorcodeinvalid_url_format",
+    [AppErrorCode.INVALID_PERMISSION]: "#apperrorcodeinvalid_permission",
+    [AppErrorCode.OUT_OF_SCOPE_PERMISSION]: "#apperrorcodeout_of_scope_permission",
+    [AppErrorCode.MANIFEST_URL_CANT_CONNECT]: "#apperrorcodemanifest_url_cant_connect",
+    [AppErrorCode.INVALID_MANIFEST_FORMAT]: "#apperrorcodeinvalid_manifest_format",
+    [AppErrorCode.REQUIRED]: "#apperrorcoderequired",
+    [AppErrorCode.UNIQUE]: "#apperrorcodeunique",
+    [AppErrorCode.UNSUPPORTED_SALEOR_VERSION]: "#apperrorcodeunsupported_saleor_version",
+    [AppErrorCode.INVALID_CUSTOM_HEADERS]: "#apperrorcodeinvalid_custom_headers",
+    [AppErrorCode.GRAPHQL_ERROR]: "#apperrorcodegraphql_error",
+    [AppErrorCode.INVALID]: "#apperrorcodeinvalid",
+    [AppErrorCode.INVALID_STATUS]: "#apperrorcodeinvalid_status",
+    [AppErrorCode.NOT_FOUND]: "#apperrorcodenot_found",
+    [AppErrorCode.FORBIDDEN]: "", // No section for this error, no link
+    [AppErrorCode.OUT_OF_SCOPE_APP]: "", // No section for this error, no link
+  };
+  const hash = hashMap[errorCode];
+
+  if (!hash) {
+    return "";
+  }
+
+  return BASE_URL + hash;
 };
 
 export const headerTitles = defineMessages({
@@ -268,6 +289,11 @@ export const messages = defineMessages({
     defaultMessage: "Learn more about {manifestFormatLink}",
     id: "0DTk+2",
     description: "Add custom extension page subheader",
+  },
+  learnMoreError: {
+    defaultMessage: "Learn more about this error",
+    description: "Add custom extension error link to Saleor Docs",
+    id: "9pGRfy",
   },
   manifestFormatLink: {
     defaultMessage: "manifest format",

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -1,73 +1,14 @@
 import { AppErrorCode } from "@dashboard/graphql";
+import { EXTENSION_MANIFEST_DOCS, EXTENSION_MANIFEST_DOCS_LINKS } from "@dashboard/links";
 import { defineMessages } from "react-intl";
 
 export const getSpecificManifestErrorDocLink = (errorCode?: AppErrorCode): string => {
-  const BASE_URL =
-    "https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes";
-
   if (!errorCode) {
-    return BASE_URL;
+    return EXTENSION_MANIFEST_DOCS;
   }
 
-  const hashMap: Record<AppErrorCode, string> = {
-    [AppErrorCode.INVALID_URL_FORMAT]: "#apperrorcodeinvalid_url_format",
-    [AppErrorCode.INVALID_PERMISSION]: "#apperrorcodeinvalid_permission",
-    [AppErrorCode.OUT_OF_SCOPE_PERMISSION]: "#apperrorcodeout_of_scope_permission",
-    [AppErrorCode.MANIFEST_URL_CANT_CONNECT]: "#apperrorcodemanifest_url_cant_connect",
-    [AppErrorCode.INVALID_MANIFEST_FORMAT]: "#apperrorcodeinvalid_manifest_format",
-    [AppErrorCode.REQUIRED]: "#apperrorcoderequired",
-    [AppErrorCode.UNIQUE]: "#apperrorcodeunique",
-    [AppErrorCode.UNSUPPORTED_SALEOR_VERSION]: "#apperrorcodeunsupported_saleor_version",
-    [AppErrorCode.INVALID_CUSTOM_HEADERS]: "#apperrorcodeinvalid_custom_headers",
-    [AppErrorCode.GRAPHQL_ERROR]: "#apperrorcodegraphql_error",
-    [AppErrorCode.INVALID]: "#apperrorcodeinvalid",
-    [AppErrorCode.INVALID_STATUS]: "#apperrorcodeinvalid_status",
-    [AppErrorCode.NOT_FOUND]: "#apperrorcodenot_found",
-    [AppErrorCode.FORBIDDEN]: "", // No section for this error, no link
-    [AppErrorCode.OUT_OF_SCOPE_APP]: "", // No section for this error, no link
-  };
-  const hash = hashMap[errorCode];
-
-  if (!hash) {
-    return "";
-  }
-
-  return BASE_URL + hash;
+  return EXTENSION_MANIFEST_DOCS_LINKS[errorCode] || "";
 };
-
-export const headerTitles = defineMessages({
-  exploreExtensions: {
-    defaultMessage: "Explore",
-    description: "page title",
-    id: "32Capp",
-  },
-  installedExtensions: {
-    defaultMessage: "All installed",
-    description: "page title",
-    id: "VQvNZx",
-  },
-  addCustomExtension: {
-    defaultMessage: "Add extension manually",
-    description: "page title - creating custom app",
-
-    id: "ecM5eL",
-  },
-  addCustomExtensionManifest: {
-    defaultMessage: "Add extension from manifest",
-    description: "page title - installing app with manifestUrl form",
-    id: "Cxkzpg",
-  },
-  addCustomExtensionManifestUrl: {
-    defaultMessage: "Add extension",
-    description: "page title - installing app with manifestUrl provided",
-    id: "BYfAwE",
-  },
-  extensions: {
-    defaultMessage: "Extensions",
-    description: "page title - extensions",
-    id: "WD+kjr",
-  },
-});
 
 export const buttonLabels = defineMessages({
   requestExtension: {

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -1,14 +1,38 @@
-import { AppErrorCode } from "@dashboard/graphql";
-import { EXTENSION_MANIFEST_DOCS, EXTENSION_MANIFEST_DOCS_LINKS } from "@dashboard/links";
 import { defineMessages } from "react-intl";
 
-export const getSpecificManifestErrorDocLink = (errorCode?: AppErrorCode): string => {
-  if (!errorCode) {
-    return EXTENSION_MANIFEST_DOCS;
-  }
+export const headerTitles = defineMessages({
+  exploreExtensions: {
+    defaultMessage: "Explore",
+    description: "page title",
+    id: "32Capp",
+  },
+  installedExtensions: {
+    defaultMessage: "All installed",
+    description: "page title",
+    id: "VQvNZx",
+  },
+  addCustomExtension: {
+    defaultMessage: "Add extension manually",
+    description: "page title - creating custom app",
 
-  return EXTENSION_MANIFEST_DOCS_LINKS[errorCode] || "";
-};
+    id: "ecM5eL",
+  },
+  addCustomExtensionManifest: {
+    defaultMessage: "Add extension from manifest",
+    description: "page title - installing app with manifestUrl form",
+    id: "Cxkzpg",
+  },
+  addCustomExtensionManifestUrl: {
+    defaultMessage: "Add extension",
+    description: "page title - installing app with manifestUrl provided",
+    id: "BYfAwE",
+  },
+  extensions: {
+    defaultMessage: "Extensions",
+    description: "page title - extensions",
+    id: "WD+kjr",
+  },
+});
 
 export const buttonLabels = defineMessages({
   requestExtension: {

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.test.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.test.tsx
@@ -65,14 +65,17 @@ describe("ManifestErrorMessage", () => {
 
     renderWithError(error);
     // Assert
-    expect(
-      screen.getByText(
-        content =>
-          content.includes("The extension's manifest has an invalid format.") &&
-          content.includes("Learn more about") && // This will fail
-          content.includes("(INVALID_MANIFEST_FORMAT)"), // This will fail
-      ),
-    ).toBeInTheDocument();
+    // Check the error message text
+    expect(screen.getByText(/The extension's manifest has an invalid format/)).toBeInTheDocument();
+    // Check the link text
+    expect(screen.getByText("Learn more about this error")).toBeInTheDocument();
+    // Check the link href
+    expect(screen.getByRole("link", { name: "Learn more about this error" })).toHaveAttribute(
+      "href",
+      "https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes#apperrorcodeinvalid_manifest_format",
+    );
+    // Check the error code is present
+    expect(screen.getByText(/INVALID_MANIFEST_FORMAT/)).toBeInTheDocument();
   });
 
   it("renders backend error without specific documentation link", () => {

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
@@ -36,28 +36,18 @@ const getFieldErrorMessage = (error: FieldError, intl: IntlShape): string | Reac
 
     if (learnMoreLink) {
       const learnMoreLinkComponent = (
-        <>
-          {" "}
-          <FormattedMessage
-            {...extensionMessages.learnMoreSubheader}
-            values={{
-              manifestFormatLink: (
-                <Text
-                  as="a"
-                  href={learnMoreLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  color="default2"
-                  textDecoration="underline"
-                  size={2}
-                  display="inline-block"
-                >
-                  <FormattedMessage {...extensionMessages.manifestFormatLink} />
-                </Text>
-              ),
-            }}
-          />
-        </>
+        <Text
+          as="a"
+          href={learnMoreLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="default2"
+          textDecoration="underline"
+          size={2}
+          display="inline-block"
+        >
+          <FormattedMessage {...extensionMessages.learnMoreError} />
+        </Text>
       );
 
       return intl.formatMessage(messageDescriptor, {

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
@@ -1,12 +1,12 @@
 import {
   appManifestErrorMessages,
-  getSpecificManifestErrorDocLink,
   messages as extensionMessages,
 } from "@dashboard/extensions/messages";
 import { getAppErrorMessageDescriptor } from "@dashboard/extensions/utils";
 import { AppErrorCode } from "@dashboard/graphql";
 import { ErrorCircle } from "@dashboard/icons/ErrorCircle";
 import { commonMessages } from "@dashboard/intl";
+import { getSpecificManifestErrorDocLink } from "@dashboard/links";
 import commonErrorMessages from "@dashboard/utils/errors/common";
 import { Box, BoxProps, Text } from "@saleor/macaw-ui-next";
 import React from "react";

--- a/src/links.ts
+++ b/src/links.ts
@@ -30,20 +30,29 @@ export const MANIFEST_FORMAT_DOCS_URL =
   "https://docs.saleor.io/developer/extending/apps/architecture/manifest";
 export const EXTENSION_MANIFEST_DOCS =
   "https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes";
-export const EXTENSION_MANIFEST_DOCS_LINKS: Record<AppErrorCode, string> = {
-  [AppErrorCode.INVALID_URL_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_url_format`,
-  [AppErrorCode.INVALID_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_permission`,
-  [AppErrorCode.OUT_OF_SCOPE_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeout_of_scope_permission`,
-  [AppErrorCode.MANIFEST_URL_CANT_CONNECT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodemanifest_url_cant_connect`,
-  [AppErrorCode.INVALID_MANIFEST_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_manifest_format`,
-  [AppErrorCode.REQUIRED]: `${EXTENSION_MANIFEST_DOCS}#apperrorcoderequired`,
-  [AppErrorCode.UNIQUE]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunique`,
-  [AppErrorCode.UNSUPPORTED_SALEOR_VERSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunsupported_saleor_version`,
-  [AppErrorCode.INVALID_CUSTOM_HEADERS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_custom_headers`,
-  [AppErrorCode.GRAPHQL_ERROR]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodegraphql_error`,
-  [AppErrorCode.INVALID]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid`,
-  [AppErrorCode.INVALID_STATUS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_status`,
-  [AppErrorCode.NOT_FOUND]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodenot_found`,
-  [AppErrorCode.FORBIDDEN]: EXTENSION_MANIFEST_DOCS, // No docs section
-  [AppErrorCode.OUT_OF_SCOPE_APP]: EXTENSION_MANIFEST_DOCS, // No docs sect
+
+export const getSpecificManifestErrorDocLink = (errorCode?: AppErrorCode): string => {
+  if (!errorCode) {
+    return EXTENSION_MANIFEST_DOCS;
+  }
+
+  const codeToLinkMap: Record<AppErrorCode, string> = {
+    [AppErrorCode.INVALID_URL_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_url_format`,
+    [AppErrorCode.INVALID_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_permission`,
+    [AppErrorCode.OUT_OF_SCOPE_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeout_of_scope_permission`,
+    [AppErrorCode.MANIFEST_URL_CANT_CONNECT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodemanifest_url_cant_connect`,
+    [AppErrorCode.INVALID_MANIFEST_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_manifest_format`,
+    [AppErrorCode.REQUIRED]: `${EXTENSION_MANIFEST_DOCS}#apperrorcoderequired`,
+    [AppErrorCode.UNIQUE]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunique`,
+    [AppErrorCode.UNSUPPORTED_SALEOR_VERSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunsupported_saleor_version`,
+    [AppErrorCode.INVALID_CUSTOM_HEADERS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_custom_headers`,
+    [AppErrorCode.GRAPHQL_ERROR]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodegraphql_error`,
+    [AppErrorCode.INVALID]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid`,
+    [AppErrorCode.INVALID_STATUS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_status`,
+    [AppErrorCode.NOT_FOUND]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodenot_found`,
+    [AppErrorCode.FORBIDDEN]: EXTENSION_MANIFEST_DOCS, // No docs section
+    [AppErrorCode.OUT_OF_SCOPE_APP]: EXTENSION_MANIFEST_DOCS, // No docs sect
+  };
+
+  return codeToLinkMap[errorCode] || "";
 };

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,3 +1,5 @@
+import { AppErrorCode } from "./graphql";
+
 export const TECHNICAL_HELP_CTA_URL =
   "https://www.getclockwise.com/c/rian-dillon-saleor-io/short-call-with-saleor";
 
@@ -26,3 +28,22 @@ export const CUSTOM_EXTENSIONS_DOCS_URL =
   "https://docs.saleor.io/developer/extending/webhooks/creating";
 export const MANIFEST_FORMAT_DOCS_URL =
   "https://docs.saleor.io/developer/extending/apps/architecture/manifest";
+export const EXTENSION_MANIFEST_DOCS =
+  "https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes";
+export const EXTENSION_MANIFEST_DOCS_LINKS: Record<AppErrorCode, string> = {
+  [AppErrorCode.INVALID_URL_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_url_format`,
+  [AppErrorCode.INVALID_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_permission`,
+  [AppErrorCode.OUT_OF_SCOPE_PERMISSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeout_of_scope_permission`,
+  [AppErrorCode.MANIFEST_URL_CANT_CONNECT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodemanifest_url_cant_connect`,
+  [AppErrorCode.INVALID_MANIFEST_FORMAT]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_manifest_format`,
+  [AppErrorCode.REQUIRED]: `${EXTENSION_MANIFEST_DOCS}#apperrorcoderequired`,
+  [AppErrorCode.UNIQUE]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunique`,
+  [AppErrorCode.UNSUPPORTED_SALEOR_VERSION]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeunsupported_saleor_version`,
+  [AppErrorCode.INVALID_CUSTOM_HEADERS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_custom_headers`,
+  [AppErrorCode.GRAPHQL_ERROR]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodegraphql_error`,
+  [AppErrorCode.INVALID]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid`,
+  [AppErrorCode.INVALID_STATUS]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodeinvalid_status`,
+  [AppErrorCode.NOT_FOUND]: `${EXTENSION_MANIFEST_DOCS}#apperrorcodenot_found`,
+  [AppErrorCode.FORBIDDEN]: EXTENSION_MANIFEST_DOCS, // No docs section
+  [AppErrorCode.OUT_OF_SCOPE_APP]: EXTENSION_MANIFEST_DOCS, // No docs sect
+};


### PR DESCRIPTION
## Scope of the change

This PR adds link to [Saleor Docs](https://docs.saleor.io/developer/extending/apps/developing-apps/app-error-codes) when specific AppErrorCode has a explanation

## Screenshots

![CleanShot 2025-05-28 at 12 41 14@2x](https://github.com/user-attachments/assets/a8d42e1f-b9b1-4e66-b640-7216fc1f9256)


https://github.com/user-attachments/assets/3856f219-4bb3-4990-9d6c-8a521ea92222


