### PR TITLE
[3.21] Store email used to login in local storage

### DIFF
--- a/.changeset/stupid-countries-admire.md
+++ b/.changeset/stupid-countries-admire.md
@@ -2,4 +2,4 @@
 "saleor-dashboard": patch
 ---
 
-Store email used to sucessfully login via password in local storage.
+Store email used to successfully login via password in local storage.

--- a/.changeset/stupid-countries-admire.md
+++ b/.changeset/stupid-countries-admire.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Store email used to sucessfully login via password in local storage.

--- a/src/auth/components/LoginPage/form.tsx
+++ b/src/auth/components/LoginPage/form.tsx
@@ -21,7 +21,7 @@ export interface LoginFormProps {
   onSubmit: (data: LoginFormData) => SubmitPromise;
 }
 
-const getLoginFormData = (defaultEmail: string | null) => {
+const getLoginFormData = (defaultEmail: string) => {
   if (DEMO_MODE) {
     return {
       email: "admin@example.com",
@@ -34,7 +34,7 @@ const getLoginFormData = (defaultEmail: string | null) => {
 
 function useLoginForm(onSubmit: (data: LoginFormData) => SubmitPromise): UseLoginFormResult {
   const { emailUsedToLogin } = useStoreEmailUsedToLogin();
-  const form = useForm(getLoginFormData(emailUsedToLogin));
+  const form = useForm(getLoginFormData(emailUsedToLogin ?? ""));
   const { change, data, reset } = form;
   const handleFormSubmit = useHandleFormSubmit({ onSubmit });
   const submit = async () => handleFormSubmit(data);

--- a/src/auth/components/LoginPage/form.tsx
+++ b/src/auth/components/LoginPage/form.tsx
@@ -1,3 +1,4 @@
+import { useStoreEmailUsedToLogin } from "@dashboard/auth/hooks/useStoreEmailUsedToLogin";
 import { DEMO_MODE } from "@dashboard/config";
 import useForm, { FormChange, SubmitPromise } from "@dashboard/hooks/useForm";
 import useHandleFormSubmit from "@dashboard/hooks/useHandleFormSubmit";
@@ -20,7 +21,7 @@ export interface LoginFormProps {
   onSubmit: (data: LoginFormData) => SubmitPromise;
 }
 
-const getLoginFormData = () => {
+const getLoginFormData = (defaultEmail: string | null) => {
   if (DEMO_MODE) {
     return {
       email: "admin@example.com",
@@ -28,11 +29,12 @@ const getLoginFormData = () => {
     };
   }
 
-  return { email: "", password: "" };
+  return { email: defaultEmail, password: "" };
 };
 
 function useLoginForm(onSubmit: (data: LoginFormData) => SubmitPromise): UseLoginFormResult {
-  const form = useForm(getLoginFormData());
+  const { emailUsedToLogin } = useStoreEmailUsedToLogin();
+  const form = useForm(getLoginFormData(emailUsedToLogin));
   const { change, data, reset } = form;
   const handleFormSubmit = useHandleFormSubmit({ onSubmit });
   const submit = async () => handleFormSubmit(data);

--- a/src/auth/hooks/useStoreEmailUsedToLogin.ts
+++ b/src/auth/hooks/useStoreEmailUsedToLogin.ts
@@ -1,0 +1,12 @@
+import useLocalStorage from "@dashboard/hooks/useLocalStorage";
+
+const STORAGE_KEY = "emailUsedToLogin";
+
+export const useStoreEmailUsedToLogin = () => {
+  const [emailUsedToLogin, setEmailUsedToLogin] = useLocalStorage<string | null>(STORAGE_KEY, null);
+
+  return {
+    emailUsedToLogin,
+    setEmailUsedToLogin,
+  };
+};

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -10,6 +10,7 @@ import LoginPage from "../components/LoginPage";
 import { LoginFormData } from "../components/LoginPage/types";
 import { useAuthParameters } from "../hooks/useAuthParameters";
 import { useLastLoginMethod } from "../hooks/useLastLoginMethod";
+import { useStoreEmailUsedToLogin } from "../hooks/useStoreEmailUsedToLogin";
 import { loginCallbackPath, LoginUrlQueryParams } from "../urls";
 
 interface LoginViewProps {
@@ -33,6 +34,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
     setRequestedExternalPluginId,
   } = useAuthParameters();
   const { lastLoginMethod, setLastLoginMethod } = useLastLoginMethod();
+  const { setEmailUsedToLogin } = useStoreEmailUsedToLogin();
 
   const handleSubmit = async (data: LoginFormData) => {
     if (!login) {
@@ -44,6 +46,7 @@ const LoginView: React.FC<LoginViewProps> = ({ params }) => {
 
     if (errors.length === 0) {
       setLastLoginMethod("password");
+      setEmailUsedToLogin(data.email);
     }
 
     return errors;


### PR DESCRIPTION
## Scope of the change
Store email used to sucessfully login via password in local storage.

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

