### PR TITLE
Fix API_URL environment replacement collision

### DIFF
--- a/.changeset/few-windows-play.md
+++ b/.changeset/few-windows-play.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix Docker runtime configuration so setting `API_URL` no longer overwrites an empty `EXTENSIONS_API_URL`.

--- a/nginx/replace-env-vars.sh
+++ b/nginx/replace-env-vars.sh
@@ -13,7 +13,7 @@ replace_env_var() {
   var_value=$(eval echo \$"$var_name")
   if [ -n "$var_value" ]; then
     echo "Setting $var_name to: $var_value"
-    sed -i "s#\([[:space:]]*\)$var_name:[[:space:]]*\"[^\"]*\"#\1$var_name: \"$var_value\"#" "$INDEX_BUNDLE_PATH"
+    sed -i "s#^\([[:space:]]*\)$var_name:[[:space:]]*\"[^\"]*\"#\1$var_name: \"$var_value\"#" "$INDEX_BUNDLE_PATH"
   else
     echo "No $var_name provided, using defaults."
   fi

--- a/src/nginx/replace-env-vars.test.ts
+++ b/src/nginx/replace-env-vars.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const script = readFileSync(join(process.cwd(), "nginx/replace-env-vars.sh"), "utf8");
+const sedLine = script.split("\n").find(line => line.trimStart().startsWith("sed -i "));
+
+if (!sedLine) {
+  throw new Error("Replacement command not found");
+}
+
+const replacementCommand = sedLine.replace("sed -i ", "sed ").replace(' "$INDEX_BUNDLE_PATH"', "");
+
+describe("replace-env-vars.sh", () => {
+  it("does not replace API_URL inside EXTENSIONS_API_URL", () => {
+    // Arrange
+    const indexHtml = ['        API_URL: "",', '        EXTENSIONS_API_URL: "",', ""].join("\n");
+    const command = [
+      'var_name="API_URL"',
+      'var_value="https://example.com/graphql/"',
+      replacementCommand,
+    ].join("\n");
+
+    // Act
+    const result = execFileSync("sh", ["-c", command], {
+      encoding: "utf8",
+      input: indexHtml,
+    });
+
+    // Assert
+    expect(result).toBe(
+      [
+        '        API_URL: "https://example.com/graphql/",',
+        '        EXTENSIONS_API_URL: "",',
+        "",
+      ].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
## Scope of the change

Fixes #6809.

Anchor the existing `sed` match to the start of the line so setting `API_URL` cannot overwrite an intentionally empty `EXTENSIONS_API_URL`. This preserves the bundled extension-catalogue fallback for self-hosted deployments.

Focused regression coverage executes the replacement expression from `nginx/replace-env-vars.sh` against both colliding keys.

Maintainer approval to proceed with this scoped fix: [#6809 comment](https://github.com/saleor/saleor-dashboard/issues/6809#issuecomment-5247770193).

### Verification

- `pnpm run test:quiet src/nginx/replace-env-vars.test.ts`
- `pnpm run lint`
- `pnpm run check-types`
- `pnpm run knip`
- `sh -n nginx/replace-env-vars.sh`
- `git diff --check`

Screenshots are not applicable because this changes container startup configuration only.

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events

Ripples and analytics are not applicable because this is a container startup fix with no feature rollout or user interaction event.