### PR TITLE
Add build numer and url to slack results

### DIFF
--- a/.github/actions/flaky-tests-report/action.yml
+++ b/.github/actions/flaky-tests-report/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Send CTRF Report to Slack
       shell: bash
-      run: npx slack-ctrf results "ctrf-reports/merged-report.json"
+      run: npx slack-ctrf results "ctrf-reports/merged-report.json" --title "Saleor Dashboard Test Results"
       
     - name: Publish PR Comment
       uses: ctrf-io/github-test-reporter@15f50159adb465644ec5ddc3b76b92af1e414432 # v1.0.11  

--- a/.github/actions/run-pw-tests/action.yml
+++ b/.github/actions/run-pw-tests/action.yml
@@ -47,6 +47,12 @@ inputs:
   DASHBOARD_VERSION:
     description: "Dashboard version"
     required: false
+  BUILD_NUMBER:
+    description: "GH Actions run ID"
+    required: false
+  BUILD_URL:
+    description: "GH actions url"
+    required: false
 
 runs:
   using: "composite"
@@ -91,6 +97,8 @@ runs:
         BRANCH_NAME: ${{ inputs.BRANCH_NAME }}
         SALEOR_CLOUD_SERVICE: ${{ inputs.SALEOR_CLOUD_SERVICE }}
         DASHBOARD_VERSION: ${{ inputs.DASHBOARD_VERSION }}
+        BUILD_NUMBER: ${{ inputs.BUILD_NUMBER }}
+        BUILD_URL: ${{ inputs.BUILD_URL }}
 
       run: |
         PROJECTS=($PROJECT)

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -213,6 +213,8 @@ jobs:
           DASHBOARD_VERSION: ${{ needs.initialize-cloud.outputs.RUN_SLUG }}
           BRANCH_NAME: ${{ github.ref}}
           SALEOR_CLOUD_SERVICE: ${{ needs.initialize-cloud.outputs.SALEOR_CLOUD_SERVICE }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   merge-reports:
     if: "!cancelled() && contains(github.event.pull_request.labels.*.name, 'run pw-e2e')"

--- a/.github/workflows/run-test-manual.yml
+++ b/.github/workflows/run-test-manual.yml
@@ -115,6 +115,8 @@ jobs:
           DASHBOARD_VERSION: ${{ needs.initialize-cloud.outputs.RUN_SLUG }}
           BRANCH_NAME: ${{ github.ref}}
           SALEOR_CLOUD_SERVICE: ${{ needs.initialize-cloud.outputs.SALEOR_CLOUD_SERVICE }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   tests-complete:
     if: "!cancelled()"

--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -237,6 +237,8 @@ jobs:
           DASHBOARD_VERSION: ${{inputs.CUSTOM_VERSION}}
           BRANCH_NAME: ${{ github.ref}}
           SALEOR_CLOUD_SERVICE: ${{ needs.initialize-cloud.outputs.SALEOR_CLOUD_SERVICE }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   tests-complete:
     if: |


### PR DESCRIPTION
## Scope of the change
Slack post with results now contain link to gh run 

Before:
<img width="505" alt="image" src="https://github.com/user-attachments/assets/1cacebc6-d638-42d5-9bd7-44257af33a7a" />

After:
<img width="521" alt="Screenshot 2025-05-28 at 15 38 18" src="https://github.com/user-attachments/assets/3c9e2d2a-8a2e-4dd7-9d6f-9bf01be12949" />


<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
