### PR TITLE
Conditionally show translate button

### DIFF
--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -1,5 +1,7 @@
 import { attributeListPath } from "@dashboard/attributes/urls";
 import { ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES } from "@dashboard/attributes/utils/data";
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
@@ -17,6 +19,7 @@ import {
   AttributeInputTypeEnum,
   AttributeTypeEnum,
   MeasurementUnitsEnum,
+  PermissionEnum,
 } from "@dashboard/graphql";
 import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import { SubmitPromise } from "@dashboard/hooks/useForm";
@@ -95,6 +98,8 @@ const AttributePage: React.FC<AttributePageProps> = ({
   children,
 }) => {
   const intl = useIntl();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();
   const { makeChangeHandler: makeMetadataChangeHandler } = useMetadataChangeTrigger();
@@ -165,19 +170,21 @@ const AttributePage: React.FC<AttributePageProps> = ({
                     : attribute?.name
                 }
               >
-                <Button
-                  variant="secondary"
-                  icon={<TranslationsIcon />}
-                  onClick={() =>
-                    navigate(
-                      languageEntityUrl(
-                        lastUsedLocaleOrFallback,
-                        TranslatableEntities.attributes,
-                        attribute?.id ?? "",
-                      ),
-                    )
-                  }
-                />
+                {canTranslate && (
+                  <Button
+                    variant="secondary"
+                    icon={<TranslationsIcon />}
+                    onClick={() =>
+                      navigate(
+                        languageEntityUrl(
+                          lastUsedLocaleOrFallback,
+                          TranslatableEntities.attributes,
+                          attribute?.id ?? "",
+                        ),
+                      )
+                    }
+                  />
+                )}
               </TopNav>
               <DetailPageLayout.Content>
                 <AttributeDetails

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -1,3 +1,5 @@
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { categoryListPath, categoryUrl } from "@dashboard/categories/urls";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { CardSpacer } from "@dashboard/components/CardSpacer";
@@ -7,7 +9,7 @@ import { Metadata } from "@dashboard/components/Metadata/Metadata";
 import { Savebar } from "@dashboard/components/Savebar";
 import { SeoForm } from "@dashboard/components/SeoForm";
 import { Tab, TabContainer } from "@dashboard/components/Tab";
-import { CategoryDetailsQuery, ProductErrorFragment } from "@dashboard/graphql";
+import { CategoryDetailsQuery, PermissionEnum, ProductErrorFragment } from "@dashboard/graphql";
 import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import { SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
@@ -79,6 +81,8 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();
   const intl = useIntl();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
 
   const categoryBackListUrl = useBackLinkWithState({
     path: categoryListPath,
@@ -91,19 +95,21 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
       {({ data, change, handlers, submit, isSaveDisabled }) => (
         <DetailPageLayout gridTemplateColumns={1}>
           <TopNav href={backHref} title={category?.name}>
-            <Button
-              variant="secondary"
-              icon={<TranslationsIcon />}
-              onClick={() =>
-                navigate(
-                  languageEntityUrl(
-                    lastUsedLocaleOrFallback,
-                    TranslatableEntities.categories,
-                    categoryId,
-                  ),
-                )
-              }
-            />
+            {canTranslate && (
+              <Button
+                variant="secondary"
+                icon={<TranslationsIcon />}
+                onClick={() =>
+                  navigate(
+                    languageEntityUrl(
+                      lastUsedLocaleOrFallback,
+                      TranslatableEntities.categories,
+                      categoryId,
+                    ),
+                  )
+                }
+              />
+            )}
           </TopNav>
           <DetailPageLayout.Content>
             <CategoryDetailsForm

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -1,4 +1,6 @@
 // @ts-strict-ignore
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { ChannelCollectionData } from "@dashboard/channels/utils";
 import { collectionListPath, CollectionUrlQueryParams } from "@dashboard/collections/urls";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
@@ -65,6 +67,8 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
 
   const collectionListBackLink = useBackLinkWithState({
     path: collectionListPath,
@@ -81,19 +85,21 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
       {({ change, data, handlers, submit, isSaveDisabled }) => (
         <DetailPageLayout>
           <TopNav href={collectionListBackLink} title={collection?.name}>
-            <Button
-              variant="secondary"
-              icon={<TranslationsIcon />}
-              onClick={() =>
-                navigate(
-                  languageEntityUrl(
-                    lastUsedLocaleOrFallback,
-                    TranslatableEntities.collections,
-                    collection.id,
-                  ),
-                )
-              }
-            />
+            {canTranslate && (
+              <Button
+                variant="secondary"
+                icon={<TranslationsIcon />}
+                onClick={() =>
+                  navigate(
+                    languageEntityUrl(
+                      lastUsedLocaleOrFallback,
+                      TranslatableEntities.collections,
+                      collection.id,
+                    ),
+                  )
+                }
+              />
+            )}
           </TopNav>
           <DetailPageLayout.Content>
             <CollectionDetails data={data} disabled={disabled} errors={errors} onChange={change} />

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -1,4 +1,6 @@
 // @ts-strict-ignore
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { ChannelVoucherData } from "@dashboard/channels/utils";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
@@ -180,6 +182,8 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const [localErrors, setLocalErrors] = React.useState<DiscountErrorFragment[]>([]);
   const { makeChangeHandler: makeMetadataChangeHandler } = useMetadataChangeTrigger();
   const channel = voucher?.channelListings?.find(
@@ -245,19 +249,21 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
         return (
           <DetailPageLayout>
             <TopNav href={voucherListBackLink} title={voucher?.name}>
-              <Button
-                variant="secondary"
-                icon={<TranslationsIcon />}
-                onClick={() =>
-                  navigate(
-                    languageEntityUrl(
-                      lastUsedLocaleOrFallback,
-                      TranslatableEntities.vouchers,
-                      voucher?.id,
-                    ),
-                  )
-                }
-              />
+              {canTranslate && (
+                <Button
+                  variant="secondary"
+                  icon={<TranslationsIcon />}
+                  onClick={() =>
+                    navigate(
+                      languageEntityUrl(
+                        lastUsedLocaleOrFallback,
+                        TranslatableEntities.vouchers,
+                        voucher?.id,
+                      ),
+                    )
+                  }
+                />
+              )}
             </TopNav>
             <DetailPageLayout.Content>
               <VoucherInfo data={data} disabled={disabled} errors={errors} onChange={change} />

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -3,6 +3,8 @@ import {
   getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@dashboard/attributes/utils/data";
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import AssignAttributeValueDialog from "@dashboard/components/AssignAttributeValueDialog";
 import { Container } from "@dashboard/components/AssignContainerDialog";
@@ -17,6 +19,7 @@ import VisibilityCard from "@dashboard/components/VisibilityCard";
 import {
   PageDetailsFragment,
   PageErrorWithAttributesFragment,
+  PermissionEnum,
   SearchAttributeValuesQuery,
   SearchPagesQuery,
   SearchPageTypesQuery,
@@ -97,6 +100,8 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
 }) => {
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const localizeDate = useDateLocalize();
   const navigate = useNavigator();
   const pageExists = page !== null;
@@ -153,19 +158,21 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
               href={pageListBackLink}
               title={!pageExists ? intl.formatMessage(messages.title) : page?.title}
             >
-              <Button
-                variant="secondary"
-                icon={<TranslationsIcon />}
-                onClick={() =>
-                  navigate(
-                    languageEntityUrl(
-                      lastUsedLocaleOrFallback,
-                      TranslatableEntities.pages,
-                      page?.id,
-                    ),
-                  )
-                }
-              />
+              {canTranslate && (
+                <Button
+                  variant="secondary"
+                  icon={<TranslationsIcon />}
+                  onClick={() =>
+                    navigate(
+                      languageEntityUrl(
+                        lastUsedLocaleOrFallback,
+                        TranslatableEntities.pages,
+                        page?.id,
+                      ),
+                    )
+                  }
+                />
+              )}
             </TopNav>
             <DetailPageLayout.Content>
               <PageInfo data={data} disabled={loading} errors={errors} onChange={change} />

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -3,6 +3,8 @@ import {
   getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@dashboard/attributes/utils/data";
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { ChannelData } from "@dashboard/channels/utils";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import AssignAttributeValueDialog from "@dashboard/components/AssignAttributeValueDialog";
@@ -164,6 +166,8 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
 }) => {
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const navigate = useNavigator();
   const [channelPickerOpen, setChannelPickerOpen] = React.useState(false);
   const [selectedCategory, setSelectedCategory] = useStateFromProps(product?.category?.name || "");
@@ -288,14 +292,16 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
         return (
           <DetailPageLayout>
             <TopNav href={backLinkProductUrl} title={header}>
-              <Button
-                marginRight={3}
-                variant="secondary"
-                icon={<TranslationsIcon />}
-                onClick={() =>
-                  navigate(createTranslateProductUrl(lastUsedLocaleOrFallback, productId))
-                }
-              />
+              {canTranslate && (
+                <Button
+                  marginRight={3}
+                  variant="secondary"
+                  icon={<TranslationsIcon />}
+                  onClick={() =>
+                    navigate(createTranslateProductUrl(lastUsedLocaleOrFallback, productId))
+                  }
+                />
+              )}
               <TopNav.Menu
                 items={[
                   ...extensionMenuItems,

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -4,6 +4,8 @@ import {
   getReferenceAttributeEntityTypeFromAttribute,
   mergeAttributeValues,
 } from "@dashboard/attributes/utils/data";
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { ChannelPriceData } from "@dashboard/channels/utils";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import AssignAttributeValueDialog from "@dashboard/components/AssignAttributeValueDialog";
@@ -21,6 +23,7 @@ import { MetadataFormData } from "@dashboard/components/Metadata";
 import { Metadata } from "@dashboard/components/Metadata/Metadata";
 import { Savebar } from "@dashboard/components/Savebar";
 import {
+  PermissionEnum,
   ProductChannelListingErrorFragment,
   ProductErrorWithAttributesFragment,
   ProductVariantFragment,
@@ -166,6 +169,8 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const { isOpen: isManageChannelsModalOpen, toggle: toggleManageChannels } = useManageChannels();
   const [isModalOpened, setModalStatus] = React.useState(false);
   const toggleModal = () => setModalStatus(!isModalOpened);
@@ -204,14 +209,16 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
         {variant?.product?.defaultVariant?.id !== variant?.id && (
           <ProductVariantSetDefault onSetDefaultVariant={onSetDefaultVariant} />
         )}
-        <Button
-          marginLeft={3}
-          variant="secondary"
-          icon={<TranslationsIcon />}
-          onClick={() =>
-            navigate(productVariantUrl(lastUsedLocaleOrFallback, productId, variant?.id))
-          }
-        />
+        {canTranslate && (
+          <Button
+            marginLeft={3}
+            variant="secondary"
+            icon={<TranslationsIcon />}
+            onClick={() =>
+              navigate(productVariantUrl(lastUsedLocaleOrFallback, productId, variant?.id))
+            }
+          />
+        )}
       </TopNav>
       <DetailPageLayout.Content>
         <ProductVariantUpdateForm

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -1,4 +1,6 @@
 // @ts-strict-ignore
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
@@ -9,6 +11,7 @@ import { Metadata } from "@dashboard/components/Metadata/Metadata";
 import { Savebar } from "@dashboard/components/Savebar";
 import {
   ChannelFragment,
+  PermissionEnum,
   ShippingErrorFragment,
   ShippingMethodTypeEnum,
   ShippingZoneDetailsFragment,
@@ -102,6 +105,8 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
 }) => {
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const navigate = useNavigator();
   const initialForm = getInitialFormData(shippingZone);
   const warehouseChoices = warehouses.map(warehouseToChoice);
@@ -119,19 +124,21 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
         return (
           <DetailPageLayout>
             <TopNav href={shippingZonesListBackLink} title={shippingZone?.name}>
-              <Button
-                variant="secondary"
-                icon={<TranslationsIcon />}
-                onClick={() =>
-                  navigate(
-                    languageEntityUrl(
-                      lastUsedLocaleOrFallback,
-                      TranslatableEntities.shippingMethods,
-                      shippingZone?.id,
-                    ),
-                  )
-                }
-              />
+              {canTranslate && (
+                <Button
+                  variant="secondary"
+                  icon={<TranslationsIcon />}
+                  onClick={() =>
+                    navigate(
+                      languageEntityUrl(
+                        lastUsedLocaleOrFallback,
+                        TranslatableEntities.shippingMethods,
+                        shippingZone?.id,
+                      ),
+                    )
+                  }
+                />
+              )}
             </TopNav>
             <DetailPageLayout.Content>
               <ShippingZoneInfo data={data} disabled={disabled} errors={errors} onChange={change} />

--- a/src/structures/components/MenuDetailsPage/MenuDetailsPage.tsx
+++ b/src/structures/components/MenuDetailsPage/MenuDetailsPage.tsx
@@ -33,7 +33,8 @@ export interface MenuDetailsPageProps {
   onItemClick: (id: string, type: MenuItemType) => void;
   onItemEdit: (id: string) => void;
   onSubmit: (data: MenuDetailsSubmitData) => SubmitPromise;
-  onTranslate: (id: string) => void;
+  // If not passed, it will not render the button. Use to control permissions
+  onTranslate?: (id: string) => void;
 }
 
 const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({

--- a/src/structures/components/MenuItems/MenuItems.tsx
+++ b/src/structures/components/MenuItems/MenuItems.tsx
@@ -18,7 +18,8 @@ export interface MenuItemsProps {
   onItemAdd: () => void;
   onItemClick: (id: string, type: MenuItemType) => void;
   onItemEdit: (id: string) => void;
-  onTranslate: (id: string) => void;
+  // If not passed, it will not render the button. Use to control permissions
+  onTranslate?: (id: string) => void;
   onUndo: () => void;
 }
 

--- a/src/structures/components/MenuItemsSortableTree/MenuItemsSortableTree.tsx
+++ b/src/structures/components/MenuItemsSortableTree/MenuItemsSortableTree.tsx
@@ -15,7 +15,8 @@ interface MenuItemsSortableTreeProps {
   onItemClick: (id: UniqueIdentifier, type: MenuItemType) => void;
   onItemEdit: (id: UniqueIdentifier) => void;
   onItemRemove: (id: UniqueIdentifier) => void;
-  onTranslate: (id: UniqueIdentifier) => void;
+  // If not passed, it will not render the button. Use to control permissions
+  onTranslate?: (id: UniqueIdentifier) => void;
 }
 
 export const MenuItemsSortableTree = ({

--- a/src/structures/components/MenuItemsSortableTree/MenuItemsSortableTreeItem.tsx
+++ b/src/structures/components/MenuItemsSortableTree/MenuItemsSortableTreeItem.tsx
@@ -14,7 +14,8 @@ interface TreeItemProps extends TreeItemComponentProps<RecursiveMenuItem> {
   onClick: (id: UniqueIdentifier, menuItemType: MenuItemType) => void;
   onEdit: (id: UniqueIdentifier) => void;
   onRemove: (id: UniqueIdentifier) => void;
-  onTranslate: (id: UniqueIdentifier) => void;
+  // If not passed, it will not render the button. Use to control permissions
+  onTranslate?: (id: UniqueIdentifier) => void;
 }
 
 export const MenuItemsSortableTreeItem = ({
@@ -80,12 +81,14 @@ export const MenuItemsSortableTreeItem = ({
             onClick={() => onEdit(id)}
             icon={<EditIcon />}
           />
-          <Button
-            data-test-id="translate-menu-item-button"
-            variant="secondary"
-            onClick={() => onTranslate(id)}
-            icon={<TranslationsIcon />}
-          />
+          {onTranslate && (
+            <Button
+              data-test-id="translate-menu-item-button"
+              variant="secondary"
+              onClick={() => onTranslate(id)}
+              icon={<TranslationsIcon />}
+            />
+          )}
           <Button
             data-test-id="remove-menu-item-button"
             variant="secondary"

--- a/src/structures/views/MenuDetails/index.tsx
+++ b/src/structures/views/MenuDetails/index.tsx
@@ -1,6 +1,9 @@
 // @ts-strict-ignore
+import { useUser } from "@dashboard/auth";
+import { hasPermission } from "@dashboard/auth/misc";
 import ActionDialog from "@dashboard/components/ActionDialog";
 import {
+  PermissionEnum,
   useMenuDeleteMutation,
   useMenuDetailsQuery,
   useMenuItemCreateMutation,
@@ -49,6 +52,8 @@ const MenuDetails: React.FC<MenuDetailsProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
+  const { user } = useUser();
+  const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const { data, loading, refetch } = useMenuDetailsQuery({
     variables: { id },
@@ -140,6 +145,10 @@ const MenuDetails: React.FC<MenuDetailsProps> = ({ id, params }) => {
     ];
   };
 
+  const handleTranslateRequest = (itemId: string) => {
+    navigate(languageEntityUrl(lastUsedLocaleOrFallback, TranslatableEntities.menuItems, itemId));
+  };
+
   return (
     <>
       <MenuDetailsPage
@@ -173,11 +182,7 @@ const MenuDetails: React.FC<MenuDetailsProps> = ({ id, params }) => {
             }),
           )
         }
-        onTranslate={itemId => {
-          navigate(
-            languageEntityUrl(lastUsedLocaleOrFallback, TranslatableEntities.menuItems, itemId),
-          );
-        }}
+        onTranslate={canTranslate ? handleTranslateRequest : undefined}
         onSubmit={handleSubmit}
         saveButtonState={menuUpdateOpts.status}
       />


### PR DESCRIPTION
Fix a bug, when user without permission tries to navigate to translations page. Hide the button instead of error page