### PR TITLE
feat: deprecate attribute filterableInStorefront ahead of 3.24 removal

### DIFF
--- a/.changeset/deprecate-filterable-in-storefront.md
+++ b/.changeset/deprecate-filterable-in-storefront.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+The "Filterable in storefront" attribute setting is now marked as deprecated. A `DEPRECATED` badge next to the setting explains, on hover, that the field will be removed in Saleor 3.24 and that attribute metadata should be used instead.
+
+Dashboard builds running against the staging schema (`FF_USE_STAGING_SCHEMA=true`) already drop the setting entirely: the toggle and its "Position in faceted navigation" field, the "Use in faceted search" column in the attribute list, and the "Filterable in Storefront" filter are hidden, and neither `filterableInStorefront` nor `storefrontSearchPosition` is sent when creating or updating an attribute.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1204,6 +1204,10 @@
     "context": "scope helper for editable order line metadata section",
     "string": "Metadata stored on this order line only. Changes here do not update the product variant."
   },
+  "2nj61B": {
+    "context": "badge on a setting that will be removed from the API",
+    "string": "Deprecated"
+  },
   "2nnp9+": {
     "context": "Info box title when product is not available for purchase",
     "string": "Visible but not purchasable."
@@ -7794,6 +7798,10 @@
   "S0QRww": {
     "context": "voucher schedule header status when not started yet",
     "string": "Scheduled"
+  },
+  "S0kwG+": {
+    "context": "tooltip explaining why a setting is deprecated",
+    "string": "Will be removed in 3.24. Use attribute metadata instead"
   },
   "S0ntb5": {
     "context": "voucher minimum quantity zero behavior hint",

--- a/src/attributes/components/AttributeListDatagrid/datagrid.ts
+++ b/src/attributes/components/AttributeListDatagrid/datagrid.ts
@@ -6,7 +6,7 @@ import { attributeInputTypeCell } from "@dashboard/components/Datagrid/customCel
 import { attributeTypeCell } from "@dashboard/components/Datagrid/customCells/AttributeTypeCell";
 import { readonlyTextCell } from "@dashboard/components/Datagrid/customCells/cells";
 import { type AvailableColumn } from "@dashboard/components/Datagrid/types";
-import { type AttributeFragment } from "@dashboard/graphql";
+import { type AttributeFragment, isMainSchema } from "@dashboard/graphql";
 import { translateBoolean } from "@dashboard/intl";
 import { type Sort } from "@dashboard/types";
 import { getColumnSortDirectionIcon } from "@dashboard/utils/columns/getColumnSortDirectionIcon";
@@ -47,11 +47,16 @@ export const attributesListStaticColumnsAdapter = (
       title: intl.formatMessage(columnsMessages.visible),
       width: 200,
     },
-    {
-      id: "use-in-faceted-search",
-      title: intl.formatMessage(columnsMessages.useInFacetedSearch),
-      width: 200,
-    },
+    // filterableInStorefront is removed from the API in 3.24
+    ...(isMainSchema()
+      ? [
+          {
+            id: "use-in-faceted-search",
+            title: intl.formatMessage(columnsMessages.useInFacetedSearch),
+            width: 200,
+          },
+        ]
+      : []),
   ].map(column => ({
     ...column,
     icon: getColumnSortDirectionIcon(sort, column.id, {

--- a/src/attributes/components/AttributeListDatagrid/datagrid.ts
+++ b/src/attributes/components/AttributeListDatagrid/datagrid.ts
@@ -6,7 +6,8 @@ import { attributeInputTypeCell } from "@dashboard/components/Datagrid/customCel
 import { attributeTypeCell } from "@dashboard/components/Datagrid/customCells/AttributeTypeCell";
 import { readonlyTextCell } from "@dashboard/components/Datagrid/customCells/cells";
 import { type AvailableColumn } from "@dashboard/components/Datagrid/types";
-import { type AttributeFragment, isMainSchema } from "@dashboard/graphql";
+import { type AttributeFragment } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import { translateBoolean } from "@dashboard/intl";
 import { type Sort } from "@dashboard/types";
 import { getColumnSortDirectionIcon } from "@dashboard/utils/columns/getColumnSortDirectionIcon";

--- a/src/attributes/components/AttributeProperties/AttributeProperties.stories.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.stories.tsx
@@ -1,0 +1,70 @@
+import { getAttributePageInitialForm } from "@dashboard/attributes/utils/attributePageForm";
+import { AttributeInputTypeEnum, AttributeTypeEnum } from "@dashboard/graphql";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { type AttributePageFormData } from "../AttributePage";
+import AttributeProperties from "./AttributeProperties";
+
+const meta: Meta<typeof AttributeProperties> = {
+  title: "Attributes / AttributeProperties",
+  component: AttributeProperties,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AttributeProperties>;
+
+const AttributePropertiesPlayground = ({
+  initial,
+}: {
+  initial: Partial<AttributePageFormData>;
+}): JSX.Element => {
+  const [data, setData] = useState<AttributePageFormData>({
+    ...getAttributePageInitialForm(),
+    ...initial,
+  });
+
+  return (
+    <AttributeProperties
+      data={data}
+      disabled={false}
+      errors={[]}
+      onChange={event =>
+        setData(current => ({ ...current, [event.target.name]: event.target.value }))
+      }
+    />
+  );
+};
+
+/** Product attribute: storefront filtering is available, and flagged as deprecated. */
+export const ProductAttribute: Story = {
+  render: () => (
+    <AttributePropertiesPlayground
+      initial={{
+        type: AttributeTypeEnum.PRODUCT_TYPE,
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        filterableInStorefront: false,
+      }}
+    />
+  ),
+};
+
+/** Storefront filtering on, revealing the nested faceted navigation position. */
+export const FacetedNavigationEnabled: Story = {
+  render: () => (
+    <AttributePropertiesPlayground
+      initial={{
+        type: AttributeTypeEnum.PRODUCT_TYPE,
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        filterableInStorefront: true,
+        storefrontSearchPosition: "2",
+      }}
+    />
+  ),
+};
+
+/** Model attribute: no storefront filtering settings at all. */
+export const ModelAttribute: Story = {
+  render: () => <AttributePropertiesPlayground initial={{ type: AttributeTypeEnum.PAGE_TYPE }} />,
+};

--- a/src/attributes/components/AttributeProperties/AttributeProperties.test.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.test.tsx
@@ -65,6 +65,17 @@ describe("AttributeProperties", () => {
     expect(screen.getByLabelText("Position in faceted navigation")).toHaveValue("2");
   });
 
+  it("marks filterable in storefront as deprecated", () => {
+    // Arrange & Act
+    render(
+      <AttributeProperties data={formData} disabled={false} errors={[]} onChange={jest.fn()} />,
+      { wrapper: Wrapper },
+    );
+
+    // Assert
+    expect(screen.getByText("Deprecated")).toBeInTheDocument();
+  });
+
   it("hides storefront filter settings for model attributes", () => {
     // Arrange & Act
     render(

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -4,12 +4,12 @@ import {
   DetailSettingNestedField,
   DetailSettingToggleRow,
 } from "@dashboard/components/DetailSettingToggleRow/DetailSettingToggleRow";
-import { type AttributeErrorFragment, AttributeTypeEnum } from "@dashboard/graphql";
+import { type AttributeErrorFragment, AttributeTypeEnum, isMainSchema } from "@dashboard/graphql";
 import { type FormChange } from "@dashboard/hooks/useForm";
 import { commonMessages } from "@dashboard/intl";
 import { getFormErrors } from "@dashboard/utils/errors";
 import getAttributeErrorMessage from "@dashboard/utils/errors/attribute";
-import { Input } from "@saleor/macaw-ui-next";
+import { Box, Input, Text, Tooltip } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { type AttributePageFormData } from "../AttributePage";
@@ -30,7 +30,9 @@ const AttributeProperties = ({
 }: AttributePropertiesProps): JSX.Element => {
   const intl = useIntl();
   const formErrors = getFormErrors(["storefrontSearchPosition"], errors);
+  // filterableInStorefront and storefrontSearchPosition are removed from the API in 3.24
   const storefrontFacetedNavigationProperties =
+    isMainSchema() &&
     ATTRIBUTE_TYPES_WITH_CONFIGURABLE_FACED_NAVIGATION.includes(data.inputType) &&
     data.type === AttributeTypeEnum.PRODUCT_TYPE;
 
@@ -53,7 +55,34 @@ const AttributeProperties = ({
 
       {storefrontFacetedNavigationProperties && (
         <DetailSettingToggleRow
-          title={<FormattedMessage {...messages.filterableInStorefront} />}
+          title={
+            <>
+              <FormattedMessage {...messages.filterableInStorefront} />
+              <Tooltip>
+                <Tooltip.Trigger>
+                  {/* stops the row's click-to-toggle from firing when reading the tooltip */}
+                  <Box
+                    as="span"
+                    display="inline-flex"
+                    marginLeft={2}
+                    paddingX={1}
+                    borderRadius={2}
+                    backgroundColor="default2"
+                    cursor="pointer"
+                    onClick={event => event.stopPropagation()}
+                  >
+                    <Text as="span" size={1} color="default2" textTransform="uppercase">
+                      <FormattedMessage {...messages.deprecated} />
+                    </Text>
+                  </Box>
+                </Tooltip.Trigger>
+                <Tooltip.Content side="top">
+                  <Tooltip.Arrow />
+                  <FormattedMessage {...messages.filterableInStorefrontDeprecation} />
+                </Tooltip.Content>
+              </Tooltip>
+            </>
+          }
           description={<FormattedMessage {...messages.filterableInStorefrontCaption} />}
           pressed={data.filterableInStorefront}
           disabled={disabled}

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -4,7 +4,8 @@ import {
   DetailSettingNestedField,
   DetailSettingToggleRow,
 } from "@dashboard/components/DetailSettingToggleRow/DetailSettingToggleRow";
-import { type AttributeErrorFragment, AttributeTypeEnum, isMainSchema } from "@dashboard/graphql";
+import { type AttributeErrorFragment, AttributeTypeEnum } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import { type FormChange } from "@dashboard/hooks/useForm";
 import { commonMessages } from "@dashboard/intl";
 import { getFormErrors } from "@dashboard/utils/errors";

--- a/src/attributes/components/AttributeProperties/messages.ts
+++ b/src/attributes/components/AttributeProperties/messages.ts
@@ -12,6 +12,16 @@ export const messages = defineMessages({
       "If enabled, customers can use this attribute to filter products in the storefront.",
     description: "caption",
   },
+  deprecated: {
+    defaultMessage: "Deprecated",
+    id: "2nj61B",
+    description: "badge on a setting that will be removed from the API",
+  },
+  filterableInStorefrontDeprecation: {
+    defaultMessage: "Will be removed in 3.24. Use attribute metadata instead",
+    id: "S0kwG+",
+    description: "tooltip explaining why a setting is deprecated",
+  },
   storefrontSearchPosition: {
     id: "cJ5ASN",
     defaultMessage: "Position in faceted navigation",

--- a/src/attributes/utils/data.stagingSchema.test.ts
+++ b/src/attributes/utils/data.stagingSchema.test.ts
@@ -1,0 +1,42 @@
+import { type AttributePageFormData } from "@dashboard/attributes/components/AttributePage";
+import { AttributeInputTypeEnum, AttributeTypeEnum } from "@dashboard/graphql";
+
+import { getAttributeData } from "./data";
+
+jest.mock("@dashboard/graphql/schemaVersion", () => ({
+  isMainSchema: () => false,
+  isStagingSchema: () => true,
+}));
+
+const formData: AttributePageFormData = {
+  availableInGrid: true,
+  entityType: null,
+  filterableInDashboard: true,
+  filterableInStorefront: true,
+  inputType: AttributeInputTypeEnum.DROPDOWN,
+  metadata: [],
+  name: "Color",
+  privateMetadata: [],
+  slug: "color",
+  storefrontSearchPosition: "3",
+  type: AttributeTypeEnum.PRODUCT_TYPE,
+  valueRequired: true,
+  visibleInStorefront: true,
+  unit: null,
+  referenceTypes: [],
+};
+
+describe("getAttributeData with staging schema", () => {
+  it("omits faceted navigation fields removed from the API in 3.24", () => {
+    // Arrange
+    const values = [{ name: "Red" }];
+
+    // Act
+    const input = getAttributeData(formData, values);
+
+    // Assert
+    expect(input.filterableInStorefront).toBeUndefined();
+    expect(input.storefrontSearchPosition).toBeUndefined();
+    expect(input.filterableInDashboard).toBe(true);
+  });
+});

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -8,7 +8,6 @@ import {
   type AttributeValueFragment,
   type AttributeValueInput,
   type FileUploadMutation,
-  isMainSchema,
   type PageSelectedAttributeFragment,
   type ProductFragment,
   type SearchCategoriesQuery,
@@ -18,6 +17,7 @@ import {
   type SelectedVariantAttributeFragment,
   type UploadErrorFragment,
 } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import { type FormsetData } from "@dashboard/hooks/useFormset";
 import { type AttributeValuesMetadata } from "@dashboard/products/utils/data";
 import { type Container, type RelayToFlat } from "@dashboard/types";

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -8,6 +8,7 @@ import {
   type AttributeValueFragment,
   type AttributeValueInput,
   type FileUploadMutation,
+  isMainSchema,
   type PageSelectedAttributeFragment,
   type ProductFragment,
   type SearchCategoriesQuery,
@@ -141,16 +142,27 @@ function getFileOrReferenceAttributeData(
   };
 }
 
+/**
+ * `filterableInStorefront` and `storefrontSearchPosition` are removed from the API in 3.24,
+ * so the staging schema build stops sending them. Drop this (and the form fields) once staging becomes main.
+ */
+export const DEPRECATED_FACETED_NAVIGATION_INPUT = isMainSchema()
+  ? {}
+  : { filterableInStorefront: undefined, storefrontSearchPosition: undefined };
+
 export function getAttributeData(
   data: AttributePageFormData,
   values: AttributeValueEditDialogFormData[],
 ) {
   if (data.inputType === AttributeInputTypeEnum.SWATCH) {
-    return getSwatchAttributeData(data, values);
+    return { ...getSwatchAttributeData(data, values), ...DEPRECATED_FACETED_NAVIGATION_INPUT };
   } else if (ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES.includes(data.inputType)) {
-    return getSimpleAttributeData(data, values);
+    return { ...getSimpleAttributeData(data, values), ...DEPRECATED_FACETED_NAVIGATION_INPUT };
   } else {
-    return getFileOrReferenceAttributeData(data, values);
+    return {
+      ...getFileOrReferenceAttributeData(data, values),
+      ...DEPRECATED_FACETED_NAVIGATION_INPUT,
+    };
   }
 }
 

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -3,6 +3,7 @@ import { useAttributeValuesSearch } from "@dashboard/attributes/hooks/useAttribu
 import {
   type AttributeValueEditDialogFormData,
   attributeValueFragmentToFormData,
+  DEPRECATED_FACETED_NAVIGATION_INPUT,
 } from "@dashboard/attributes/utils/data";
 import { getAssignedModelTypesForAttribute } from "@dashboard/attributes/utils/getAssignedModelTypesForAttribute";
 import { mapAssignedTypeConnection } from "@dashboard/attributes/utils/mapAssignedTypeConnection";
@@ -360,6 +361,7 @@ const AttributeDetails = ({ id, params }: AttributeDetailsProps) => {
             ...omit(data, ["entityType", "inputType", "metadata", "privateMetadata"]),
             storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 10),
             referenceTypes: data.referenceTypes.map(ref => ref.value),
+            ...DEPRECATED_FACETED_NAVIGATION_INPUT,
           },
         },
       }),

--- a/src/components/ConditionalFilter/constants.ts
+++ b/src/components/ConditionalFilter/constants.ts
@@ -1,3 +1,5 @@
+import { isMainSchema } from "@dashboard/graphql";
+
 import { type ConditionItem } from "./FilterElement/ConditionOptions";
 import { type ItemOption } from "./FilterElement/ConditionValue";
 import { type LeftOperand } from "./LeftOperandsProvider";
@@ -813,14 +815,21 @@ export const STAFF_MEMBER_OPTIONS: LeftOperand[] = [
   },
 ];
 
+// filterableInStorefront is removed from the API in 3.24
+const FILTERABLE_IN_STOREFRONT_OPTIONS: LeftOperand[] = isMainSchema()
+  ? [
+      {
+        value: "filterableInStorefront",
+        label: "Filterable in Storefront",
+        type: "filterableInStorefront",
+        slug: "filterableInStorefront",
+        maxOccurrences: 1,
+      },
+    ]
+  : [];
+
 export const STATIC_ATTRIBUTES_OPTIONS: LeftOperand[] = [
-  {
-    value: "filterableInStorefront",
-    label: "Filterable in Storefront",
-    type: "filterableInStorefront",
-    slug: "filterableInStorefront",
-    maxOccurrences: 1,
-  },
+  ...FILTERABLE_IN_STOREFRONT_OPTIONS,
   {
     value: "isVariantOnly",
     label: "Variant only",

--- a/src/components/ConditionalFilter/constants.ts
+++ b/src/components/ConditionalFilter/constants.ts
@@ -1,4 +1,6 @@
-import { isMainSchema } from "@dashboard/graphql";
+// Imported from the leaf module, not the @dashboard/graphql barrel: tests that replace the whole
+// barrel with jest.mock would otherwise leave isMainSchema undefined at module evaluation time.
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 
 import { type ConditionItem } from "./FilterElement/ConditionOptions";
 import { type ItemOption } from "./FilterElement/ConditionValue";

--- a/src/fragments/attributes.ts
+++ b/src/fragments/attributes.ts
@@ -33,6 +33,9 @@ export const attributeFragment = gql`
     type
     visibleInStorefront
     filterableInDashboard
+    # Removed from the API in 3.24, still queried because it is only deprecated in both schemas
+    # today. All UI/mutation usage is already gated behind isMainSchema() — delete this line and
+    # its remaining readers once staging becomes main.
     filterableInStorefront
     unit
     inputType


### PR DESCRIPTION
The API removes `filterableInStorefront` (and the `storefrontSearchPosition` that hangs off it) in 3.24. In Core the flag is only a stored boolean — nothing reads it — so the Dashboard is the only thing keeping it alive.

Under the staging schema every user-reachable trace of it is gone: the "Filterable in storefront" toggle and its nested position field, the "Use in faceted search" list column, and the "Filterable in Storefront" expression filter. Both mutation paths stop sending the two fields via a single switch, `DEPRECATED_FACETED_NAVIGATION_INPUT`.

Under the main schema (3.23) the setting stays, now labelled with a DEPRECATED badge whose tooltip points at attribute metadata as the replacement.
