### PR TITLE
Added eslint-plugin-react-you-might-not-need-an-effect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ import tseslint from "typescript-eslint";
 import localRules from "./lint/rules/index.mjs";
 import unusedImports from "eslint-plugin-unused-imports";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
+import reactYouMightNotNeedAnEffect from "eslint-plugin-react-you-might-not-need-an-effect";
 
 export default tseslint.config(
   globalIgnores([
@@ -36,6 +37,7 @@ export default tseslint.config(
   react.configs.flat["jsx-runtime"],
   reactHooks.configs["recommended-latest"],
   reactRefresh.configs.vite,
+  reactYouMightNotNeedAnEffect.configs.recommended,
 
   {
     settings: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "eslint-plugin-react-you-might-not-need-an-effect": "^0.5.6",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unicorn": "^61.0.2",
         "eslint-plugin-unused-imports": "^4.2.0",
@@ -13979,6 +13980,23 @@
         "eslint": ">=8.40"
       }
     },
+    "node_modules/eslint-plugin-react-you-might-not-need-an-effect": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-you-might-not-need-an-effect/-/eslint-plugin-react-you-might-not-need-an-effect-0.5.6.tgz",
+      "integrity": "sha512-WZe5XlnsqempwyyLOrVMJWnA9yHC6TxibCwQyz4o9NfGKOh9svoydld10sFfaLVIOi+yO8G7BfYuOmZ6DCRuTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "globals": "^16.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -14144,6 +14162,35 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.5.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unicorn": "^61.0.2",
     "eslint-plugin-unused-imports": "^4.2.0",


### PR DESCRIPTION
Added ESLint plugin to detect unnecesary usage of `useEffect` in our codebase.

Following new warnings were added:

```
src/apps/hooks/useActiveAppsInstallations.ts:88:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/apps/hooks/useActiveAppsInstallations.ts:140:22: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/apps/hooks/useActiveAppsInstallations.ts:144:11: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/attributes/components/AttributeDetails/NumericUnits.tsx:74:19: Avoid passing live state to parents in an effect. Instead, lift the state to the parent and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-live-state-to-parent]
src/attributes/components/AttributeDetails/NumericUnits.tsx:101:7: Avoid initializing state in an effect. Instead, pass "unitData"'s initial value to its `useState`. [Warning/react-you-might-not-need-an-effect/no-initialize-state]
src/attributes/components/AttributeDetails/NumericUnits.tsx:106:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/attributes/views/AttributeCreate/AttributeCreate.tsx:83:19: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/channels/components/AssignmentList/AssignmentListFooter.tsx:40:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/collections/components/CollectionProducts/useProductDrag.ts:26:5: Avoid storing derived state. Compute "items" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/AssignProductDialog/AssignProductDialogSingle.tsx:61:3: Avoid resetting all state when a prop changes. If "selectedId" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/components/AssignProductDialog/AssignProductDialogSingle.tsx:62:5: Avoid storing derived state. Compute "selectedProductId" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/CardMenu/CardMenu.tsx:114:3: Avoid resetting all state when a prop changes. If "menuItems" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/components/CardMenu/CardMenu.tsx:115:43: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/components/CardMenu/CardMenu.tsx:120:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/components/ColorPicker/ColorPicker.tsx:82:7: Avoid passing live state to parents in an effect. Instead, lift the state to the parent and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-live-state-to-parent]
src/components/ColorPicker/ColorPicker.tsx:85:9: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/components/Combobox/components/Combobox.tsx:45:7: Avoid storing derived state. Compute "selectedValue" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/Combobox/components/Multiselect.tsx:44:5: Avoid resetting all state when a prop changes. If "value" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/components/Combobox/components/Multiselect.tsx:45:7: Avoid storing derived state. Compute "selectedValues" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/ConditionalFilter/useContainerState.ts:61:7: Avoid storing derived state. Compute "value" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/ConfirmButton/ConfirmButton.tsx:51:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/components/ConfirmButton/ConfirmButton.tsx:54:3: Avoid resetting all state when a prop changes. If "noTransition" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/components/Datagrid/ColumnPicker/useAvailableColumnsQuery.ts:10:7: Avoid storing derived state. Compute "query" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/Datagrid/ColumnPicker/useCategorySelection.ts:15:7: Avoid storing derived state. Compute "selectedCategory" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/components/Datagrid/Datagrid.tsx:166:7: Avoid passing live state to parents in an effect. Instead, lift the state to the parent and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-live-state-to-parent]
src/components/DateTimeTimezoneField.tsx:53:5: Avoid passing live state to parents in an effect. Instead, lift the state to the parent and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-live-state-to-parent]
src/components/SortableTree/hooks/useItems.ts:19:5: Avoid storing derived state. Compute "items" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/discounts/components/DiscountCreateForm/hooks/useRulesHandlers.ts:10:5: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/discounts/components/DiscountRules/DiscountRules.tsx:56:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/extensions/components/WebhookDetailsPage/WebhookDetailsPage.tsx:84:5: Avoid storing derived state. Compute "query" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/extensions/views/EditCustomExtension/EditCustomApp.tsx:62:3: This effect only uses props. Consider lifting the logic up to the parent. [Warning/react-you-might-not-need-an-effect/no-manage-parent]
src/extensions/views/EditCustomExtension/components/TokenCreateDialog/TokenCreateDialog.tsx:44:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/extensions/views/InstalledExtensions/hooks/useActiveAppsInstallations.ts:87:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/extensions/views/InstalledExtensions/hooks/useActiveAppsInstallations.ts:139:22: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/extensions/views/InstalledExtensions/hooks/useActiveAppsInstallations.ts:143:11: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/giftCards/GiftCardCreateDialog/GiftCardCreateMoneyInput.tsx:54:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/utils.ts:21:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/giftCards/components/GiftCardDeleteDialog/GiftCardDeleteDialogContent.tsx:44:3: Avoid resetting all state when a prop changes. If "open" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/giftCards/components/GiftCardDeleteDialog/GiftCardDeleteDialogContent.tsx:46:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/giftCards/components/GiftCardSendToCustomer/GiftCardSendToCustomer.tsx:33:19: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/hooks/useLocalPageInfo.ts:12:5: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/hooks/useLocalPaginator.ts:48:5: Avoid storing derived state. Compute "state" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/hooks/useLocalPaginator.ts:77:7: Avoid storing derived state. Compute "paginationSection" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/hooks/useModalDialogOpen/useModalDialogOpen.ts:14:7: Avoid storing derived state. Compute "prevOpen" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/hooks/useStateFromProps.ts:25:57: Avoid passing live state to parents in an effect. Instead, lift the state to the parent and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-live-state-to-parent]
src/hooks/useStateFromProps.ts:28:7: Avoid storing derived state. Compute "prevData" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx:132:19: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx:133:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/orders/components/OrderTransactionRefundPage/components/OrderTransactionReasonModal/OrderTransactionReasonModal.tsx:24:3: Avoid resetting all state when a prop changes. If "reason" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/orders/components/OrderTransactionRefundPage/components/OrderTransactionReasonModal/OrderTransactionReasonModal.tsx:25:5: Avoid storing derived state. Compute "tempReason" directly during render, optionally with `useMemo` if it's expensive. [Warning/react-you-might-not-need-an-effect/no-derived-state]
src/orders/components/OrderTransactionRefundPage/utils.ts:147:11: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/orders/components/OrderTransactionRefundPage/utils.ts:156:9: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/orders/views/OrderDetails/OrderNormalDetails/index.tsx:168:34: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/orders/views/OrderDetails/OrderNormalDetails/index.tsx:169:7: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/productTypes/components/ProductTypeVariantAttributes/ProductTypeVariantAttributes.tsx:113:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]
src/products/views/ProductVariant/ProductVariant.tsx:82:3: Avoid resetting all state when a prop changes. If "variantId" is a key, pass it as `key` instead so React will reset the component. [Warning/react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change]
src/products/views/ProductVariant/ProductVariant.tsx:83:5: Avoid adjusting state when a prop changes. Instead, adjust the state directly during render, or refactor your state to avoid this need entirely. [Warning/react-you-might-not-need-an-effect/no-adjust-state-on-prop-change]
src/taxes/utils/useTaxUrlRedirect.ts:35:3: This effect only uses props. Consider lifting the logic up to the parent. [Warning/react-you-might-not-need-an-effect/no-manage-parent]
src/utils/handlers/attributeValueSearchHandler.ts:52:9: Avoid using state and effects as an event handler. Instead, call the event handling code directly when the event occurs. [Warning/react-you-might-not-need-an-effect/no-event-handler]
src/warehouses/components/WarehouseSettings/WarehouseSettings.tsx:57:7: Avoid passing data to parents in an effect. Instead, let the parent fetch the data itself and pass it down to the child as a prop. [Warning/react-you-might-not-need-an-effect/no-pass-data-to-parent]

```
