### PR TITLE
feat: add ESLint rule to deprecate Material-UI and Macaw-UI icons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -153,6 +153,7 @@
       }
     ],
     "local-rules/named-styles": "error",
+    "local-rules/no-deprecated-icons": "warn",
     "no-restricted-imports": [
       "error",
       {

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,5 +1,6 @@
 "use strict";
 
 module.exports = {
-  "named-styles": require("./lint/rules/named-styles")
+  "named-styles": require("./lint/rules/named-styles"),
+  "no-deprecated-icons": require("./lint/rules/no-deprecated-icons")
 };

--- a/lint/rules/no-deprecated-icons.js
+++ b/lint/rules/no-deprecated-icons.js
@@ -1,0 +1,60 @@
+module.exports = {
+  create: context => ({
+    ImportDeclaration: node => {
+      let iconImports = [];
+      let messageId = "";
+      let libraryName = "";
+
+      // Check if importing from @saleor/macaw-ui-next
+      if (node.source.value === "@saleor/macaw-ui-next") {
+        iconImports = node.specifiers.filter(specifier => {
+          return specifier.type === "ImportSpecifier" && specifier.imported.name.endsWith("Icon");
+        });
+        messageId = "noMacawUiIcons";
+        libraryName = "@saleor/macaw-ui-next";
+      }
+      // Check if importing from @material-ui/icons
+      else if (
+        node.source.value === "@material-ui/icons" ||
+        node.source.value.startsWith("@material-ui/icons/")
+      ) {
+        // For @material-ui/icons, all imports are icons
+        iconImports = node.specifiers.filter(
+          specifier =>
+            specifier.type === "ImportSpecifier" || specifier.type === "ImportDefaultSpecifier",
+        );
+        messageId = "noMaterialUiIcons";
+        libraryName = "@material-ui/icons";
+      }
+
+      if (iconImports.length > 0) {
+        const iconNames = iconImports
+          .map(spec =>
+            spec.type === "ImportDefaultSpecifier" ? spec.local.name : spec.imported.name,
+          )
+          .join(", ");
+
+        context.report({
+          node,
+          messageId,
+          data: {
+            icons: iconNames,
+            library: libraryName,
+          },
+        });
+      }
+    },
+  }),
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Warn when importing icons from deprecated UI libraries",
+      category: "Best Practices",
+    },
+    messages: {
+      noMacawUiIcons: "Avoid importing icons ({{icons}}) from @saleor/macaw-ui-next. Use lucide-react instead.",
+      noMaterialUiIcons: "Avoid importing icons ({{icons}}) from @material-ui/icons. Use lucide-react instead."
+    },
+    schema: [],
+  },
+};

--- a/src/icons/ArrowDropdown.tsx
+++ b/src/icons/ArrowDropdown.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { ChevronDown } from "lucide-react";
+ * // Use <ChevronDown /> instead
+ */
 const ArrowDropdown = createSvgIcon(
   <g style={{ fillRule: "evenodd" }}>
     <path d="M7 10l5 5 5-5z" />

--- a/src/icons/ArrowSort.tsx
+++ b/src/icons/ArrowSort.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { ArrowUpDown } from "lucide-react";
+ * // Use <ArrowUpDown /> instead
+ */
 const ArrowSort = createSvgIcon(
   <>
     <rect width="24" height="24" fill="transparent" />

--- a/src/icons/Attributes.tsx
+++ b/src/icons/Attributes.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Settings } from "lucide-react";
+ * // Use <Settings /> instead
+ */
 const AttributesIcons = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Channels.tsx
+++ b/src/icons/Channels.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Radio } from "lucide-react";
+ * // Use <Radio /> instead
+ */
 const ChannelsIcon = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Cloud.tsx
+++ b/src/icons/Cloud.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Cloud } from "lucide-react";
+ * // Use <Cloud /> instead
+ */
 export const Cloud = () => (
   <svg fill="none" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" data-macaw-ui-candidate>
     <g clipPath="url(#a)">

--- a/src/icons/Configuration.tsx
+++ b/src/icons/Configuration.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Settings } from "lucide-react";
+ * // Use <Settings /> instead
+ */
 export const ConfigurationIcon = () => (
   <svg
     width="20"

--- a/src/icons/Contents.tsx
+++ b/src/icons/Contents.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { FolderOpen } from "lucide-react";
+ * // Use <FolderOpen /> instead
+ */
 export const ContentsIcon = () => (
   <svg
     width="20"

--- a/src/icons/Customers.tsx
+++ b/src/icons/Customers.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Users } from "lucide-react";
+ * // Use <Users /> instead
+ */
 export const CustomersIcon = () => (
   <svg
     width="20"

--- a/src/icons/Discounts.tsx
+++ b/src/icons/Discounts.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Percent } from "lucide-react";
+ * // Use <Percent /> instead
+ */
 export const DiscountsIcon = () => (
   <svg
     width="20"

--- a/src/icons/Drag.tsx
+++ b/src/icons/Drag.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { GripVertical } from "lucide-react";
+ * // Use <GripVertical /> instead
+ */
 const Drag = createSvgIcon(
   <>
     <svg

--- a/src/icons/ErrorCircle.tsx
+++ b/src/icons/ErrorCircle.tsx
@@ -1,6 +1,13 @@
 import { Box, BoxProps } from "@saleor/macaw-ui-next";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI Next which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { XCircle } from "lucide-react";
+ * // Use <XCircle /> instead
+ */
 export const ErrorCircle = ({
   height = "12px",
   width = "12px",

--- a/src/icons/ErrorExclamationCircle.tsx
+++ b/src/icons/ErrorExclamationCircle.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { AlertCircle } from "lucide-react";
+ * // Use <AlertCircle /> instead
+ */
 const ErrorExclamationCircle = createSvgIcon(
   <>
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/icons/FullScreenIcon.tsx
+++ b/src/icons/FullScreenIcon.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Maximize } from "lucide-react";
+ * // Use <Maximize /> instead
+ */
 const FullScreenIcon = createSvgIcon(
   <>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384.97 384.97">

--- a/src/icons/Graphql.tsx
+++ b/src/icons/Graphql.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Database } from "lucide-react";
+ * // Use <Database /> instead
+ */
 export const Graphql = () => {
   return (
     // Mark component as candidate for macaw-ui

--- a/src/icons/Home.tsx
+++ b/src/icons/Home.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Home } from "lucide-react";
+ * // Use <Home /> instead
+ */
 export const HomeIcon = () => (
   <svg
     width="20"

--- a/src/icons/Marketplace.tsx
+++ b/src/icons/Marketplace.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Store } from "lucide-react";
+ * // Use <Store /> instead
+ */
 export const MarketplaceIcon = () => (
   <svg
     width="20"

--- a/src/icons/Miscellaneous.tsx
+++ b/src/icons/Miscellaneous.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Grid3X3 } from "lucide-react";
+ * // Use <Grid3X3 /> instead
+ */
 const MiscellaneousIcon = createSvgIcon(
   <>
     <path

--- a/src/icons/Navigation.tsx
+++ b/src/icons/Navigation.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Navigation } from "lucide-react";
+ * // Use <Navigation /> instead
+ */
 const NavigationIcon = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Orders.tsx
+++ b/src/icons/Orders.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { ShoppingCart } from "lucide-react";
+ * // Use <ShoppingCart /> instead
+ */
 export const OrdersIcon = () => (
   <svg
     width="20"

--- a/src/icons/PageTypes.tsx
+++ b/src/icons/PageTypes.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { FileText } from "lucide-react";
+ * // Use <FileText /> instead
+ */
 const PageTypesIcons = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/PermissionGroups.tsx
+++ b/src/icons/PermissionGroups.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Shield } from "lucide-react";
+ * // Use <Shield /> instead
+ */
 const PermissionGroupsIcon = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Plugins.tsx
+++ b/src/icons/Plugins.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon } from "@material-ui/core/utils";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Puzzle } from "lucide-react";
+ * // Use <Puzzle /> instead
+ */
 const Plugins = createSvgIcon(
   <>
     <g>

--- a/src/icons/ProductTypes.tsx
+++ b/src/icons/ProductTypes.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Box } from "lucide-react";
+ * // Use <Box /> instead
+ */
 const ProductTypesIcon = createSvgIcon(
   <>
     <path

--- a/src/icons/Products.tsx
+++ b/src/icons/Products.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Package } from "lucide-react";
+ * // Use <Package /> instead
+ */
 export const ProductsIcon = () => (
   <svg
     width="20"

--- a/src/icons/ShippingMethods.tsx
+++ b/src/icons/ShippingMethods.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Truck } from "lucide-react";
+ * // Use <Truck /> instead
+ */
 const ShippingMethodsIcons = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/SiteSettings.tsx
+++ b/src/icons/SiteSettings.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Settings } from "lucide-react";
+ * // Use <Settings /> instead
+ */
 const SiteSettingsIcon = createSvgIcon(
   <>
     <path

--- a/src/icons/StaffMembers.tsx
+++ b/src/icons/StaffMembers.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Users } from "lucide-react";
+ * // Use <Users /> instead
+ */
 const StaffMembersIcon = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Taxes.tsx
+++ b/src/icons/Taxes.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Receipt } from "lucide-react";
+ * // Use <Receipt /> instead
+ */
 const TaxesIcon = createSvgIcon(
   <path
     fillRule="evenodd"

--- a/src/icons/Translations.tsx
+++ b/src/icons/Translations.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 
+/**
+ * @deprecated This icon uses Macaw-UI patterns which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Languages } from "lucide-react";
+ * // Use <Languages /> instead
+ */
 export const TranslationsIcon = () => (
   <svg
     width="20"

--- a/src/icons/Trash.tsx
+++ b/src/icons/Trash.tsx
@@ -2,6 +2,13 @@ import { createSvgIcon } from "@material-ui/core/utils";
 import { useTheme } from "@saleor/macaw-ui";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI and Macaw-UI which are deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Trash2 } from "lucide-react";
+ * // Use <Trash2 /> instead
+ */
 const Trash: React.FC = () => {
   const { themeType } = useTheme();
   const TrashComponent = createSvgIcon(

--- a/src/icons/Warehouses.tsx
+++ b/src/icons/Warehouses.tsx
@@ -1,6 +1,13 @@
 import { createSvgIcon, SvgIconProps } from "@material-ui/core";
 import React from "react";
 
+/**
+ * @deprecated This icon uses Material-UI which is deprecated. Please use Lucide React icons instead.
+ * @see https://lucide.dev/ for available icons
+ * @example
+ * import { Warehouse } from "lucide-react";
+ * // Use <Warehouse /> instead
+ */
 const WarehousesIcon = createSvgIcon(
   <path
     fillRule="evenodd"


### PR DESCRIPTION
- Add new ESLint rule 'no-deprecated-icons' to warn against importing icons from @material-ui/icons and @saleor/macaw-ui-next
- Add deprecation JSDoc comments to all existing icon components with migration guidance to lucide-react
- Configure ESLint to use the new rule as a warning
- Update 34 icon files with deprecation notices and usage examples

This helps migrate away from deprecated UI libraries towards lucide-react icons.

## Changes
- **New ESLint rule**: `lint/rules/no-deprecated-icons.js` - warns when importing icons from deprecated libraries
- **ESLint config**: Added the rule as a warning in `.eslintrc.json`
- **Icon deprecations**: Added JSDoc deprecation notices to 34 icon components with migration examples
- **Rule registration**: Updated `eslint-local-rules.js` to include the new rule

## Migration Path
Developers will now see warnings when importing icons from:
- `@material-ui/icons`
- `@saleor/macaw-ui-next` (icon imports)

The warnings guide them to use `lucide-react` icons instead.