### PR TITLE
Keep the sidebar intact when opening your own staff page

### DIFF
--- a/.changeset/staff-self-details-menu.md
+++ b/.changeset/staff-self-details-menu.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix the sidebar emptying after you open your own staff / account settings page being logged-in as cloud user. Gated sections stay visible instead of disappearing once the page finishes loading.

--- a/src/fragments/staff.ts
+++ b/src/fragments/staff.ts
@@ -18,10 +18,6 @@ export const staffMemberDetailsFragment = gql`
       name
       userCanManage
     }
-    userPermissions {
-      code
-      name
-    }
     avatar(size: 512) {
       url
     }

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -3623,10 +3623,6 @@ export const StaffMemberDetailsFragmentDoc = gql`
     name
     userCanManage
   }
-  userPermissions {
-    code
-    name
-  }
   avatar(size: 512) {
     url
   }

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -12205,7 +12205,7 @@ export type ShopFragment = { __typename: 'Shop', customerSetPasswordUrl: string 
 
 export type StaffMemberFragment = { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string };
 
-export type StaffMemberDetailsFragment = { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, userPermissions: Array<{ __typename: 'UserPermission', code: PermissionEnum, name: string }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> };
+export type StaffMemberDetailsFragment = { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> };
 
 export type StaffMemberAvatarFragment = { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, avatar: { __typename: 'Image', url: string } | null };
 
@@ -13951,7 +13951,7 @@ export type StaffMemberAddMutationVariables = Exact<{
 }>;
 
 
-export type StaffMemberAddMutation = { __typename: 'Mutation', staffCreate: { __typename: 'StaffCreate', errors: Array<{ __typename: 'StaffError', code: AccountErrorCode, field: string | null, message: string | null }>, user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, userPermissions: Array<{ __typename: 'UserPermission', code: PermissionEnum, name: string }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null } | null };
+export type StaffMemberAddMutation = { __typename: 'Mutation', staffCreate: { __typename: 'StaffCreate', errors: Array<{ __typename: 'StaffError', code: AccountErrorCode, field: string | null, message: string | null }>, user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null } | null };
 
 export type StaffMemberUpdateMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -13959,7 +13959,7 @@ export type StaffMemberUpdateMutationVariables = Exact<{
 }>;
 
 
-export type StaffMemberUpdateMutation = { __typename: 'Mutation', staffUpdate: { __typename: 'StaffUpdate', errors: Array<{ __typename: 'StaffError', code: AccountErrorCode, field: string | null, message: string | null }>, user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, userPermissions: Array<{ __typename: 'UserPermission', code: PermissionEnum, name: string }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null } | null };
+export type StaffMemberUpdateMutation = { __typename: 'Mutation', staffUpdate: { __typename: 'StaffUpdate', errors: Array<{ __typename: 'StaffError', code: AccountErrorCode, field: string | null, message: string | null }>, user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null } | null };
 
 export type UserAccountUpdateMutationVariables = Exact<{
   input: AccountInput;
@@ -14013,7 +14013,7 @@ export type StaffMemberDetailsQueryVariables = Exact<{
 }>;
 
 
-export type StaffMemberDetailsQuery = { __typename: 'Query', user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, orders: { __typename: 'OrderCountableConnection', edges: Array<{ __typename: 'OrderCountableEdge', node: { __typename: 'Order', id: string } }> } | null, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, userPermissions: Array<{ __typename: 'UserPermission', code: PermissionEnum, name: string }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null };
+export type StaffMemberDetailsQuery = { __typename: 'Query', user: { __typename: 'User', id: string, email: string, firstName: string, isActive: boolean, lastLogin: any | null, lastName: string, orders: { __typename: 'OrderCountableConnection', edges: Array<{ __typename: 'OrderCountableEdge', node: { __typename: 'Order', id: string } }> } | null, permissionGroups: Array<{ __typename: 'Group', id: string, name: string, userCanManage: boolean }> | null, avatar: { __typename: 'Image', url: string } | null, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null };
 
 export type MenuCreateMutationVariables = Exact<{
   input: MenuCreateInput;

--- a/src/staff/fixtures.ts
+++ b/src/staff/fixtures.ts
@@ -1,6 +1,5 @@
 // @ts-strict-ignore
 import avatarImage from "@assets/images/avatars/avatar.png";
-import { permissions } from "@dashboard/fixtures";
 import {
   type StaffListQuery,
   type StaffMemberAvatarFragment,
@@ -182,10 +181,6 @@ export const staffMember: StaffMemberDetailsFragment = {
   lastLogin: "2024-01-01T00:00:00+00:00",
   lastName: "Smith",
   permissionGroups: [],
-  userPermissions: permissions.map(p => ({
-    ...p,
-    __typename: "UserPermission",
-  })),
   metadata: [],
   privateMetadata: [],
 };

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -63,10 +63,15 @@ export const StaffDetailsView: React.FC<StaffDetailsViewProps> = ({ id, params }
   const hasManageStaffPermission = hasPermissions(user.user.userPermissions, [
     PermissionEnum.MANAGE_STAFF,
   ]);
+  // `user(id:)` and `me` normalize to the same Apollo User. A cache write from
+  // staff details can replace `userPermissions` and empty the sidebar (only
+  // Home / Extensions have no permission gate). Skip when we do not need the
+  // extra staff fields; otherwise keep the result out of the cache.
   const { data, loading, refetch } = useStaffMemberDetailsQuery({
     displayLoader: true,
     variables: { id },
     skip: isUserSameAsViewer && !hasManageStaffPermission,
+    fetchPolicy: isUserSameAsViewer ? "no-cache" : "cache-first",
   });
   const { deleteResult, deleteStaffMember, updateStaffMember, updateStaffMemberOpts } =
     useStaffUserOperations();
@@ -121,9 +126,7 @@ export const StaffDetailsView: React.FC<StaffDetailsViewProps> = ({ id, params }
     deleteUserAvatar,
     updateUserAvatar,
   } = useProfileOperations({ closeModal, id, refetch });
-  // Prefer staff details (includes isActive / lastLogin). Own-profile used to always
-  // take the auth User fragment, which lacked those fields → false "Not active".
-  const staffMember = data !== undefined ? data.user : isUserSameAsViewer ? user.user : undefined;
+  const staffMember = isUserSameAsViewer ? (data?.user ?? user.user) : data?.user;
   const canViewCustomerProfile = (data?.user?.orders?.edges.length ?? 0) > 0;
   const canEditMetadata = !!data?.user;
   const isActive = isMemberActive(staffMember);


### PR DESCRIPTION
Staff details and the signed-in me user share one cache record, so fetching unused userPermissions on that page could replace the session list and hide every gated menu item.