### PR TITLE
Fix fulfillment warehouse line scope

### DIFF
--- a/.changeset/fair-fulfillment-warehouse.md
+++ b/.changeset/fair-fulfillment-warehouse.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Keep every order line in a fulfillment when selecting warehouses, so one tracking number and one customer notification can cover the whole shipment.

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.test.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.test.tsx
@@ -1,0 +1,96 @@
+import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
+import { SavebarRefProvider } from "@dashboard/components/Savebar/SavebarRefContext";
+import Wrapper from "@test/wrapper";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { orderToFulfill } from "./fixtures";
+import OrderFulfillPage from "./OrderFulfillPage";
+
+jest.mock(
+  "@dashboard/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog",
+  () => ({
+    OrderChangeWarehouseDialog: ({ line }: { line: { productName: string } }) => (
+      <div data-test-id="change-warehouse-dialog">{line.productName}</div>
+    ),
+  }),
+);
+
+const defaultProps = {
+  loading: false,
+  errors: [],
+  order: orderToFulfill,
+  saveButtonBar: "default" as ConfirmButtonTransitionState,
+  onSubmit: jest.fn(),
+  openModal: jest.fn(),
+  closeModal: jest.fn(),
+};
+
+const renderPage = (params = {}) =>
+  render(
+    <MemoryRouter>
+      <Wrapper>
+        <SavebarRefProvider>
+          <OrderFulfillPage {...defaultProps} params={params} />
+        </SavebarRefProvider>
+      </Wrapper>
+    </MemoryRouter>,
+  );
+
+describe("OrderFulfillPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps every order line visible while changing a warehouse", () => {
+    // Arrange
+    const warehouseLineId = orderToFulfill.lines[0].id;
+
+    // Act
+    renderPage({
+      action: "change-warehouse",
+      warehouseLineId,
+      warehouseId: orderToFulfill.lines[0].variant?.stocks?.[0]?.warehouse.id,
+    });
+
+    // Assert
+    expect(screen.getAllByText("T-Shirt")).toHaveLength(2);
+    expect(screen.getByText("Lemon Juice")).toBeInTheDocument();
+    expect(screen.getByText("Orange Juice")).toBeInTheDocument();
+    expect(screen.getByText("Items ready to ship")).toBeInTheDocument();
+    expect(screen.queryByText(/Opened from the line matrix/)).not.toBeInTheDocument();
+  });
+
+  it("still limits fulfillment when deliberately opened from the line matrix", () => {
+    // Arrange
+    const lineId = orderToFulfill.lines[0].id;
+
+    // Act
+    renderPage({ lineId });
+
+    // Assert
+    expect(screen.getByText("T-Shirt")).toBeInTheDocument();
+    expect(screen.queryByText("Lemon Juice")).not.toBeInTheDocument();
+    expect(screen.queryByText("Orange Juice")).not.toBeInTheDocument();
+    expect(screen.getByText(/Opened from the line matrix/)).toBeInTheDocument();
+  });
+
+  it("opens the warehouse picker with its own line parameter", () => {
+    // Arrange
+    renderPage();
+
+    const warehouseInputs = screen.getAllByTestId("select-warehouse-button");
+
+    // Act
+    fireEvent.click(warehouseInputs[1]);
+
+    // Assert
+    expect(defaultProps.openModal).toHaveBeenCalledWith(
+      "change-warehouse",
+      expect.objectContaining({
+        warehouseLineId: orderToFulfill.lines[1].id,
+      }),
+    );
+    expect(defaultProps.openModal.mock.calls[0][1]).not.toHaveProperty("lineId");
+  });
+});

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -173,7 +173,7 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
 
   const changeWarehouseLine =
     params.action === "change-warehouse"
-      ? order?.lines.find(orderLine => orderLine.id === params.lineId)
+      ? order?.lines.find(orderLine => orderLine.id === params.warehouseLineId)
       : undefined;
 
   return (
@@ -259,7 +259,7 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
                               formsetChange={formsetChange}
                               onWarehouseChange={() =>
                                 openModal("change-warehouse", {
-                                  lineId: line.id,
+                                  warehouseLineId: line.id,
                                   warehouseId: formsetData[lineIndex]?.value?.[0]?.warehouse?.id,
                                 })
                               }
@@ -346,14 +346,14 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
             line={changeWarehouseLine}
             currentWarehouseId={params.warehouseId}
             onConfirm={warehouse => {
-              if (!params.lineId || !warehouse) {
+              if (!params.warehouseLineId || !warehouse) {
                 return;
               }
 
-              const lineFormQuantity = formsetData.find(item => item.id === params.lineId)
+              const lineFormQuantity = formsetData.find(item => item.id === params.warehouseLineId)
                 ?.value?.[0]?.quantity;
 
-              formsetChange(params.lineId, [
+              formsetChange(params.warehouseLineId, [
                 {
                   quantity: lineFormQuantity,
                   warehouse,

--- a/src/orders/components/OrderFulfillPage/fixtures.ts
+++ b/src/orders/components/OrderFulfillPage/fixtures.ts
@@ -2,7 +2,7 @@ import * as placeholderImage from "@assets/images/sample-product.jpg";
 import { type OrderFulfillDataQuery } from "@dashboard/graphql";
 import { warehouseList } from "@dashboard/warehouses/fixtures";
 
-export const orderToFulfill: OrderFulfillDataQuery["order"] = {
+export const orderToFulfill: NonNullable<OrderFulfillDataQuery["order"]> = {
   __typename: "Order",
   id: "T3JkZXI6Mg==",
   isPaid: true,

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -304,7 +304,7 @@ export const withOrderFulfillmentDialog = (
   type: undefined,
 });
 
-type OrderFulfillUrlFiltersType = "warehouseId" | "lineId";
+type OrderFulfillUrlFiltersType = "warehouseId" | "warehouseLineId" | "lineId";
 type OrderFulfillUrlFilters = Filters<OrderFulfillUrlFiltersType>;
 export type OrderFulfillUrlDialog = "change-warehouse";
 export type OrderFulfillUrlQueryParams = Dialog<OrderFulfillUrlDialog> & OrderFulfillUrlFilters;

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -33,7 +33,10 @@ const OrderFulfill = ({ orderId, params }: OrderFulfillProps) => {
   const [openModal, closeModal] = createDialogActionHandlers<
     OrderFulfillUrlDialog,
     OrderFulfillUrlQueryParams
-  >(navigate, params => orderFulfillUrl(orderId, params), params);
+  >(navigate, params => orderFulfillUrl(orderId, params), params, [
+    "warehouseLineId",
+    "warehouseId",
+  ]);
   const { data: settings, loading: settingsLoading } = useOrderFulfillSettingsQuery({});
   const { data, loading } = useOrderFulfillDataQuery({
     displayLoader: true,

--- a/src/utils/handlers/dialogActionHandlers.test.ts
+++ b/src/utils/handlers/dialogActionHandlers.test.ts
@@ -115,4 +115,35 @@ describe("createDialogActionHandlers", () => {
       history.location = originalLocation;
     }
   });
+
+  it("clears warehouse picker params without clearing line focus", () => {
+    // Arrange
+    const navigate = jest.fn();
+    const params = {
+      lineId: "focused-line",
+      warehouseLineId: "warehouse-line",
+      warehouseId: "warehouse-1",
+      action: "change-warehouse",
+    };
+    const [, closeModal] = createDialogActionHandlers(navigate, buildUrl, params, [
+      "warehouseLineId",
+      "warehouseId",
+    ]);
+
+    // Act
+    closeModal();
+
+    // Assert
+    expect(navigate).toHaveBeenCalledWith(
+      buildUrl({
+        lineId: "focused-line",
+        warehouseLineId: undefined,
+        warehouseId: undefined,
+        action: undefined,
+        id: undefined,
+        ids: undefined,
+      }),
+      { replace: true },
+    );
+  });
 });


### PR DESCRIPTION
## Scope of the change

Fixes #6813.

Selecting a warehouse for a fulfillment line reused `lineId`, which is also the URL state for the intentional single-line flow opened from Line Matrix. As a result, opening the warehouse picker filtered the form down to that line and hid the remaining order lines.

This change:
- introduces `warehouseLineId` for warehouse-picker state;
- keeps `lineId` exclusively for intentional Line Matrix focus;
- clears `warehouseLineId` and `warehouseId` when the picker closes;
- adds regression coverage for multi-line fulfillment, Line Matrix focus, and dialog cleanup.

This preserves one order-level fulfillment containing multiple lines, one tracking number, and one customer notification.

## Verification

- `pnpm run lint` (0 errors)
- `pnpm run test:quiet src/orders/components/OrderFulfillPage/OrderFulfillPage.test.tsx src/utils/handlers/dialogActionHandlers.test.ts src/orders/urls.test.ts` (19/19)
- `pnpm run check-types` (3848 strict files passed)
- `pnpm run knip` (exit 0; existing repository warnings only)

- [x] This is a bug fix to existing behavior and does not require a ripple.
- [x] No new analytics event is required for this fix.
