### PR TITLE
Improve cancel fulfilment  

### DIFF
--- a/.changeset/sharp-shrimps-talk.md
+++ b/.changeset/sharp-shrimps-talk.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Improved order fulfillment cancel dialog: in case the fulfillment is in waiting for approval state, providing a warehouse will be no longer required.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -117,6 +117,9 @@
   "+bhokL": {
     "string": "Search discounts..."
   },
+  "+cGU63": {
+    "string": "Are you sure you want to cancel fulfillment?"
+  },
   "+djx5u": {
     "string": "You can't give this extension permissions you don't have."
   },
@@ -4757,6 +4760,9 @@
   },
   "QUyUJy": {
     "string": "Main Product"
+  },
+  "QV5QKO": {
+    "string": "Canceling a fulfillment will restock products at a selected warehouse."
   },
   "QVNg8A": {
     "context": "product field",
@@ -10176,9 +10182,6 @@
   "xZhxBJ": {
     "context": "dialog header",
     "string": "Assign Products"
-  },
-  "xco5tZ": {
-    "string": "Are you sure you want to cancel fulfillment? Canceling a fulfillment will restock products at a selected warehouse."
   },
   "xfGZsi": {
     "context": "configuration section name",

--- a/src/orders/components/OrderFulfillmentCancelDialog/OrderFulfillmentCancelDialog.tsx
+++ b/src/orders/components/OrderFulfillmentCancelDialog/OrderFulfillmentCancelDialog.tsx
@@ -4,7 +4,7 @@ import { Combobox } from "@dashboard/components/Combobox";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import Form from "@dashboard/components/Form";
 import { DashboardModal } from "@dashboard/components/Modal";
-import { OrderErrorFragment, WarehouseFragment } from "@dashboard/graphql";
+import { FulfillmentStatus, OrderErrorFragment, WarehouseFragment } from "@dashboard/graphql";
 import { buttonMessages } from "@dashboard/intl";
 import getOrderErrorMessage from "@dashboard/utils/errors/order";
 import createSingleAutocompleteSelectHandler from "@dashboard/utils/handlers/singleAutocompleteSelectChangeHandler";
@@ -37,12 +37,13 @@ export interface OrderFulfillmentCancelDialogProps {
   errors: OrderErrorFragment[];
   open: boolean;
   warehouses: WarehouseFragment[];
+  fulfillmentStatus: string;
   onClose: () => any;
   onConfirm: (data: OrderFulfillmentCancelDialogFormData) => any;
 }
 
 const OrderFulfillmentCancelDialog = (props: OrderFulfillmentCancelDialogProps) => {
-  const { confirmButtonState, errors, open, warehouses, onConfirm, onClose } = props;
+  const { confirmButtonState, errors, open, warehouses, fulfillmentStatus, onConfirm, onClose } = props;
   const classes = useStyles(props);
   const intl = useIntl();
   const [displayValue, setDisplayValue] = React.useState("");
@@ -50,6 +51,7 @@ const OrderFulfillmentCancelDialog = (props: OrderFulfillmentCancelDialogProps) 
     label: warehouse.name,
     value: warehouse.id,
   }));
+  const waitingForApproval = fulfillmentStatus === FulfillmentStatus.WAITING_FOR_APPROVAL;
 
   return (
     <DashboardModal onChange={onClose} open={open}>
@@ -73,31 +75,39 @@ const OrderFulfillmentCancelDialog = (props: OrderFulfillmentCancelDialogProps) 
 
               <Text>
                 <FormattedMessage
-                  id="xco5tZ"
-                  defaultMessage="Are you sure you want to cancel fulfillment? Canceling a fulfillment will restock products at a selected warehouse."
+                  id="+cGU63"
+                  defaultMessage="Are you sure you want to cancel fulfillment?"
                 />
+                {!waitingForApproval && (
+                  <FormattedMessage
+                    id="QV5QKO"
+                    defaultMessage=" Canceling a fulfillment will restock products at a selected warehouse."
+                  />
+                )}
               </Text>
 
-              <div
-                className={classes.selectCcontainer}
-                data-test-id="cancel-fulfillment-select-field"
-              >
-                <Combobox
-                  label={intl.formatMessage({
-                    id: "aHc89n",
-                    defaultMessage: "Select Warehouse",
-                    description: "select warehouse to restock items",
-                  })}
-                  options={choices}
-                  fetchOptions={() => undefined}
-                  name="warehouseId"
-                  value={{
-                    label: displayValue,
-                    value: formData.warehouseId,
-                  }}
-                  onChange={handleChange}
-                />
-              </div>
+              {!waitingForApproval && (
+                <div
+                  className={classes.selectCcontainer}
+                  data-test-id="cancel-fulfillment-select-field"
+                >
+                  <Combobox
+                    label={intl.formatMessage({
+                      id: "aHc89n",
+                      defaultMessage: "Select Warehouse",
+                      description: "select warehouse to restock items",
+                    })}
+                    options={choices}
+                    fetchOptions={() => undefined}
+                    name="warehouseId"
+                    value={{
+                      label: displayValue,
+                      value: formData.warehouseId,
+                    }}
+                    onChange={handleChange}
+                  />
+                </div>
+              )}
 
               {errors.length > 0 &&
                 errors.map((err, index) => (
@@ -110,7 +120,7 @@ const OrderFulfillmentCancelDialog = (props: OrderFulfillmentCancelDialogProps) 
                 <BackButton onClick={onClose} />
                 <ConfirmButton
                   data-test-id="submit"
-                  disabled={formData.warehouseId === null}
+                  disabled={!waitingForApproval && formData.warehouseId === null}
                   transitionState={confirmButtonState}
                   onClick={submit}
                 >

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -394,6 +394,7 @@ export const OrderNormalDetails = ({
         errors={orderFulfillmentCancel.opts.data?.orderFulfillmentCancel.errors || []}
         open={params.action === "cancel-fulfillment"}
         warehouses={warehouses || []}
+        fulfillmentStatus={order?.fulfillments.find(getById(params.id))?.status}
         onConfirm={variables =>
           orderFulfillmentCancel.mutate({
             id: params.id,

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -36,7 +36,12 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { customerUrl } from "../../../../customers/urls";
-import { extractMutationErrors, getMutationState, getStringOrPlaceholder } from "../../../../misc";
+import {
+  extractMutationErrors,
+  getById,
+  getMutationState,
+  getStringOrPlaceholder,
+} from "../../../../misc";
 import { productUrl } from "../../../../products/urls";
 import OrderAddressFields from "../../../components/OrderAddressFields/OrderAddressFields";
 import OrderCancelDialog from "../../../components/OrderCancelDialog";
@@ -414,6 +419,7 @@ export const OrderUnconfirmedDetails = ({
         errors={orderFulfillmentCancel.opts.data?.orderFulfillmentCancel.errors || []}
         open={params.action === "cancel-fulfillment"}
         warehouses={mapEdgesToItems(warehouses?.data?.warehouses)}
+        fulfillmentStatus={order?.fulfillments.find(getById(params.id))?.status}
         onConfirm={variables =>
           orderFulfillmentCancel.mutate({
             id: params.id,


### PR DESCRIPTION
Port of https://github.com/saleor/saleor-dashboard/pull/5815

## Scope of the change

When a waiting for approval fulfilment is cancelled, providing a warehouse is not required. The backend ignores the warehouse in this case, so I omitted it.

ℹ️ 
Will be ported to main as well.

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->
Cancel fulfilment with `waiting for approval` status
<img width="1471" height="1115" alt="image" src="https://github.com/user-attachments/assets/674cd1ba-4669-4170-835d-52449b9c0165" />


Cancel for fulfilments with another status:
<img width="1468" height="888" alt="image" src="https://github.com/user-attachments/assets/4a17a7d5-3c8a-4378-869d-996f542acdc8" />

