### PR TITLE
[3.21] Fix Voucher codes minimal value

### DIFF
--- a/.changeset/common-facts-sneeze.md
+++ b/.changeset/common-facts-sneeze.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Voucher detail page: fixed how we calculate minimal requirements state. After this change we won't take selected channel into consideration for checking if requirement is `minimal order value` - instead we will use channel listing `minSpent` amount. Thanks to that UI should now properly display requirement.

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -134,6 +134,7 @@ const CategoriesTab = Tab(VoucherDetailsPageTab.categories);
 const CollectionsTab = Tab(VoucherDetailsPageTab.collections);
 const ProductsTab = Tab(VoucherDetailsPageTab.products);
 const VariantsTab = Tab(VoucherDetailsPageTab.variants);
+
 const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
   activeTab,
   tabItemsCount = {},
@@ -186,14 +187,15 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
   const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
   const [localErrors, setLocalErrors] = React.useState<DiscountErrorFragment[]>([]);
   const { makeChangeHandler: makeMetadataChangeHandler } = useMetadataChangeTrigger();
-  const channel = voucher?.channelListings?.find(
-    listing => listing.channel.id === selectedChannelId,
+  const hasMinimalOrderValueRequirement = voucher?.channelListings?.some(
+    listing => listing.minSpent?.amount > 0,
   );
+
   let requirementsPickerInitValue;
 
   if (voucher?.minCheckoutItemsQuantity > 0) {
     requirementsPickerInitValue = RequirementsPicker.ITEM;
-  } else if (channel?.minSpent?.amount > 0) {
+  } else if (hasMinimalOrderValueRequirement) {
     requirementsPickerInitValue = RequirementsPicker.ORDER;
   } else {
     requirementsPickerInitValue = RequirementsPicker.NONE;


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
Voucher detail page: fixed how we calculate minimal requirements state. After this change we won't take selected channel into consideration for checking if requirement is `minimal order value` - instead we will use channel listing `minSpent` amount. Thanks to that UI should now properly display requirement.

Fixes #5812 