### PR TITLE
Add message in configuration list about extensions

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2603,6 +2603,9 @@
   "DovGIa": {
     "string": "Permission Group Deleted"
   },
+  "Dqo3Vf": {
+    "string": "Plugins and Webhook Events have been moved to the \"Extensions\" page, available from the sidebar navigation."
+  },
   "DyGpz4": {
     "context": "unapproved fulfillment, section header",
     "string": "Waiting for approval"
@@ -5499,6 +5502,9 @@
   "V1MytH": {
     "context": "shipping zones section name",
     "string": "Shipping Zones"
+  },
+  "V1aPhG": {
+    "string": "Navigation has changed"
   },
   "V1mqpZ": {
     "context": "button",
@@ -9763,6 +9769,9 @@
   "vZMs8f": {
     "context": "default product variant indicator",
     "string": "Default"
+  },
+  "vZglQ7": {
+    "string": "Go to Extensions"
   },
   "vcwrgW": {
     "string": "No translatable entities found"

--- a/src/configuration/ConfigurationPage.test.tsx
+++ b/src/configuration/ConfigurationPage.test.tsx
@@ -10,11 +10,16 @@ import { ConfigurationPage } from "./ConfigurationPage";
 import { MenuSection } from "./types";
 
 jest.mock("@material-ui/core/useMediaQuery", () => jest.fn());
+jest.mock("@dashboard/featureFlags", () => ({
+  useFlag: jest.fn(() => ({ enabled: true })),
+}));
+jest.mock("@dashboard/hooks/useNavigator", () => () => jest.fn());
 jest.mock("react-intl", () => ({
   defineMessages: (messages: unknown) => messages,
   useIntl: jest.fn(() => ({
     formatMessage: ({ defaultMessage }: { defaultMessage: string }) => defaultMessage,
   })),
+  FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <>{defaultMessage}</>,
 }));
 jest.mock("react-router-dom", () => ({
   Link: jest.fn(({ children }) => children),

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -1,14 +1,19 @@
 // @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
+import { DashboardCard } from "@dashboard/components/Card";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { useFlag } from "@dashboard/featureFlags";
 import { UserFragment } from "@dashboard/graphql";
+import useNavigator from "@dashboard/hooks/useNavigator";
+import { ExclamationIcon } from "@dashboard/icons/ExclamationIcon";
 import { sectionNames } from "@dashboard/intl";
 import { useTheme } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { NavigationCard } from "@saleor/macaw-ui";
-import { Box, Text } from "@saleor/macaw-ui-next";
+import { Box, Button, Text } from "@saleor/macaw-ui-next";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
 import VersionInfo from "../components/VersionInfo";
@@ -40,6 +45,12 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
     <VersionInfo dashboardVersion={dashboardVersion} coreVersion={coreVersion} />
   );
   const intl = useIntl();
+
+  const { enabled: isExtensionsEnabled } = useFlag("extensions");
+  const navigate = useNavigator();
+  const goToExtensions = () => {
+    navigate(ExtensionsUrls.resolveInstalledExtensionsUrl());
+  };
 
   return (
     <DetailPageLayout gridTemplateColumns={1} withSavebar={false}>
@@ -83,6 +94,31 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
                 </div>
               </div>
             ))}
+          {isExtensionsEnabled && (
+            <Box marginY={4}>
+              <DashboardCard withBorder gap={1} __width="fit-content">
+                <DashboardCard.Title display="flex" gap={3} alignItems="center">
+                  <ExclamationIcon />
+                  <FormattedMessage defaultMessage="Navigation has changed" id="V1aPhG" />
+                </DashboardCard.Title>
+                <DashboardCard.Content fontSize={3} paddingRight={0}>
+                  <FormattedMessage
+                    defaultMessage={`Plugins and Webhook Events have been moved to the "Extensions" page, available from the sidebar navigation.`}
+                    id="Dqo3Vf"
+                  />
+
+                  <Button
+                    onClick={goToExtensions}
+                    variant="primary"
+                    size="small"
+                    style={{ marginTop: 8 }}
+                  >
+                    <FormattedMessage defaultMessage="Go to Extensions" id="vZglQ7" />
+                  </Button>
+                </DashboardCard.Content>
+              </DashboardCard>
+            </Box>
+          )}
         </Box>
       </DetailPageLayout.Content>
     </DetailPageLayout>

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -48,6 +48,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
 
   const { enabled: isExtensionsEnabled } = useFlag("extensions");
   const navigate = useNavigator();
+
   const goToExtensions = () => {
     navigate(ExtensionsUrls.resolveInstalledExtensionsUrl());
   };

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -96,7 +96,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
             ))}
           {isExtensionsEnabled && (
             <Box marginY={4}>
-              <DashboardCard withBorder gap={1} __width="fit-content">
+              <DashboardCard withBorder gap={2} __width="fit-content">
                 <DashboardCard.Title display="flex" gap={3} alignItems="center">
                   <ExclamationIcon />
                   <FormattedMessage defaultMessage="Navigation has changed" id="V1aPhG" />


### PR DESCRIPTION
## Scope of the change

Added message on configuration list that menu items were moved:

![CleanShot 2025-06-02 at 15 13 59@2x](https://github.com/user-attachments/assets/3b7aa3bb-a7d6-4c73-ab41-695f2fa5f847)
