### PR TITLE
refactor: improve UnderlineLink component API and structure

### DIFF
--- a/src/orders-v2/order-customer/order-customer-header.tsx
+++ b/src/orders-v2/order-customer/order-customer-header.tsx
@@ -26,10 +26,10 @@ export const OrderCustomerHeader = ({ userId, ...props }: Props) => {
       </Text>
       <Box display="flex" gap={4}>
         {/* TODO: add link to order list with filter by customer id */}
-        <UnderlineLink href={orderListUrl()} size={2}>
+        <UnderlineLink to={orderListUrl()}>
           {intl.formatMessage({ id: "4ABral", defaultMessage: "View orders" })}
         </UnderlineLink>
-        <UnderlineLink href={customerUrl(userId)} size={2}>
+        <UnderlineLink to={customerUrl(userId)}>
           {intl.formatMessage({ id: "yGGPTl", defaultMessage: "View profile" })}
         </UnderlineLink>
       </Box>

--- a/src/orders-v2/order-header.tsx
+++ b/src/orders-v2/order-header.tsx
@@ -71,9 +71,7 @@ export const OrderHeader = ({ status, orderNumber, created, channel, ...props }:
                 },
                 {
                   channelNameLink: (
-                    <UnderlineLink href={channelUrl(channel.id)} size={2}>
-                      {channel.name}
-                    </UnderlineLink>
+                    <UnderlineLink to={channelUrl(channel.id)}>{channel.name}</UnderlineLink>
                   ),
                 },
               )}

--- a/src/orders-v2/underline-link.tsx
+++ b/src/orders-v2/underline-link.tsx
@@ -1,23 +1,20 @@
 import { Text, TextProps } from "@saleor/macaw-ui-next";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, LinkProps } from "react-router-dom";
 
-interface Props extends TextProps {
-  href: string;
-  children: React.ReactNode;
+interface UnderlineLinkProps extends LinkProps {
+  textProps?: Omit<TextProps, "children">;
 }
 
 // TODO: move to MacawUI
-export const UnderlineLink = ({ href, children, ...props }: Props) => (
-  <Link to={href}>
-    <Text
-      as="span"
-      textDecoration="underline"
-      {...props}
-      data-macaw-ui-candidate
-      fontWeight="medium"
-    >
-      {children}
-    </Text>
+export const UnderlineLink = ({ children, textProps, ...props }: UnderlineLinkProps) => (
+  <Link {...props}>
+    <UnderlineText {...textProps}>{children}</UnderlineText>
   </Link>
+);
+
+export const UnderlineText = ({ children, ...props }: TextProps) => (
+  <Text as="span" textDecoration="underline" fontWeight="medium" size={2} {...props}>
+    {children}
+  </Text>
 );

--- a/src/orders-v2/underline-link.tsx
+++ b/src/orders-v2/underline-link.tsx
@@ -6,15 +6,22 @@ interface UnderlineLinkProps extends LinkProps {
   textProps?: Omit<TextProps, "children">;
 }
 
-// TODO: move to MacawUI
 export const UnderlineLink = ({ children, textProps, ...props }: UnderlineLinkProps) => (
   <Link {...props}>
     <UnderlineText {...textProps}>{children}</UnderlineText>
   </Link>
 );
 
+// TODO: move to MacawUI
 export const UnderlineText = ({ children, ...props }: TextProps) => (
-  <Text as="span" textDecoration="underline" fontWeight="medium" size={2} {...props}>
+  <Text
+    as="span"
+    textDecoration="underline"
+    fontWeight="medium"
+    size={2}
+    data-macaw-ui-candidate
+    {...props}
+  >
     {children}
   </Text>
 );


### PR DESCRIPTION
## Summary

This PR refactors the UnderlineLink component to improve its API design and component structure.

## Changes

- **Extract UnderlineText component** for better separation of concerns
- **Change UnderlineLink interface** to extend anchor attributes instead of TextProps for better type safety
- **Add textProps parameter** for customizing text styling while keeping link and text concerns separate
- **Set default size={2}** in UnderlineText component to maintain consistent styling
- **Remove redundant size props** from component usage across the codebase

## Benefits

- Better separation of concerns between link functionality and text styling
- More intuitive API that properly extends HTML anchor attributes
- Maintains existing visual appearance while improving code structure
- Prepares component for potential migration to MacawUI (as noted in TODO)

## Files Changed

- \`src/orders-v2/underline-link.tsx\` - Main component refactor
- \`src/orders-v2/order-customer/order-customer-header.tsx\` - Removed redundant size props
- \`src/orders-v2/order-header.tsx\` - Removed redundant size props