### PR TITLE
Remove extensions dead code

### DIFF
--- a/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.tsx
+++ b/src/extensions/views/ExploreExtensions/components/ExploreExtensionsActions.tsx
@@ -1,28 +1,17 @@
-import { InstallWithManifestFormButton } from "@dashboard/apps/components/InstallWithManifestFormButton";
-import { AppUrls } from "@dashboard/apps/urls";
 import { ButtonWithDropdown } from "@dashboard/components/ButtonWithDropdown";
 import { RequestExtensionsButton } from "@dashboard/extensions/components/RequestExtensionsButton";
 import { buttonLabels } from "@dashboard/extensions/messages";
 import { ExtensionsUrls } from "@dashboard/extensions/urls";
-import { useFlag } from "@dashboard/featureFlags";
 import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { Box } from "@saleor/macaw-ui-next";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 export const ExploreExtensionsActions = () => {
   const intl = useIntl();
   const navigate = useNavigator();
-  const { enabled: isExtensionsDevEnabled } = useFlag("extensions");
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
-
-  const navigateToAppInstallPage = useCallback(
-    (manifestUrl: string) => {
-      navigate(AppUrls.resolveAppInstallUrl(manifestUrl));
-    },
-    [navigate],
-  );
 
   const addExtensionOptions = useMemo(
     () => [
@@ -45,19 +34,13 @@ export const ExploreExtensionsActions = () => {
       <RequestExtensionsButton />
 
       {hasManagedAppsPermission && (
-        <>
-          {isExtensionsDevEnabled ? (
-            <ButtonWithDropdown
-              variant="primary"
-              options={addExtensionOptions}
-              testId="add-extension-button"
-            >
-              <FormattedMessage {...buttonLabels.addExtension} />
-            </ButtonWithDropdown>
-          ) : (
-            <InstallWithManifestFormButton onSubmitted={navigateToAppInstallPage} />
-          )}
-        </>
+        <ButtonWithDropdown
+          variant="primary"
+          options={addExtensionOptions}
+          testId="add-extension-button"
+        >
+          <FormattedMessage {...buttonLabels.addExtension} />
+        </ButtonWithDropdown>
       )}
     </Box>
   );

--- a/src/extensions/views/InstalledExtensions/InstalledExtensions.test.tsx
+++ b/src/extensions/views/InstalledExtensions/InstalledExtensions.test.tsx
@@ -193,7 +193,7 @@ describe("InstalledExtensions", () => {
     expect(mockCloseModal).toHaveBeenCalled();
   });
 
-  it("shows Install App button when user has permission", () => {
+  it("shows Add Extension button when user has permission", () => {
     // Arrange
     mockUseHasManagedAppsPermission.mockImplementation(() => ({ hasManagedAppsPermission: true }));
 
@@ -201,10 +201,10 @@ describe("InstalledExtensions", () => {
     render(<InstalledExtensions {...defaultProps} />);
 
     // Assert
-    expect(screen.getByText("Install external app")).toBeInTheDocument();
+    expect(screen.getByText("Add Extension")).toBeInTheDocument();
   });
 
-  it("does not show Install App button when user lacks permission", () => {
+  it("does not show Add Extension button when user lacks permission", () => {
     // Arrange
     mockUseHasManagedAppsPermission.mockImplementation(() => ({ hasManagedAppsPermission: false }));
 
@@ -212,6 +212,6 @@ describe("InstalledExtensions", () => {
     render(<InstalledExtensions {...defaultProps} />);
 
     // Assert
-    expect(screen.queryByText("Install external app")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add Extension")).not.toBeInTheDocument();
   });
 });

--- a/src/extensions/views/InstalledExtensions/components/AddExtensionDropdown/AddExtensionDropdown.test.tsx
+++ b/src/extensions/views/InstalledExtensions/components/AddExtensionDropdown/AddExtensionDropdown.test.tsx
@@ -1,0 +1,73 @@
+import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
+import useNavigator from "@dashboard/hooks/useNavigator";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { AddExtensionDropdown } from "./AddExtensionDropdown";
+
+jest.mock("@dashboard/hooks/useHasManagedAppsPermission", () => ({
+  useHasManagedAppsPermission: jest.fn(),
+}));
+
+jest.mock("@dashboard/hooks/useNavigator", () => jest.fn());
+
+jest.mock("react-intl", () => ({
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage }: { defaultMessage: string }) => defaultMessage,
+  }),
+  defineMessages: (message: unknown) => message,
+}));
+
+jest.mock("@dashboard/extensions/urls", () => ({
+  ExtensionsUrls: {
+    resolveExploreExtensionsUrl: jest.fn(() => "/explore-extensions"),
+    installCustomExtensionUrl: jest.fn(() => "/install-custom-extension"),
+    addCustomExtensionUrl: jest.fn(() => "/add-custom-extension"),
+  },
+}));
+
+describe("AddExtensionDropdown", () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigator as jest.Mock).mockReturnValue(mockNavigate);
+  });
+
+  it("renders the dropdown button when user has MANAGE_APPS permission", () => {
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+    render(<AddExtensionDropdown />);
+    expect(screen.getByTestId("add-extension-button")).toBeInTheDocument();
+  });
+
+  it("does not render the dropdown button when user lacks MANAGE_APPS permission", () => {
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: false });
+    render(<AddExtensionDropdown />);
+    expect(screen.queryByTestId("add-extension-button")).not.toBeInTheDocument();
+  });
+
+  it("navigates to explore extensions when selecting from dropdown", async () => {
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+    render(<AddExtensionDropdown />);
+    await userEvent.click(screen.getByTestId("add-extension-button"));
+    await userEvent.click(screen.getByTestId("explore-extensions"));
+    expect(mockNavigate).toHaveBeenCalledWith("/explore-extensions");
+  });
+
+  it("navigates to install custom extension when selecting from dropdown", async () => {
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+    render(<AddExtensionDropdown />);
+    await userEvent.click(screen.getByTestId("add-extension-button"));
+    await userEvent.click(screen.getByTestId("install-custom-extension"));
+    expect(mockNavigate).toHaveBeenCalledWith("/install-custom-extension");
+  });
+
+  it("navigates to add custom extension when selecting from dropdown", async () => {
+    (useHasManagedAppsPermission as jest.Mock).mockReturnValue({ hasManagedAppsPermission: true });
+    render(<AddExtensionDropdown />);
+    await userEvent.click(screen.getByTestId("add-extension-button"));
+    await userEvent.click(screen.getByTestId("add-custom-extension"));
+    expect(mockNavigate).toHaveBeenCalledWith("/add-custom-extension");
+  });
+});

--- a/src/extensions/views/InstalledExtensions/components/AddExtensionDropdown/AddExtensionDropdown.tsx
+++ b/src/extensions/views/InstalledExtensions/components/AddExtensionDropdown/AddExtensionDropdown.tsx
@@ -1,10 +1,6 @@
-import { InstallWithManifestFormButton } from "@dashboard/apps/components/InstallWithManifestFormButton";
-import { AppUrls } from "@dashboard/apps/urls";
 import { ButtonWithDropdown } from "@dashboard/components/ButtonWithDropdown";
-import { RequestExtensionsButton } from "@dashboard/extensions/components/RequestExtensionsButton";
 import { buttonLabels } from "@dashboard/extensions/messages";
 import { ExtensionsUrls } from "@dashboard/extensions/urls";
-import { useFlag } from "@dashboard/featureFlags";
 import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import React, { useMemo } from "react";
@@ -13,12 +9,7 @@ import { useIntl } from "react-intl";
 export const AddExtensionDropdown = () => {
   const intl = useIntl();
   const navigate = useNavigator();
-  const { enabled: isExtensionsDevEnabled } = useFlag("extensions");
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
-
-  const navigateToAppInstallPage = (manifestUrl: string) => {
-    navigate(AppUrls.resolveAppInstallUrl(manifestUrl));
-  };
 
   const addExtensionOptions = useMemo(
     () => [
@@ -41,25 +32,17 @@ export const AddExtensionDropdown = () => {
     [intl, navigate],
   );
 
-  if (!isExtensionsDevEnabled) {
-    // Display old navigation
+  if (hasManagedAppsPermission) {
     return (
-      <>
-        <RequestExtensionsButton />
-        {hasManagedAppsPermission && (
-          <InstallWithManifestFormButton onSubmitted={navigateToAppInstallPage} />
-        )}
-      </>
+      <ButtonWithDropdown
+        variant="primary"
+        options={addExtensionOptions}
+        testId="add-extension-button"
+      >
+        {intl.formatMessage(buttonLabels.addExtension)}
+      </ButtonWithDropdown>
     );
   }
 
-  return (
-    <ButtonWithDropdown
-      variant="primary"
-      options={addExtensionOptions}
-      testId="add-extension-button"
-    >
-      {intl.formatMessage(buttonLabels.addExtension)}
-    </ButtonWithDropdown>
-  );
+  return null;
 };


### PR DESCRIPTION
This PR removes extensions dead code after we have already got rid of `extensions_dev` feature flag.

`false` state was no longer used since these views are only visible if you have `extensions` set to `true`
