### PR TITLE
Fix local apps not linking to correct page when disabled

### DIFF
--- a/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
+++ b/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
@@ -89,12 +89,12 @@ const resolveExtensionHref = ({
     return undefined;
   }
 
-  if (!isActive) {
-    return ExtensionsUrls.resolveEditManifestExtensionUrl(id);
-  }
-
   if (type === AppTypeEnum.LOCAL) {
     return ExtensionsUrls.editCustomExtensionUrl(id);
+  }
+
+  if (!isActive) {
+    return ExtensionsUrls.resolveEditManifestExtensionUrl(id);
   }
 
   return ExtensionsUrls.resolveViewManifestExtensionUrl(id);


### PR DESCRIPTION
## Scope of the change

Custom apps now are correctly linked from installed extensions list, previously they linked to manifest app edit page
