### PR TITLE
Add deprecation comments

### DIFF
--- a/src/apps/apps-debug.ts
+++ b/src/apps/apps-debug.ts
@@ -1,3 +1,4 @@
 import { createDebug } from "@dashboard/debug";
 
+/** @deprecated use utility from extensions/ */
 export const createAppsDebug = (namespace: string) => createDebug(`apps:${namespace}`);

--- a/src/apps/appstore.types.ts
+++ b/src/apps/appstore.types.ts
@@ -1,5 +1,7 @@
 /**
  * Interfaces for shapes of data fetched from AppStore API.
+ * @deprecated This Appstore SDK is deprecated, and was replaced by Extensions endpoint
+ * It's now used in extensions/
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AppstoreApi {

--- a/src/apps/components/AppActivateDialog/AppActivateDialog.tsx
+++ b/src/apps/components/AppActivateDialog/AppActivateDialog.tsx
@@ -8,6 +8,7 @@ import { useIntl } from "react-intl";
 
 import msgs from "./messages";
 
+/** @deprecated use component from extensions/ */
 export interface AppActivateDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
   open: boolean;
@@ -16,6 +17,7 @@ export interface AppActivateDialogProps {
   onConfirm: () => void;
 }
 
+/** @deprecated use component from extensions/ */
 const AppActivateDialog: React.FC<AppActivateDialogProps> = ({
   confirmButtonState,
   open,

--- a/src/apps/components/AppActivateDialog/messages.ts
+++ b/src/apps/components/AppActivateDialog/messages.ts
@@ -1,5 +1,6 @@
 import { defineMessages } from "react-intl";
 
+/** @deprecated use messages from extensions/ */
 export default defineMessages({
   activateAppTitle: {
     id: "YHNozE",

--- a/src/apps/components/AppAlerts/useAppsAlert.ts
+++ b/src/apps/components/AppAlerts/useAppsAlert.ts
@@ -8,6 +8,7 @@ import { useSidebarDotState } from "./useSidebarDotState";
 
 const DELIVERIES_FETCHING_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
+/** @todo Move to extensions/* or sidebar */
 export const useAppsAlert = (enabled: boolean | undefined = true) => {
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
   const { hasNewFailedAttempts, handleFailedAttempt, handleAppsListItemClick } =

--- a/src/apps/components/AppAvatar/AppAvatar.tsx
+++ b/src/apps/components/AppAvatar/AppAvatar.tsx
@@ -5,6 +5,7 @@ import React from "react";
 type Logo = AppLogo | undefined;
 type Size = 4 | 6 | 8 | 12;
 
+/** @deprecated Use component from extensions/ */
 export const AppAvatar = ({ logo, size = 8, ...props }: { logo?: Logo; size?: Size } & BoxProps) =>
   logo ? (
     <Box

--- a/src/apps/components/AppDeactivateDialog/AppDeactivateDialog.tsx
+++ b/src/apps/components/AppDeactivateDialog/AppDeactivateDialog.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import msgs from "./messages";
 
+/** @deprecated use component from extensions/ */
 export interface AppDeactivateDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
   open: boolean;
@@ -17,6 +18,7 @@ export interface AppDeactivateDialogProps {
   onConfirm: () => void;
 }
 
+/** @deprecated use component from extensions/ */
 const AppDeactivateDialog: React.FC<AppDeactivateDialogProps> = ({
   confirmButtonState,
   open,

--- a/src/apps/components/AppDeactivateDialog/messages.ts
+++ b/src/apps/components/AppDeactivateDialog/messages.ts
@@ -1,5 +1,6 @@
 import { defineMessages } from "react-intl";
 
+/** @deprecated use messages from extensions/ */
 export default defineMessages({
   deactivateAppTitle: {
     id: "0d6W6p",

--- a/src/apps/components/AppDeleteDialog/AppDeleteDialog.tsx
+++ b/src/apps/components/AppDeleteDialog/AppDeleteDialog.tsx
@@ -16,6 +16,7 @@ export interface AppDeleteDialogProps {
   type: "CUSTOM" | "EXTERNAL";
 }
 
+/** @deprecated Use component from extensions/ */
 const AppDeleteDialog: React.FC<AppDeleteDialogProps> = ({
   confirmButtonState,
   open,

--- a/src/apps/components/AppDialog/AppDialog.tsx
+++ b/src/apps/components/AppDialog/AppDialog.tsx
@@ -8,6 +8,7 @@ interface AppDialogProps {
   open: boolean;
 }
 
+/** @deprecated Use component from extensions/ */
 export const AppDialog: React.FC<AppDialogProps> = ({ children, title, onClose, ...props }) => {
   return (
     <DashboardModal aria-labelledby="extension app dialog" {...props} onChange={onClose}>

--- a/src/apps/components/AppFrame/AppFrame.tsx
+++ b/src/apps/components/AppFrame/AppFrame.tsx
@@ -26,6 +26,7 @@ interface Props {
 
 const getOrigin = (url: string) => new URL(url).origin;
 
+/** @deprecated Use component from extensions/ */
 export const AppFrame: React.FC<Props> = ({
   src,
   appToken,

--- a/src/apps/components/AppFrame/AppIFrame.tsx
+++ b/src/apps/components/AppFrame/AppIFrame.tsx
@@ -15,6 +15,7 @@ interface AppIFrameProps {
   className: string;
 }
 
+/** @deprecated Use component from extensions/ */
 const _AppIFrame = forwardRef<HTMLIFrameElement, AppIFrameProps>(
   ({ appId, src, featureFlags, params, onLoad, onError, className }, ref) => {
     const themeRef = useRef<ThemeType>();

--- a/src/apps/components/AppFrame/appActionsHandler.ts
+++ b/src/apps/components/AppFrame/appActionsHandler.ts
@@ -225,6 +225,7 @@ const useHandlePermissionRequest = (appId: string) => {
   };
 };
 
+/** @deprecated Use utils from extensions/ */
 export const AppActionsHandler = {
   useHandleNotificationAction,
   useHandleUpdateRoutingAction,

--- a/src/apps/components/AppFrame/useAppActions.ts
+++ b/src/apps/components/AppFrame/useAppActions.ts
@@ -4,6 +4,7 @@ import { Actions, DispatchResponseEvent } from "@saleor/app-sdk/app-bridge";
 import React, { useState } from "react";
 
 /**
+ * @deprecated Use hook from extensions/
  * TODO Refactor to named attributes
  */
 export const useAppActions = (

--- a/src/apps/components/AppFrame/useAppDashboardUpdates.ts
+++ b/src/apps/components/AppFrame/useAppDashboardUpdates.ts
@@ -5,6 +5,7 @@ import { useTheme } from "@saleor/macaw-ui";
 import { useEffect } from "react";
 
 /**
+ * @deprecated Use hook from extensions/
  * TODO: Refactor prop-drilling, use context or some atomic state
  */
 export const useAppDashboardUpdates = (

--- a/src/apps/components/AppFrame/usePostToExtension.ts
+++ b/src/apps/components/AppFrame/usePostToExtension.ts
@@ -1,6 +1,7 @@
 import { Events } from "@saleor/app-sdk/app-bridge";
 import { useCallback } from "react";
 
+/** Use hook from extensions/ */
 export const usePostToExtension = (iframeElement: HTMLIFrameElement | null, appOrigin: string) => {
   const postToExtension = useCallback(
     (event: Events) => {

--- a/src/apps/components/AppFrame/useTokenRefresh.ts
+++ b/src/apps/components/AppFrame/useTokenRefresh.ts
@@ -58,4 +58,5 @@ const useTokenRefresh = (token?: string, refetch?: () => void) => {
   }, [token]);
 };
 
+/** Use hook from extensions/ */
 export default useTokenRefresh;

--- a/src/apps/components/AppFrame/useUpdateAppToken.ts
+++ b/src/apps/components/AppFrame/useUpdateAppToken.ts
@@ -3,6 +3,7 @@ import { DashboardEventFactory, Events } from "@saleor/app-sdk/app-bridge";
 import { useEffect, useRef } from "react";
 
 /**
+ * @deprecated Use hook from extensions/
  * https://usehooks.com/usePrevious/
  */
 function usePreviousValue(value: unknown) {

--- a/src/apps/getPermissionsDiff.ts
+++ b/src/apps/getPermissionsDiff.ts
@@ -1,6 +1,7 @@
 import { PermissionEnum } from "@dashboard/graphql";
 import difference from "lodash/difference";
 
+/** @deprecated use hook from extensions/ */
 export const getPermissionsDiff = (
   initialPermissionsCodes: PermissionEnum[],
   newPermissionsCodes: PermissionEnum[],

--- a/src/apps/hooks/useActiveAppsInstallations.ts
+++ b/src/apps/hooks/useActiveAppsInstallations.ts
@@ -22,6 +22,7 @@ interface UseActiveAppsInstallations {
   onRemoveInProgressAppSuccess: () => void;
 }
 
+/** @deprecated use hook from extensions/ */
 function useActiveAppsInstallations({
   appsInProgressData,
   appsInProgressRefetch,

--- a/src/apps/hooks/useGetAvailableAppPermissions.ts
+++ b/src/apps/hooks/useGetAvailableAppPermissions.ts
@@ -1,6 +1,7 @@
 import { PermissionEnum } from "@dashboard/graphql";
 import useShop from "@dashboard/hooks/useShop";
 
+/** @deprecated use hook from extensions/ */
 export const useGetAvailableAppPermissions = () => {
   const shopData = useShop();
   /**

--- a/src/apps/isUrlAbsolute.ts
+++ b/src/apps/isUrlAbsolute.ts
@@ -1,3 +1,4 @@
+/** @deprecated use utility from extensions/ */
 export const isUrlAbsolute = (url: string) => {
   try {
     new URL(url);

--- a/src/apps/types.ts
+++ b/src/apps/types.ts
@@ -1,21 +1,25 @@
 import { AppInstallationFragment, AppListItemFragment } from "@dashboard/graphql";
 
+/** @deprecated use type from extensions/ */
 export interface AppLogo {
   source?: string;
 }
 
+/** @deprecated use type from extensions/ */
 export interface InstalledApp {
   app: AppListItemFragment;
   isExternal: boolean;
   logo?: AppLogo;
 }
 
+/** @deprecated use type from extensions/ */
 export interface AppInstallation {
   appInstallation: AppInstallationFragment;
   isExternal: boolean;
   logo?: AppLogo;
 }
 
+/** @deprecated use type from extensions/ */
 export interface AppLink {
   name: string;
   url: string;

--- a/src/apps/utils.ts
+++ b/src/apps/utils.ts
@@ -48,6 +48,7 @@ export const getAppstoreAppsLists = (
   };
 };
 
+/** @deprecated This is no longer used on production (tunnelUrlKeywords are empty) */
 export const isAppInTunnel = (manifestUrl: string) =>
   Boolean(
     getAppsConfig().tunnelUrlKeywords.find(keyword => new URL(manifestUrl).host.includes(keyword)),


### PR DESCRIPTION
Added comments to mark components, hooks, utilityies from apps/ as deprecated (we should use only the ones in extensions/)

These will be removed in 3.22 once we remove extensions feature flag
