### PR TITLE
feat: add options.aliases to SEARCH_ACTION extensions

### DIFF
--- a/.changeset/search-action-aliases.md
+++ b/.changeset/search-action-aliases.md
@@ -1,0 +1,21 @@
+---
+"saleor-dashboard": patch
+---
+
+`SEARCH_ACTION` extensions can now declare `options.aliases` — extra terms the command palette (Cmd+K) matches against, on top of the extension label and the owning app's name.
+
+Use it when the words a user types are not the words in your label. An action labelled "Configure Avalara" can be found by typing "taxes", "legal" or "avatax":
+
+```json
+{
+  "label": "Configure Avalara",
+  "mount": "SEARCH_ACTION",
+  "target": "POPUP",
+  "url": "https://example.com/action",
+  "options": {
+    "aliases": ["taxes", "legal", "avatax"]
+  }
+}
+```
+
+Aliases are matched, never displayed, and matching is case-insensitive and typo-tolerant like the rest of the palette. The option is valid only on the `SEARCH_ACTION` mount; setting it elsewhere fails manifest validation.

--- a/src/components/NavigatorSearch/SearchActionsList.test.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.test.tsx
@@ -10,7 +10,8 @@ const context: SearchActionContext = {
   params: { productId: "UHJvZHVjdDox" },
 };
 
-// Neither label contains "avatax" - only the owning app's name does.
+// Neither label contains "avatax" - only the owning app's name does. Likewise
+// "inventory" appears only in the second action's aliases.
 const actions: ContextualSearchAction[] = [
   {
     id: "extension-1",
@@ -24,6 +25,7 @@ const actions: ContextualSearchAction[] = [
     label: "Sync to external catalog",
     section: "App actions",
     appName: "Catalog Sync",
+    aliases: ["Inventory", "stock feed"],
     onSelect: () => undefined,
   },
 ];
@@ -65,5 +67,22 @@ describe("SearchActionsList", () => {
 
     // Assert
     expect(screen.getByText("Configure tax classes")).toBeInTheDocument();
+  });
+
+  it("finds an action by an alias that appears in neither its label nor its app name", () => {
+    // Arrange & Act
+    renderList("inventory");
+
+    // Assert
+    expect(screen.getByText("Sync to external catalog")).toBeInTheDocument();
+    expect(screen.queryByText("Configure tax classes")).not.toBeInTheDocument();
+  });
+
+  it("does not surface an action for a query matching none of its aliases", () => {
+    // Arrange & Act
+    renderList("refunds");
+
+    // Assert
+    expect(screen.queryByText("Sync to external catalog")).not.toBeInTheDocument();
   });
 });

--- a/src/components/NavigatorSearch/SearchActionsList.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.tsx
@@ -16,7 +16,7 @@ export const SearchActionsList = ({
   query,
   onActionSelected,
 }: SearchActionsListProps) => {
-  const searchResults = fuzzySearch(actions, query, ["label", "appName"]);
+  const searchResults = fuzzySearch(actions, query, ["label", "appName", "aliases"]);
 
   if (searchResults.length === 0) {
     return null;

--- a/src/extensions/domain/app-extension-manifest-options.ts
+++ b/src/extensions/domain/app-extension-manifest-options.ts
@@ -33,6 +33,14 @@ export const appExtensionManifestOptionsSchema = z
       .min(1, { message: "views must contain at least one view when provided" })
       .optional()
       .nullable(),
+    // Only valid on the SEARCH_ACTION mount (enforced in app-extension-manifest.ts).
+    // Extra terms the command palette matches against, never displayed. Deliberately
+    // liberal: a useless alias only costs a missed match, while a stricter rule would
+    // fail the whole options parse at runtime and silently drop `views` with it.
+    aliases: z
+      .array(z.string(), { message: "aliases must be an array of strings" })
+      .optional()
+      .nullable(),
   })
   .refine(
     data => {

--- a/src/extensions/domain/app-extension-manifest-search-action.test.ts
+++ b/src/extensions/domain/app-extension-manifest-search-action.test.ts
@@ -112,6 +112,78 @@ describe("App Extension Manifest Schema - SEARCH_ACTION mount", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts a SEARCH_ACTION extension with search aliases", () => {
+    // Arrange
+    const data: AppExtensionManifest = {
+      label: "Configure Avalara",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { aliases: ["taxes", "legal", "avatax"] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty aliases array as a no-op", () => {
+    // Arrange
+    const data: AppExtensionManifest = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { aliases: [] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects aliases that are not strings", () => {
+    // Arrange
+    const data = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { aliases: [{ term: "taxes" }] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects the aliases option on a non-SEARCH_ACTION mount", () => {
+    // Arrange
+    const data = {
+      label: "Product action",
+      url: "https://example.com/action",
+      mountName: "PRODUCT_DETAILS_MORE_ACTIONS",
+      targetName: "POPUP",
+      permissions: [],
+      options: { aliases: ["taxes"] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
   it("rejects the views option on a non-SEARCH_ACTION mount", () => {
     // Arrange
     const data = {

--- a/src/extensions/domain/app-extension-manifest.ts
+++ b/src/extensions/domain/app-extension-manifest.ts
@@ -112,6 +112,19 @@ export const appExtensionManifest = z
     {
       message: "views option can only be set on SEARCH_ACTION mount",
     },
+  )
+  .refine(
+    data => {
+      // aliases option is specific to the SEARCH_ACTION mount
+      if (data.options?.aliases && data.mountName !== "SEARCH_ACTION") {
+        return false;
+      }
+
+      return true;
+    },
+    {
+      message: "aliases option can only be set on SEARCH_ACTION mount",
+    },
   );
 
 export type AppExtensionManifest = z.infer<typeof appExtensionManifest>;

--- a/src/extensions/search-actions/types.ts
+++ b/src/extensions/search-actions/types.ts
@@ -20,6 +20,8 @@ export interface ContextualSearchAction {
   permissions?: PermissionEnum[];
   /** Owning app's name for extension-provided actions. Searchable, not displayed. */
   appName?: string;
+  /** Extra terms the action should match on, e.g. ["taxes", "avatax"]. Searchable, not displayed. */
+  aliases?: string[];
   /** Optional icon (app logo for extension-provided actions). */
   avatar?: string;
   /** Invoked when the action is activated, receiving the current view + entity context. */

--- a/src/extensions/search-actions/useSearchActions.ts
+++ b/src/extensions/search-actions/useSearchActions.ts
@@ -21,12 +21,19 @@ const messages = defineMessages({
   },
 });
 
-const parseExtensionViews = (
+const parseExtensionOptions = (
   settings: ExtensionWithParams["settings"],
-): AppExtensionView[] | undefined => {
+): { views: AppExtensionView[] | undefined; aliases: string[] | undefined } => {
   const result = appExtensionManifestOptionsSchema.safeParse(settings);
 
-  return result.success ? (result.data.views ?? undefined) : undefined;
+  if (!result.success) {
+    return { views: undefined, aliases: undefined };
+  }
+
+  return {
+    views: result.data.views ?? undefined,
+    aliases: result.data.aliases ?? undefined,
+  };
 };
 
 /**
@@ -48,16 +55,21 @@ export const useSearchActions = () => {
     // Extension.open loses its params in the map's type; the runtime objects accept them.
     const extensions: ExtensionWithParams[] = SEARCH_ACTION;
 
-    const extensionActions: ContextualSearchAction[] = extensions.map(extension => ({
-      id: `extension-${extension.id}`,
-      label: extension.label,
-      section: intl.formatMessage(messages.appActionsSection),
-      views: parseExtensionViews(extension.settings),
-      permissions: extension.permissions,
-      appName: extension.app.name ?? undefined,
-      avatar: extension.app.brand?.logo.default,
-      onSelect: context => extension.open(context.params),
-    }));
+    const extensionActions: ContextualSearchAction[] = extensions.map(extension => {
+      const { views, aliases } = parseExtensionOptions(extension.settings);
+
+      return {
+        id: `extension-${extension.id}`,
+        label: extension.label,
+        section: intl.formatMessage(messages.appActionsSection),
+        views,
+        aliases,
+        permissions: extension.permissions,
+        appName: extension.app.name ?? undefined,
+        avatar: extension.app.brand?.logo.default,
+        onSelect: context => extension.open(context.params),
+      };
+    });
 
     return filterSearchActions([...nativeActions, ...extensionActions], context, user);
   }, [SEARCH_ACTION, nativeActions, context, user, intl]);


### PR DESCRIPTION
Apps can now declare extra terms the command palette matches against, so an action labelled "Configure Avalara" is reachable by typing "taxes" or "legal". Aliases are matched, never displayed.

The field is deliberately permissive (any string array). The options schema is parsed at runtime as well as at install, and a stricter rule would fail the whole parse for a stored bad value, silently dropping `views` with it — a useless alias only costs a missed match.

sdk https://github.com/saleor/app-sdk/pull/522