### PR TITLE
Extensions UI improvements

### DIFF
--- a/.changeset/sour-goats-boil.md
+++ b/.changeset/sour-goats-boil.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed Pills color not updating after rerender (previously for example when changing plugin from active to inactive color didn't change from red to green).

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2505,9 +2505,6 @@
     "context": "button",
     "string": "Save Search"
   },
-  "DGCzal": {
-    "string": "This token gives you access to your shop's API, which you'll find here: {url}"
-  },
   "DGWVA9": {
     "context": "variant created error message",
     "string": "Variant creation failed"

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -5,14 +5,11 @@ import { useTheme } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import React from "react";
 
-const useStyles = makeStyles<{
-  color: string;
-}>(
+const useStyles = makeStyles(
   {
     pill: {
       borderRadius: "32px",
       border: "none",
-      backgroundColor: ({ color }) => `${color} !important`,
     },
   },
   { name: "Pill" },
@@ -24,15 +21,23 @@ const useStyles = makeStyles<{
 export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
   ({ color: status, ...props }, ref) => {
     const { theme: currentTheme } = useTheme();
+
     const color = getStatusColor({
       status,
       currentTheme,
     }).base;
-    const classes = useStyles({
-      color,
-    });
+    const classes = useStyles();
 
-    return <MacawuiPill {...props} ref={ref} className={clsx(classes.pill, props.className)} />;
+    return (
+      <MacawuiPill
+        {...props}
+        ref={ref}
+        className={clsx(classes.pill, props.className)}
+        style={{
+          backgroundColor: color,
+        }}
+      />
+    );
   },
 );
 

--- a/src/custom-apps/components/CustomAppDefaultToken/CustomAppDefaultToken.tsx
+++ b/src/custom-apps/components/CustomAppDefaultToken/CustomAppDefaultToken.tsx
@@ -1,5 +1,4 @@
 import { DashboardCard } from "@dashboard/components/Card";
-import Link from "@dashboard/components/Link";
 import useClipboard from "@dashboard/hooks/useClipboard";
 import CloseIcon from "@material-ui/icons/Close";
 import { Box, Button, Text } from "@saleor/macaw-ui-next";
@@ -9,14 +8,12 @@ import { FormattedMessage } from "react-intl";
 import { Mono } from "../TokenCreateDialog/Mono";
 
 export interface CustomAppDefaultTokenProps {
-  apiUrl: string;
   token: string;
-  onApiUrlClick: () => void;
   onTokenClose: () => void;
 }
 
 const CustomAppDefaultToken: React.FC<CustomAppDefaultTokenProps> = props => {
-  const { apiUrl, token, onApiUrlClick, onTokenClose } = props;
+  const { token, onTokenClose } = props;
   const [copied, copy] = useClipboard();
 
   return (
@@ -28,19 +25,6 @@ const CustomAppDefaultToken: React.FC<CustomAppDefaultTokenProps> = props => {
               <FormattedMessage
                 id="ixjvkM"
                 defaultMessage="We’ve created your default token. Make sure to copy your new personal access token now. You won’t be able to see it again."
-              />
-            </Text>
-            <Text display="block">
-              <FormattedMessage
-                id="DGCzal"
-                defaultMessage="This token gives you access to your shop's API, which you'll find here: {url}"
-                values={{
-                  url: (
-                    <Link href={apiUrl} onClick={onApiUrlClick}>
-                      {apiUrl}
-                    </Link>
-                  ),
-                }}
               />
             </Text>
           </div>

--- a/src/custom-apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/custom-apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -36,14 +36,12 @@ export interface CustomAppDetailsPageFormData {
   permissions: PermissionEnum[];
 }
 export interface CustomAppDetailsPageProps {
-  apiUrl: string;
   disabled: boolean;
   errors: AppErrorFragment[];
   permissions: ShopInfoQuery["shop"]["permissions"];
   saveButtonBarState: ConfirmButtonTransitionState;
   app: AppUpdateMutation["appUpdate"]["app"];
   token: string;
-  onApiUrlClick: () => void;
   onTokenDelete: (id: string) => void;
   onTokenClose: () => void;
   onTokenCreate: () => void;
@@ -56,14 +54,12 @@ export interface CustomAppDetailsPageProps {
 
 const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
   const {
-    apiUrl,
     disabled,
     errors,
     permissions,
     saveButtonBarState,
     app,
     token,
-    onApiUrlClick,
     onTokenClose,
     onTokenCreate,
     onTokenDelete,
@@ -117,12 +113,7 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
           <DetailPageLayout.Content>
             {token && (
               <>
-                <CustomAppDefaultToken
-                  apiUrl={apiUrl}
-                  token={token}
-                  onApiUrlClick={onApiUrlClick}
-                  onTokenClose={onTokenClose}
-                />
+                <CustomAppDefaultToken token={token} onTokenClose={onTokenClose} />
                 <CardSpacer />
               </>
             )}

--- a/src/custom-apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/custom-apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -22,10 +22,8 @@ import { getFormErrors } from "@dashboard/utils/errors";
 import getAppErrorMessage from "@dashboard/utils/errors/app";
 import { Button } from "@saleor/macaw-ui-next";
 import React from "react";
-import SVG from "react-inlinesvg";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import activateIcon from "../../../../assets/images/activate-icon.svg";
 import CustomAppDefaultToken from "../CustomAppDefaultToken";
 import CustomAppInformation from "../CustomAppInformation";
 import CustomAppTokens from "../CustomAppTokens";
@@ -109,7 +107,6 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
               className={classes.activateButton}
               onClick={data.isActive ? onAppDeactivateOpen : onAppActivateOpen}
             >
-              <SVG src={activateIcon} />
               {data?.isActive ? (
                 <FormattedMessage id="whTEcF" defaultMessage="Deactivate" description="link" />
               ) : (

--- a/src/custom-apps/views/CustomAppDetails/CustomAppDetails.tsx
+++ b/src/custom-apps/views/CustomAppDetails/CustomAppDetails.tsx
@@ -4,7 +4,6 @@ import AppDeactivateDialog from "@dashboard/apps/components/AppDeactivateDialog"
 import { appMessages } from "@dashboard/apps/messages";
 import NotFoundPage from "@dashboard/components/NotFoundPage";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
-import { getApiUrl } from "@dashboard/config";
 import TokenCreateDialog from "@dashboard/custom-apps/components/TokenCreateDialog";
 import TokenDeleteDialog from "@dashboard/custom-apps/components/TokenDeleteDialog";
 import WebhookDeleteDialog from "@dashboard/custom-apps/components/WebhookDeleteDialog";
@@ -201,11 +200,9 @@ export const CustomAppDetails: React.FC<OrderListProps> = ({ id, params, token, 
     <>
       <WindowTitle title={getStringOrPlaceholder(customApp?.name)} />
       <CustomAppDetailsPage
-        apiUrl={getApiUrl()}
         disabled={loading}
         errors={updateAppOpts.data?.appUpdate?.errors || []}
         token={token}
-        onApiUrlClick={() => open(getApiUrl(), "blank")}
         onSubmit={handleSubmit}
         onTokenClose={onTokenClose}
         onTokenCreate={() => openModal("create-token")}

--- a/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
+++ b/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
@@ -2,7 +2,6 @@
 import { useApolloClient } from "@apollo/client";
 import NotFoundPage from "@dashboard/components/NotFoundPage";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
-import { getApiUrl } from "@dashboard/config";
 import AppActivateDialog from "@dashboard/extensions/components/AppActivateDialog";
 import AppDeactivateDialog from "@dashboard/extensions/components/AppDeactivateDialog";
 import AppDeleteDialog from "@dashboard/extensions/components/AppDeleteDialog";
@@ -257,11 +256,9 @@ export const EditCustomExtension: React.FC<OrderListProps> = ({
     <>
       <WindowTitle title={getStringOrPlaceholder(customApp?.name)} />
       <CustomExtensionDetailsPage
-        apiUrl={getApiUrl()}
         disabled={loading}
         errors={updateAppOpts.data?.appUpdate?.errors || []}
         token={token}
-        onApiUrlClick={() => open(getApiUrl(), "blank")}
         onSubmit={handleSubmit}
         onTokenClose={onTokenClose}
         onTokenCreate={() => openModal("create-token")}

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionDefaultToken/CustomExtensionDefaultToken.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionDefaultToken/CustomExtensionDefaultToken.tsx
@@ -1,6 +1,5 @@
 import { DashboardCard } from "@dashboard/components/Card";
 import { ConfirmButton } from "@dashboard/components/ConfirmButton";
-import Link from "@dashboard/components/Link";
 import { Box, Button, CloseIcon, Text } from "@saleor/macaw-ui-next";
 import React from "react";
 import { FormattedMessage } from "react-intl";

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionDefaultToken/CustomExtensionDefaultToken.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionDefaultToken/CustomExtensionDefaultToken.tsx
@@ -9,14 +9,12 @@ import { Mono } from "../TokenCreateDialog/Mono";
 import { useClipboardCopy } from "../TokenCreateDialog/useClipboardCopy";
 
 export interface CustomExtensionDefaultTokenProps {
-  apiUrl: string;
   token: string;
-  onApiUrlClick: () => void;
   onTokenClose: () => void;
 }
 
 const CustomExtensionDefaultToken: React.FC<CustomExtensionDefaultTokenProps> = props => {
-  const { apiUrl, token, onApiUrlClick, onTokenClose } = props;
+  const { token, onTokenClose } = props;
   const { copyToClipboard, copyState } = useClipboardCopy();
 
   return (
@@ -28,19 +26,6 @@ const CustomExtensionDefaultToken: React.FC<CustomExtensionDefaultTokenProps> = 
               <FormattedMessage
                 id="ixjvkM"
                 defaultMessage="We’ve created your default token. Make sure to copy your new personal access token now. You won’t be able to see it again."
-              />
-            </Text>
-            <Text display="block" marginTop={1}>
-              <FormattedMessage
-                id="DGCzal"
-                defaultMessage="This token gives you access to your shop's API, which you'll find here: {url}"
-                values={{
-                  url: (
-                    <Link href={apiUrl} onClick={onApiUrlClick}>
-                      {apiUrl}
-                    </Link>
-                  ),
-                }}
               />
             </Text>
           </div>

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionDetailsPage/CustomExtensionDetailsPage.tsx
@@ -35,7 +35,6 @@ export interface CustomExtensionDetailsPageFormData {
   permissions: PermissionEnum[];
 }
 export interface CustomExtensionDetailsPageProps {
-  apiUrl: string;
   disabled: boolean;
   errors: AppErrorFragment[];
   permissions: ShopInfoQuery["shop"]["permissions"] | null | undefined;
@@ -44,7 +43,6 @@ export interface CustomExtensionDetailsPageProps {
   token: string;
   hasManagedAppsPermission: boolean;
   isLoading: boolean;
-  onApiUrlClick: () => void;
   onTokenDelete: (id: string) => void;
   onTokenClose: () => void;
   onTokenCreate: () => void;
@@ -58,7 +56,6 @@ export interface CustomExtensionDetailsPageProps {
 
 const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = props => {
   const {
-    apiUrl,
     disabled,
     errors,
     permissions,
@@ -66,7 +63,6 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
     app,
     token,
     hasManagedAppsPermission,
-    onApiUrlClick,
     onTokenClose,
     onTokenCreate,
     onTokenDelete,
@@ -114,12 +110,7 @@ const CustomExtensionDetailsPage: React.FC<CustomExtensionDetailsPageProps> = pr
 
             {token && (
               <>
-                <CustomExtensionDefaultToken
-                  apiUrl={apiUrl}
-                  token={token}
-                  onApiUrlClick={onApiUrlClick}
-                  onTokenClose={onTokenClose}
-                />
+                <CustomExtensionDefaultToken token={token} onTokenClose={onTokenClose} />
                 <CardSpacer />
               </>
             )}


### PR DESCRIPTION
This PR adds small fixes to extensions UI:

- Fix old icon button on old custom-app (when extensions flag is disabled)
- Remove link to api url from create custom app message, this didn't always work correctly on some envs (link was not displayed)
- Fix pill color not updating after change (rerender) - this could happen for example when changing plugin from active to inactive and vice-versa, text updated but color didn't update
