### PR TITLE
Add product tax preview experiment

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -234,6 +234,10 @@
     "context": "creation label",
     "string": "Creation"
   },
+  "/B3Ap7": {
+    "context": "tax preview gross price label",
+    "string": "Gross"
+  },
   "/BJQIq": {
     "context": "dialog header",
     "string": "Add Tracking Code"
@@ -605,6 +609,10 @@
     "context": "Scheduled date for availability",
     "string": "scheduled {date}"
   },
+  "1HX3rZ": {
+    "context": "tax preview configuration source label",
+    "string": "Configuration source"
+  },
   "1J/bhZ": {
     "context": "expiry date section header",
     "string": "Expiry date"
@@ -675,6 +683,10 @@
   },
   "1wyZpQ": {
     "string": "These passwords are too similar"
+  },
+  "1yA2Fz": {
+    "context": "tax preview story money step description",
+    "string": "These are the line values Saleor derives from the preview price."
   },
   "1zuQ2P": {
     "context": "unassign country",
@@ -1038,6 +1050,10 @@
   "45aV8u": {
     "context": "gift card bulk create modal bottom explanation",
     "string": "After creation Saleor will create a list of gift card codes that you will be able to download."
+  },
+  "47E3KR": {
+    "context": "tax preview missing channel message",
+    "string": "Select a tax channel to preview product taxes."
   },
   "48dMqY": {
     "context": "Dry run trigger button",
@@ -1583,6 +1599,10 @@
   "7Chrsf": {
     "string": "Passwords do not match"
   },
+  "7E5N02": {
+    "context": "tax preview gross input context",
+    "string": "Price entered with tax"
+  },
   "7EDqed": {
     "context": "tab name",
     "string": "All gift cards"
@@ -1598,6 +1618,10 @@
   "7H2D5m": {
     "context": "attribute value deleted",
     "string": "Value deleted"
+  },
+  "7HJazX": {
+    "context": "tax preview story source step description",
+    "string": "Saleor uses {source} for orders shipped to {country}. This decides whether taxes are charged and how prices are displayed."
   },
   "7Hdiw2": {
     "string": "Rule name is required"
@@ -2083,6 +2107,10 @@
   "A+g/VP": {
     "string": "Unsaved preset"
   },
+  "A/AFx4": {
+    "context": "tax preview story source step title",
+    "string": "Based on"
+  },
   "A02NDR": {
     "context": "plain text attribute value was truncated",
     "string": "Attribute value too long and truncated at {length} characters."
@@ -2213,6 +2241,10 @@
   },
   "AyQkmp": {
     "string": "Sorting by this column is not available"
+  },
+  "Az6sOC": {
+    "context": "tax preview tax amount label",
+    "string": "Tax"
   },
   "AzMSmb": {
     "context": "caption",
@@ -2768,6 +2800,10 @@
   },
   "EEWsPs": {
     "string": "Plugin built-in to Saleor's core codebase"
+  },
+  "EFsMl1": {
+    "context": "tax preview price mode label",
+    "string": "Price mode"
   },
   "EGycu/": {
     "context": "voucher status active",
@@ -3796,6 +3832,10 @@
   "JRfJD9": {
     "string": "The plugin may stop working after this field is cleared. Are you sure you want to proceed?"
   },
+  "JRlLbn": {
+    "context": "tax preview story price mode step title",
+    "string": "Price treatment"
+  },
   "JTcz2G": {
     "context": "csv file exporting has finished, header",
     "string": "Exporting CSV finished"
@@ -3861,6 +3901,10 @@
   "JjeZEG": {
     "context": "section header",
     "string": "Organize Product"
+  },
+  "Jk04Tv": {
+    "context": "tax preview story tax class step title",
+    "string": "Product tax class"
   },
   "JkO0jp": {
     "context": "input description",
@@ -3977,6 +4021,10 @@
   },
   "KYMCYg": {
     "string": "Shipping rate deleted"
+  },
+  "Ka/f5l": {
+    "context": "tax preview story flat rate step description",
+    "string": "A {rate}% flat rate is applied to the preview price. {rateSource} provides the rate."
   },
   "KcsJKm": {
     "context": "error with activatation alert message",
@@ -4232,6 +4280,10 @@
     "context": "Number of warehouses configured",
     "string": "{count, plural, one {# warehouse} other {# warehouses}}"
   },
+  "MFJZZR": {
+    "context": "tax preview card subtitle",
+    "string": "Preview how channel and country tax settings affect a product variant."
+  },
   "MFUQrr": {
     "context": "Placeholder for date picker",
     "string": "dd/mm/yyyy, --:--"
@@ -4239,6 +4291,10 @@
   "MFirbo": {
     "context": "Button label to dismiss all problems for an app",
     "string": "Dismiss all problems raised by the app"
+  },
+  "MGN47G": {
+    "context": "tax preview net price label",
+    "string": "Net"
   },
   "MH1qA1": {
     "string": "Test Action"
@@ -4286,6 +4342,10 @@
   },
   "MS86iy": {
     "string": "The extension identifier is already in use. ({errorCode})"
+  },
+  "MSEoHc": {
+    "context": "tax preview storefront price label",
+    "string": "Storefront"
   },
   "MSItJD": {
     "string": "You are about to leave the Dashboard. Do you want to continue?"
@@ -4448,6 +4508,10 @@
     "context": "dialog content",
     "string": "Are you sure you want to delete {voucherCode}?"
   },
+  "NEMrmj": {
+    "context": "tax preview story price mode step description",
+    "string": "Saleor treats the preview price as {priceMode}, then calculates net, tax, and gross values from it."
+  },
   "NGWTE4": {
     "string": "Create webhook/extension manually"
   },
@@ -4506,6 +4570,10 @@
   "NZtcLb": {
     "context": "gift card bulk create success dialog content",
     "string": "We have issued all of your requested gift cards. You can download the list of new gift cards using the button below."
+  },
+  "NcyOgB": {
+    "context": "tax preview channel defaults source",
+    "string": "Channel defaults"
   },
   "NelCIl": {
     "context": "content section name",
@@ -4888,6 +4956,10 @@
   "PcPMjC": {
     "context": "order history message",
     "string": "Fulfillment awaits approval"
+  },
+  "PcPuwW": {
+    "context": "tax preview tax rate label",
+    "string": "Rate"
   },
   "PcQRxi": {
     "context": "gift card history message",
@@ -5322,6 +5394,10 @@
     "context": "search placeholder",
     "string": "Search by product name, attribute, product type etc..."
   },
+  "S4QNA4": {
+    "context": "tax preview storefront net label",
+    "string": "Storefront will render net"
+  },
   "S5/nSq": {
     "context": "grant refund table, column header",
     "string": "Quantity"
@@ -5659,6 +5735,10 @@
     "context": "Label for published toggle",
     "string": "Published"
   },
+  "U7iwsw": {
+    "context": "tax preview calculation accordion trigger description",
+    "string": "Open the product and tax overview for the current channel."
+  },
   "U86VKF": {
     "context": "number of structures",
     "string": "Items"
@@ -5737,6 +5817,10 @@
   "UYKEsx": {
     "context": "collection filter published",
     "string": "Published"
+  },
+  "UcX1iR": {
+    "context": "tax preview story rate step title",
+    "string": "Applied rate"
   },
   "UcrXYE": {
     "context": "Description for scheduled status when publication date is in the future",
@@ -5983,6 +6067,10 @@
   "W0kQd+": {
     "context": "dialog title",
     "string": "Add Address"
+  },
+  "W1tLAR": {
+    "context": "tax preview calculation accordion trigger",
+    "string": "See how your taxes calculate"
   },
   "W2OIhn": {
     "string": "Use app: {name}"
@@ -6883,6 +6971,10 @@
   "aheQdn": {
     "string": "Last Name"
   },
+  "ajEopg": {
+    "context": "tax preview empty products message",
+    "string": "No products with a priced variant were found for this channel."
+  },
   "ak62Oe": {
     "context": "plugin details page header",
     "string": "{pluginName} details"
@@ -6968,6 +7060,10 @@
   "bDHiYK": {
     "context": "gift card export success alert description",
     "string": "We are currently exporting your gift card codes. As soon as your file is available it will be sent to your email address"
+  },
+  "bE3xgu": {
+    "context": "tax preview app stub rate field label",
+    "string": "Assumed app rate"
   },
   "bGqAdR": {
     "context": "seo complete text",
@@ -7844,6 +7940,10 @@
   "gVqSnA": {
     "string": "Assign and save"
   },
+  "gX6Vcm": {
+    "context": "tax preview country default flat rate source",
+    "string": "Country default rate"
+  },
   "gaOXvo": {
     "context": "notification, form submitted",
     "string": "Refund grant for order #{orderNumber} was updated"
@@ -7964,6 +8064,10 @@
   "hJZwTS": {
     "string": "Email address"
   },
+  "hKQC/q": {
+    "context": "tax preview product tax class flat rate source",
+    "string": "Tax class rate"
+  },
   "hLOEeb": {
     "context": "button",
     "string": "Set as default billing address"
@@ -8053,6 +8157,10 @@
     "context": "Warning when scheduling a visible product for the future",
     "string": "Product will be hidden until {date}."
   },
+  "hpRAU1": {
+    "context": "tax preview story app rate step description",
+    "string": "Because this channel uses app taxes, the tax app is not called. This preview uses a stubbed {rate}% app response."
+  },
   "hptDxW": {
     "context": "money",
     "string": "to {money}"
@@ -8070,6 +8178,10 @@
   },
   "htvX+Z": {
     "string": "Deny"
+  },
+  "hu4E30": {
+    "context": "tax preview product selector label",
+    "string": "Product"
   },
   "hw9Fah": {
     "context": "button",
@@ -8095,6 +8207,10 @@
   "i+Vox0": {
     "context": "invoice generating has finished, header",
     "string": "Invoice Generated"
+  },
+  "i/ElwG": {
+    "context": "tax preview story tax class step description",
+    "string": "The selected product resolves to {taxClass}. Saleor uses it to look for a matching flat-rate rule for the purchase country."
   },
   "i/ZhxL": {
     "context": "section header returned",
@@ -8620,6 +8736,10 @@
   "kv3FWU": {
     "context": "btn label",
     "string": "Go to orders"
+  },
+  "l/ny6E": {
+    "context": "tax preview card title",
+    "string": "Product tax preview"
   },
   "l0a2tU": {
     "context": "onboarding step description",
@@ -9465,6 +9585,10 @@
     "context": "voucher usage limit, header",
     "string": "Usage Limit"
   },
+  "pzssSl": {
+    "context": "tax preview price field label",
+    "string": "Price"
+  },
   "q/FMPM": {
     "context": "dialog header",
     "string": "Publish models"
@@ -9559,6 +9683,10 @@
   "qNeXG1": {
     "context": "User registration",
     "string": "User registration"
+  },
+  "qOSQFP": {
+    "context": "tax preview story money step title",
+    "string": "Tax will be calculated as"
   },
   "qOXgxv": {
     "context": "gift card history message",
@@ -9674,6 +9802,10 @@
   "qwp4zK": {
     "context": "Health check subtitle when product can be purchased",
     "string": "Product is visible in store and available for purchase"
+  },
+  "qxrGrN": {
+    "context": "tax preview country exception source",
+    "string": "Country exception"
   },
   "qy/XqL": {
     "string": "Select transaction"
@@ -9965,6 +10097,10 @@
   "sfErC+": {
     "string": "Voucher Name"
   },
+  "sfmKC1": {
+    "context": "tax preview variant selector label",
+    "string": "Variant"
+  },
   "shmSDX": {
     "context": "no products placeholder",
     "string": "No products are available in the channel assigned to this order."
@@ -10074,6 +10210,10 @@
   "tTuCYj": {
     "context": "all gift cards label",
     "string": "All Gift Cards"
+  },
+  "tUVHhE": {
+    "context": "tax preview storefront gross label",
+    "string": "Storefront will render gross"
   },
   "tUlsq+": {
     "string": "Translating"
@@ -10212,6 +10352,10 @@
   "u9WrRb": {
     "string": "Add Custom Extensions"
   },
+  "uBgj4Y": {
+    "context": "tax preview no tax class value",
+    "string": "No product tax class"
+  },
   "uCn/rd": {
     "context": "dialog header",
     "string": "Delete Image"
@@ -10230,6 +10374,10 @@
   "uKlrEk": {
     "context": "all selected items message",
     "string": "All available {itemsName} have been selected"
+  },
+  "uKy/82": {
+    "context": "tax app stub notice",
+    "string": "Tax app is not called. This preview uses a stubbed {rate}% app response for calculation."
   },
   "uN88fb": {
     "context": "button, submit form",
@@ -10493,6 +10641,10 @@
     "context": "name",
     "string": "Product name"
   },
+  "vWVSTJ": {
+    "context": "tax preview net input context",
+    "string": "Price entered without tax"
+  },
   "vWapBZ": {
     "context": "card title",
     "string": "Order Weight"
@@ -10547,6 +10699,10 @@
   },
   "vfG+nh": {
     "string": "Confirm Password"
+  },
+  "vfucYP": {
+    "context": "tax preview calculation section label",
+    "string": "Tax Overview"
   },
   "viFkCw": {
     "context": "site settings section name",
@@ -10965,6 +11121,10 @@
     "context": "dialog title when opening generator with unsaved changes",
     "string": "Unsaved changes"
   },
+  "y9gbe5": {
+    "context": "tax preview country selector label",
+    "string": "Purchase country"
+  },
   "yAFaVK": {
     "context": "Webhook details synchronous events",
     "string": "Synchronous"
@@ -11026,6 +11186,10 @@
   "ychKsb": {
     "context": "error message",
     "string": "Shipping method is required for this order"
+  },
+  "yd1V3G": {
+    "context": "tax preview controls section label",
+    "string": "Product Overview"
   },
   "yeX6fA": {
     "context": "extensions page subheader",
@@ -11184,6 +11348,10 @@
   },
   "zSOvI0": {
     "string": "Filters"
+  },
+  "zShjJM": {
+    "context": "tax preview tax class label",
+    "string": "Tax class"
   },
   "zT1CvH": {
     "string": "Learn more about {extendingSaleor}"

--- a/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/ProductTaxPreview.module.css
+++ b/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/ProductTaxPreview.module.css
@@ -1,0 +1,153 @@
+.section {
+  display: grid;
+  gap: 12px;
+}
+
+.sectionLabel {
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.controls {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.fullWidth {
+  grid-column: 1 / -1;
+}
+
+.previewAccordion {
+  background: var(--mu-colors-background-surface-default1);
+  border: 1px solid var(--mu-colors-border-default1);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.previewTrigger {
+  padding: 16px 20px;
+}
+
+.previewContent {
+  border-top: 1px solid var(--mu-colors-border-default1);
+  display: grid;
+  gap: 20px;
+  padding: 20px;
+}
+
+.calculationPanel {
+  background: var(--mu-colors-background-surface-default1);
+  border: 1px solid var(--mu-colors-border-default1);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.storySteps {
+  display: grid;
+  gap: 0;
+  padding: 16px 20px 16px 18px;
+}
+
+.storyStep {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 28px minmax(0, 1fr);
+  position: relative;
+}
+
+.storyStep:not(:last-child) {
+  padding-bottom: 18px;
+}
+
+.storyStep:not(:last-child)::before {
+  background: var(--mu-colors-border-default1);
+  bottom: 2px;
+  content: "";
+  left: 13px;
+  position: absolute;
+  top: 30px;
+  width: 1px;
+}
+
+.storyStepMarker {
+  align-items: center;
+  background: var(--mu-colors-background-surface-default2);
+  border: 1px solid var(--mu-colors-border-default1);
+  border-radius: 50%;
+  color: var(--mu-colors-foreground-default2);
+  display: flex;
+  font-size: 12px;
+  height: 28px;
+  justify-content: center;
+  line-height: 1;
+  position: relative;
+  width: 28px;
+  z-index: 1;
+}
+
+.storyStepBody {
+  display: grid;
+  gap: 8px;
+  padding-top: 3px;
+}
+
+.storyMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.storyToken {
+  background: var(--mu-colors-background-surface-default2);
+  border: 1px solid var(--mu-colors-border-default1);
+  border-radius: 6px;
+  display: grid;
+  gap: 2px;
+  min-width: 144px;
+  padding: 8px 10px;
+}
+
+.priceLines {
+  display: grid;
+  gap: 6px;
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+}
+
+.priceLine,
+.priceLineSeparated {
+  align-items: baseline;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.priceLineSeparated {
+  border-top: 1px solid var(--mu-colors-border-default1);
+  margin-top: 2px;
+  padding-top: 8px;
+}
+
+.storefrontLine {
+  align-items: baseline;
+  border-top: 1px solid var(--mu-colors-border-default1);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-top: 2px;
+  padding-top: 8px;
+}
+
+.stubNotice {
+  border: 1px solid var(--mu-colors-border-caution1);
+  border-radius: 6px;
+  padding: 12px;
+}
+
+@media (max-width: 960px) {
+  .controls {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/ProductTaxPreview.tsx
+++ b/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/ProductTaxPreview.tsx
@@ -1,0 +1,757 @@
+import { DashboardCard } from "@dashboard/components/Card";
+import Money from "@dashboard/components/Money";
+import PriceField from "@dashboard/components/PriceField";
+import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";
+import {
+  type CountryCode,
+  type CountryFragment,
+  type MoneyFragment,
+  type SearchProductsQuery,
+  type TaxConfigurationFragment,
+  useProductDetailsQuery,
+  useTaxCountriesListQuery,
+} from "@dashboard/graphql";
+import useProductSearch from "@dashboard/searches/useProductSearch";
+import { mapEdgesToItems } from "@dashboard/utils/maps";
+import {
+  Accordion,
+  Box,
+  DynamicCombobox,
+  Input,
+  type Option,
+  Skeleton,
+  Text,
+} from "@saleor/macaw-ui-next";
+import { type ReactNode, useMemo, useState } from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { type TaxConfigurationFormData } from "../helpers";
+import styles from "./ProductTaxPreview.module.css";
+import {
+  calculateTaxPreview,
+  getEffectiveTaxSettings,
+  getFlatRate,
+  isAppTaxStrategy,
+} from "./utils";
+
+const messages = defineMessages({
+  title: {
+    id: "l/ny6E",
+    defaultMessage: "Product tax preview",
+    description: "tax preview card title",
+  },
+  subtitle: {
+    id: "MFJZZR",
+    defaultMessage: "Preview how channel and country tax settings affect a product variant.",
+    description: "tax preview card subtitle",
+  },
+  product: {
+    id: "hu4E30",
+    defaultMessage: "Product",
+    description: "tax preview product selector label",
+  },
+  variant: {
+    id: "sfmKC1",
+    defaultMessage: "Variant",
+    description: "tax preview variant selector label",
+  },
+  country: {
+    id: "y9gbe5",
+    defaultMessage: "Purchase country",
+    description: "tax preview country selector label",
+  },
+  priceOverride: {
+    id: "pzssSl",
+    defaultMessage: "Price",
+    description: "tax preview price field label",
+  },
+  appRate: {
+    id: "bE3xgu",
+    defaultMessage: "Assumed app rate",
+    description: "tax preview app stub rate field label",
+  },
+  appStubNotice: {
+    id: "uKy/82",
+    defaultMessage:
+      "Tax app is not called. This preview uses a stubbed {rate}% app response for calculation.",
+    description: "tax app stub notice",
+  },
+  noProducts: {
+    id: "ajEopg",
+    defaultMessage: "No products with a priced variant were found for this channel.",
+    description: "tax preview empty products message",
+  },
+  noChannel: {
+    id: "47E3KR",
+    defaultMessage: "Select a tax channel to preview product taxes.",
+    description: "tax preview missing channel message",
+  },
+  taxClass: {
+    id: "zShjJM",
+    defaultMessage: "Tax class",
+    description: "tax preview tax class label",
+  },
+  noTaxClass: {
+    id: "uBgj4Y",
+    defaultMessage: "No product tax class",
+    description: "tax preview no tax class value",
+  },
+  rate: {
+    id: "PcPuwW",
+    defaultMessage: "Rate",
+    description: "tax preview tax rate label",
+  },
+  net: {
+    id: "MGN47G",
+    defaultMessage: "Net",
+    description: "tax preview net price label",
+  },
+  tax: {
+    id: "Az6sOC",
+    defaultMessage: "Tax",
+    description: "tax preview tax amount label",
+  },
+  gross: {
+    id: "/B3Ap7",
+    defaultMessage: "Gross",
+    description: "tax preview gross price label",
+  },
+  storefront: {
+    id: "MSEoHc",
+    defaultMessage: "Storefront",
+    description: "tax preview storefront price label",
+  },
+  countryException: {
+    id: "qxrGrN",
+    defaultMessage: "Country exception",
+    description: "tax preview country exception source",
+  },
+  channelDefaults: {
+    id: "NcyOgB",
+    defaultMessage: "Channel defaults",
+    description: "tax preview channel defaults source",
+  },
+  priceEnteredGross: {
+    id: "7E5N02",
+    defaultMessage: "Price entered with tax",
+    description: "tax preview gross input context",
+  },
+  priceEnteredNet: {
+    id: "vWVSTJ",
+    defaultMessage: "Price entered without tax",
+    description: "tax preview net input context",
+  },
+  controlsSection: {
+    id: "yd1V3G",
+    defaultMessage: "Product Overview",
+    description: "tax preview controls section label",
+  },
+  calculationSection: {
+    id: "vfucYP",
+    defaultMessage: "Tax Overview",
+    description: "tax preview calculation section label",
+  },
+  calculationCta: {
+    id: "W1tLAR",
+    defaultMessage: "See how your taxes calculate",
+    description: "tax preview calculation accordion trigger",
+  },
+  calculationCtaDescription: {
+    id: "U7iwsw",
+    defaultMessage: "Open the product and tax overview for the current channel.",
+    description: "tax preview calculation accordion trigger description",
+  },
+  configurationSource: {
+    id: "1HX3rZ",
+    defaultMessage: "Configuration source",
+    description: "tax preview configuration source label",
+  },
+  priceMode: {
+    id: "EFsMl1",
+    defaultMessage: "Price mode",
+    description: "tax preview price mode label",
+  },
+  basedOn: {
+    id: "A/AFx4",
+    defaultMessage: "Based on",
+    description: "tax preview story source step title",
+  },
+  sourceStory: {
+    id: "7HJazX",
+    defaultMessage:
+      "Saleor uses {source} for orders shipped to {country}. This decides whether taxes are charged and how prices are displayed.",
+    description: "tax preview story source step description",
+  },
+  productTaxClassStoryTitle: {
+    id: "Jk04Tv",
+    defaultMessage: "Product tax class",
+    description: "tax preview story tax class step title",
+  },
+  productTaxClassStory: {
+    id: "i/ElwG",
+    defaultMessage:
+      "The selected product resolves to {taxClass}. Saleor uses it to look for a matching flat-rate rule for the purchase country.",
+    description: "tax preview story tax class step description",
+  },
+  rateStoryTitle: {
+    id: "UcX1iR",
+    defaultMessage: "Applied rate",
+    description: "tax preview story rate step title",
+  },
+  flatRateStory: {
+    id: "Ka/f5l",
+    defaultMessage:
+      "A {rate}% flat rate is applied to the preview price. {rateSource} provides the rate.",
+    description: "tax preview story flat rate step description",
+  },
+  appRateStory: {
+    id: "hpRAU1",
+    defaultMessage:
+      "Because this channel uses app taxes, the tax app is not called. This preview uses a stubbed {rate}% app response.",
+    description: "tax preview story app rate step description",
+  },
+  priceModeStoryTitle: {
+    id: "JRlLbn",
+    defaultMessage: "Price treatment",
+    description: "tax preview story price mode step title",
+  },
+  priceModeStory: {
+    id: "NEMrmj",
+    defaultMessage:
+      "Saleor treats the preview price as {priceMode}, then calculates net, tax, and gross values from it.",
+    description: "tax preview story price mode step description",
+  },
+  taxWillBeTitle: {
+    id: "qOSQFP",
+    defaultMessage: "Tax will be calculated as",
+    description: "tax preview story money step title",
+  },
+  taxWillBeStory: {
+    id: "1yA2Fz",
+    defaultMessage: "These are the line values Saleor derives from the preview price.",
+    description: "tax preview story money step description",
+  },
+  storefrontRenderGross: {
+    id: "tUVHhE",
+    defaultMessage: "Storefront will render gross",
+    description: "tax preview storefront gross label",
+  },
+  storefrontRenderNet: {
+    id: "S4QNA4",
+    defaultMessage: "Storefront will render net",
+    description: "tax preview storefront net label",
+  },
+  countryDefaultRate: {
+    id: "gX6Vcm",
+    defaultMessage: "Country default rate",
+    description: "tax preview country default flat rate source",
+  },
+  taxClassRate: {
+    id: "hKQC/q",
+    defaultMessage: "Tax class rate",
+    description: "tax preview product tax class flat rate source",
+  },
+});
+
+type SearchProduct = NonNullable<
+  NonNullable<SearchProductsQuery["search"]>["edges"][number]
+>["node"];
+type SearchVariant = NonNullable<SearchProduct["variants"]>[number];
+
+interface ProductTaxPreviewProps {
+  allCountries: CountryFragment[] | undefined;
+  disabled: boolean;
+  taxConfiguration: TaxConfigurationFragment | undefined;
+  values: TaxConfigurationFormData;
+}
+
+const getVariantPrice = (
+  variant: SearchVariant | undefined,
+  channelId: string | undefined,
+): MoneyFragment | null =>
+  variant?.channelListings?.find(listing => listing.channel.id === channelId)?.price ?? null;
+
+const getPricedVariants = (
+  product: SearchProduct | null,
+  channelId: string | undefined,
+): SearchVariant[] =>
+  product?.variants?.filter(variant => getVariantPrice(variant, channelId) !== null) ?? [];
+
+const getVariantName = (variant: SearchVariant, product: SearchProduct | null): string =>
+  variant.name || variant.sku || product?.name || "";
+
+const parsePreviewNumber = (value: string, fallback: number): number => {
+  if (value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const ProductTaxPreview = ({
+  allCountries,
+  disabled,
+  taxConfiguration,
+  values,
+}: ProductTaxPreviewProps): JSX.Element => {
+  const intl = useIntl();
+  const channelId = taxConfiguration?.channel.id;
+  const [selectedProductId, setSelectedProductId] = useState("");
+  const [selectedVariantId, setSelectedVariantId] = useState("");
+  const [selectedCountryCode, setSelectedCountryCode] = useState<CountryCode | "">("");
+  const [priceOverride, setPriceOverride] = useState<{ value: string; variantId: string } | null>(
+    null,
+  );
+  const [appRate, setAppRate] = useState("10");
+  const {
+    loadMore,
+    search,
+    result: productSearch,
+  } = useProductSearch({ variables: DEFAULT_INITIAL_SEARCH_DATA });
+  const { data: taxCountriesData } = useTaxCountriesListQuery({});
+  const products = useMemo(
+    () => mapEdgesToItems(productSearch.data?.search) ?? [],
+    [productSearch.data?.search],
+  );
+  const productsWithChannelPrice = useMemo(
+    () => products.filter(product => getPricedVariants(product, channelId).length > 0),
+    [channelId, products],
+  );
+  const selectedProduct =
+    productsWithChannelPrice.find(product => product.id === selectedProductId) ??
+    productsWithChannelPrice[0] ??
+    null;
+  const { data: selectedProductDetails } = useProductDetailsQuery({
+    skip: !selectedProduct,
+    variables: {
+      firstValues: 10,
+      id: selectedProduct?.id ?? "",
+    },
+  });
+  const selectedProductTaxClass =
+    selectedProductDetails?.product?.id === selectedProduct?.id
+      ? selectedProductDetails.product.taxClass
+      : null;
+  const productOptions: Option[] = productsWithChannelPrice.map(product => ({
+    label: product.name,
+    value: product.id,
+  }));
+  const selectedProductOption: Option | null = selectedProduct
+    ? {
+        label: selectedProduct.name,
+        value: selectedProduct.id,
+      }
+    : null;
+  const countryOptions: Option[] =
+    allCountries?.map(country => ({
+      label: country.country,
+      value: country.code,
+    })) ?? [];
+  const countryCode = selectedCountryCode || ((countryOptions[0]?.value as CountryCode) ?? "");
+  const selectedCountryOption =
+    countryOptions.find(country => country.value === countryCode) ?? null;
+  const pricedVariants = useMemo(
+    () => getPricedVariants(selectedProduct, channelId),
+    [channelId, selectedProduct],
+  );
+  const variantOptions: Option[] = pricedVariants.map(variant => ({
+    label: getVariantName(variant, selectedProduct),
+    value: variant.id,
+  }));
+  const selectedVariant =
+    pricedVariants.find(variant => variant.id === selectedVariantId) ?? pricedVariants[0];
+  const selectedVariantOption =
+    variantOptions.find(variant => variant.value === selectedVariant?.id) ?? null;
+  const productPrice = getVariantPrice(selectedVariant, channelId);
+  const price =
+    priceOverride && priceOverride.variantId === selectedVariant?.id
+      ? priceOverride.value
+      : (productPrice?.amount.toString() ?? "");
+  const previewPrice = parsePreviewNumber(price, productPrice?.amount ?? 0);
+  const effectiveTaxSettings = getEffectiveTaxSettings({
+    countryCode: countryCode || undefined,
+    values,
+  });
+  const isTaxAppPreview =
+    effectiveTaxSettings.chargeTaxes &&
+    isAppTaxStrategy(effectiveTaxSettings.taxCalculationStrategy);
+  const flatRate = getFlatRate({
+    countryCode: countryCode || undefined,
+    taxClassId: selectedProductTaxClass?.id,
+    taxCountryConfigurations: taxCountriesData?.taxCountryConfigurations ?? undefined,
+  });
+  const taxRate = isTaxAppPreview
+    ? parsePreviewNumber(appRate, 10)
+    : effectiveTaxSettings.chargeTaxes
+      ? flatRate.rate
+      : 0;
+  const calculation = calculateTaxPreview({
+    chargeTaxes: effectiveTaxSettings.chargeTaxes,
+    displayGrossPrices: effectiveTaxSettings.displayGrossPrices,
+    price: previewPrice,
+    pricesEnteredWithTax: values.pricesEnteredWithTax,
+    rate: taxRate,
+  });
+  const currency = productPrice?.currency ?? "";
+  const configurationSourceLabel =
+    effectiveTaxSettings.source === "country"
+      ? intl.formatMessage(messages.countryException)
+      : intl.formatMessage(messages.channelDefaults);
+  const taxClassLabel = selectedProductTaxClass?.name ?? intl.formatMessage(messages.noTaxClass);
+  const priceModeLabel = values.pricesEnteredWithTax
+    ? intl.formatMessage(messages.priceEnteredGross)
+    : intl.formatMessage(messages.priceEnteredNet);
+  const flatRateSourceLabel =
+    flatRate.source === "tax-class"
+      ? intl.formatMessage(messages.taxClassRate)
+      : intl.formatMessage(messages.countryDefaultRate);
+  const storefrontDisplayLabel = effectiveTaxSettings.displayGrossPrices
+    ? intl.formatMessage(messages.storefrontRenderGross)
+    : intl.formatMessage(messages.storefrontRenderNet);
+  const accordionCta = intl.formatMessage(messages.calculationCta);
+  const accordionDescription = intl.formatMessage(messages.calculationCtaDescription);
+
+  if (!taxConfiguration) {
+    return (
+      <ProductTaxPreviewAccordion cta={accordionCta} description={accordionDescription}>
+        <Skeleton height={4} />
+      </ProductTaxPreviewAccordion>
+    );
+  }
+
+  if (!channelId) {
+    return (
+      <ProductTaxPreviewAccordion cta={accordionCta} description={accordionDescription}>
+        <Box display="flex" flexDirection="column" gap={1}>
+          <DashboardCard.Title>{intl.formatMessage(messages.title)}</DashboardCard.Title>
+          <Text size={2} color="default2">
+            {intl.formatMessage(messages.subtitle)}
+          </Text>
+        </Box>
+        <Text size={2}>{intl.formatMessage(messages.noChannel)}</Text>
+      </ProductTaxPreviewAccordion>
+    );
+  }
+
+  return (
+    <ProductTaxPreviewAccordion cta={accordionCta} description={accordionDescription}>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <DashboardCard.Title>{intl.formatMessage(messages.title)}</DashboardCard.Title>
+        <Text size={2} color="default2">
+          {intl.formatMessage(messages.subtitle)}
+        </Text>
+      </Box>
+
+      <section className={styles.section}>
+        <Text size={1} color="default2" className={styles.sectionLabel}>
+          {intl.formatMessage(messages.controlsSection)}
+        </Text>
+        <div className={styles.controls}>
+          <div className={styles.fullWidth}>
+            <DynamicCombobox
+              data-test-id="tax-preview-product-selector"
+              disabled={disabled}
+              label={intl.formatMessage(messages.product)}
+              loading={productSearch.loading}
+              name="tax-preview-product"
+              onChange={option => {
+                setSelectedProductId(option?.value ?? "");
+                setSelectedVariantId("");
+                setPriceOverride(null);
+              }}
+              onInputValueChange={search}
+              onScrollEnd={() => {
+                if (productSearch.data?.search?.pageInfo.hasNextPage) {
+                  loadMore();
+                }
+              }}
+              options={productOptions}
+              value={selectedProductOption}
+            />
+          </div>
+          <DynamicCombobox
+            data-test-id="tax-preview-variant-selector"
+            disabled={disabled || !selectedProduct}
+            label={intl.formatMessage(messages.variant)}
+            name="tax-preview-variant"
+            onChange={option => {
+              setSelectedVariantId(option?.value ?? "");
+              setPriceOverride(null);
+            }}
+            options={variantOptions}
+            value={selectedVariantOption}
+          />
+          <DynamicCombobox
+            data-test-id="tax-preview-country-selector"
+            disabled={disabled}
+            label={intl.formatMessage(messages.country)}
+            name="tax-preview-country"
+            onChange={option => setSelectedCountryCode((option?.value ?? "") as CountryCode | "")}
+            options={countryOptions}
+            value={selectedCountryOption}
+          />
+          <PriceField
+            currencySymbol={productPrice?.currency}
+            disabled={disabled || !productPrice}
+            label={intl.formatMessage(messages.priceOverride)}
+            name="tax-preview-price"
+            onChange={event =>
+              setPriceOverride({
+                value: event.target.value,
+                variantId: selectedVariant?.id ?? "",
+              })
+            }
+            value={price}
+          />
+          {isTaxAppPreview && (
+            <Input
+              data-test-id="tax-preview-app-rate"
+              disabled={disabled}
+              endAdornment={<Text marginRight={2}>%</Text>}
+              label={intl.formatMessage(messages.appRate)}
+              min={0}
+              name="tax-preview-app-rate"
+              onChange={event => setAppRate(event.target.value)}
+              type="number"
+              value={appRate}
+            />
+          )}
+        </div>
+      </section>
+
+      {productSearch.loading && !selectedProduct ? (
+        <Skeleton height={4} />
+      ) : !selectedProduct ? (
+        <Text size={2}>{intl.formatMessage(messages.noProducts)}</Text>
+      ) : (
+        <>
+          {isTaxAppPreview && (
+            <Box className={styles.stubNotice}>
+              <Text size={2}>
+                {intl.formatMessage(messages.appStubNotice, {
+                  rate: taxRate,
+                })}
+              </Text>
+            </Box>
+          )}
+          <section className={styles.section}>
+            <Text size={1} color="default2" className={styles.sectionLabel}>
+              {intl.formatMessage(messages.calculationSection)}
+            </Text>
+            <div className={styles.calculationPanel}>
+              <div className={styles.storySteps}>
+                <TaxStoryStep
+                  index={1}
+                  title={intl.formatMessage(messages.basedOn)}
+                  description={intl.formatMessage(messages.sourceStory, {
+                    country: selectedCountryOption?.label ?? countryCode,
+                    source: configurationSourceLabel,
+                  })}
+                  meta={[
+                    {
+                      label: intl.formatMessage(messages.configurationSource),
+                      value: configurationSourceLabel,
+                    },
+                  ]}
+                />
+                <TaxStoryStep
+                  index={2}
+                  title={intl.formatMessage(messages.productTaxClassStoryTitle)}
+                  description={intl.formatMessage(messages.productTaxClassStory, {
+                    taxClass: taxClassLabel,
+                  })}
+                  meta={[
+                    {
+                      label: intl.formatMessage(messages.taxClass),
+                      value: taxClassLabel,
+                    },
+                  ]}
+                />
+                <TaxStoryStep
+                  index={3}
+                  title={intl.formatMessage(messages.rateStoryTitle)}
+                  description={
+                    isTaxAppPreview
+                      ? intl.formatMessage(messages.appRateStory, {
+                          rate: taxRate,
+                        })
+                      : intl.formatMessage(messages.flatRateStory, {
+                          rate: taxRate,
+                          rateSource: flatRateSourceLabel,
+                        })
+                  }
+                  meta={[
+                    {
+                      label: intl.formatMessage(messages.rate),
+                      value: `${taxRate}%`,
+                    },
+                    ...(!isTaxAppPreview && flatRate.taxClassName
+                      ? [
+                          {
+                            label: intl.formatMessage(messages.taxClassRate),
+                            value: flatRate.taxClassName,
+                          },
+                        ]
+                      : []),
+                  ]}
+                />
+                <TaxStoryStep
+                  index={4}
+                  title={intl.formatMessage(messages.priceModeStoryTitle)}
+                  description={intl.formatMessage(messages.priceModeStory, {
+                    priceMode: priceModeLabel,
+                  })}
+                  meta={[
+                    {
+                      label: intl.formatMessage(messages.priceMode),
+                      value: priceModeLabel,
+                    },
+                  ]}
+                />
+                <TaxStoryStep
+                  index={5}
+                  title={intl.formatMessage(messages.taxWillBeTitle)}
+                  description={intl.formatMessage(messages.taxWillBeStory)}
+                >
+                  <ul className={styles.priceLines}>
+                    <PriceLine
+                      label={intl.formatMessage(messages.net)}
+                      amount={calculation.net}
+                      currency={currency}
+                    />
+                    <PriceLine
+                      label={intl.formatMessage(messages.tax)}
+                      amount={calculation.tax}
+                      currency={currency}
+                    />
+                    <PriceLine
+                      label={intl.formatMessage(messages.gross)}
+                      amount={calculation.gross}
+                      currency={currency}
+                      separated
+                    />
+                  </ul>
+                  <StorefrontLine
+                    label={storefrontDisplayLabel}
+                    amount={calculation.storefrontPrice}
+                    currency={currency}
+                  />
+                </TaxStoryStep>
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+    </ProductTaxPreviewAccordion>
+  );
+};
+
+interface ProductTaxPreviewAccordionProps {
+  children: ReactNode;
+  cta: string;
+  description: string;
+}
+
+const ProductTaxPreviewAccordion = ({
+  children,
+  cta,
+  description,
+}: ProductTaxPreviewAccordionProps): JSX.Element => (
+  <DashboardCard data-test-id="product-tax-preview">
+    <DashboardCard.Content>
+      <Accordion>
+        <Accordion.Item value="product-tax-preview">
+          <div className={styles.previewAccordion}>
+            <Accordion.Trigger className={styles.previewTrigger}>
+              <Box display="flex" flexDirection="column" gap={1}>
+                <Text size={4} fontWeight="medium">
+                  {cta}
+                </Text>
+                <Text size={2} color="default2">
+                  {description}
+                </Text>
+              </Box>
+              <Accordion.TriggerButton dataTestId="tax-preview-expand" />
+            </Accordion.Trigger>
+            <Accordion.Content>
+              <div className={styles.previewContent}>{children}</div>
+            </Accordion.Content>
+          </div>
+        </Accordion.Item>
+      </Accordion>
+    </DashboardCard.Content>
+  </DashboardCard>
+);
+
+interface TaxStoryStepMeta {
+  label: string;
+  value: string;
+}
+
+interface TaxStoryStepProps {
+  children?: ReactNode;
+  description: string;
+  index: number;
+  meta?: TaxStoryStepMeta[];
+  title: string;
+}
+
+const TaxStoryStep = ({
+  children,
+  description,
+  index,
+  meta = [],
+  title,
+}: TaxStoryStepProps): JSX.Element => (
+  <div className={styles.storyStep}>
+    <div className={styles.storyStepMarker}>{index}</div>
+    <div className={styles.storyStepBody}>
+      <Text size={2}>{title}</Text>
+      <Text size={2} color="default2">
+        {description}
+      </Text>
+      {meta.length > 0 && (
+        <div className={styles.storyMeta}>
+          {meta.map(item => (
+            <div className={styles.storyToken} key={`${item.label}-${item.value}`}>
+              <Text size={1} color="default2">
+                {item.label}
+              </Text>
+              <Text size={2}>{item.value}</Text>
+            </div>
+          ))}
+        </div>
+      )}
+      {children}
+    </div>
+  </div>
+);
+
+interface PriceLineProps {
+  amount: number;
+  currency: string;
+  label: string;
+  separated?: boolean;
+}
+
+const PriceLine = ({ amount, currency, label, separated }: PriceLineProps): JSX.Element => (
+  <li className={separated ? styles.priceLineSeparated : styles.priceLine}>
+    <Text size={3}>{label}</Text>
+    <Text size={3}>
+      <Money money={{ amount, currency }} />
+    </Text>
+  </li>
+);
+
+const StorefrontLine = ({ amount, currency, label }: PriceLineProps): JSX.Element => (
+  <div className={styles.storefrontLine}>
+    <Text size={2} color="default2">
+      {label}
+    </Text>
+    <Text size={2} color="default2">
+      <Money money={{ amount, currency }} />
+    </Text>
+  </div>
+);

--- a/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/utils.test.ts
+++ b/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/utils.test.ts
@@ -1,0 +1,152 @@
+import {
+  type CountryCode,
+  TaxCalculationStrategy,
+  type TaxCountryConfigurationFragment,
+} from "@dashboard/graphql";
+
+import { type TaxConfigurationFormData } from "../helpers";
+import { calculateTaxPreview, getEffectiveTaxSettings, getFlatRate } from "./utils";
+
+const baseFormData: TaxConfigurationFormData = {
+  chargeTaxes: true,
+  displayGrossPrices: true,
+  pricesEnteredWithTax: false,
+  removeCountriesConfiguration: [],
+  taxCalculationStrategy: TaxCalculationStrategy.FLAT_RATES,
+  updateCountriesConfiguration: [],
+};
+
+describe("ProductTaxPreview utils", () => {
+  it("uses country exception tax settings when selected country has an override", () => {
+    // Arrange
+    const formData: TaxConfigurationFormData = {
+      ...baseFormData,
+      updateCountriesConfiguration: [
+        {
+          __typename: "TaxConfigurationPerCountry",
+          chargeTaxes: false,
+          country: {
+            __typename: "CountryDisplay",
+            code: "PL",
+            country: "Poland",
+          },
+          displayGrossPrices: false,
+          taxAppId: "app-id",
+          taxCalculationStrategy: "app-id",
+        },
+      ],
+    };
+
+    // Act
+    const result = getEffectiveTaxSettings({ countryCode: "PL" as CountryCode, values: formData });
+
+    // Assert
+    expect(result).toEqual({
+      chargeTaxes: false,
+      displayGrossPrices: false,
+      source: "country",
+      taxCalculationStrategy: "app-id",
+    });
+  });
+
+  it("falls back from missing tax class rate to country default rate", () => {
+    // Arrange
+    const taxCountryConfigurations: TaxCountryConfigurationFragment[] = [
+      {
+        __typename: "TaxCountryConfiguration",
+        country: {
+          __typename: "CountryDisplay",
+          code: "US",
+          country: "United States of America",
+        },
+        taxClassCountryRates: [
+          {
+            __typename: "TaxClassCountryRate",
+            rate: 8,
+            taxClass: null,
+          },
+          {
+            __typename: "TaxClassCountryRate",
+            rate: 12,
+            taxClass: {
+              __typename: "TaxClass",
+              id: "tax-class-1",
+              name: "Standard",
+            },
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const result = getFlatRate({
+      countryCode: "US" as CountryCode,
+      taxClassId: "tax-class-2",
+      taxCountryConfigurations,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      rate: 8,
+      source: "country-default",
+      taxClassName: undefined,
+    });
+  });
+
+  it("uses country default rate when product has no tax class", () => {
+    // Arrange
+    const taxCountryConfigurations: TaxCountryConfigurationFragment[] = [
+      {
+        __typename: "TaxCountryConfiguration",
+        country: {
+          __typename: "CountryDisplay",
+          code: "US",
+          country: "United States of America",
+        },
+        taxClassCountryRates: [
+          {
+            __typename: "TaxClassCountryRate",
+            rate: 8,
+            taxClass: null,
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const result = getFlatRate({
+      countryCode: "US" as CountryCode,
+      taxClassId: undefined,
+      taxCountryConfigurations,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      rate: 8,
+      source: "country-default",
+      taxClassName: undefined,
+    });
+  });
+
+  it("calculates net from a gross entered product price", () => {
+    // Arrange
+    const price = 120;
+
+    // Act
+    const result = calculateTaxPreview({
+      chargeTaxes: true,
+      displayGrossPrices: false,
+      price,
+      pricesEnteredWithTax: true,
+      rate: 20,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      gross: 120,
+      net: 100,
+      storefrontPrice: 100,
+      tax: 20,
+    });
+  });
+});

--- a/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/utils.ts
+++ b/src/taxes/pages/TaxChannelsPage/ProductTaxPreview/utils.ts
@@ -1,0 +1,129 @@
+import {
+  type CountryCode,
+  TaxCalculationStrategy,
+  type TaxCountryConfigurationFragment,
+} from "@dashboard/graphql";
+
+import { getTaxCalculationStrategy, type TaxConfigurationFormData } from "../helpers";
+
+interface EffectiveTaxSettings {
+  chargeTaxes: boolean;
+  displayGrossPrices: boolean;
+  taxCalculationStrategy: string;
+  source: "channel" | "country";
+}
+
+interface GetEffectiveTaxSettingsArgs {
+  countryCode: CountryCode | undefined;
+  values: TaxConfigurationFormData;
+}
+
+export const getEffectiveTaxSettings = ({
+  countryCode,
+  values,
+}: GetEffectiveTaxSettingsArgs): EffectiveTaxSettings => {
+  const countryException = values.updateCountriesConfiguration.find(
+    config => config.country.code === countryCode,
+  );
+
+  if (countryException) {
+    return {
+      chargeTaxes: countryException.chargeTaxes,
+      displayGrossPrices: countryException.displayGrossPrices,
+      taxCalculationStrategy: countryException.taxCalculationStrategy,
+      source: "country",
+    };
+  }
+
+  return {
+    chargeTaxes: values.chargeTaxes,
+    displayGrossPrices: values.displayGrossPrices,
+    taxCalculationStrategy: values.taxCalculationStrategy,
+    source: "channel",
+  };
+};
+
+interface GetFlatRateArgs {
+  countryCode: CountryCode | undefined;
+  taxClassId: string | undefined;
+  taxCountryConfigurations: TaxCountryConfigurationFragment[] | undefined;
+}
+
+interface FlatRate {
+  rate: number;
+  source: "country-default" | "tax-class";
+  taxClassName: string | undefined;
+}
+
+export const getFlatRate = ({
+  countryCode,
+  taxClassId,
+  taxCountryConfigurations,
+}: GetFlatRateArgs): FlatRate => {
+  const countryConfiguration = taxCountryConfigurations?.find(
+    configuration => configuration.country.code === countryCode,
+  );
+  const productTaxClassRate = taxClassId
+    ? countryConfiguration?.taxClassCountryRates.find(rate => rate.taxClass?.id === taxClassId)
+    : undefined;
+  const countryDefaultRate = countryConfiguration?.taxClassCountryRates.find(
+    rate => rate.taxClass === null,
+  );
+  const selectedRate = productTaxClassRate ?? countryDefaultRate;
+
+  return {
+    rate: selectedRate?.rate ?? 0,
+    source: productTaxClassRate ? ("tax-class" as const) : ("country-default" as const),
+    taxClassName: productTaxClassRate?.taxClass?.name,
+  };
+};
+
+interface TaxPreviewCalculation {
+  net: number;
+  gross: number;
+  tax: number;
+  storefrontPrice: number;
+}
+
+interface CalculateTaxPreviewArgs {
+  chargeTaxes: boolean;
+  displayGrossPrices: boolean;
+  price: number;
+  pricesEnteredWithTax: boolean;
+  rate: number;
+}
+
+const roundMoney = (value: number): number => Math.round(value * 100) / 100;
+
+export const calculateTaxPreview = ({
+  chargeTaxes,
+  displayGrossPrices,
+  price,
+  pricesEnteredWithTax,
+  rate,
+}: CalculateTaxPreviewArgs): TaxPreviewCalculation => {
+  if (!chargeTaxes || rate <= 0) {
+    return {
+      net: roundMoney(price),
+      gross: roundMoney(price),
+      tax: 0,
+      storefrontPrice: roundMoney(price),
+    };
+  }
+
+  const multiplier = 1 + rate / 100;
+  const gross = pricesEnteredWithTax ? price : price * multiplier;
+  const net = pricesEnteredWithTax ? price / multiplier : price;
+  const tax = gross - net;
+  const storefrontPrice = displayGrossPrices ? gross : net;
+
+  return {
+    net: roundMoney(net),
+    gross: roundMoney(gross),
+    tax: roundMoney(tax),
+    storefrontPrice: roundMoney(storefrontPrice),
+  };
+};
+
+export const isAppTaxStrategy = (taxCalculationStrategy: string): boolean =>
+  getTaxCalculationStrategy(taxCalculationStrategy) === TaxCalculationStrategy.TAX_APP;

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -12,7 +12,6 @@ import {
   type CountryCode,
   type CountryFragment,
   type TaxConfigurationFragment,
-  type TaxConfigurationPerCountryFragment,
   type TaxConfigurationUpdateInput,
 } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
@@ -25,7 +24,14 @@ import { List, ListHeader, ListItem, ListItemCell, PageTab, PageTabs } from "@sa
 import { Box, Button, Skeleton } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { getSelectedTaxStrategy, getTaxAppId, getTaxCalculationStrategy } from "./helpers";
+import {
+  getSelectedTaxStrategy,
+  getTaxAppId,
+  getTaxCalculationStrategy,
+  type TaxConfigurationFormData,
+  type TaxCountryConfiguration,
+} from "./helpers";
+import { ProductTaxPreview } from "./ProductTaxPreview/ProductTaxPreview";
 import { useStyles } from "./styles";
 import { TaxChannelsMenu } from "./TaxChannelsMenu";
 import TaxCountryExceptionListItem from "./TaxCountryExceptionListItem";
@@ -43,22 +49,6 @@ interface TaxChannelsPageProps {
   onSubmit: (input: TaxConfigurationUpdateInput) => void;
   savebarState: ConfirmButtonTransitionState;
   disabled: boolean;
-}
-
-export type TaxCountryConfiguration = Omit<
-  TaxConfigurationPerCountryFragment,
-  "taxCalculationStrategy"
-> & {
-  taxCalculationStrategy: string;
-};
-
-export interface TaxConfigurationFormData {
-  chargeTaxes: boolean;
-  taxCalculationStrategy: string;
-  displayGrossPrices: boolean;
-  pricesEnteredWithTax: boolean;
-  updateCountriesConfiguration: TaxCountryConfiguration[];
-  removeCountriesConfiguration: CountryCode[];
 }
 
 const TaxChannelsPage = (props: TaxChannelsPageProps) => {
@@ -260,6 +250,13 @@ const TaxChannelsPage = (props: TaxChannelsPageProps) => {
                         </List>
                       )}
                     </Card>
+                    <VerticalSpacer spacing={3} />
+                    <ProductTaxPreview
+                      allCountries={allCountries}
+                      taxConfiguration={currentTaxConfiguration}
+                      values={data}
+                      disabled={disabled}
+                    />
                   </div>
                 </Grid>
 

--- a/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxCountryExceptionListItem/TaxCountryExceptionListItem.tsx
@@ -10,8 +10,8 @@ import { ListItem, ListItemCell } from "@saleor/macaw-ui";
 import { Box, Button, type Option } from "@saleor/macaw-ui-next";
 import { Trash2 } from "lucide-react";
 
+import { type TaxCountryConfiguration } from "../helpers";
 import { useStyles } from "../styles";
-import { type TaxCountryConfiguration } from "../TaxChannelsPage";
 
 interface TaxCountryExceptionListItemProps {
   country: TaxCountryConfiguration | undefined;

--- a/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
@@ -18,7 +18,7 @@ import {
 import { type Option } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { type TaxConfigurationFormData } from "../TaxChannelsPage";
+import { type TaxConfigurationFormData } from "../helpers";
 import { useStyles } from "./styles";
 
 interface TaxSettingsCardProps {

--- a/src/taxes/pages/TaxChannelsPage/helpers.tsx
+++ b/src/taxes/pages/TaxChannelsPage/helpers.tsx
@@ -1,8 +1,25 @@
 import {
+  type CountryCode,
   TaxCalculationStrategy,
   type TaxConfigurationFragment,
   type TaxConfigurationPerCountryFragment,
 } from "@dashboard/graphql";
+
+export type TaxCountryConfiguration = Omit<
+  TaxConfigurationPerCountryFragment,
+  "taxCalculationStrategy"
+> & {
+  taxCalculationStrategy: string;
+};
+
+export interface TaxConfigurationFormData {
+  chargeTaxes: boolean;
+  taxCalculationStrategy: string;
+  displayGrossPrices: boolean;
+  pricesEnteredWithTax: boolean;
+  updateCountriesConfiguration: TaxCountryConfiguration[];
+  removeCountriesConfiguration: CountryCode[];
+}
 
 const isStrategyFlatRates = (strategy: string | null) =>
   strategy === TaxCalculationStrategy.FLAT_RATES;


### PR DESCRIPTION
## Context

This is an experiment for visualizing Saleor tax behavior directly on the Taxes page. The intent is to make complex tax settings easier to inspect before we decide whether this UX should become a permanent part of the dashboard.

## What changed

<img width="2560" height="1440" alt="Zrzut ekranu 2026-06-1 o 12 02 32" src="https://github.com/user-attachments/assets/86316a8b-8632-4944-b086-646146faf37d" />

- Adds a collapsible Product Tax Preview accordion to the tax channel view.
- Lets staff pick a real product and variant, use its real channel price, adjust the preview price, and change the purchase country.
- Shows a narrative Tax Overview that walks through configuration source, tax class, rate selection, price treatment, and the final net/tax/gross/storefront values.
- For app-based taxes, clearly avoids calling the tax app and uses a stubbed assumed app rate instead.
- Moves shared tax channel form types into helpers so the preview and existing tax settings can use the same data shape.

## Validation

- `pnpm run lint`
- `pnpm run extract-messages`
- `pnpm run test:quiet src/taxes/pages/TaxChannelsPage/ProductTaxPreview/utils.test.ts`
- `pnpm run check-types`
- `pnpm run knip`

Notes: local commands emit the existing Node engine warning because this environment uses Node v22.18.0 while the project expects >=24 <25. `knip` also reports the existing unused export/dependency warnings and missing Sentry token warnings.

