### PR TITLE
Fix error on page load (voucher modal opened URL parameter)

### DIFF
--- a/.changeset/six-flies-invent.md
+++ b/.changeset/six-flies-invent.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed exception that happened when voucher details page was opened / refreshed with modal open for selecting collections and variants. Now page loads correctly.

--- a/src/components/AssignContainerDialog/AssignContainerDialog.tsx
+++ b/src/components/AssignContainerDialog/AssignContainerDialog.tsx
@@ -89,7 +89,7 @@ const AssignContainerDialog: React.FC<AssignContainerDialogProps> = props => {
 
         <InfiniteScroll
           id={scrollableTargetId}
-          dataLength={containers?.length}
+          dataLength={containers?.length ?? 0}
           next={onFetchMore}
           hasMore={hasMore}
           scrollThreshold="100px"

--- a/src/components/AssignVariantDialog/AssignVariantDialog.tsx
+++ b/src/components/AssignVariantDialog/AssignVariantDialog.tsx
@@ -104,7 +104,7 @@ const AssignVariantDialog: React.FC<AssignVariantDialogProps> = props => {
 
         <InfiniteScroll
           id={scrollableTargetId}
-          dataLength={variants?.length}
+          dataLength={variants?.length ?? 0}
           next={onFetchMore}
           hasMore={hasMore}
           scrollThreshold="100px"


### PR DESCRIPTION
Fixed exception when opening voucher details page directly / refreshed (via URL). Now page doesn't crash due to infinite scroll not having fallback for length.