### PR TITLE
Fix products list filter crash

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6220,6 +6220,9 @@
   "aGx3Z5": {
     "string": "Created {formattedDate}"
   },
+  "aHIrs/": {
+    "string": "Failed to load filter data. Please refresh page to try again."
+  },
   "aHc89n": {
     "context": "select warehouse to restock items",
     "string": "Select Warehouse"

--- a/src/components/ConditionalFilter/API/initialState/product/useProductInitialAPIState.tsx
+++ b/src/components/ConditionalFilter/API/initialState/product/useProductInitialAPIState.tsx
@@ -26,7 +26,9 @@ import {
   _SearchProductVariantOperandsQueryVariables,
   AttributeEntityTypeEnum,
 } from "@dashboard/graphql";
+import useNotifier from "@dashboard/hooks/useNotifier";
 import { useState } from "react";
+import { useIntl } from "react-intl";
 
 import { FetchingParams } from "../../../ValueProvider/TokenArray/fetchingParams";
 import { createAttributeProductVariantOptionsFromAPI, createOptionsFromAPI } from "../../Handler";
@@ -46,6 +48,8 @@ export interface InitialProductAPIState {
 
 export const useProductInitialAPIState = (): InitialProductAPIState => {
   const client = useApolloClient();
+  const notify = useNotifier();
+  const intl = useIntl();
   const [data, setData] = useState<InitialProductStateResponse>(
     InitialProductStateResponse.empty(),
   );
@@ -62,160 +66,174 @@ export const useProductInitialAPIState = (): InitialProductAPIState => {
   }: FetchingParams) => {
     setLoading(true);
 
-    if (channel.length > 0) {
-      queriesToRun.push(
-        client.query<_GetChannelOperandsQuery, _GetChannelOperandsQueryVariables>({
-          query: _GetChannelOperandsDocument,
-        }),
-      );
-    }
-
-    if (collection.length > 0) {
-      queriesToRun.push(
-        client.query<_SearchCollectionsOperandsQuery, _SearchCollectionsOperandsQueryVariables>({
-          query: _SearchCollectionsOperandsDocument,
-          variables: {
-            collectionsSlugs: collection,
-            first: collection.length,
-          },
-        }),
-      );
-    }
-
-    if (category.length > 0) {
-      queriesToRun.push(
-        client.query<_SearchCategoriesOperandsQuery, _SearchCategoriesOperandsQueryVariables>({
-          query: _SearchCategoriesOperandsDocument,
-          variables: {
-            categoriesSlugs: category,
-            first: category.length,
-          },
-        }),
-      );
-    }
-
-    if (productType.length > 0) {
-      queriesToRun.push(
-        client.query<_SearchProductTypesOperandsQuery, _SearchProductTypesOperandsQueryVariables>({
-          query: _SearchProductTypesOperandsDocument,
-          variables: {
-            productTypesSlugs: productType,
-            first: productType.length,
-          },
-        }),
-      );
-    }
-
-    // Fetch attribute definitions for both regular and reference attributes
-    // (We need the definitions for URL parsing, but values are fetched separately)
-    const allAttributeSlugs = [...Object.keys(attribute), ...Object.keys(attributeReference)];
-
-    if (allAttributeSlugs.length > 0) {
-      // Only fetch choices values for regular attributes, not reference attributes
-      // (if we try fetching reference attribute options Saleor returns 500 error)
-      const regularChoiceIds = Object.values(attribute).flat().filter(Boolean);
-
-      queriesToRun.push(
-        client.query<_SearchAttributeOperandsQuery, _SearchAttributeOperandsQueryVariables>({
-          query: _SearchAttributeOperandsDocument,
-          variables: {
-            attributesSlugs: allAttributeSlugs,
-            choicesIds: regularChoiceIds,
-            first: allAttributeSlugs.length,
-          },
-        }),
-      );
-    }
-
-    const data = await Promise.all(queriesToRun);
-    let initialState = createInitialProductStateFromData(data, channel);
-
-    // Fetch Choices for Reference Attributes
-    const referenceChoicePromises: Array<Promise<ReferenceAttributeChoices>> = [];
-
-    for (const [slug, values] of Object.entries(attributeReference)) {
-      const attributeDef = initialState.attribute[slug];
-
-      if (!attributeDef) continue;
-
-      switch (attributeDef.entityType) {
-        case AttributeEntityTypeEnum.PAGE:
-          referenceChoicePromises.push(
-            client
-              .query<_SearchPageOperandsQuery, _SearchPageOperandsQueryVariables>({
-                query: _SearchPageOperandsDocument,
-                variables: {
-                  first: values.length,
-                  pageSlugs: values,
-                },
-              })
-              .then(result => ({
-                slug,
-                itemOptions: createOptionsFromAPI(result.data.pages?.edges ?? []),
-              })),
-          );
-          break;
-        case AttributeEntityTypeEnum.PRODUCT:
-          referenceChoicePromises.push(
-            client
-              .query<_SearchProductOperandsQuery, _SearchProductOperandsQueryVariables>({
-                query: _SearchProductOperandsDocument,
-                variables: {
-                  first: values.length,
-                  productSlugs: values,
-                },
-              })
-              .then(result => ({
-                slug,
-                itemOptions: createOptionsFromAPI(result.data.products?.edges ?? []),
-              })),
-          );
-          break;
-        case AttributeEntityTypeEnum.PRODUCT_VARIANT:
-          referenceChoicePromises.push(
-            client
-              .query<
-                _SearchProductVariantOperandsQuery,
-                _SearchProductVariantOperandsQueryVariables
-              >({
-                query: _SearchProductVariantOperandsDocument,
-                variables: {
-                  first: values.length,
-                  ids: values,
-                },
-              })
-              .then(result => ({
-                slug,
-                itemOptions: createAttributeProductVariantOptionsFromAPI(
-                  result.data.productVariants?.edges ?? [],
-                ),
-              })),
-          );
-          break;
+    try {
+      if (channel.length > 0) {
+        queriesToRun.push(
+          client.query<_GetChannelOperandsQuery, _GetChannelOperandsQueryVariables>({
+            query: _GetChannelOperandsDocument,
+          }),
+        );
       }
+
+      if (collection.length > 0) {
+        queriesToRun.push(
+          client.query<_SearchCollectionsOperandsQuery, _SearchCollectionsOperandsQueryVariables>({
+            query: _SearchCollectionsOperandsDocument,
+            variables: {
+              collectionsSlugs: collection,
+              first: collection.length,
+            },
+          }),
+        );
+      }
+
+      if (category.length > 0) {
+        queriesToRun.push(
+          client.query<_SearchCategoriesOperandsQuery, _SearchCategoriesOperandsQueryVariables>({
+            query: _SearchCategoriesOperandsDocument,
+            variables: {
+              categoriesSlugs: category,
+              first: category.length,
+            },
+          }),
+        );
+      }
+
+      if (productType.length > 0) {
+        queriesToRun.push(
+          client.query<_SearchProductTypesOperandsQuery, _SearchProductTypesOperandsQueryVariables>(
+            {
+              query: _SearchProductTypesOperandsDocument,
+              variables: {
+                productTypesSlugs: productType,
+                first: productType.length,
+              },
+            },
+          ),
+        );
+      }
+
+      // Fetch attribute definitions for both regular and reference attributes
+      // (We need the definitions for URL parsing, but values are fetched separately)
+      const allAttributeSlugs = [...Object.keys(attribute), ...Object.keys(attributeReference)];
+
+      if (allAttributeSlugs.length > 0) {
+        // Only fetch choices values for regular attributes, not reference attributes
+        // (if we try fetching reference attribute options Saleor returns 500 error)
+        const regularChoiceIds = Object.values(attribute).flat().filter(Boolean);
+
+        queriesToRun.push(
+          client.query<_SearchAttributeOperandsQuery, _SearchAttributeOperandsQueryVariables>({
+            query: _SearchAttributeOperandsDocument,
+            variables: {
+              attributesSlugs: allAttributeSlugs,
+              choicesIds: regularChoiceIds,
+              first: allAttributeSlugs.length,
+            },
+          }),
+        );
+      }
+
+      const data = await Promise.all(queriesToRun);
+      let initialState = createInitialProductStateFromData(data, channel);
+
+      // Fetch Choices for Reference Attributes
+      const referenceChoicePromises: Array<Promise<ReferenceAttributeChoices>> = [];
+
+      for (const [slug, values] of Object.entries(attributeReference)) {
+        const attributeDef = initialState.attribute[slug];
+
+        if (!attributeDef) continue;
+
+        switch (attributeDef.entityType) {
+          case AttributeEntityTypeEnum.PAGE:
+            referenceChoicePromises.push(
+              client
+                .query<_SearchPageOperandsQuery, _SearchPageOperandsQueryVariables>({
+                  query: _SearchPageOperandsDocument,
+                  variables: {
+                    first: values.length,
+                    pageSlugs: values,
+                  },
+                })
+                .then(result => ({
+                  slug,
+                  itemOptions: createOptionsFromAPI(result.data.pages?.edges ?? []),
+                })),
+            );
+            break;
+          case AttributeEntityTypeEnum.PRODUCT:
+            referenceChoicePromises.push(
+              client
+                .query<_SearchProductOperandsQuery, _SearchProductOperandsQueryVariables>({
+                  query: _SearchProductOperandsDocument,
+                  variables: {
+                    first: values.length,
+                    productSlugs: values,
+                  },
+                })
+                .then(result => ({
+                  slug,
+                  itemOptions: createOptionsFromAPI(result.data.products?.edges ?? []),
+                })),
+            );
+            break;
+          case AttributeEntityTypeEnum.PRODUCT_VARIANT:
+            referenceChoicePromises.push(
+              client
+                .query<
+                  _SearchProductVariantOperandsQuery,
+                  _SearchProductVariantOperandsQueryVariables
+                >({
+                  query: _SearchProductVariantOperandsDocument,
+                  variables: {
+                    first: values.length,
+                    ids: values,
+                  },
+                })
+                .then(result => ({
+                  slug,
+                  itemOptions: createAttributeProductVariantOptionsFromAPI(
+                    result.data.productVariants?.edges ?? [],
+                  ),
+                })),
+            );
+            break;
+        }
+      }
+
+      if (referenceChoicePromises.length > 0) {
+        const referenceChoices = await Promise.all(referenceChoicePromises);
+
+        initialState = mergeInitialProductsStateReferenceAttributes(initialState, referenceChoices);
+      }
+
+      setData(
+        new InitialProductStateResponse(
+          initialState.category,
+          initialState.attribute,
+          initialState.channel,
+          initialState.collection,
+          initialState.productType,
+          initialState.isAvailable,
+          initialState.isPublished,
+          initialState.isVisibleInListing,
+          initialState.hasCategory,
+          initialState.giftCard,
+        ),
+      );
+    } catch (error) {
+      console.error("Failed to fetch filter initial data:", error);
+      notify({
+        status: "error",
+        text: intl.formatMessage({
+          id: "aHIrs/",
+          defaultMessage: "Failed to load filter data. Please refresh page to try again.",
+        }),
+      });
+    } finally {
+      setLoading(false);
     }
-
-    if (referenceChoicePromises.length > 0) {
-      const referenceChoices = await Promise.all(referenceChoicePromises);
-
-      initialState = mergeInitialProductsStateReferenceAttributes(initialState, referenceChoices);
-    }
-
-    setData(
-      new InitialProductStateResponse(
-        initialState.category,
-        initialState.attribute,
-        initialState.channel,
-        initialState.collection,
-        initialState.productType,
-        initialState.isAvailable,
-        initialState.isPublished,
-        initialState.isVisibleInListing,
-        initialState.hasCategory,
-        initialState.giftCard,
-      ),
-    );
-    setLoading(false);
   };
 
   return {

--- a/src/components/ConditionalFilter/API/initialState/product/useProductInitialAPIState.tsx
+++ b/src/components/ConditionalFilter/API/initialState/product/useProductInitialAPIState.tsx
@@ -60,6 +60,8 @@ export const useProductInitialAPIState = (): InitialProductAPIState => {
     attribute,
     attributeReference,
   }: FetchingParams) => {
+    setLoading(true);
+
     if (channel.length > 0) {
       queriesToRun.push(
         client.query<_GetChannelOperandsQuery, _GetChannelOperandsQueryVariables>({

--- a/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
+++ b/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
@@ -112,7 +112,7 @@ export const useUrlValueProvider = (
     if (loading) return;
 
     setValue(tokenizedUrl.asFilterValuesFromResponse(data));
-    // Run only after we fetch the initial data, otherwise we might have race-condition
+    // Only run after fetching the initial data; otherwise, a race condition may occur.
   }, [initialState?.data, initialState?.loading]);
 
   useEffect(() => {

--- a/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
+++ b/src/components/ConditionalFilter/ValueProvider/useUrlValueProvider.ts
@@ -112,7 +112,8 @@ export const useUrlValueProvider = (
     if (loading) return;
 
     setValue(tokenizedUrl.asFilterValuesFromResponse(data));
-  }, [initialState?.data, initialState?.loading, tokenizedUrl]);
+    // Run only after we fetch the initial data, otherwise we might have race-condition
+  }, [initialState?.data, initialState?.loading]);
 
   useEffect(() => {
     if (initialState) return;


### PR DESCRIPTION
This PR fixes crash on Product list filtering save, that was happening in production build ocassionally due to race-condtion between URL parsing and fetchig initial data.

Now we should fetch initial data first, and the parse URL changes.

Defensive checks were added in places where Dashboard can crash if we have a race condition, which will be reported to Sentry in order for us to fix them properly if they happen again.
