### PR TITLE
Fix workflow branch reference for Playwright tests

### DIFF
--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -60,6 +60,7 @@ jobs:
       IS_OLD_VERSION: ${{ steps.get-environment-variables.outputs.IS_OLD_VERSION }}
       ACCOUNTS: ${{ steps.accounts.outputs.ACCOUNTS }}
       SALEOR_CLOUD_SERVICE: ${{ steps.cloud_variables.outputs.SALEOR_CLOUD_SERVICE }}
+      BRANCH_NAME: ${{ env.BRANCH_NAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -154,7 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.add-check-and-prepare-instance.outputs.VERSION }}
+          ref: ${{ needs.add-check-and-prepare-instance.outputs.BRANCH_NAME }}
 
       - name: Run playwright tests
         uses: ./.github/actions/run-pw-tests


### PR DESCRIPTION
## Summary
- Pass `BRANCH_NAME` to the run-pw-tests job outputs
- Use `BRANCH_NAME` instead of `VERSION` for checkout reference in Playwright tests step

This ensures that Playwright tests run against the correct branch reference.

## Test plan
- [ ] Verify workflow runs successfully on release branches
- [ ] Confirm Playwright tests checkout the correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)