### PR TITLE
Close app extension popup on redirect action

### DIFF
--- a/.changeset/close-popup-on-redirect.md
+++ b/.changeset/close-popup-on-redirect.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Close the app extension popup when the app dispatches a `redirect` action to a Dashboard page. Previously the Dashboard navigated behind the popup and the popup stayed open on top of the new page.

--- a/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.test.ts
+++ b/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.test.ts
@@ -339,6 +339,20 @@ describe("AppActionsHandler", function () {
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith("/orders");
       });
+      it("Closes the open popup when redirecting within the dashboard", () => {
+        // Arrange & Act
+        hookRenderResult.result.current.handle({
+          type: "redirect",
+          payload: {
+            actionId: "123",
+            to: "/orders",
+            newContext: false,
+          },
+        });
+
+        // Assert
+        expect(mockDeactivate).toHaveBeenCalledTimes(1);
+      });
       it("Update route within the same app", () => {
         // Arrange
         const mockHistoryPushState = jest.fn();

--- a/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.ts
+++ b/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.ts
@@ -58,6 +58,7 @@ const useHandleNotificationAction = () => {
 const useHandleRedirectAction = (appId: string) => {
   const navigate = useNavigator();
   const { closeApp } = useExternalApp();
+  const { deactivate } = useActiveAppExtension();
   const intl = useIntl();
   const handleAppDeepChange = (action: RedirectAction) => {
     debug("Handling deep app URL change");
@@ -128,7 +129,10 @@ const useHandleRedirectAction = (appId: string) => {
       window.open(exactLocation);
     } else {
       navigate(action.payload.to);
+      // Dashboard navigated underneath - close whichever popup is open
+      // (legacy ExternalApp dialog or the app-extension popup).
       closeApp();
+      deactivate();
     }
 
     return createResponseStatus(action.payload.actionId, true);


### PR DESCRIPTION
The redirect handler only closed the legacy ExternalApp dialog, so a popup extension dispatching `redirect` to a Dashboard page navigated underneath and stayed open on top of the new page. Also deactivate the app-extension popup (no-op when none is open).
