### PR TITLE
Configure changesets to use @changesets/changelog-github

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "@changesets/changelog-github",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.27.9",
         "@editorjs/embed": "^2.5.3",
         "@eslint/js": "^9.8.0",
@@ -1450,6 +1451,28 @@
         "@changesets/types": "^6.1.0"
       }
     },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.5.1.tgz",
+      "integrity": "sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.6.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
+    "node_modules/@changesets/changelog-github/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@changesets/cli": {
       "version": "2.29.5",
       "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.5.tgz",
@@ -1528,6 +1551,24 @@
         "picocolors": "^1.1.0",
         "semver": "^7.5.3"
       }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.6.0.tgz",
+      "integrity": "sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
+      }
+    },
+    "node_modules/@changesets/get-github-info/node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@changesets/get-release-plan": {
       "version": "4.0.13",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.27.9",
     "@editorjs/embed": "^2.5.3",
     "@eslint/js": "^9.8.0",


### PR DESCRIPTION
## Summary
- Updated `.changeset/config.json` to use `@changesets/changelog-github` instead of the default CLI changelog
- Added `@changesets/changelog-github` package as a dev dependency

This enables automatic GitHub release notes generation with PR links and contributor mentions in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)