### PR TITLE
[3.21] Hide voucher usage / count when voucher doesn't have limit

### DIFF
--- a/.changeset/heavy-glasses-camp.md
+++ b/.changeset/heavy-glasses-camp.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Hide voucher usage limit and usage count on voucher details page when voucher doesn't have limit set.

--- a/src/discounts/components/VoucherSummary/VoucherSummary.tsx
+++ b/src/discounts/components/VoucherSummary/VoucherSummary.tsx
@@ -96,19 +96,27 @@ const VoucherSummary: React.FC<VoucherSummaryProps> = ({ selectedChannelId, vouc
         </Text>
         <FormSpacer />
 
-        <Text size={2} fontWeight="light">
-          <FormattedMessage
-            id="HLqWXA"
-            defaultMessage="Usage Limit"
-            description="voucher value requirement"
-          />
-        </Text>
-        <Text display="block">{voucher?.usageLimit ? voucher.usageLimit : "-"}</Text>
-        <FormSpacer />
-        <Text size={2} fontWeight="light">
-          <FormattedMessage id="h65vZI" defaultMessage="Used" description="times voucher used" />
-        </Text>
-        <Text display="block">{voucher?.used ?? <Skeleton />}</Text>
+        {voucher?.usageLimit && (
+          <>
+            <Text size={2} fontWeight="light">
+              <FormattedMessage
+                id="HLqWXA"
+                defaultMessage="Usage Limit"
+                description="voucher value requirement"
+              />
+            </Text>
+            <Text display="block">{voucher?.usageLimit ? voucher.usageLimit : "-"}</Text>
+            <FormSpacer />
+            <Text size={2} fontWeight="light">
+              <FormattedMessage
+                id="h65vZI"
+                defaultMessage="Used"
+                description="times voucher used"
+              />
+            </Text>
+            <Text display="block">{voucher?.used ?? <Skeleton />}</Text>
+          </>
+        )}
       </DashboardCard.Content>
     </DashboardCard>
   );


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
Hide voucher usage limit and usage count on voucher details page when voucher doesn't have limit set.
No limit set:
![2025-08-27 at 10 44 56 - CleanShot@2x](https://github.com/user-attachments/assets/37f18131-a685-4577-9e9b-433caa0ad632)

Wit limit set:
![2025-08-27 at 10 45 30 - CleanShot@2x](https://github.com/user-attachments/assets/aafdcef4-1a5e-4bce-b5f5-c2d6b5afd334)
