### PR TITLE
Fix Assign attribute dialog never opening on product types

### DIFF
--- a/.changeset/product-type-assign-attribute-modal.md
+++ b/.changeset/product-type-assign-attribute-modal.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix Assign attribute on product types: clicking the button now opens the dialog again. The same broken links on model types and warehouses are fixed too.

--- a/src/components/AssignAttributeDialog/AssignAttributeDialog.tsx
+++ b/src/components/AssignAttributeDialog/AssignAttributeDialog.tsx
@@ -89,7 +89,14 @@ const AssignAttributeDialog = ({
   });
 
   return (
-    <DashboardModal onChange={onClose} open={open}>
+    <DashboardModal
+      onChange={nextOpen => {
+        if (!nextOpen) {
+          onClose();
+        }
+      }}
+      open={open}
+    >
       <DashboardModal.Content size="sm">
         <DashboardModal.PickerHeader
           toolbar={

--- a/src/components/CreateAttributeDialog/CreateAttributeDialog.tsx
+++ b/src/components/CreateAttributeDialog/CreateAttributeDialog.tsx
@@ -154,7 +154,14 @@ export const CreateAttributeDialog = ({
 
   return (
     <>
-      <DashboardModal onChange={onClose} open={open}>
+      <DashboardModal
+        onChange={nextOpen => {
+          if (!nextOpen) {
+            onClose();
+          }
+        }}
+        open={open}
+      >
         {open ? (
           <Form initial={initialForm} onSubmit={handleSubmit} disabled={disabled}>
             {({ change, clearErrors, data, errors, set, setError, submit, triggerChange }) => {

--- a/src/components/Form/useExitFormDialog.test.tsx
+++ b/src/components/Form/useExitFormDialog.test.tsx
@@ -561,6 +561,10 @@ describe("isDialogOnlyQueryChange", () => {
   it("treats opening a dialog as a dialog-only change", () => {
     expect(isDialogOnlyQueryChange("", "?action=assign-attribute-value&id=123")).toBe(true);
   });
+  it("treats product-type assign dialog type param as dialog-only", () => {
+    expect(isDialogOnlyQueryChange("", "?action=assign-attribute&type=PRODUCT")).toBe(true);
+    expect(isDialogOnlyQueryChange("", "?action=create-attribute&type=VARIANT")).toBe(true);
+  });
   it("treats switching dialog actions as a dialog-only change", () => {
     expect(isDialogOnlyQueryChange("?action=setup", "?action=remove")).toBe(true);
   });

--- a/src/components/Form/useExitFormDialogProvider.tsx
+++ b/src/components/Form/useExitFormDialogProvider.tsx
@@ -14,7 +14,9 @@ import { type ExitFormDialogData, type FormData, type FormsData } from "./types"
 // Toggling these on the same pathname must not trigger the "leave without
 // saving" prompt for ordinary page forms — unless a dirty form has opted in
 // via `setBlockDialogClose` (URL-driven wizards that own their own dirty state).
-const DIALOG_QUERY_PARAMS = ["action", "id", "ids", "channelId"];
+// `type` scopes product/model-type attribute assign/create dialogs
+// (`?action=assign-attribute&type=PRODUCT`).
+const DIALOG_QUERY_PARAMS = ["action", "id", "ids", "channelId", "type"];
 
 // ConditionalFilter (list pages and modal pickers) serializes filter tokens
 // under numeric query keys (?0=...&1=...). Filter state is never part of a

--- a/src/modelTypes/components/PageTypeList/PageTypeList.tsx
+++ b/src/modelTypes/components/PageTypeList/PageTypeList.tsx
@@ -7,7 +7,7 @@ import { TablePaginationWithContext } from "@dashboard/components/TablePaginatio
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { type PageTypeFragment } from "@dashboard/graphql";
 import { getPrevLocationState } from "@dashboard/hooks/useBackLinkWithState";
-import { PageTypeListUrlSortField, pageTypeUrl } from "@dashboard/modelTypes/urls";
+import { PageTypeListUrlSortField, pageTypePath } from "@dashboard/modelTypes/urls";
 import { getArrowDirection } from "@dashboard/utils/sort";
 import { TableBody, TableCell } from "@material-ui/core";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -96,7 +96,7 @@ const PageTypeList = (props: PageTypeListProps) => {
                 href={
                   pageType
                     ? {
-                        pathname: pageTypeUrl(pageType.id),
+                        pathname: pageTypePath(encodeURIComponent(pageType.id)),
                         state: getPrevLocationState(location),
                       }
                     : undefined

--- a/src/modelTypes/urls.ts
+++ b/src/modelTypes/urls.ts
@@ -1,4 +1,4 @@
-import { stringifyQs } from "@dashboard/utils/urls";
+import { withQuery } from "@dashboard/utils/urls";
 import urlJoin from "url-join";
 
 import {
@@ -32,7 +32,7 @@ export type PageTypeListUrlQueryParams = ActiveTab &
   PageTypeListUrlFilters &
   PageTypeListUrlSort;
 export const pageTypeListUrl = (params?: PageTypeListUrlQueryParams) =>
-  modelTypesPath + "?" + stringifyQs(params);
+  withQuery(modelTypesPath, params);
 
 export const pageTypeAddPath = urlJoin(modelTypesSection, "add");
 export const pageTypeAddUrl = pageTypeAddPath;
@@ -51,4 +51,4 @@ export type PageTypeUrlQueryParams = BulkAction &
     type?: string;
   };
 export const pageTypeUrl = (id: string, params?: PageTypeUrlQueryParams) =>
-  pageTypePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
+  withQuery(pageTypePath(encodeURIComponent(id)), params);

--- a/src/productTypes/components/ProductTypeList/ProductTypeList.tsx
+++ b/src/productTypes/components/ProductTypeList/ProductTypeList.tsx
@@ -7,7 +7,7 @@ import { TablePaginationWithContext } from "@dashboard/components/TablePaginatio
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { type ProductTypeFragment } from "@dashboard/graphql";
 import { getPrevLocationState } from "@dashboard/hooks/useBackLinkWithState";
-import { ProductTypeListUrlSortField, productTypeUrl } from "@dashboard/productTypes/urls";
+import { ProductTypeListUrlSortField, productTypePath } from "@dashboard/productTypes/urls";
 import { getArrowDirection } from "@dashboard/utils/sort";
 import { TableBody, TableCell } from "@material-ui/core";
 import { makeStyles } from "@saleor/macaw-ui";
@@ -122,7 +122,7 @@ const ProductTypeList = ({
                 href={
                   productType
                     ? {
-                        pathname: productTypeUrl(productType.id),
+                        pathname: productTypePath(encodeURIComponent(productType.id)),
                         state: getPrevLocationState(location),
                       }
                     : undefined

--- a/src/productTypes/index.tsx
+++ b/src/productTypes/index.tsx
@@ -4,6 +4,7 @@ import { sectionNames } from "@dashboard/intl";
 import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router";
 import { Redirect, type RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
@@ -20,7 +21,8 @@ import ProductTypeListComponent from "./views/ProductTypeList";
 import ProductTypeUpdateComponent from "./views/ProductTypeUpdate";
 
 const ProductTypeList = () => {
-  const qs = parseQs(location.search, {
+  const { search } = useLocation();
+  const qs = parseQs(search, {
     ignoreQueryPrefix: true,
     // As a product types list still keeps ids to remove in query params,
     // we need to increase the array limit to 100, default 20,
@@ -30,7 +32,7 @@ const ProductTypeList = () => {
   const params: ProductTypeListUrlQueryParams = asSortParams(qs, ProductTypeListUrlSortField);
 
   return (
-    <ConditionalProductTypesFilterProvider locationSearch={location.search}>
+    <ConditionalProductTypesFilterProvider locationSearch={search}>
       <ProductTypeListComponent params={params} />
     </ConditionalProductTypesFilterProvider>
   );
@@ -44,7 +46,8 @@ interface ProductTypeUpdateRouteParams {
 }
 
 const ProductTypeUpdate = ({ match }: RouteComponentProps<ProductTypeUpdateRouteParams>) => {
-  const qs = parseQs(location.search.substr(1));
+  const { search } = useLocation();
+  const qs = parseQs(search, { ignoreQueryPrefix: true });
   const params: ProductTypeUrlQueryParams = qs;
 
   return <ProductTypeUpdateComponent id={decodeURIComponent(match.params.id)} params={params} />;

--- a/src/productTypes/urls.ts
+++ b/src/productTypes/urls.ts
@@ -1,5 +1,5 @@
 import { type ProductTypeKindEnum } from "@dashboard/graphql";
-import { stringifyQs } from "@dashboard/utils/urls";
+import { withQuery } from "@dashboard/utils/urls";
 import urlJoin from "url-join";
 
 import {
@@ -35,7 +35,7 @@ export type ProductTypeListUrlQueryParams = ActiveTab &
   ProductTypeListUrlFilters &
   ProductTypeListUrlSort;
 export const productTypeListUrl = (params?: ProductTypeListUrlQueryParams) =>
-  productTypeListPath + "?" + stringifyQs(params);
+  withQuery(productTypeListPath, params);
 
 interface ProductTypeAddUrlKind {
   kind?: ProductTypeKindEnum;
@@ -43,7 +43,7 @@ interface ProductTypeAddUrlKind {
 export type ProductTypeAddUrlQueryParams = ProductTypeAddUrlKind;
 export const productTypeAddPath = urlJoin(productTypeSection, "add");
 export const productTypeAddUrl = (params?: ProductTypeAddUrlQueryParams) =>
-  productTypeAddPath + "?" + stringifyQs(params);
+  withQuery(productTypeAddPath, params);
 
 export const productTypePath = (id: string) => urlJoin(productTypeSection, id);
 export type ProductTypeUrlDialog =
@@ -60,4 +60,4 @@ export type ProductTypeUrlQueryParams = BulkAction &
     type?: string;
   };
 export const productTypeUrl = (id: string, params?: ProductTypeUrlQueryParams) =>
-  productTypePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
+  withQuery(productTypePath(encodeURIComponent(id)), params);

--- a/src/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/src/productTypes/views/ProductTypeUpdate/index.tsx
@@ -77,7 +77,7 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
   const [openModal, closeModal] = createDialogActionHandlers<
     ProductTypeUrlDialog,
     ProductTypeUrlQueryParams
-  >(navigate, dialogParams => productTypeUrl(id, dialogParams), params);
+  >(navigate, dialogParams => productTypeUrl(id, dialogParams), params, ["type"]);
   const productAttributeListActions = useBulkActions();
   const variantAttributeListActions = useBulkActions();
   const assignAttributesActions = useListSelectedItems<string>();
@@ -449,36 +449,6 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
       />
       {!dataLoading && (
         <>
-          {Object.keys(ProductAttributeType).map(key => (
-            <AssignAttributeDialog
-              attributes={mapEdgesToItems(result?.data?.productType?.availableAttributes)}
-              confirmButtonState={assignAttribute.opts.status}
-              errors={maybe(
-                () =>
-                  assignAttribute.opts.data.productAttributeAssign.errors.map(err => err.message),
-                [],
-              )}
-              loading={result.loading}
-              onClose={() => {
-                closeModal();
-                assignAttributesActions.clearSelectedItems();
-              }}
-              onSubmit={handleAssignAttribute}
-              onFetch={search}
-              onFetchMore={loadMore}
-              onOpen={result.refetch}
-              hasMore={maybe(
-                () => result.data.productType.availableAttributes.pageInfo.hasNextPage,
-                false,
-              )}
-              open={
-                params.action === "assign-attribute" && params.type === ProductAttributeType[key]
-              }
-              selected={assignAttributesActions.selectedItems}
-              onToggle={assignAttributesActions.toggleSelectItem}
-              key={key}
-            />
-          ))}
           {productType && (
             <>
               <ProductTypeMetadataDialog
@@ -517,6 +487,33 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
           )}
         </>
       )}
+      {Object.keys(ProductAttributeType).map(key => (
+        <AssignAttributeDialog
+          attributes={mapEdgesToItems(result?.data?.productType?.availableAttributes)}
+          confirmButtonState={assignAttribute.opts.status}
+          errors={maybe(
+            () => assignAttribute.opts.data.productAttributeAssign.errors.map(err => err.message),
+            [],
+          )}
+          loading={result.loading}
+          onClose={() => {
+            closeModal();
+            assignAttributesActions.clearSelectedItems();
+          }}
+          onSubmit={handleAssignAttribute}
+          onFetch={search}
+          onFetchMore={loadMore}
+          onOpen={result.refetch}
+          hasMore={maybe(
+            () => result.data.productType.availableAttributes.pageInfo.hasNextPage,
+            false,
+          )}
+          open={params.action === "assign-attribute" && params.type === ProductAttributeType[key]}
+          selected={assignAttributesActions.selectedItems}
+          onToggle={assignAttributesActions.toggleSelectItem}
+          key={key}
+        />
+      ))}
 
       <BulkAttributeUnassignDialog
         title={intl.formatMessage({

--- a/src/utils/handlers/dialogActionHandlers.test.ts
+++ b/src/utils/handlers/dialogActionHandlers.test.ts
@@ -79,4 +79,40 @@ describe("createDialogActionHandlers", () => {
       history.location = originalLocation;
     }
   });
+
+  it("does not produce a double question mark when pathname already ends with ?", () => {
+    // Arrange - pathname polluted by putting entityUrl(id) into LocationDescriptor.pathname
+    const originalLocation = history.location;
+
+    history.location = {
+      ...originalLocation,
+      pathname: "/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D?",
+      search: "",
+    };
+
+    const navigate = jest.fn();
+    const buildProductTypeUrl = (params: Record<string, unknown>) => {
+      const query = stringifyQs(params);
+
+      return query
+        ? `/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D?${query}`
+        : `/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D`;
+    };
+    const [openModal] = createDialogActionHandlers(navigate, buildProductTypeUrl, {});
+
+    try {
+      // Act
+      openModal("assign-attribute", { type: "PRODUCT" });
+
+      // Assert
+      expect(navigate).toHaveBeenCalledWith(
+        `/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D?${stringifyQs({
+          type: "PRODUCT",
+          action: "assign-attribute",
+        })}`,
+      );
+    } finally {
+      history.location = originalLocation;
+    }
+  });
 });

--- a/src/utils/handlers/dialogActionHandlers.ts
+++ b/src/utils/handlers/dialogActionHandlers.ts
@@ -44,7 +44,9 @@ const withCurrentLocationIfSamePage = (generatedUrl: string): string => {
   const queryIndex = generatedUrl.indexOf("?");
   const generatedPath = queryIndex >= 0 ? generatedUrl.slice(0, queryIndex) : generatedUrl;
   const generatedSearch = queryIndex >= 0 ? generatedUrl.slice(queryIndex) : "";
-  const currentPath = history.location.pathname;
+  // List links have historically put `entityUrl(id)` (which ends with `?`) into
+  // LocationDescriptor.pathname, so history.pathname can literally contain `?`.
+  const currentPath = history.location.pathname.split("?")[0];
 
   if (normalizePathname(generatedPath) !== normalizePathname(currentPath)) {
     return generatedUrl;

--- a/src/utils/urls.test.ts
+++ b/src/utils/urls.test.ts
@@ -1,4 +1,48 @@
-import { getMultipleUrlValues } from "@dashboard/utils/urls";
+import { productTypeUrl } from "@dashboard/productTypes/urls";
+import { getMultipleUrlValues, withQuery } from "@dashboard/utils/urls";
+
+describe("withQuery", () => {
+  it("omits the query string when there are no params", () => {
+    // Arrange / Act / Assert
+    expect(withQuery("/product-types/id")).toBe("/product-types/id");
+    expect(withQuery("/product-types/id", undefined)).toBe("/product-types/id");
+    expect(withQuery("/product-types/id", {})).toBe("/product-types/id");
+    expect(withQuery("/product-types/id", { action: undefined })).toBe("/product-types/id");
+  });
+
+  it("appends a single query string when params are present", () => {
+    // Act
+    const url = withQuery("/product-types/id", { action: "assign-attribute", type: "PRODUCT" });
+
+    // Assert
+    expect(url).toBe("/product-types/id?action=assign-attribute&type=PRODUCT");
+  });
+});
+
+describe("productTypeUrl", () => {
+  // A trailing "?" used to leak into LocationDescriptor.pathname, so opening a
+  // dialog appended a second "?" and the params never parsed.
+  it("does not emit a bare question mark without params", () => {
+    // Act
+    const url = productTypeUrl("UHJvZHVjdFR5cGU6Mg==");
+
+    // Assert
+    expect(url).toBe("/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D");
+  });
+
+  it("encodes the id and appends dialog params", () => {
+    // Act
+    const url = productTypeUrl("UHJvZHVjdFR5cGU6Mg==", {
+      action: "assign-attribute",
+      type: "PRODUCT",
+    });
+
+    // Assert
+    expect(url).toBe(
+      "/product-types/UHJvZHVjdFR5cGU6Mg%3D%3D?action=assign-attribute&type=PRODUCT",
+    );
+  });
+});
 
 describe("getMultipleUrlValues", () => {
   it("Returns empty array if no value in url", () => {

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -10,6 +10,18 @@ export function stringifyQs(
   });
 }
 
+/**
+ * Build a url, omitting the query string entirely when there are no params.
+ * A bare trailing "?" is not just cosmetic: url helpers are sometimes passed as
+ * `LocationDescriptor.pathname`, where it ends up inside the path and a later
+ * dialog navigation appends a second "?", making the query unparseable.
+ */
+export function withQuery(path: string, params?: unknown): string {
+  const query = stringifyQs(params);
+
+  return query ? `${path}?${query}` : path;
+}
+
 export function getArrayQueryParam(
   param: string | string[] | Record<string, string> | undefined,
 ): string[] | undefined {

--- a/src/warehouses/components/WarehouseList/WarehouseList.tsx
+++ b/src/warehouses/components/WarehouseList/WarehouseList.tsx
@@ -10,7 +10,7 @@ import { renderCollection } from "@dashboard/misc";
 import { type ListProps, type SortPage } from "@dashboard/types";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { getArrowDirection } from "@dashboard/utils/sort";
-import { WarehouseListUrlSortField, warehouseUrl } from "@dashboard/warehouses/urls";
+import { WarehouseListUrlSortField, warehousePath } from "@dashboard/warehouses/urls";
 import { TableBody, TableCell, TableHead } from "@material-ui/core";
 import { makeStyles } from "@saleor/macaw-ui";
 import { Button, Skeleton } from "@saleor/macaw-ui-next";
@@ -102,7 +102,7 @@ const WarehouseList = (props: WarehouseListProps) => {
               href={
                 warehouse
                   ? {
-                      pathname: warehouseUrl(warehouse.id),
+                      pathname: warehousePath(encodeURIComponent(warehouse.id)),
                       state: getPrevLocationState(location),
                     }
                   : undefined

--- a/src/warehouses/urls.ts
+++ b/src/warehouses/urls.ts
@@ -1,4 +1,4 @@
-import { stringifyQs } from "@dashboard/utils/urls";
+import { withQuery } from "@dashboard/utils/urls";
 import urlJoin from "url-join";
 
 import {
@@ -30,13 +30,13 @@ export type WarehouseListUrlQueryParams = ActiveTab &
   WarehouseListUrlSort &
   SingleAction;
 export const warehouseListUrl = (params?: WarehouseListUrlQueryParams) =>
-  warehouseListPath + "?" + stringifyQs(params);
+  withQuery(warehouseListPath, params);
 
 export const warehousePath = (id: string) => urlJoin(warehouseSection, id);
 type WarehouseUrlDialog = "delete" | "view-warehouse-metadata";
 export type WarehouseUrlQueryParams = Dialog<WarehouseUrlDialog> & SingleAction;
 export const warehouseUrl = (id: string, params?: WarehouseUrlQueryParams) =>
-  warehousePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
+  withQuery(warehousePath(encodeURIComponent(id)), params);
 
 export const warehouseAddPath = urlJoin(warehouseSection, "add");
 export const warehouseAddUrl = warehouseAddPath;


### PR DESCRIPTION
List rows put a url that ended in "?" into the path, so opening a dialog appended a second "?" and the params never parsed. Omit empty query strings, link rows to the path, and close dialogs only on the close event.