### PR TITLE
[3.21] Unify category product create

### DIFF
--- a/.changeset/shaggy-bottles-sleep.md
+++ b/.changeset/shaggy-bottles-sleep.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Unify Category organization options for product create and update. After this change all comboboxes will use the same `parent / children` pattern of displaying options

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -41,6 +41,7 @@ import { Box, Option } from "@saleor/macaw-ui-next";
 import React from "react";
 import { useIntl } from "react-intl";
 
+import { getChoicesWithAncestors } from "@dashboard/products/utils/utils";
 import { FetchMoreProps, RelayToFlat } from "../../../types";
 import { ProductDetailsForm } from "../ProductDetailsForm";
 import { ProductShipping } from "../ProductShipping";
@@ -150,7 +151,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
   const [selectedCategory, setSelectedCategory] = useStateFromProps(initial?.category || "");
   const [selectedCollections, setSelectedCollections] = useStateFromProps<Option[]>([]);
   const [selectedTaxClass, setSelectedTaxClass] = useStateFromProps(initial?.taxClassId ?? "");
-  const categories = getChoices(categoryChoiceList);
+  const categories = getChoicesWithAncestors(categoryChoiceList);
   const collections = getChoices(collectionChoiceList);
   const productTypes = getChoices(productTypeChoiceList);
   const taxClassChoices =

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -36,12 +36,12 @@ import { ProductOrganization } from "@dashboard/products/components/ProductOrgan
 import { ProductVariantPrice } from "@dashboard/products/components/ProductVariantPrice";
 import { ProductCreateUrlQueryParams, productListUrl } from "@dashboard/products/urls";
 import { getChoices } from "@dashboard/products/utils/data";
+import { getChoicesWithAncestors } from "@dashboard/products/utils/utils";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { Box, Option } from "@saleor/macaw-ui-next";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { getChoicesWithAncestors } from "@dashboard/products/utils/utils";
 import { FetchMoreProps, RelayToFlat } from "../../../types";
 import { ProductDetailsForm } from "../ProductDetailsForm";
 import { ProductShipping } from "../ProductShipping";

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -88,8 +88,6 @@ export const ProductOrganization: React.FC<ProductOrganizationProps> = props => 
       ? formErrors.isPublished
       : null;
 
-  console.log("ProductOrganization rendered", selectedProductCategory);
-
   return (
     <DashboardCard>
       <DashboardCard.Header>

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -88,6 +88,8 @@ export const ProductOrganization: React.FC<ProductOrganizationProps> = props => 
       ? formErrors.isPublished
       : null;
 
+  console.log("ProductOrganization rendered", selectedProductCategory);
+
   return (
     <DashboardCard>
       <DashboardCard.Header>


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

Unify Category organization options for product create and update. After this change all comboboxes will use the same `parent / children` pattern of displaying options