### PR TITLE
[3.21] Improve order refund UI for Payments API

### DIFF
--- a/.changeset/blue-nails-drive.md
+++ b/.changeset/blue-nails-drive.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Improve order refund UI for orders that uses Payments API. After this change `Automatic Refund` will be avaiable when `Refund products` option is selected. Miscellaneous refund will require providing `Manual Amount` as this is what Saleor API requires.

--- a/src/components/SimpleRadioGroupField.tsx
+++ b/src/components/SimpleRadioGroupField.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent } from "@dashboard/hooks/useForm";
 import { RadioGroup, RadioGroupRootProps, Text } from "@saleor/macaw-ui-next";
 import React from "react";
 
-type RadioGroupFieldChoice = {
+export type SimpleRadioGroupFieldChoice = {
   label: string | React.ReactNode;
   value: string;
   disabled?: boolean;
@@ -12,7 +12,7 @@ interface SimpleRadioGroupFieldProps
   extends Omit<RadioGroupRootProps, "onChange" | "children" | "name"> {
   name: string;
   onChange: (event: ChangeEvent) => void;
-  choices: RadioGroupFieldChoice[];
+  choices: SimpleRadioGroupFieldChoice[];
   size?: RadioGroupRootProps["size"];
   errorMessage?: string;
 }

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -55,7 +55,7 @@ interface OrderRefundFormProps {
 function getOrderRefundPageFormData(defaultType: OrderRefundType): OrderRefundData {
   return {
     amount: undefined,
-    amountCalculationMode: OrderRefundAmountCalculationMode.AUTOMATIC,
+    amountCalculationMode: OrderRefundAmountCalculationMode.NONE,
     refundShipmentCosts: false,
     type: defaultType,
   };

--- a/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCard.tsx
+++ b/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCard.tsx
@@ -2,13 +2,16 @@
 import { ButtonWithLoader } from "@dashboard/components/ButtonWithLoader/ButtonWithLoader";
 import { DashboardCard } from "@dashboard/components/Card";
 import Hr from "@dashboard/components/Hr";
-import { SimpleRadioGroupField } from "@dashboard/components/SimpleRadioGroupField";
+import {
+  SimpleRadioGroupField,
+  SimpleRadioGroupFieldChoice,
+} from "@dashboard/components/SimpleRadioGroupField";
 import { OrderDetailsFragment, OrderErrorFragment, OrderRefundDataQuery } from "@dashboard/graphql";
 import { ChangeEvent } from "@dashboard/hooks/useForm";
 import { makeStyles } from "@saleor/macaw-ui";
 import { Checkbox, Text } from "@saleor/macaw-ui-next";
 import React from "react";
-import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+import { defineMessages, FormattedMessage, IntlShape, useIntl } from "react-intl";
 
 import {
   OrderRefundAmountCalculationMode,
@@ -74,6 +77,56 @@ interface PaymentSubmitCardProps {
   onRefund: () => void;
 }
 
+const getAmountCalculationModeOptions = ({
+  type,
+  intl,
+  allowNoRefund,
+  disabled,
+}: {
+  type: OrderRefundType;
+  intl: IntlShape;
+  allowNoRefund: boolean;
+  disabled: boolean;
+}): SimpleRadioGroupFieldChoice[] => {
+  const manualOption = {
+    label: intl.formatMessage({
+      id: "FOehC/",
+      defaultMessage: "Manual Amount",
+      description: "label",
+    }),
+    value: OrderRefundAmountCalculationMode.MANUAL,
+    disabled: disabled,
+  };
+
+  const noRefundOption = {
+    label: intl.formatMessage({
+      id: "zzfj8H",
+      defaultMessage: "No refund",
+      description: "label",
+    }),
+    value: OrderRefundAmountCalculationMode.NONE,
+    disabled: !allowNoRefund || disabled,
+  };
+
+  if (type === OrderRefundType.MISCELLANEOUS) {
+    return [noRefundOption, manualOption];
+  }
+
+  return [
+    noRefundOption,
+    {
+      label: intl.formatMessage({
+        id: "JEIN47",
+        defaultMessage: "Automatic Amount",
+        description: "label",
+      }),
+      value: OrderRefundAmountCalculationMode.AUTOMATIC,
+      disabled: disabled,
+    },
+    manualOption,
+  ];
+};
+
 export const PaymentSubmitCard: React.FC<PaymentSubmitCardProps> = props => {
   const {
     data,
@@ -132,7 +185,8 @@ export const PaymentSubmitCard: React.FC<PaymentSubmitCardProps> = props => {
   const disableRefundButton = shouldRefundButtonBeDisabled();
 
   const showRefundShipmentCheckbox =
-    data.amountCalculationMode !== OrderRefundAmountCalculationMode.NONE;
+    data.amountCalculationMode === OrderRefundAmountCalculationMode.AUTOMATIC &&
+    type === OrderRefundType.PRODUCTS;
 
   return (
     <DashboardCard>
@@ -147,35 +201,12 @@ export const PaymentSubmitCard: React.FC<PaymentSubmitCardProps> = props => {
       </DashboardCard.Header>
       <DashboardCard.Content className={classes.content}>
         <SimpleRadioGroupField
-          choices={[
-            {
-              label: intl.formatMessage({
-                id: "zzfj8H",
-                defaultMessage: "No refund",
-                description: "label",
-              }),
-              value: OrderRefundAmountCalculationMode.NONE,
-              disabled: !allowNoRefund || disabled,
-            },
-            {
-              label: intl.formatMessage({
-                id: "JEIN47",
-                defaultMessage: "Automatic Amount",
-                description: "label",
-              }),
-              value: OrderRefundAmountCalculationMode.AUTOMATIC,
-              disabled: disabled,
-            },
-            {
-              label: intl.formatMessage({
-                id: "FOehC/",
-                defaultMessage: "Manual Amount",
-                description: "label",
-              }),
-              value: OrderRefundAmountCalculationMode.MANUAL,
-              disabled: disabled,
-            },
-          ]}
+          choices={getAmountCalculationModeOptions({
+            type,
+            intl,
+            allowNoRefund,
+            disabled,
+          })}
           disabled={disabled}
           name={"amountCalculationMode" as keyof FormData}
           value={data.amountCalculationMode}
@@ -263,16 +294,18 @@ export const PaymentSubmitCard: React.FC<PaymentSubmitCardProps> = props => {
               previouslyRefunded={previouslyRefunded}
               maxRefund={maxRefund}
             />
-            <RefundAmountInput
-              data={data as OrderRefundFormData}
-              maxRefund={maxRefund}
-              amountTooSmall={isAmountTooSmall}
-              amountTooBig={isAmountTooBig}
-              currencySymbol={amountCurrency}
-              disabled={disabled}
-              onChange={onChange}
-              errors={errors}
-            />
+            {data.amountCalculationMode === OrderRefundAmountCalculationMode.MANUAL && (
+              <RefundAmountInput
+                data={data as OrderRefundFormData}
+                maxRefund={maxRefund}
+                amountTooSmall={isAmountTooSmall}
+                amountTooBig={isAmountTooBig}
+                currencySymbol={amountCurrency}
+                disabled={disabled}
+                onChange={onChange}
+                errors={errors}
+              />
+            )}
           </>
         )}
         <ButtonWithLoader

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -72,7 +72,7 @@ interface OrderReturnProps {
 
 const getOrderRefundPageFormData = (): OrderReturnData => ({
   amount: undefined,
-  amountCalculationMode: OrderRefundAmountCalculationMode.AUTOMATIC,
+  amountCalculationMode: OrderRefundAmountCalculationMode.MANUAL,
   refundShipmentCosts: false,
   autoGrantRefund: false,
   autoSendRefund: false,


### PR DESCRIPTION
## Scope of the change

Improve order refund UI for orders that uses Payments API. After this change `Automatic Refund` will be available when `Refund products` option is selected. Miscellaneous refund will require providing `Manual Amount` as this is what Saleor API requires.


![2025-08-27 at 14 59 48 - CleanShot@2x](https://github.com/user-attachments/assets/7de21fff-c395-4551-8f54-343eab2bc47c)

![2025-08-27 at 14 59 59 - CleanShot@2x](https://github.com/user-attachments/assets/7cb26ccf-bd9b-457a-95ea-a557a192d406)
