### PR TITLE
Fix ProductCreate form isDirty

### DIFF
--- a/.changeset/true-ideas-grin.md
+++ b/.changeset/true-ideas-grin.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix ProductCreatePage form showing "Leave without saving changes" dialog on successful submission.
+
+The form was incorrectly marking itself as dirty after successful submission, causing the exit dialog to appear even when the form was successfully saved. This change clears the dirty state when submission succeeds and removes the automatic dirty state setting in the useEffect hook.

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -68,8 +68,7 @@ import { useMultipleRichText } from "@dashboard/utils/richText/useMultipleRichTe
 import useRichText from "@dashboard/utils/richText/useRichText";
 import { OutputData } from "@editorjs/editorjs";
 import { Option } from "@saleor/macaw-ui-next";
-import { useEffect, useState } from "react";
-import * as React from "react";
+import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 
 import { ProductStockFormsetData, ProductStockInput } from "../ProductStocks";
@@ -140,9 +139,9 @@ export type UseProductCreateFormRenderProps = Omit<UseProductCreateFormOutput, "
 
 export interface UseProductCreateFormOpts
   extends Record<"categories" | "collections" | "taxClasses", Option[]> {
-  setSelectedCategory: React.Dispatch<React.SetStateAction<string>>;
-  setSelectedCollections: React.Dispatch<React.SetStateAction<Option[]>>;
-  setSelectedTaxClass: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedCategory: Dispatch<SetStateAction<string>>;
+  setSelectedCollections: Dispatch<SetStateAction<Option[]>>;
+  setSelectedTaxClass: Dispatch<SetStateAction<string>>;
   setChannels: (channels: ChannelData[]) => void;
   selectedCollections: Option[];
   productTypes: RelayToFlat<SearchProductTypesQuery["search"]>;
@@ -165,7 +164,7 @@ export interface UseProductCreateFormOpts
 }
 
 export interface ProductCreateFormProps extends UseProductCreateFormOpts {
-  children: (props: UseProductCreateFormRenderProps) => React.ReactNode;
+  children: (props: UseProductCreateFormRenderProps) => ReactNode;
   initial?: Partial<ProductCreateFormData>;
   onSubmit: (data: ProductCreateData) => SubmitPromise;
   loading: boolean;
@@ -369,6 +368,9 @@ function useProductCreateForm(
     if (errors.length) {
       setIsSubmitDisabled(isSubmitDisabled);
       setIsDirty(true);
+    } else {
+      // Clear dirty state on successful submission
+      setIsDirty(false);
     }
 
     return errors;
@@ -407,7 +409,6 @@ function useProductCreateForm(
 
   useEffect(() => {
     setIsSubmitDisabled(isSubmitDisabled);
-    setIsDirty(true);
   }, [isSubmitDisabled]);
 
   return {


### PR DESCRIPTION
## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->
Fix ProductCreatePage form showing "Leave without saving changes" dialog on successful submission.

The form was incorrectly marking itself as dirty after successful submission, causing the exit dialog to appear even when the form was successfully saved. This change clears the dirty state when submission succeeds and removes the automatic dirty state setting in the useEffect hook.