### PR TITLE
Optimize Claude Code hooks to only run on src/ changes

### DIFF
--- a/.claude/hooks/check-as-any-pre.py
+++ b/.claude/hooks/check-as-any-pre.py
@@ -30,6 +30,10 @@ def main():
     if not file_path:
         sys.exit(0)
 
+    # Only check files in src/ directory
+    if not file_path.startswith("src/") and "/src/" not in file_path:
+        sys.exit(0)
+
     # Convert to Path object for easier handling
     path = Path(file_path)
 

--- a/.claude/hooks/graphql-check.py
+++ b/.claude/hooks/graphql-check.py
@@ -29,6 +29,11 @@ try:
             if file_path:
                 files_to_check.append(file_path)
 
+    # Only proceed if files are in src/ directory
+    src_files = [f for f in files_to_check if f.startswith("src/") or "/src/" in f]
+    if not src_files:
+        sys.exit(0)
+
     # Check if any of the files are GraphQL query/mutation files
     graphql_files_modified = any(
         file_path.endswith("mutations.ts") or file_path.endswith("queries.ts")

--- a/.claude/hooks/validation-check.sh
+++ b/.claude/hooks/validation-check.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if there are any changes in src/ directory
+if ! git diff --name-only HEAD | grep -q '^src/'; then
+    echo 'ℹ️ No changes in src/ directory, skipping validation' >&2
+    exit 0
+fi
+
 echo '🔍 Running final validation...' >&2
 
 # Run type checking
@@ -10,7 +16,7 @@ fi
 
 # Run linting
 if ! npm run lint; then
-    echo '❌ ESLint validation failed - please fix linting errors before completing the task' >&2  
+    echo '❌ ESLint validation failed - please fix linting errors before completing the task' >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Summary

- Optimized Claude Code validation hooks to skip execution when changes are outside the `src/` directory
- Reduces unnecessary validation time when working on documentation, configuration, or other non-source files

## Changes

### [check-as-any-pre.py](.claude/hooks/check-as-any-pre.py)
- Added early exit if file path is not in `src/` directory

### [graphql-check.py](.claude/hooks/graphql-check.py) 
- Filter files to only check those in `src/` directory
- Skip hook entirely if no `src/` files modified

### [validation-check.sh](.claude/hooks/validation-check.sh)
- Check for `src/` changes before running type checking and linting
- Display info message when skipping validation

## Test plan

- [x] Tested with changes in `src/` directory - hooks run as expected
- [x] Tested with changes outside `src/` - hooks skip appropriately
- [x] Verified all three hooks work correctly with the optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)