### PR TITLE
Add repo config to @changesets/changelog-github

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "saleor/saleor-dashboard"
+    }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary
- Added `repo` configuration to `@changesets/changelog-github` in `.changeset/config.json`

## Problem
The `@changesets/changelog-github` package requires a repo configuration to function properly. Without it, the changeset version command fails with:
```
Error: Please provide a repo to this changelog generator like this:
"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]
```

This was causing the "Prepare release with Changesets" GitHub Action to fail.

## Solution
Updated the changelog configuration from:
```json
"changelog": "@changesets/changelog-github"
```

to:
```json
"changelog": [
  "@changesets/changelog-github",
  {
    "repo": "saleor/saleor-dashboard"
  }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)