### PR TITLE
fix: typo in image upload error message

### DIFF
--- a/.changeset/little-kings-brake.md
+++ b/.changeset/little-kings-brake.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+fix: typo in image upload error message

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -712,7 +712,7 @@
     "string": "Invite Staff Member"
   },
   "26+K4N": {
-    "string": "There was a poblem with the file you uploaded as an image and it couldn't be used. Please try a different file."
+    "string": "There was a problem with the file you uploaded as an image and it couldn't be used. Please try a different file."
   },
   "26BKkX": {
     "context": "order status",

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -236,7 +236,7 @@ export const errorMessages = defineMessages({
   imageUploadErrorText: {
     id: "26+K4N",
     defaultMessage:
-      "There was a poblem with the file you uploaded as an image and it couldn't be used. Please try a different file.",
+      "There was a problem with the file you uploaded as an image and it couldn't be used. Please try a different file.",
   },
   preorderEndDateInFutureErrorText: {
     id: "6QjMei",


### PR DESCRIPTION
This fixes a typo in the image upload error handling ("poblem" -> "problem")

## Scope of the change

Before:

<img width="400" alt="Screenshot 2025-07-01 at 11 55 13 AM" src="https://github.com/user-attachments/assets/3237a46d-d827-4eac-8274-1ca3edef99e0" />



<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
