### PR TITLE
Update bulk publish in "Channel->Add products" to keep existing prices

### DIFF
--- a/.changeset/bulk-publish-keep-existing-prices.md
+++ b/.changeset/bulk-publish-keep-existing-prices.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+When adding products to a channel with the bulk publish wizard, leaving the price blank now keeps each product’s current prices instead of requiring a new price for every product.
+
+That means you can update stock or visibility for products already in the channel without overwriting variant prices. The review step shows current prices as placeholders, marks rows that will change, and warns before a single price would flatten different variant prices or leave unpriced variants unlisted. New products still need a price so they can be listed in the channel.

--- a/docs/bulk-catalog-edits-scope.md
+++ b/docs/bulk-catalog-edits-scope.md
@@ -1,0 +1,242 @@
+# Bulk catalog edits — scope
+
+**Status:** proposal
+**Trigger:** merchant feedback — "I have to edit each variant individually, which is very time-consuming"
+
+The merchant asked for four things: activating multiple products/variants at once, adding a warehouse
+to multiple products/variants, updating inventory/warehouse settings across products, and "other
+similar changes to multiple products at the same time".
+
+---
+
+## The structural gap
+
+**No surface in the dashboard spans variants across products.** Every multi-variant editor is scoped
+to a single product. That single fact explains all four complaints.
+
+Two of the four asks are already partly solvable with features the merchant almost certainly hasn't
+found; the rest are genuinely missing.
+
+| Ask                              | Today                                                                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Activate multiple products       | Bulk publish wizard covers it — but only from **Channel → Catalog → Add products** (see below)                         |
+| Add warehouse to many variants   | **Nothing.** `AssignWarehouseDialog` is one variant at a time; the warehouse detail page has no product or stock UI    |
+| Update inventory across variants | Works **inside one product** (variant grid warehouse columns, fill handle, spreadsheet paste); nothing across products |
+| Other bulk changes               | Product list is a read-only grid; only bulk delete and export                                                          |
+
+### The publish wizard was an onboarding tool — now partly a bulk editor
+
+Worth recording, because it is the template for everything below.
+
+Originally **price was mandatory and uniform per product**: `ProductPublishDraft.price` is one string
+applied to every variant, it started empty even for already-listed products, and validation blocked
+the wizard until it was filled. That meant you could not change _only_ stock or _only_ visibility —
+every run rewrote prices — and on a product whose variants are deliberately priced differently, one
+run **flattened them all to one value**, silently and irreversibly. A merchant looking for a way past
+the gate could also type `0`, which validation accepts, zeroing an entire selection.
+
+**Fixed.** Price is now required only where there is nothing to fall back on — a product with no
+listing in the channel, since Saleor needs a price to create one. For already-listed products a blank
+price leaves prices untouched (`channelListings.update` simply omits the field), matching how cost
+price and stock already behaved. The review step shows each product's current price as the field
+placeholder, marks rows whose price will change, and warns inline before flattening a product whose
+variants are priced differently.
+
+Still open, in rough priority order:
+
+- **Visibility flags are still an unconditional overwrite.** `productChannelListingUpdate` always
+  writes `isPublished`, `visibleInListings`, and `isAvailableForPurchase` from the defaults step, so
+  running the wizard on a listed product to change _only_ stock will also republish it. This is the
+  same destructive-overwrite class we just fixed for price, and the fix is the same shape — the
+  defaults step needs a "leave unchanged" state per toggle, not just on/off. Deliberately not done
+  here because it changes the defaults UX rather than correcting a bug.
+- The wizard sets **one price per product**, so per-variant repricing needs the Phase 3 grid.
+- It is still reachable only from the channel page.
+
+A vocabulary problem sits underneath the first row: **"active" has no product-level meaning in Saleor.**
+Live = `isPublished` + `visibleInListings` + `isAvailableForPurchase` per channel, _plus_ a variant
+channel listing with a price. Four booleans and a price across two entities. Merchants clicking into
+every variant may be doing so because they have no model of what "live" means. Any UI here should
+express one concept ("make available for sale in _channel_") and handle all five underneath.
+
+---
+
+## API ceiling
+
+Verified against `schema.graphql` and the Saleor bulk docs. These constraints shape every option below.
+
+- **No `productBulkUpdate`.** Product-level changes (category, collections, publication) are N separate
+  `productUpdate` / `productChannelListingUpdate` calls. `productBulkCreate`, `productBulkDelete`,
+  `productBulkTranslate` exist; only delete is used.
+- **`productVariantBulkUpdate` takes `product: ID!`** — bulk _within_ a product, not across the catalog.
+  Cross-product edits mean one call per product, chunked at 100 variants. Supports `stocks`
+  (create/update/remove), `channelListings`, `trackInventory`, `quantityLimitPerCustomer`, `sku`, `name`,
+  `weight`, `metadata`.
+- **`stockBulkUpdate` is the only genuinely cross-catalog mutation** — a flat list of
+  `{ variantId, warehouseId, quantity }`, unused by the dashboard. **It cannot create stock rows:**
+  `NOT_FOUND` when the warehouse isn't already assigned to the variant. Creation must go through
+  `productVariantBulkUpdate.stocks.create`, which in turn errors `STOCK_ALREADY_EXISTS` if the row is
+  already there. Any warehouse operation must therefore read current stocks and split create vs update.
+- **Top-level `productVariants` query exists** with `search`, sorting, and `where` on sku / attributes /
+  metadata / updatedAt — but **no filtering by channel, category, stock level, or warehouse**. A
+  standalone variants list is buildable but its filters would be too weak to answer "variants with no
+  stock in warehouse X". Selection has to stay on the product list, which has rich filters.
+- **No import.** Export emails CSV/XLSX; nothing reads it back. The export → edit → import round trip
+  power merchants want is core work, not dashboard work.
+
+---
+
+## Jobs to be done
+
+1. **"Open a new location."** A warehouse goes live and every variant needs a stock row there. Rare,
+   completely blocking, currently impossible at scale. **Highest priority.**
+2. **"Get this batch live."** New drop or new supplier — publish, set visibility, price, stock.
+   Episodic, same change applied broadly. Partly served, badly discoverable.
+3. **"Run the weekly count."** Different quantity per variant across many products. Needs to _see_ the
+   numbers — a spreadsheet job, not a wizard job. `stockBulkUpdate` is built for exactly this.
+4. **"Change a policy."** Track inventory, quantity limit per customer, across a segment. Same value
+   applied broadly — wizard job.
+5. **"Find what's broken."** Unstated but load-bearing: merchants often don't know _which_ products
+   lack a price in a channel or have zero stock, so they can't even build a correct selection.
+
+---
+
+## Design: three modes, one frame
+
+"Datagrid vs bulk tool" is a false choice — they serve different job shapes.
+
+- **Bulk apply (wizard)** — same change, or a rule, across many rows. Jobs 1, 2, 4.
+- **Inline grid** — different value per row; the merchant must see the data. Job 3.
+- **Find-and-fix** — the merchant doesn't know which rows need changing. Job 5.
+
+The frame to build is a **single bulk-action wizard on the product list with a pluggable operation
+catalogue**. Merchants learn one flow; each new capability is a new operation, not a new UI.
+
+`BulkPublishToChannelDialog` already provides the shell: wizard steps, product picker with select-all
+and caps, draft model with defaults → per-row overrides, spreadsheet paste, sequential loop with
+chunking, per-item progress, retry-failed, idempotent re-fetch before mutating. The work is extracting
+the operation-specific parts behind an interface.
+
+---
+
+## Phase 1 — "Add warehouse" from the product list
+
+Delivers job 1 and establishes the frame.
+
+### UX
+
+Entry: product list → select products → **Bulk edit** button next to `BulkDeleteButton` in
+`ListFilters.actions` (`ProductListPage.tsx` ~L243). Opens URL-driven modal (`?action=bulk-edit`).
+
+1. **Operation** — pick from the catalogue. Phase 1 ships "Add warehouse"; later phases add entries here.
+2. **Configure** — choose warehouse, and a quantity strategy: fixed value / copy from another warehouse /
+   zero. Warn when the warehouse isn't assigned to the channels the selected products sell in (stock
+   there won't be allocatable).
+3. **Review** — per-product rows with the resolved quantity, overridable, spreadsheet paste. Show the
+   blast radius: _"Creates stock rows for N variants across M products; K already have stock here and
+   will be updated."_
+4. **Apply** — per-product progress list, retry failed, partial-failure warning toast.
+
+### Implementation
+
+Generalise, don't fork:
+
+- Extract from `src/channels/components/BulkPublishToChannelDialog/` into
+  `src/products/components/BulkEditProductsDialog/` (or a shared `src/components/BulkEdit/`):
+  the wizard shell, `chunkBulkPublishItems`, the progress/retry machinery in
+  `BulkPublishConfirmStep.tsx`, the draft merge model in `bulkPublishDrafts.ts`, and
+  `fetchBulkPublishProductVariants.ts`.
+- `bulkPublishVariantStocks.ts` → `buildBulkPublishVariantStocksInput` is **already the exact primitive**
+  needed: it reads `variant.stocks`, splits into `create` (missing rows) and `update` (by stock id).
+  Rename and reuse as-is.
+- Define a `BulkOperation` interface: config step component, review row component, draft type, a
+  `buildProductMutations(product, variants, draft)` function, and validation. `useBulkPublishToChannelSubmit`
+  becomes a generic runner that walks products sequentially and delegates per-product work to the operation.
+- Keep `disableErrorHandling: true` and `ErrorPolicyEnum.REJECT_FAILED_ROWS`.
+- Keep the re-fetch-before-mutate step (`useBulkPublishToChannelSubmit.ts` L321–324) — it is what makes
+  retries idempotent, and it doubles as the read of current stocks that the create/update split needs.
+
+Once extracted, re-point the channel wizard at the shared frame so there is one implementation.
+
+---
+
+## Phase 2 — Operation catalogue
+
+Each is small once the frame exists.
+
+- **Make available in channel** — today's publish wizard, reachable from the product list. The
+  "leave prices unchanged" behaviour it needs to run against an existing catalog is already done.
+- **Inventory policy** — `trackInventory`, `quantityLimitPerCustomer` via `productVariantBulkUpdate`.
+- **Pricing** — set / ±% / round, per channel, via `channelListings.update`.
+- **Organisation** — category and collections. Note: N× `productUpdate` (no product bulk update);
+  collections have dedicated `collectionAddProducts` / `collectionRemoveProducts`.
+- **Remove warehouse** — `stocks.remove`, with a hard warning about allocated stock.
+
+---
+
+## Phase 3 — Cross-product stock grid
+
+Job 3 needs a grid, not a wizard, because values differ per row. Given the weak variant filters, scope
+it as "select products → edit all their variants' stock in one grid" rather than a standalone variants
+list view.
+
+Reuse the `ProductVariants` datagrid machinery (warehouse column adapter, fill handle, paste, staged
+edits via `variantGridStagedEdits.ts`). Save via a **single `stockBulkUpdate` call** — the one place the
+flat cross-product API fits, and dramatically faster than the per-product loop. Rows whose stock does
+not yet exist must be routed through `productVariantBulkUpdate.stocks.create` instead, or blocked with a
+prompt to run "Add warehouse" first.
+
+---
+
+## Phase 4 — Find-and-fix
+
+Catalog readiness filters on the product list — no price in channel, no stock anywhere, not published,
+missing category — feeding directly into the bulk actions. Builds on the catalog health signals already
+on the channel detail page.
+
+---
+
+## Scale
+
+The current wizard caps at 50 products. A merchant with thousands of SKUs hits that immediately.
+
+**Decision: stay client-side, raise the cap to a few hundred, and make progress resumable.**
+
+- Raising the cap alone isn't enough — a sequential per-product loop at 500 products takes minutes with
+  the tab held hostage. Progress must persist (session storage keyed by operation + selection) so a
+  refresh or accidental close resumes rather than restarts.
+- Keep the per-product progress list as the primary feedback; it already communicates "this is a long
+  job" honestly.
+- Warn before starting when the estimate exceeds ~1 minute.
+- The real answer at catalog scale is an **async server-side bulk-edit job** modelled on the existing
+  export job. That is core work — worth raising separately, out of scope here.
+
+---
+
+## Safety rules
+
+- **No undo.** Bulk edits are irreversible, so the review step is load-bearing: always state
+  "this will change N variants across M products" before applying.
+- **Never silently partial.** Per-item errors in the progress list, warning toast on partial failure,
+  modal stays open, retry applies only to failed IDs.
+- **Idempotent retries.** Re-fetch state before mutating so a retry can't duplicate listings or trip
+  `STOCK_ALREADY_EXISTS`.
+
+---
+
+## Open questions
+
+- Which channels' warehouses should "Add warehouse" offer — all shop warehouses, or only those assigned
+  to channels the selected products sell in? Offering all is simpler but creates unallocatable stock.
+- Should the merchant's "activating" mean per-channel publication, or is there an expectation of a
+  global on/off that Saleor doesn't have? Worth confirming before building Phase 2's first operation.
+- Does the merchant work from spreadsheets today? If yes, Phase 3 and the (core-side) import story
+  matter more than the wizard catalogue.
+
+---
+
+## Summary
+
+> Close the cross-product gap with one bulk-action wizard on the product list, generalised from the
+> channel bulk publish wizard, starting with "add warehouse to many variants" — the one job with no path
+> at all today — then grow the operation catalogue and add a cross-product stock grid for per-row edits.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -375,6 +375,10 @@
     "context": "product type has-variants toggle title",
     "string": "Products of this type have options"
   },
+  "/NkQFN": {
+    "context": "bulk publish review warning when one price replaces varied variant prices",
+    "string": "Overwrites {count, plural, one {# variant price} other {# different variant prices}}"
+  },
   "/PUjN6": {
     "context": "voucher discount amount type",
     "string": "Percentage"
@@ -988,6 +992,10 @@
   },
   "1wyZpQ": {
     "string": "These passwords are too similar"
+  },
+  "1xn94O": {
+    "context": "bulk publish review price placeholder when the price is kept",
+    "string": "Unchanged"
   },
   "1y3hRg": {
     "context": "hint linking to model types settings",
@@ -2163,6 +2171,10 @@
   "6cqHxE": {
     "context": "Footnote shown beneath the per-warehouse stock table on the variant detail page when the shop is in legacy stock-availability mode (stock visibility filtered through shipping zones).",
     "string": "Customers see this stock when the warehouse is assigned to a channel and covered by a shipping zone for the destination."
+  },
+  "6e2YdE": {
+    "context": "bulk publish confirm products with no price change",
+    "string": "{count, plural, one {# product keeps its current prices} other {# products keep their current prices}}"
   },
   "6eKMnl": {
     "context": "placeholder for custom template editor",
@@ -3454,6 +3466,10 @@
     "context": "page title - installing app with manifestUrl provided",
     "string": "Add extension"
   },
+  "BZyOKE": {
+    "context": "bulk publish already listed badge tooltip",
+    "string": "{hasStock, select, true {Already in this channel. Leave price or stock blank to keep the current values.} other {Already in this channel. Leave the price blank to keep the current prices.}}"
+  },
   "BalldE": {
     "string": "Order line"
   },
@@ -3500,6 +3516,10 @@
   "BgEWXq": {
     "context": "section title for legacy and developer store settings",
     "string": "Advanced"
+  },
+  "BhLnBj": {
+    "context": "bulk publish review warning about variants left without a channel listing",
+    "string": "{count, plural, one {# variant has no price here and stays unlisted} other {# variants have no price here and stay unlisted}}. Set a price to publish {count, plural, one {it} other {them}}."
   },
   "BikTYV": {
     "context": "Collection is visible in channel without scheduled date",
@@ -3583,6 +3603,10 @@
   },
   "C0MnAi": {
     "string": "off"
+  },
+  "C1+aT0": {
+    "context": "bulk publish review table price column hint",
+    "string": "Blank keeps current"
   },
   "C1aDzb": {
     "context": "shipping method types help example row three cart",
@@ -4279,6 +4303,10 @@
     "context": "Expanded help for channel setup",
     "string": "Saleor sells through channels (like markets). Each channel needs a stock location—and shipping if you deliver—before customers can check out."
   },
+  "Em4Fzl": {
+    "context": "bulk publish price validation",
+    "string": "Enter a price for products that are not in this channel yet."
+  },
   "EoNN9v": {
     "context": "Label for visible in listings toggle",
     "string": "Show in listings"
@@ -4556,6 +4584,10 @@
     "context": "voucher minimum quantity validation error",
     "string": "Enter at least 1 item."
   },
+  "FmZAfR": {
+    "context": "bulk publish review count of products whose price will change",
+    "string": "{count, plural, =0 {No price changes} one {# price change} other {# price changes}}"
+  },
   "FmeBxD": {
     "context": "custom app tokens list - missing token name",
     "string": "(unknown)"
@@ -4804,6 +4836,10 @@
     "context": "Tooltip explanation for legacy stock-availability mode",
     "string": "Stock is considered available only when the warehouse is both assigned to this channel and covered by an active shipping zone for the destination address."
   },
+  "GYXouB": {
+    "context": "bulk publish confirm title when no price is set",
+    "string": "Prices unchanged"
+  },
   "GbBCmr": {
     "context": "window title",
     "string": "Order #{orderNumber}"
@@ -4961,6 +4997,10 @@
   "H1L1cc": {
     "context": "url",
     "string": "URL"
+  },
+  "H31h5O": {
+    "context": "bulk publish price format validation",
+    "string": "Enter a valid price or leave it blank to keep the current one."
   },
   "H4Lcuk": {
     "string": "Category updated"
@@ -6939,10 +6979,6 @@
   "ObRk1O": {
     "string": "If this option is disabled, discount will be counted for every eligible product"
   },
-  "Oct6t4": {
-    "context": "bulk publish price validation",
-    "string": "Enter a valid price for every product."
-  },
   "Oe62bR": {
     "context": "product availability",
     "string": "Availability"
@@ -8811,10 +8847,6 @@
   "VmMDLN": {
     "context": "permission list item description",
     "string": "This group is last source of that permission"
-  },
-  "VnPjPG": {
-    "context": "bulk publish already listed badge tooltip",
-    "string": "{hasStock, select, true {Prices and stock will be updated across all variants.} other {Prices will be updated across all variants.}}"
   },
   "VrFy8e": {
     "string": "No notes from customer"

--- a/src/channels/components/BulkPublishToChannelDialog/BulkPublishConfirmStep.tsx
+++ b/src/channels/components/BulkPublishToChannelDialog/BulkPublishConfirmStep.tsx
@@ -14,6 +14,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import styles from "./BulkPublishConfirmStep.module.css";
 import {
   type BulkPublishNumericRange,
+  countBulkPublishDraftsKeepingPrice,
   countBulkPublishDraftsWithCostPrice,
   countBulkPublishDraftsWithStock,
   getBulkPublishCostPriceRange,
@@ -112,6 +113,7 @@ export const BulkPublishConfirmStep = ({
   const priceRange = getBulkPublishPriceRange(productDrafts);
   const costPriceRange = getBulkPublishCostPriceRange(productDrafts);
   const costPricesCount = countBulkPublishDraftsWithCostPrice(productDrafts);
+  const keepingPriceCount = countBulkPublishDraftsKeepingPrice(productDrafts);
   const stockQuantityRange = getBulkPublishStockQuantityRange(productDrafts);
   const productsWithStockCount = countBulkPublishDraftsWithStock(productDrafts);
   const { previewNames, remainingCount } = getBulkPublishProductNamePreview(productDrafts);
@@ -157,8 +159,14 @@ export const BulkPublishConfirmStep = ({
       previewNames
     );
 
+  // Keeping existing prices is the headline for a partial update, so it outranks cost-price detail.
   const pricingDetail =
-    costPricesCount === 0 ? (
+    keepingPriceCount > 0 ? (
+      <FormattedMessage
+        {...messages.confirmPricesUnchanged}
+        values={{ count: keepingPriceCount }}
+      />
+    ) : costPricesCount === 0 ? (
       <FormattedMessage {...messages.confirmNoCostPrices} />
     ) : costPricesCount < productDrafts.length ? (
       <FormattedMessage
@@ -274,13 +282,15 @@ export const BulkPublishConfirmStep = ({
         <SummarySection
           label={<FormattedMessage {...messages.confirmSectionPricing} />}
           title={
-            priceRange
-              ? formatBulkPublishMoneyRange({
-                  range: priceRange,
-                  currency: channel.currencyCode,
-                  locale,
-                })
-              : "—"
+            priceRange ? (
+              formatBulkPublishMoneyRange({
+                range: priceRange,
+                currency: channel.currencyCode,
+                locale,
+              })
+            ) : (
+              <FormattedMessage {...messages.confirmNoPriceChanges} />
+            )
           }
           detail={pricingDetail}
         />

--- a/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewRow.tsx
+++ b/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewRow.tsx
@@ -2,11 +2,13 @@ import {
   BULK_PUBLISH_MAX_VARIANTS_PER_PRODUCT,
   type ProductPublishDraft,
 } from "@dashboard/channels/components/BulkPublishToChannelDialog/types";
+import { formatMoney, formatMoneyRange } from "@dashboard/components/Money";
 import { PriceFieldV2 } from "@dashboard/components/PriceFieldV2/PriceFieldV2";
 import { Box, Chip, Input, Text, Tooltip } from "@saleor/macaw-ui-next";
 import { type ClipboardEvent, memo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { hasBulkPublishPrice } from "./bulkPublishDrafts";
 import styles from "./BulkPublishReviewStep.module.css";
 import { type BulkPublishPasteField } from "./bulkPublishSpreadsheetPaste";
 import { messages } from "./messages";
@@ -45,9 +47,26 @@ export const BulkPublishReviewRow = memo(
     onFieldPaste,
   }: BulkPublishReviewRowProps) => {
     const intl = useIntl();
+    const { currentListing } = draft;
+    const currentPrice = currentListing?.price;
+    const willChangePrice = hasBulkPublishPrice(draft.price);
+    const pricePlaceholder = currentPrice
+      ? currentPrice.isMixed
+        ? formatMoneyRange(
+            { amount: currentPrice.min, currency },
+            { amount: currentPrice.max, currency },
+            intl.locale,
+          )
+        : formatMoney({ amount: currentPrice.min, currency }, intl.locale)
+      : draft.alreadyInChannel
+        ? intl.formatMessage(messages.reviewPriceUnchangedPlaceholder)
+        : undefined;
+    // A blank price cannot create a listing, so these variants stay unsellable unless one is set.
+    const staleUnlistedVariantCount =
+      !willChangePrice && currentListing ? currentListing.unlistedVariantCount : 0;
 
     return (
-      <Box className={styles.row}>
+      <Box className={styles.row} data-price-changed={willChangePrice ? "true" : undefined}>
         <Box className={styles.rowMain}>
           <Text size={3} fontWeight="medium">
             {draft.name}
@@ -93,6 +112,22 @@ export const BulkPublishReviewRow = memo(
               </Chip>
             ) : null}
           </Box>
+          {currentPrice?.isMixed && willChangePrice ? (
+            <Text size={1} className={styles.rowWarning}>
+              <FormattedMessage
+                {...messages.reviewPriceOverwritesMixed}
+                values={{ count: currentListing?.listedVariantCount ?? 0 }}
+              />
+            </Text>
+          ) : null}
+          {staleUnlistedVariantCount > 0 ? (
+            <Text size={1} className={styles.rowWarning}>
+              <FormattedMessage
+                {...messages.reviewVariantsStayUnlisted}
+                values={{ count: staleUnlistedVariantCount }}
+              />
+            </Text>
+          ) : null}
         </Box>
         <Box className={fieldGroupClassName}>
           <div
@@ -103,6 +138,7 @@ export const BulkPublishReviewRow = memo(
               aria-label={intl.formatMessage(messages.productPrice)}
               size="small"
               currencySymbol={currency}
+              placeholder={pricePlaceholder}
               value={draft.price}
               onChange={price => onFieldChange(draft.productId, "price", price)}
             />
@@ -115,6 +151,11 @@ export const BulkPublishReviewRow = memo(
               aria-label={intl.formatMessage(messages.productCostPrice)}
               size="small"
               currencySymbol={currency}
+              placeholder={
+                draft.alreadyInChannel
+                  ? intl.formatMessage(messages.reviewPriceUnchangedPlaceholder)
+                  : undefined
+              }
               value={draft.costPrice}
               onChange={costPrice => onFieldChange(draft.productId, "costPrice", costPrice)}
             />

--- a/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewStep.module.css
+++ b/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewStep.module.css
@@ -59,6 +59,16 @@
   border-bottom: none;
 }
 
+/* Marks rows the merchant has actually edited, so a partial update reads as a diff. */
+.row[data-price-changed="true"] {
+  box-shadow: inset 2px 0 0 0 var(--mu-colors-background-accent1);
+}
+
+/* Warning, not error: these runs are destructive but intended, and nothing blocks Next. */
+.rowWarning {
+  color: var(--mu-colors-text-warning1);
+}
+
 .rowMain {
   min-width: 0;
   display: flex;

--- a/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewStep.tsx
+++ b/src/channels/components/BulkPublishToChannelDialog/BulkPublishReviewStep.tsx
@@ -15,6 +15,7 @@ import {
   getDraftsExceedingVariantLimit,
   getDraftsMissingCategoryForPublish,
   getDraftsWithManyVariants,
+  hasListedDrafts,
 } from "./bulkPublishDrafts";
 import { type BulkPublishReviewField, BulkPublishReviewRow } from "./BulkPublishReviewRow";
 import styles from "./BulkPublishReviewStep.module.css";
@@ -63,6 +64,9 @@ export const BulkPublishReviewStep = ({
   );
   const oversizedProductNames = oversizedDrafts.map(draft => draft.name).join(", ");
   const missingCategoryProductNames = missingCategoryDrafts.map(draft => draft.name).join(", ");
+  // Only meaningful once some products already have prices to keep — on a pure onboarding run
+  // every price is required, so a "leave blank" hint would be misleading.
+  const showPriceDiff = useMemo(() => hasListedDrafts(productDrafts), [productDrafts]);
 
   // Rows are memoized, so the handlers they receive have to stay stable across keystrokes.
   const latestDraftsRef = useRef(productDrafts);
@@ -160,6 +164,11 @@ export const BulkPublishReviewStep = ({
                 <Box className={styles.inputCell}>
                   <ReviewColumnHeader
                     title={<FormattedMessage {...messages.reviewColumnPrice} />}
+                    hint={
+                      showPriceDiff ? (
+                        <FormattedMessage {...messages.reviewColumnPriceUnchangedHint} />
+                      ) : undefined
+                    }
                   />
                 </Box>
                 <Box className={styles.inputCell}>

--- a/src/channels/components/BulkPublishToChannelDialog/BulkPublishToChannelDialog.tsx
+++ b/src/channels/components/BulkPublishToChannelDialog/BulkPublishToChannelDialog.tsx
@@ -18,6 +18,7 @@ import { ModalProductFilterProvider } from "@dashboard/components/ModalFilters/e
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";
 import {
   type SearchProductsQueryVariables,
+  useBulkPublishProductPricesQuery,
   useBulkPublishProductsDataQuery,
 } from "@dashboard/graphql";
 import {
@@ -36,15 +37,19 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { BulkPublishConfirmStep } from "./BulkPublishConfirmStep";
+import { getBulkPublishCurrentListings } from "./bulkPublishCurrentListings";
 import { BulkPublishDefaultsStep } from "./BulkPublishDefaultsStep";
 import {
+  countDraftsWithPriceUpdate,
   createProductDrafts,
   getAppliedDefaultStock,
   getDraftsExceedingVariantLimit,
   getDraftsMissingCategoryForPublish,
   getDraftsMissingPrice,
   getDraftsWithInvalidCostPrice,
+  getDraftsWithInvalidPrice,
   getDraftsWithInvalidStock,
+  hasListedDrafts,
   isValidBulkPublishStock,
   mergeProductDrafts,
 } from "./bulkPublishDrafts";
@@ -61,6 +66,7 @@ import {
   BULK_PUBLISH_MAX_PRODUCTS,
   BULK_PUBLISH_MAX_VARIANTS_PER_PRODUCT,
   BULK_PUBLISH_PICKER_PAGE_SIZE,
+  BULK_PUBLISH_PRICE_SAMPLE_LIMIT,
   type BulkPublishChannel,
   type BulkPublishDefaults,
   type BulkPublishSelectedProduct,
@@ -258,6 +264,11 @@ const BulkPublishToChannelDialogContent = ({
     () => getDraftsExceedingVariantLimit(productDrafts).length > 0,
     [productDrafts],
   );
+  const showPriceDiff = useMemo(() => hasListedDrafts(productDrafts), [productDrafts]);
+  const priceUpdateCount = useMemo(
+    () => countDraftsWithPriceUpdate(productDrafts),
+    [productDrafts],
+  );
 
   useEffect(
     function syncBulkPublishLeaveTrap() {
@@ -336,6 +347,43 @@ const BulkPublishToChannelDialogContent = ({
       first: 1,
     },
   });
+  const { refetch: fetchProductPrices } = useBulkPublishProductPricesQuery({
+    skip: true,
+    variables: {
+      ids: [],
+      first: 1,
+      variantsFirst: BULK_PUBLISH_PRICE_SAMPLE_LIMIT,
+    },
+  });
+
+  /**
+   * Only products already in the channel have prices to keep, and pulling variant prices is the
+   * expensive part of preparing the review step — so the onboarding path skips this entirely.
+   */
+  const loadCurrentListings = useCallback(
+    async (listedProductIds: string[]) => {
+      if (listedProductIds.length === 0) {
+        return undefined;
+      }
+
+      try {
+        const { data } = await fetchProductPrices({
+          ids: listedProductIds,
+          first: listedProductIds.length,
+          variantsFirst: BULK_PUBLISH_PRICE_SAMPLE_LIMIT,
+        });
+
+        return getBulkPublishCurrentListings({
+          products: mapEdgesToItems(data?.products) ?? [],
+          channelId: channel.id,
+        });
+      } catch {
+        // Placeholders and warnings are a convenience — losing them must not block the wizard.
+        return undefined;
+      }
+    },
+    [channel.id, fetchProductPrices],
+  );
 
   const handleNextFromSelect = () => {
     if (selectedProducts.length === 0) {
@@ -418,12 +466,18 @@ const BulkPublishToChannelDialogContent = ({
       }
 
       const appliedDefaultStock = getAppliedDefaultStock(defaults);
+      const currentListings = await loadCurrentListings(
+        products
+          .filter(product => isProductListedInChannel(product, channel.id))
+          .map(product => product.id),
+      );
 
       setProductDrafts(previousDrafts => {
         const freshDrafts = createProductDrafts({
           products,
           channelId: channel.id,
           defaultStock: appliedDefaultStock,
+          currentListings,
         });
 
         if (previousDrafts.length === 0) {
@@ -449,6 +503,17 @@ const BulkPublishToChannelDialogContent = ({
   };
 
   const handleNextFromReview = () => {
+    const invalidPriceDrafts = getDraftsWithInvalidPrice(productDrafts);
+
+    if (invalidPriceDrafts.length > 0) {
+      notify({
+        status: "error",
+        text: intl.formatMessage(messages.priceInvalid),
+      });
+
+      return;
+    }
+
     const missingPriceDrafts = getDraftsMissingPrice(productDrafts);
 
     if (missingPriceDrafts.length > 0) {
@@ -692,6 +757,15 @@ const BulkPublishToChannelDialogContent = ({
                       {...messages.reviewCardSubtitle}
                       values={{ count: productDrafts.length }}
                     />
+                    {showPriceDiff ? (
+                      <>
+                        {" · "}
+                        <FormattedMessage
+                          {...messages.reviewPriceUpdateCount}
+                          values={{ count: priceUpdateCount }}
+                        />
+                      </>
+                    ) : null}
                   </Text>
                 ) : null}
                 <BackButton disabled={submitting || isPreparingReview} onClick={handleBack} />

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishConfirmSummary.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishConfirmSummary.ts
@@ -3,6 +3,7 @@ import { type ProductPublishDraft } from "@dashboard/channels/components/BulkPub
 import {
   getEffectiveStockQuantity,
   hasBulkPublishCostPrice,
+  hasBulkPublishPrice,
   hasBulkPublishStock,
 } from "./bulkPublishDrafts";
 
@@ -57,6 +58,9 @@ export const getBulkPublishStockQuantityRange = (
 
 export const countBulkPublishDraftsWithCostPrice = (drafts: ProductPublishDraft[]): number =>
   drafts.filter(draft => hasBulkPublishCostPrice(draft.costPrice)).length;
+
+export const countBulkPublishDraftsKeepingPrice = (drafts: ProductPublishDraft[]): number =>
+  drafts.filter(draft => !hasBulkPublishPrice(draft.price)).length;
 
 export const countBulkPublishDraftsWithStock = (drafts: ProductPublishDraft[]): number =>
   drafts.filter(draft => hasBulkPublishStock(draft.stock)).length;

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishCurrentListings.test.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishCurrentListings.test.ts
@@ -1,0 +1,140 @@
+import {
+  type BulkPublishListedProduct,
+  getBulkPublishCurrentListing,
+  getBulkPublishCurrentListings,
+} from "./bulkPublishCurrentListings";
+import { BULK_PUBLISH_PRICE_SAMPLE_LIMIT } from "./types";
+
+const buildProduct = ({
+  id = "p1",
+  prices,
+  totalCount,
+}: {
+  id?: string;
+  prices: Array<number | null>;
+  totalCount?: number;
+}): BulkPublishListedProduct => ({
+  id,
+  productVariants: {
+    totalCount: totalCount ?? prices.length,
+    edges: prices.map(amount => ({
+      node: {
+        channelListings: amount === null ? [] : [{ channel: { id: "ch1" }, price: { amount } }],
+      },
+    })),
+  },
+});
+
+describe("getBulkPublishCurrentListing", () => {
+  it("returns a single price when every variant shares one", () => {
+    // Arrange
+    const product = buildProduct({ prices: [24, 24, 24] });
+
+    // Act
+    const listing = getBulkPublishCurrentListing({ product, channelId: "ch1" });
+
+    // Assert
+    expect(listing).toEqual({
+      price: { min: 24, max: 24, isMixed: false },
+      listedVariantCount: 3,
+      unlistedVariantCount: 0,
+    });
+  });
+
+  it("returns a mixed range when variant prices differ", () => {
+    // Arrange
+    const product = buildProduct({ prices: [10, 25, 18] });
+
+    // Act
+    const listing = getBulkPublishCurrentListing({ product, channelId: "ch1" });
+
+    // Assert
+    expect(listing?.price).toEqual({ min: 10, max: 25, isMixed: true });
+  });
+
+  it("counts variants that have no listing in the channel", () => {
+    // Arrange
+    const product = buildProduct({ prices: [12, null, null] });
+
+    // Act
+    const listing = getBulkPublishCurrentListing({ product, channelId: "ch1" });
+
+    // Assert
+    expect(listing).toEqual({
+      price: { min: 12, max: 12, isMixed: false },
+      listedVariantCount: 1,
+      unlistedVariantCount: 2,
+    });
+  });
+
+  it("reports every variant as unlisted when none is priced in the channel", () => {
+    // Arrange
+    const product = buildProduct({ prices: [null, null] });
+
+    // Act
+    const listing = getBulkPublishCurrentListing({ product, channelId: "ch1" });
+
+    // Assert
+    expect(listing).toEqual({
+      price: undefined,
+      listedVariantCount: 0,
+      unlistedVariantCount: 2,
+    });
+  });
+
+  it("ignores prices from other channels", () => {
+    // Arrange
+    const product: BulkPublishListedProduct = {
+      id: "p1",
+      productVariants: {
+        totalCount: 1,
+        edges: [{ node: { channelListings: [{ channel: { id: "ch2" }, price: { amount: 9 } }] } }],
+      },
+    };
+
+    // Act
+    const listing = getBulkPublishCurrentListing({ product, channelId: "ch1" });
+
+    // Assert
+    expect(listing?.price).toBeUndefined();
+    expect(listing?.unlistedVariantCount).toBe(1);
+  });
+
+  it("returns nothing when variants exceed the sample limit, so counts are never partial", () => {
+    // Arrange
+    const product = buildProduct({
+      prices: [10, 20],
+      totalCount: BULK_PUBLISH_PRICE_SAMPLE_LIMIT + 1,
+    });
+
+    // Act & Assert
+    expect(getBulkPublishCurrentListing({ product, channelId: "ch1" })).toBeUndefined();
+  });
+
+  it("returns nothing for a product with no variants", () => {
+    // Arrange
+    const product = buildProduct({ prices: [] });
+
+    // Act & Assert
+    expect(getBulkPublishCurrentListing({ product, channelId: "ch1" })).toBeUndefined();
+  });
+});
+
+describe("getBulkPublishCurrentListings", () => {
+  it("maps every product it can describe", () => {
+    // Arrange
+    const products = [
+      buildProduct({ id: "p1", prices: [15] }),
+      buildProduct({ id: "p2", prices: [null] }),
+      buildProduct({ id: "p3", prices: [1], totalCount: BULK_PUBLISH_PRICE_SAMPLE_LIMIT + 1 }),
+    ];
+
+    // Act
+    const listings = getBulkPublishCurrentListings({ products, channelId: "ch1" });
+
+    // Assert
+    expect(listings.get("p1")?.price?.min).toBe(15);
+    expect(listings.get("p2")?.unlistedVariantCount).toBe(1);
+    expect(listings.has("p3")).toBe(false);
+  });
+});

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishCurrentListings.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishCurrentListings.ts
@@ -1,0 +1,76 @@
+import {
+  BULK_PUBLISH_PRICE_SAMPLE_LIMIT,
+  type BulkPublishCurrentListing,
+} from "@dashboard/channels/components/BulkPublishToChannelDialog/types";
+
+export type BulkPublishListedVariant = {
+  channelListings?: Array<{
+    channel: { id: string };
+    price?: { amount: number } | null;
+  }> | null;
+};
+
+export type BulkPublishListedProduct = {
+  id: string;
+  productVariants?: {
+    totalCount?: number | null;
+    edges: Array<{ node: BulkPublishListedVariant }>;
+  } | null;
+};
+
+export const getBulkPublishCurrentListing = ({
+  product,
+  channelId,
+}: {
+  product: BulkPublishListedProduct;
+  channelId: string;
+}): BulkPublishCurrentListing | undefined => {
+  const variantEdges = product.productVariants?.edges ?? [];
+  const totalCount = product.productVariants?.totalCount ?? variantEdges.length;
+
+  // Anything built from a partial sample could understate both the price spread and how many
+  // variants are unlisted, so we show nothing rather than numbers the merchant might trust.
+  if (totalCount > BULK_PUBLISH_PRICE_SAMPLE_LIMIT || totalCount > variantEdges.length) {
+    return undefined;
+  }
+
+  const prices = variantEdges
+    .map(
+      edge =>
+        edge.node.channelListings?.find(listing => listing.channel.id === channelId)?.price?.amount,
+    )
+    .filter((amount): amount is number => typeof amount === "number" && Number.isFinite(amount));
+
+  if (variantEdges.length === 0) {
+    return undefined;
+  }
+
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+
+  return {
+    price: prices.length > 0 ? { min, max, isMixed: min !== max } : undefined,
+    listedVariantCount: prices.length,
+    unlistedVariantCount: variantEdges.length - prices.length,
+  };
+};
+
+export const getBulkPublishCurrentListings = ({
+  products,
+  channelId,
+}: {
+  products: BulkPublishListedProduct[];
+  channelId: string;
+}): Map<string, BulkPublishCurrentListing> => {
+  const currentListings = new Map<string, BulkPublishCurrentListing>();
+
+  for (const product of products) {
+    const currentListing = getBulkPublishCurrentListing({ product, channelId });
+
+    if (currentListing) {
+      currentListings.set(product.id, currentListing);
+    }
+  }
+
+  return currentListings;
+};

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishDrafts.test.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishDrafts.test.ts
@@ -1,6 +1,7 @@
 import {
   type BulkPublishProductForDraft,
   chunkBulkPublishItems,
+  countDraftsWithPriceUpdate,
   countVariantsInDrafts,
   createProductDrafts,
   getAppliedDefaultStock,
@@ -8,10 +9,12 @@ import {
   getDraftsMissingCategoryForPublish,
   getDraftsMissingPrice,
   getDraftsWithInvalidCostPrice,
+  getDraftsWithInvalidPrice,
   getDraftsWithInvalidStock,
   getDraftsWithManyVariants,
   getEffectiveStockQuantity,
   hasBulkPublishStock,
+  hasListedDrafts,
   isStillDefaultBulkPublishStock,
   isValidBulkPublishCostPrice,
   isValidBulkPublishPrice,
@@ -485,13 +488,66 @@ describe("bulkPublishDrafts", () => {
   });
 
   describe("getDraftsMissingPrice", () => {
-    it("returns drafts without a valid price", () => {
+    it("only requires a price for products that are not in the channel yet", () => {
+      // Arrange
+      // p1 is already listed in ch1, p2 is not.
       const drafts = createProductDrafts({
         products,
         channelId: "ch1",
       });
 
-      expect(getDraftsMissingPrice(drafts)).toHaveLength(2);
+      // Act
+      const missing = getDraftsMissingPrice(drafts);
+
+      // Assert
+      expect(missing).toHaveLength(1);
+      expect(missing[0].productId).toBe("p2");
+    });
+
+    it("accepts a blank price on a listed product", () => {
+      // Arrange
+      const drafts = createProductDrafts({
+        products: [products[0]],
+        channelId: "ch1",
+      });
+
+      // Act & Assert
+      expect(getDraftsMissingPrice(drafts)).toHaveLength(0);
+    });
+  });
+
+  describe("getDraftsWithInvalidPrice", () => {
+    it("treats a blank price as valid but rejects garbage", () => {
+      // Arrange
+      const [listed, unlisted] = createProductDrafts({ products, channelId: "ch1" });
+
+      // Act & Assert
+      expect(getDraftsWithInvalidPrice([listed])).toHaveLength(0);
+      expect(getDraftsWithInvalidPrice([{ ...unlisted, price: "abc" }])).toHaveLength(1);
+      expect(getDraftsWithInvalidPrice([{ ...unlisted, price: "-1" }])).toHaveLength(1);
+      expect(getDraftsWithInvalidPrice([{ ...unlisted, price: "12.5" }])).toHaveLength(0);
+    });
+  });
+
+  describe("countDraftsWithPriceUpdate", () => {
+    it("counts only drafts with a price filled in", () => {
+      // Arrange
+      const [listed, unlisted] = createProductDrafts({ products, channelId: "ch1" });
+
+      // Act & Assert
+      expect(countDraftsWithPriceUpdate([listed, unlisted])).toBe(0);
+      expect(countDraftsWithPriceUpdate([{ ...listed, price: "10" }, unlisted])).toBe(1);
+    });
+  });
+
+  describe("hasListedDrafts", () => {
+    it("detects whether any product is already in the channel", () => {
+      // Arrange
+      const drafts = createProductDrafts({ products, channelId: "ch1" });
+
+      // Act & Assert
+      expect(hasListedDrafts(drafts)).toBe(true);
+      expect(hasListedDrafts(createProductDrafts({ products, channelId: "ch2" }))).toBe(false);
     });
   });
 

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishDrafts.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishDrafts.ts
@@ -1,6 +1,7 @@
 import {
   BULK_PUBLISH_MANY_VARIANTS_THRESHOLD,
   BULK_PUBLISH_MAX_VARIANTS_PER_PRODUCT,
+  type BulkPublishCurrentListing,
   type BulkPublishDefaults,
   type ProductPublishDraft,
 } from "@dashboard/channels/components/BulkPublishToChannelDialog/types";
@@ -48,6 +49,12 @@ export const isValidBulkPublishPrice = (price: string): boolean => {
   // Saleor PositiveDecimal is nonnegative (0 or greater), not strictly positive.
   return Number.isFinite(parsed) && parsed >= 0;
 };
+
+export const hasBulkPublishPrice = (price: string): boolean => price.trim() !== "";
+
+/** Empty means "leave the current price alone", so only a filled-in price has to parse. */
+export const isValidBulkPublishPriceInput = (price: string): boolean =>
+  !hasBulkPublishPrice(price) || isValidBulkPublishPrice(price);
 
 export const isValidBulkPublishCostPrice = (costPrice: string): boolean => {
   if (costPrice.trim() === "") {
@@ -105,10 +112,12 @@ export const createProductDrafts = ({
   products,
   channelId,
   defaultStock,
+  currentListings,
 }: {
   products: BulkPublishProductForDraft[];
   channelId: string;
   defaultStock?: string;
+  currentListings?: Map<string, BulkPublishCurrentListing>;
 }): ProductPublishDraft[] => {
   const trimmedDefaultStock = defaultStock?.trim() ?? "";
   const shouldPrefillStock =
@@ -131,6 +140,7 @@ export const createProductDrafts = ({
       price: "",
       costPrice: "",
       stock: shouldPrefillStock ? trimmedDefaultStock : "",
+      currentListing: currentListings?.get(product.id),
     };
   });
 };
@@ -165,12 +175,25 @@ export const mergeProductDrafts = ({
     };
   });
 
+/**
+ * Price is only required where there is nothing to fall back on — Saleor needs a price to create a
+ * channel listing. Products already in the channel keep their existing prices when left blank.
+ */
 export const getDraftsMissingPrice = (drafts: ProductPublishDraft[]): ProductPublishDraft[] =>
-  drafts.filter(draft => !isValidBulkPublishPrice(draft.price));
+  drafts.filter(draft => !draft.alreadyInChannel && !isValidBulkPublishPrice(draft.price));
+
+export const getDraftsWithInvalidPrice = (drafts: ProductPublishDraft[]): ProductPublishDraft[] =>
+  drafts.filter(draft => !isValidBulkPublishPriceInput(draft.price));
 
 export const getDraftsWithInvalidCostPrice = (
   drafts: ProductPublishDraft[],
 ): ProductPublishDraft[] => drafts.filter(draft => !isValidBulkPublishCostPrice(draft.costPrice));
+
+export const countDraftsWithPriceUpdate = (drafts: ProductPublishDraft[]): number =>
+  drafts.filter(draft => hasBulkPublishPrice(draft.price)).length;
+
+export const hasListedDrafts = (drafts: ProductPublishDraft[]): boolean =>
+  drafts.some(draft => draft.alreadyInChannel);
 
 export const getDraftsExceedingVariantLimit = (
   drafts: ProductPublishDraft[],

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishVariantChannelListings.test.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishVariantChannelListings.test.ts
@@ -1,0 +1,100 @@
+import {
+  buildBulkPublishVariantChannelListingsInput,
+  type BulkPublishVariantChannelListingSource,
+} from "./bulkPublishVariantChannelListings";
+
+const listedVariant: BulkPublishVariantChannelListingSource = {
+  channelListings: [{ id: "listing-1", channel: { id: "ch1" } }],
+};
+const unlistedVariant: BulkPublishVariantChannelListingSource = { channelListings: [] };
+
+describe("buildBulkPublishVariantChannelListingsInput", () => {
+  it("updates an existing listing when a price is given", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: listedVariant,
+      channelId: "ch1",
+      price: "20",
+    });
+
+    // Assert
+    expect(input).toEqual({ update: [{ channelListing: "listing-1", price: "20" }] });
+  });
+
+  it("leaves an existing price untouched when the price is blank", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: listedVariant,
+      channelId: "ch1",
+    });
+
+    // Assert
+    expect(input).toBeUndefined();
+  });
+
+  it("updates only the cost price when the price is blank", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: listedVariant,
+      channelId: "ch1",
+      costPrice: "5",
+    });
+
+    // Assert
+    expect(input).toEqual({ update: [{ channelListing: "listing-1", costPrice: "5" }] });
+  });
+
+  it("creates a listing when the variant has none and a price is given", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: unlistedVariant,
+      channelId: "ch1",
+      price: "20",
+      costPrice: "5",
+    });
+
+    // Assert
+    expect(input).toEqual({ create: [{ channelId: "ch1", price: "20", costPrice: "5" }] });
+  });
+
+  it("leaves an unlisted variant alone when there is no price to create a listing with", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: unlistedVariant,
+      channelId: "ch1",
+      costPrice: "5",
+    });
+
+    // Assert
+    expect(input).toBeUndefined();
+  });
+
+  it("ignores listings from other channels when deciding create vs update", () => {
+    // Arrange
+    const variant: BulkPublishVariantChannelListingSource = {
+      channelListings: [{ id: "listing-other", channel: { id: "ch2" } }],
+    };
+
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant,
+      channelId: "ch1",
+      price: "20",
+    });
+
+    // Assert
+    expect(input).toEqual({ create: [{ channelId: "ch1", price: "20" }] });
+  });
+
+  it("treats a zero price as a real value, not a blank", () => {
+    // Act
+    const input = buildBulkPublishVariantChannelListingsInput({
+      variant: listedVariant,
+      channelId: "ch1",
+      price: "0",
+    });
+
+    // Assert
+    expect(input).toEqual({ update: [{ channelListing: "listing-1", price: "0" }] });
+  });
+});

--- a/src/channels/components/BulkPublishToChannelDialog/bulkPublishVariantChannelListings.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/bulkPublishVariantChannelListings.ts
@@ -1,0 +1,62 @@
+import { type ProductVariantBulkUpdateInput } from "@dashboard/graphql";
+
+export type BulkPublishVariantChannelListingSource = {
+  channelListings?: Array<{
+    id: string;
+    channel: { id: string };
+  }> | null;
+};
+
+/**
+ * Decides what a run does to one variant's price in the target channel.
+ *
+ * An undefined price means "leave it alone": on an existing listing we omit the field so the
+ * current price survives, and on a variant with no listing there is nothing to update — Saleor
+ * requires a price to create one, so the variant stays unlisted rather than being published at an
+ * invented price.
+ */
+export const buildBulkPublishVariantChannelListingsInput = ({
+  variant,
+  channelId,
+  price,
+  costPrice,
+}: {
+  variant: BulkPublishVariantChannelListingSource;
+  channelId: string;
+  price?: string;
+  costPrice?: string;
+}): ProductVariantBulkUpdateInput["channelListings"] => {
+  const existingListing = variant.channelListings?.find(
+    listing => listing.channel.id === channelId,
+  );
+
+  if (existingListing) {
+    if (price === undefined && costPrice === undefined) {
+      return undefined;
+    }
+
+    return {
+      update: [
+        {
+          channelListing: existingListing.id,
+          ...(price !== undefined ? { price } : {}),
+          ...(costPrice !== undefined ? { costPrice } : {}),
+        },
+      ],
+    };
+  }
+
+  if (price === undefined) {
+    return undefined;
+  }
+
+  return {
+    create: [
+      {
+        channelId,
+        price,
+        ...(costPrice !== undefined ? { costPrice } : {}),
+      },
+    ],
+  };
+};

--- a/src/channels/components/BulkPublishToChannelDialog/messages.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/messages.ts
@@ -166,6 +166,34 @@ export const messages = defineMessages({
     defaultMessage: "Price",
     description: "bulk publish review table price column",
   },
+  reviewColumnPriceUnchangedHint: {
+    defaultMessage: "Blank keeps current",
+    id: "C1+aT0",
+    description: "bulk publish review table price column hint",
+  },
+  reviewPriceUnchangedPlaceholder: {
+    defaultMessage: "Unchanged",
+    id: "1xn94O",
+    description: "bulk publish review price placeholder when the price is kept",
+  },
+  reviewPriceOverwritesMixed: {
+    defaultMessage:
+      "Overwrites {count, plural, one {# variant price} other {# different variant prices}}",
+    id: "/NkQFN",
+    description: "bulk publish review warning when one price replaces varied variant prices",
+  },
+  reviewVariantsStayUnlisted: {
+    defaultMessage:
+      "{count, plural, one {# variant has no price here and stays unlisted} other {# variants have no price here and stay unlisted}}. Set a price to publish {count, plural, one {it} other {them}}.",
+    id: "BhLnBj",
+    description: "bulk publish review warning about variants left without a channel listing",
+  },
+  reviewPriceUpdateCount: {
+    defaultMessage:
+      "{count, plural, =0 {No price changes} one {# price change} other {# price changes}}",
+    id: "FmZAfR",
+    description: "bulk publish review count of products whose price will change",
+  },
   reviewColumnCostPrice: {
     id: "7E7y/o",
     defaultMessage: "Cost price (optional)",
@@ -279,6 +307,17 @@ export const messages = defineMessages({
     defaultMessage: "Cost prices set for {count, plural, one {# product} other {# products}}",
     description: "bulk publish confirm partial cost prices",
   },
+  confirmPricesUnchanged: {
+    defaultMessage:
+      "{count, plural, one {# product keeps its current prices} other {# products keep their current prices}}",
+    id: "6e2YdE",
+    description: "bulk publish confirm products with no price change",
+  },
+  confirmNoPriceChanges: {
+    defaultMessage: "Prices unchanged",
+    id: "GYXouB",
+    description: "bulk publish confirm title when no price is set",
+  },
   confirmStockSkippedTitle: {
     id: "RB7zH3",
     defaultMessage: "Stock will not be changed",
@@ -367,9 +406,9 @@ export const messages = defineMessages({
     description: "bulk publish product already listed badge",
   },
   alreadyInChannelTooltip: {
-    id: "VnPjPG",
     defaultMessage:
-      "{hasStock, select, true {Prices and stock will be updated across all variants.} other {Prices will be updated across all variants.}}",
+      "{hasStock, select, true {Already in this channel. Leave price or stock blank to keep the current values.} other {Already in this channel. Leave the price blank to keep the current prices.}}",
+    id: "BZyOKE",
     description: "bulk publish already listed badge tooltip",
   },
   publishLabel: {
@@ -425,9 +464,14 @@ export const messages = defineMessages({
     description: "bulk publish stock disabled without any warehouses",
   },
   priceRequired: {
-    id: "Oct6t4",
-    defaultMessage: "Enter a valid price for every product.",
+    defaultMessage: "Enter a price for products that are not in this channel yet.",
+    id: "Em4Fzl",
     description: "bulk publish price validation",
+  },
+  priceInvalid: {
+    defaultMessage: "Enter a valid price or leave it blank to keep the current one.",
+    id: "H31h5O",
+    description: "bulk publish price format validation",
   },
   costPriceInvalid: {
     id: "bJ8HZb",

--- a/src/channels/components/BulkPublishToChannelDialog/types.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/types.ts
@@ -40,6 +40,23 @@ export type BulkPublishDefaults = {
   isAvailableForPurchase: boolean;
 };
 
+/** What the product's variants are priced at in the target channel today. */
+export type BulkPublishCurrentPrice = {
+  min: number;
+  max: number;
+  /** True when listed variants do not all share the same price. */
+  isMixed: boolean;
+};
+
+/** How the product sits in the target channel today, used to describe what a run will change. */
+export type BulkPublishCurrentListing = {
+  /** Undefined when no variant is listed in the channel yet. */
+  price?: BulkPublishCurrentPrice;
+  listedVariantCount: number;
+  /** Variants with no listing here. They need a price, so a blank one leaves them unlisted. */
+  unlistedVariantCount: number;
+};
+
 export type ProductPublishDraft = {
   productId: string;
   name: string;
@@ -51,12 +68,21 @@ export type ProductPublishDraft = {
   /** Saleor requires a category before a product can be published. */
   hasCategory: boolean;
   alreadyInChannel: boolean;
-  /** Single price applied to all variants of this product */
+  /**
+   * Single price applied to all variants of this product. Empty leaves prices untouched, which is
+   * only possible for products already listed in the channel — creating a listing requires a price.
+   */
   price: string;
   /** Optional cost price applied to all variants; empty skips the update */
   costPrice: string;
   /** Stock per variant per warehouse; empty uses the default quantity */
   stock: string;
+  /**
+   * How the product looks in the channel today, used for the "unchanged" placeholder and to warn
+   * about variants a blank price would leave unlisted. Undefined when the product is not listed
+   * yet, or when it has too many variants to sample exactly.
+   */
+  currentListing?: BulkPublishCurrentListing;
 };
 
 export type PublishProgressStatus = "pending" | "in_progress" | "success" | "error";
@@ -81,3 +107,9 @@ export const BULK_PUBLISH_MANY_VARIANTS_THRESHOLD = 100;
 
 /** Hard cap per product for this wizard; products above cannot be published here. */
 export const BULK_PUBLISH_MAX_VARIANTS_PER_PRODUCT = 500;
+
+/**
+ * How many variants we sample to show a product's current price. Saleor caps `first` at 100, so
+ * products above this get no placeholder rather than a range we cannot guarantee is complete.
+ */
+export const BULK_PUBLISH_PRICE_SAMPLE_LIMIT = 100;

--- a/src/channels/components/BulkPublishToChannelDialog/useBulkPublishToChannelSubmit.ts
+++ b/src/channels/components/BulkPublishToChannelDialog/useBulkPublishToChannelSubmit.ts
@@ -26,11 +26,14 @@ import { type IntlShape, useIntl } from "react-intl";
 
 import {
   chunkBulkPublishItems,
+  getDraftsMissingPrice,
+  getDraftsWithInvalidPrice,
   getEffectiveStockQuantity,
   hasBulkPublishCostPrice,
-  isValidBulkPublishPrice,
+  hasBulkPublishPrice,
 } from "./bulkPublishDrafts";
 import { getBulkPublishStockWarehouses } from "./bulkPublishStockWarehouses";
+import { buildBulkPublishVariantChannelListingsInput } from "./bulkPublishVariantChannelListings";
 import { buildBulkPublishVariantStocksInput } from "./bulkPublishVariantStocks";
 import {
   type BulkPublishVariantNode,
@@ -99,55 +102,40 @@ const buildVariantBulkUpdateInputs = ({
 }: {
   variants: BulkPublishVariantNode[];
   channelId: string;
-  price: string;
+  price?: string;
   costPrice?: string;
   stock?: {
     warehouseIds: string[];
     quantity: number;
   };
 }): ProductVariantBulkUpdateInput[] =>
-  variants.map(variant => {
-    const existingListing = variant.channelListings?.find(
-      listing => listing.channel.id === channelId,
-    );
-    const stocks = stock
-      ? buildBulkPublishVariantStocksInput({
-          variant,
-          warehouseIds: stock.warehouseIds,
-          quantity: stock.quantity,
-        })
-      : undefined;
+  variants
+    .map((variant): ProductVariantBulkUpdateInput | undefined => {
+      const channelListings = buildBulkPublishVariantChannelListingsInput({
+        variant,
+        channelId,
+        price,
+        costPrice,
+      });
+      const stocks = stock
+        ? buildBulkPublishVariantStocksInput({
+            variant,
+            warehouseIds: stock.warehouseIds,
+            quantity: stock.quantity,
+          })
+        : undefined;
 
-    if (existingListing) {
+      if (!channelListings && !stocks) {
+        return undefined;
+      }
+
       return {
         id: variant.id,
-        channelListings: {
-          update: [
-            {
-              channelListing: existingListing.id,
-              price,
-              ...(costPrice !== undefined ? { costPrice } : {}),
-            },
-          ],
-        },
+        ...(channelListings ? { channelListings } : {}),
         ...(stocks ? { stocks } : {}),
       };
-    }
-
-    return {
-      id: variant.id,
-      channelListings: {
-        create: [
-          {
-            channelId,
-            price,
-            ...(costPrice !== undefined ? { costPrice } : {}),
-          },
-        ],
-      },
-      ...(stocks ? { stocks } : {}),
-    };
-  });
+    })
+    .filter((input): input is ProductVariantBulkUpdateInput => input !== undefined);
 
 export type BulkPublishSubmitResult = {
   failedProductIds: string[];
@@ -205,9 +193,12 @@ export const useBulkPublishToChannelSubmit = ({
         return { failedProductIds: [] };
       }
 
-      const invalidDraft = draftsToPublish.find(draft => !isValidBulkPublishPrice(draft.price));
+      // Same rules the review step enforces — kept here as a backstop against a caller that skips it.
+      const hasUnusablePrice =
+        getDraftsWithInvalidPrice(draftsToPublish).length > 0 ||
+        getDraftsMissingPrice(draftsToPublish).length > 0;
 
-      if (invalidDraft) {
+      if (hasUnusablePrice) {
         notify({
           status: "error",
           text: intl.formatMessage(messages.priceRequired),
@@ -322,7 +313,7 @@ export const useBulkPublishToChannelSubmit = ({
             // when listings were already created (e.g. by a prior failed publish attempt).
             // Also loads stocks so we can create missing rows and update existing ones.
             const variants = await fetchAllBulkPublishProductVariants(client, product.id);
-            const price = draft.price;
+            const price = hasBulkPublishPrice(draft.price) ? draft.price : undefined;
             const costPrice = hasBulkPublishCostPrice(draft.costPrice)
               ? draft.costPrice
               : undefined;

--- a/src/channels/queries.ts
+++ b/src/channels/queries.ts
@@ -161,6 +161,35 @@ export const bulkPublishProductsData = gql`
   }
 `;
 
+export const bulkPublishProductPrices = gql`
+  query BulkPublishProductPrices($ids: [ID!]!, $first: Int!, $variantsFirst: Int!) {
+    products(first: $first, where: { ids: $ids }) {
+      edges {
+        node {
+          id
+          productVariants(first: $variantsFirst) {
+            totalCount
+            edges {
+              node {
+                id
+                channelListings {
+                  id
+                  channel {
+                    id
+                  }
+                  price {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const bulkPublishProductVariants = gql`
   query BulkPublishProductVariants($id: ID!, $first: Int!, $after: String) {
     product(id: $id) {

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -5798,6 +5798,63 @@ export function useBulkPublishProductsDataLazyQuery(baseOptions?: ApolloReactHoo
 export type BulkPublishProductsDataQueryHookResult = ReturnType<typeof useBulkPublishProductsDataQuery>;
 export type BulkPublishProductsDataLazyQueryHookResult = ReturnType<typeof useBulkPublishProductsDataLazyQuery>;
 export type BulkPublishProductsDataQueryResult = Apollo.QueryResult<Types.BulkPublishProductsDataQuery, Types.BulkPublishProductsDataQueryVariables>;
+export const BulkPublishProductPricesDocument = gql`
+    query BulkPublishProductPrices($ids: [ID!]!, $first: Int!, $variantsFirst: Int!) {
+  products(first: $first, where: {ids: $ids}) {
+    edges {
+      node {
+        id
+        productVariants(first: $variantsFirst) {
+          totalCount
+          edges {
+            node {
+              id
+              channelListings {
+                channel {
+                  id
+                }
+                price {
+                  amount
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useBulkPublishProductPricesQuery__
+ *
+ * To run a query within a React component, call `useBulkPublishProductPricesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBulkPublishProductPricesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBulkPublishProductPricesQuery({
+ *   variables: {
+ *      ids: // value for 'ids'
+ *      first: // value for 'first'
+ *      variantsFirst: // value for 'variantsFirst'
+ *   },
+ * });
+ */
+export function useBulkPublishProductPricesQuery(baseOptions: ApolloReactHooks.QueryHookOptions<Types.BulkPublishProductPricesQuery, Types.BulkPublishProductPricesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.BulkPublishProductPricesQuery, Types.BulkPublishProductPricesQueryVariables>(BulkPublishProductPricesDocument, options);
+      }
+export function useBulkPublishProductPricesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.BulkPublishProductPricesQuery, Types.BulkPublishProductPricesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.BulkPublishProductPricesQuery, Types.BulkPublishProductPricesQueryVariables>(BulkPublishProductPricesDocument, options);
+        }
+export type BulkPublishProductPricesQueryHookResult = ReturnType<typeof useBulkPublishProductPricesQuery>;
+export type BulkPublishProductPricesLazyQueryHookResult = ReturnType<typeof useBulkPublishProductPricesLazyQuery>;
+export type BulkPublishProductPricesQueryResult = Apollo.QueryResult<Types.BulkPublishProductPricesQuery, Types.BulkPublishProductPricesQueryVariables>;
 export const BulkPublishProductVariantsDocument = gql`
     query BulkPublishProductVariants($id: ID!, $first: Int!, $after: String) {
   product(id: $id) {

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -10923,6 +10923,15 @@ export type BulkPublishProductsDataQueryVariables = Exact<{
 
 export type BulkPublishProductsDataQuery = { __typename: 'Query', products: { __typename: 'ProductCountableConnection', edges: Array<{ __typename: 'ProductCountableEdge', node: { __typename: 'Product', id: string, name: string, category: { __typename: 'Category', id: string } | null, channelListings: Array<{ __typename: 'ProductChannelListing', channel: { __typename: 'Channel', id: string } }> | null, productVariants: { __typename: 'ProductVariantCountableConnection', totalCount: number | null, edges: Array<{ __typename: 'ProductVariantCountableEdge', node: { __typename: 'ProductVariant', id: string } }> } | null } }> } | null };
 
+export type BulkPublishProductPricesQueryVariables = Exact<{
+  ids: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+  first: Scalars['Int']['input'];
+  variantsFirst: Scalars['Int']['input'];
+}>;
+
+
+export type BulkPublishProductPricesQuery = { __typename: 'Query', products: { __typename: 'ProductCountableConnection', edges: Array<{ __typename: 'ProductCountableEdge', node: { __typename: 'Product', id: string, productVariants: { __typename: 'ProductVariantCountableConnection', totalCount: number | null, edges: Array<{ __typename: 'ProductVariantCountableEdge', node: { __typename: 'ProductVariant', id: string, channelListings: Array<{ __typename: 'ProductVariantChannelListing', channel: { __typename: 'Channel', id: string }, price: { __typename: 'Money', amount: number } | null }> | null } }> } | null } }> } | null };
+
 export type BulkPublishProductVariantsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   first: Scalars['Int']['input'];


### PR DESCRIPTION
When adding products to a channel with the bulk publish wizard, leaving the price blank now keeps each product’s current prices instead of requiring a new price for every product.

That means you can update stock or visibility for products already in the channel without overwriting variant prices. The review step shows current prices as placeholders, marks rows that will change, and warns before a single price would flatten different variant prices or leave unpriced variants unlisted. New products still need a price so they can be listed in the channel.