### PR TITLE
[codex] Add offer savings preview

### DIFF
--- a/.changeset/offer-savings-preview.md
+++ b/.changeset/offer-savings-preview.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added a read-only offer savings preview to promotion details, including current job-advertisement pricing, employer savings, and clear loading, empty, and error states.

--- a/docs/offer-savings-preview.md
+++ b/docs/offer-savings-preview.md
@@ -1,0 +1,13 @@
+# Offer savings preview
+
+The promotion detail page includes a read-only offer savings preview for hiring campaigns. The
+preview is requested only when an operator selects **Preview offer**, and the request always uses
+the latest campaign rules and channel pricing from Saleor Core.
+
+The dashboard renders the `Promotion.offerSavingsPreview` response without calculating or rounding
+prices in the browser. Each result shows the job advertisement, publication channel, standard
+listing price, campaign price, and employer savings. An empty result explains that the campaign has
+no matching job advertisements; request failures can be retried with the same button.
+
+The preview query is deliberately separate from the normal promotion detail query so clients that
+do not request the additive field retain their existing behavior.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -826,6 +826,9 @@
     "context": "header",
     "string": "Custom request headers"
   },
+  "2BSc10": {
+    "string": "Review affected job advertisements and employer pricing before activation."
+  },
   "2CBcub": {
     "context": "CreateVariantTitle manage",
     "string": "Manage"
@@ -3106,6 +3109,9 @@
     "context": "shipping section name",
     "string": "Shipping Methods"
   },
+  "DAx3D1": {
+    "string": "Employer savings"
+  },
   "DDYrvn": {
     "string": "Rule reward value must be less than 100"
   },
@@ -3188,6 +3194,9 @@
   },
   "DbNXK5": {
     "string": "Saleor could not connect to the provided manifest URL. ({errorCode})"
+  },
+  "DcR2sX": {
+    "string": "We couldn't load the offer preview. Select Preview offer to try again."
   },
   "Dd0Dwl": {
     "string": "Go to promotions"
@@ -3785,6 +3794,9 @@
   "GVinbz": {
     "context": "column title",
     "string": "Value"
+  },
+  "GY4TaU": {
+    "string": "Standard listing price"
   },
   "GY93MP": {
     "context": "order line return/refund reason",
@@ -4388,6 +4400,9 @@
     "context": "export scope option disabled when list has no active filters",
     "string": "Apply filters or search on the list to enable this option."
   },
+  "JCJQKi": {
+    "string": "{offerCount, plural, one {# offer} other {# offers}} across {channelCount, plural, one {# channel} other {# channels}}"
+  },
   "JDvxO6": {
     "context": "search gift card placeholder",
     "string": "Search Gift Cards (e.g. by code, email, user name)"
@@ -4566,6 +4581,9 @@
   "Jp+4eZ": {
     "context": "shipping zone country list summary",
     "string": "{count, plural, one {Delivers to # country} other {Delivers to # countries}}"
+  },
+  "JqeFqy": {
+    "string": "Campaign price"
   },
   "JqiqNj": {
     "string": "Something went wrong"
@@ -5268,6 +5286,9 @@
   "NQgbYA": {
     "string": "Account Settings"
   },
+  "NRCihE": {
+    "string": "Publication channel: {channelSlug}"
+  },
   "NSOHa/": {
     "context": "gift card export dialog intro",
     "string": "Choose which gift cards to export and the file format. Only active, unused gift cards are included."
@@ -5751,6 +5772,9 @@
   "PhXtJy": {
     "context": "factor label for line-level voucher discount",
     "string": "Voucher (line)"
+  },
+  "PiNOJH": {
+    "string": "No matching offers"
   },
   "PiSXjb": {
     "context": "check to require numeric attribute unit",
@@ -6359,6 +6383,9 @@
   },
   "SceSNp": {
     "string": "Remove following permissions:"
+  },
+  "SdXHGa": {
+    "string": "No matching job advertisements are configured for this campaign."
   },
   "SdnSCt": {
     "context": "note about separators input in model type tab grouping help",
@@ -7969,6 +7996,9 @@
   "aSn2Ud": {
     "string": "Add reason"
   },
+  "aTCWOh": {
+    "string": "Offer savings preview"
+  },
   "aTDks/": {
     "context": "order return reason card, structured reason select label",
     "string": "Reason"
@@ -8463,6 +8493,9 @@
   },
   "cS1wAx": {
     "string": "I know what I'm doing - confirm"
+  },
+  "cUZ5hl": {
+    "string": "Preview offer"
   },
   "cVjewM": {
     "context": "label for radio button",
@@ -10845,6 +10878,9 @@
   "oB0y5Y": {
     "context": "order status",
     "string": "Unfulfilled"
+  },
+  "oD+y0j": {
+    "string": "Select Preview offer to calculate the current campaign impact."
   },
   "oEFc87": {
     "context": "Warning when no shipping zones configured",

--- a/schema-main.graphql
+++ b/schema-main.graphql
@@ -16747,6 +16747,15 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
 
   """The list of events associated with the promotion."""
   events: [PromotionEvent!]
+
+  """
+  Preview matching published job advertisements in active EUR channels. Returns at most 100 offer entries and does not activate the promotion.
+
+  Added in Saleor 3.23.
+
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  offerSavingsPreview: OfferSavingsPreview!
 }
 
 enum PromotionTypeEnum @doc(category: "Discounts") {
@@ -17021,6 +17030,111 @@ type PromotionRuleDeletedEvent implements Node & PromotionEventInterface & Promo
 
   """The rule ID associated with the promotion event."""
   ruleId: String
+}
+
+"""
+Read-only pricing preview for a hiring campaign.
+
+Added in Saleor 3.23.
+"""
+type OfferSavingsPreview {
+  """
+  Total number of matching product and channel pairs.
+
+  Added in Saleor 3.23.
+  """
+  offerCount: Int!
+
+  """
+  Number of active EUR channels represented in returned offers.
+
+  Added in Saleor 3.23.
+  """
+  channelCount: Int!
+
+  """
+  Matching job advertisement previews, capped at 100 entries.
+
+  Added in Saleor 3.23.
+  """
+  offers: [OfferPreviewItem!]!
+
+  """
+  Non-fatal limitations or empty-state explanations.
+
+  Added in Saleor 3.23.
+  """
+  warnings: [OfferPreviewWarning!]!
+}
+
+"""
+A job advertisement price preview for one channel.
+
+Added in Saleor 3.23.
+"""
+type OfferPreviewItem {
+  """
+  ID of the matching product (job advertisement).
+
+  Added in Saleor 3.23.
+  """
+  productId: ID!
+
+  """
+  Name of the matching product (job advertisement).
+
+  Added in Saleor 3.23.
+  """
+  productName: String!
+
+  """
+  Slug of the active EUR publication channel.
+
+  Added in Saleor 3.23.
+  """
+  channelSlug: String!
+
+  """
+  Standard EUR listing price before this campaign.
+
+  Added in Saleor 3.23.
+  """
+  originalPrice: Money!
+
+  """
+  EUR listing price after this campaign.
+
+  Added in Saleor 3.23.
+  """
+  promotionalPrice: Money!
+
+  """
+  EUR savings produced by this campaign.
+
+  Added in Saleor 3.23.
+  """
+  savingsAmount: Money!
+}
+
+"""
+A non-fatal campaign preview warning.
+
+Added in Saleor 3.23.
+"""
+type OfferPreviewWarning {
+  """
+  Stable warning code for programmatic handling.
+
+  Added in Saleor 3.23.
+  """
+  code: String!
+
+  """
+  Operator-facing explanation of the preview warning.
+
+  Added in Saleor 3.23.
+  """
+  message: String!
 }
 
 type PromotionCountableConnection @doc(category: "Discounts") {

--- a/src/discounts/components/DiscountDetailsPage/DiscountDetailsPage.tsx
+++ b/src/discounts/components/DiscountDetailsPage/DiscountDetailsPage.tsx
@@ -25,6 +25,7 @@ import { DiscountDetailsForm } from "../DiscountDetailsForm";
 import { DiscountGeneralInfo } from "../DiscountGeneralInfo";
 import { DiscountRules } from "../DiscountRules";
 import { DiscountSavebar } from "../DiscountSavebar";
+import { OfferSavingsPreview } from "../OfferSavingsPreview/OfferSavingsPreview";
 import { DiscountDetailsTitle } from "./Title";
 
 const messages = defineMessages({
@@ -133,6 +134,8 @@ export const DiscountDetailsPage = ({
               channels={channels}
               disabled={disabled}
             />
+
+            <OfferSavingsPreview promotionId={data?.id ?? null} />
           </DetailPageLayout.Content>
 
           <DetailPageLayout.RightSidebar>

--- a/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.stories.tsx
+++ b/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { type OfferSavingsPreviewData, OfferSavingsPreviewView } from "./OfferSavingsPreview";
+
+const preview: OfferSavingsPreviewData = {
+  __typename: "OfferSavingsPreview",
+  offerCount: 1,
+  channelCount: 1,
+  offers: [
+    {
+      __typename: "OfferPreviewItem",
+      productId: "UHJvZHVjdDox",
+      productName: "Senior Backend Engineer - Berlin",
+      channelSlug: "germany-jobs-marketplace",
+      originalPrice: { __typename: "Money", amount: 999, currency: "EUR" },
+      promotionalPrice: { __typename: "Money", amount: 799.2, currency: "EUR" },
+      savingsAmount: { __typename: "Money", amount: 199.8, currency: "EUR" },
+    },
+  ],
+  warnings: [],
+};
+
+const meta: Meta<typeof OfferSavingsPreviewView> = {
+  title: "Discounts/OfferSavingsPreview",
+  component: OfferSavingsPreviewView,
+  args: {
+    called: true,
+    loading: false,
+    error: false,
+    preview,
+    promotionId: "UHJvbW90aW9uOjE=",
+    onPreview: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OfferSavingsPreviewView>;
+
+export const Populated: Story = {};
+
+export const Initial: Story = {
+  args: { called: false, preview: undefined },
+};
+
+export const Loading: Story = {
+  args: { loading: true, preview: undefined },
+};
+
+export const Empty: Story = {
+  args: {
+    preview: { ...preview, offerCount: 0, channelCount: 0, offers: [] },
+  },
+};
+
+export const Error: Story = {
+  args: { error: true, preview: undefined },
+};

--- a/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.test.tsx
+++ b/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.test.tsx
@@ -1,0 +1,157 @@
+import { Locale, RawLocaleProvider } from "@dashboard/components/Locale";
+import { ThemeWrapper } from "@test/themeWrapper";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode } from "react";
+
+import {
+  OfferSavingsPreview,
+  type OfferSavingsPreviewData,
+  OfferSavingsPreviewView,
+} from "./OfferSavingsPreview";
+
+const mockLoadPreview = jest.fn();
+
+jest.mock("@dashboard/graphql", () => ({
+  usePromotionOfferSavingsPreviewLazyQuery: jest.fn(() => [
+    mockLoadPreview,
+    {
+      called: false,
+      loading: false,
+      data: undefined,
+      error: undefined,
+    },
+  ]),
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <RawLocaleProvider value={{ locale: Locale.EN, setLocale: () => undefined }}>
+    <ThemeWrapper>{children}</ThemeWrapper>
+  </RawLocaleProvider>
+);
+
+const preview: OfferSavingsPreviewData = {
+  __typename: "OfferSavingsPreview",
+  offerCount: 1,
+  channelCount: 1,
+  offers: [
+    {
+      __typename: "OfferPreviewItem",
+      productId: "UHJvZHVjdDox",
+      productName: "Senior Backend Engineer - Berlin",
+      channelSlug: "germany-jobs-marketplace",
+      originalPrice: {
+        __typename: "Money",
+        amount: 999,
+        currency: "EUR",
+      },
+      promotionalPrice: {
+        __typename: "Money",
+        amount: 799.2,
+        currency: "EUR",
+      },
+      savingsAmount: {
+        __typename: "Money",
+        amount: 199.8,
+        currency: "EUR",
+      },
+    },
+  ],
+  warnings: [],
+};
+
+const renderView = (
+  props: Partial<React.ComponentProps<typeof OfferSavingsPreviewView>> = {},
+): ReturnType<typeof render> => {
+  const defaultProps: React.ComponentProps<typeof OfferSavingsPreviewView> = {
+    called: true,
+    loading: false,
+    error: false,
+    preview,
+    promotionId: "UHJvbW90aW9uOjE=",
+    onPreview: jest.fn(),
+  };
+
+  return render(<OfferSavingsPreviewView {...defaultProps} {...props} />, {
+    wrapper: Wrapper,
+  });
+};
+
+describe("OfferSavingsPreview", () => {
+  it("renders the returned offer and Money values without deriving prices", () => {
+    // Arrange & Act
+    renderView();
+
+    // Assert
+    expect(screen.getByText("Senior Backend Engineer - Berlin")).toBeTruthy();
+    expect(screen.getByText("Publication channel: {channelSlug}")).toBeTruthy();
+    expect(screen.getByText("Standard listing price")).toBeTruthy();
+    expect(screen.getByText("Campaign price")).toBeTruthy();
+    expect(screen.getByText("Employer savings")).toBeTruthy();
+    expect(screen.getAllByTestId("money-value").map(node => node.textContent)).toEqual([
+      "EUR999.00",
+      "EUR799.20",
+      "EUR199.80",
+    ]);
+  });
+
+  it("shows a loading state and disables repeated requests while loading", () => {
+    // Arrange & Act
+    renderView({ loading: true, preview: undefined });
+
+    // Assert
+    expect(screen.getByTestId("preview-loading")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Preview offer" })).toHaveProperty("disabled", true);
+  });
+
+  it("shows an informative empty state", () => {
+    // Arrange
+    const emptyPreview: OfferSavingsPreviewData = {
+      ...preview,
+      offerCount: 0,
+      channelCount: 0,
+      offers: [],
+    };
+
+    // Act
+    renderView({ preview: emptyPreview });
+
+    // Assert
+    expect(screen.getByText("No matching offers")).toBeTruthy();
+    expect(
+      screen.getByText("No matching job advertisements are configured for this campaign."),
+    ).toBeTruthy();
+  });
+
+  it("shows a retryable error state", () => {
+    // Arrange & Act
+    renderView({ error: true, preview: undefined });
+
+    // Assert
+    expect(screen.getByRole("alert").textContent).toContain(
+      "We couldn't load the offer preview. Select Preview offer to try again.",
+    );
+    expect(screen.getByRole("button", { name: "Preview offer" })).toHaveProperty("disabled", false);
+  });
+
+  it("requests a fresh preview on every click", async () => {
+    // Arrange
+    mockLoadPreview.mockClear();
+    render(<OfferSavingsPreview promotionId="UHJvbW90aW9uOjE=" />, { wrapper: Wrapper });
+
+    // Act
+    const button = screen.getByRole("button", { name: "Preview offer" });
+
+    await userEvent.click(button);
+    await userEvent.click(button);
+
+    // Assert
+    expect(mockLoadPreview).toHaveBeenCalledTimes(2);
+    expect(mockLoadPreview).toHaveBeenNthCalledWith(1, {
+      variables: { id: "UHJvbW90aW9uOjE=" },
+    });
+    expect(mockLoadPreview).toHaveBeenNthCalledWith(2, {
+      variables: { id: "UHJvbW90aW9uOjE=" },
+    });
+  });
+});

--- a/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.tsx
+++ b/src/discounts/components/OfferSavingsPreview/OfferSavingsPreview.tsx
@@ -1,0 +1,228 @@
+import { DashboardCard } from "@dashboard/components/Card";
+import Money from "@dashboard/components/Money";
+import {
+  type PromotionOfferSavingsPreviewQuery,
+  usePromotionOfferSavingsPreviewLazyQuery,
+} from "@dashboard/graphql";
+import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui-next";
+import { defineMessages, useIntl } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    id: "aTCWOh",
+    defaultMessage: "Offer savings preview",
+  },
+  description: {
+    id: "2BSc10",
+    defaultMessage: "Review affected job advertisements and employer pricing before activation.",
+  },
+  previewOffer: {
+    id: "cUZ5hl",
+    defaultMessage: "Preview offer",
+  },
+  initial: {
+    id: "oD+y0j",
+    defaultMessage: "Select Preview offer to calculate the current campaign impact.",
+  },
+  error: {
+    id: "DcR2sX",
+    defaultMessage: "We couldn't load the offer preview. Select Preview offer to try again.",
+  },
+  emptyTitle: {
+    id: "PiNOJH",
+    defaultMessage: "No matching offers",
+  },
+  emptyDescription: {
+    id: "SdXHGa",
+    defaultMessage: "No matching job advertisements are configured for this campaign.",
+  },
+  summary: {
+    id: "JCJQKi",
+    defaultMessage:
+      "{offerCount, plural, one {# offer} other {# offers}} across {channelCount, plural, one {# channel} other {# channels}}",
+  },
+  channel: {
+    id: "NRCihE",
+    defaultMessage: "Publication channel: {channelSlug}",
+  },
+  originalPrice: {
+    id: "GY4TaU",
+    defaultMessage: "Standard listing price",
+  },
+  promotionalPrice: {
+    id: "JqeFqy",
+    defaultMessage: "Campaign price",
+  },
+  savingsAmount: {
+    id: "DAx3D1",
+    defaultMessage: "Employer savings",
+  },
+});
+
+export type OfferSavingsPreviewData = NonNullable<
+  NonNullable<PromotionOfferSavingsPreviewQuery["promotion"]>["offerSavingsPreview"]
+>;
+
+interface OfferSavingsPreviewViewProps {
+  called: boolean;
+  loading: boolean;
+  error: boolean;
+  preview?: OfferSavingsPreviewData;
+  promotionId: string | null;
+  onPreview: () => void;
+}
+
+export const OfferSavingsPreviewView = ({
+  called,
+  loading,
+  error,
+  preview,
+  promotionId,
+  onPreview,
+}: OfferSavingsPreviewViewProps): JSX.Element => {
+  const intl = useIntl();
+
+  return (
+    <DashboardCard marginBottom={20} data-test-id="offer-savings-preview">
+      <DashboardCard.Header>
+        <Box display="flex" flexDirection="column">
+          <DashboardCard.Title>{intl.formatMessage(messages.title)}</DashboardCard.Title>
+          <DashboardCard.Subtitle fontSize={3} color="default2">
+            {intl.formatMessage(messages.description)}
+          </DashboardCard.Subtitle>
+        </Box>
+        <DashboardCard.Toolbar>
+          <Button
+            variant="secondary"
+            disabled={!promotionId || loading}
+            onClick={onPreview}
+            data-test-id="preview-offer"
+          >
+            {intl.formatMessage(messages.previewOffer)}
+          </Button>
+        </DashboardCard.Toolbar>
+      </DashboardCard.Header>
+      <DashboardCard.Content display="flex" flexDirection="column" gap={4}>
+        {!called ? <Text color="default2">{intl.formatMessage(messages.initial)}</Text> : null}
+
+        {loading ? (
+          <Box display="flex" flexDirection="column" gap={2} data-test-id="preview-loading">
+            <Skeleton __height="1rem" __width="12rem" />
+            <Skeleton __height="4rem" />
+          </Box>
+        ) : null}
+
+        {!loading && error ? (
+          <Box backgroundColor="critical1" padding={4} borderRadius={3} role="alert">
+            <Text>{intl.formatMessage(messages.error)}</Text>
+          </Box>
+        ) : null}
+
+        {!loading && !error && preview ? (
+          <>
+            {preview.offers.length === 0 ? (
+              <Box display="flex" flexDirection="column" gap={1} data-test-id="preview-empty">
+                <Text fontWeight="bold">{intl.formatMessage(messages.emptyTitle)}</Text>
+                <Text color="default2">{intl.formatMessage(messages.emptyDescription)}</Text>
+              </Box>
+            ) : (
+              <>
+                <Text color="default2" data-test-id="preview-summary">
+                  {intl.formatMessage(messages.summary, {
+                    offerCount: preview.offerCount,
+                    channelCount: preview.channelCount,
+                  })}
+                </Text>
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  gap={3}
+                  __maxHeight="28rem"
+                  overflowY="auto"
+                  paddingRight={1}
+                  data-test-id="offer-preview-list"
+                >
+                  {preview.offers.map(offer => (
+                    <Box
+                      key={`${offer.productId}-${offer.channelSlug}`}
+                      display="flex"
+                      flexDirection="column"
+                      gap={3}
+                      padding={4}
+                      borderWidth={1}
+                      borderStyle="solid"
+                      borderColor="default1"
+                      borderRadius={3}
+                      data-test-id="offer-preview-item"
+                    >
+                      <Box display="flex" flexDirection="column" gap={1}>
+                        <Text fontWeight="bold">{offer.productName}</Text>
+                        <Text color="default2">
+                          {intl.formatMessage(messages.channel, {
+                            channelSlug: offer.channelSlug,
+                          })}
+                        </Text>
+                      </Box>
+                      <Box
+                        display="grid"
+                        __gridTemplateColumns="repeat(auto-fit, minmax(9rem, 1fr))"
+                        gap={4}
+                      >
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Text color="default2">{intl.formatMessage(messages.originalPrice)}</Text>
+                          <Money money={offer.originalPrice} />
+                        </Box>
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Text color="default2">
+                            {intl.formatMessage(messages.promotionalPrice)}
+                          </Text>
+                          <Money money={offer.promotionalPrice} />
+                        </Box>
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Text color="default2">{intl.formatMessage(messages.savingsAmount)}</Text>
+                          <Money money={offer.savingsAmount} />
+                        </Box>
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              </>
+            )}
+            {preview.warnings.map(warning => (
+              <Box key={warning.code} backgroundColor="warning1" padding={3} borderRadius={3}>
+                <Text>{warning.message}</Text>
+              </Box>
+            ))}
+          </>
+        ) : null}
+      </DashboardCard.Content>
+    </DashboardCard>
+  );
+};
+
+interface OfferSavingsPreviewProps {
+  promotionId: string | null;
+}
+
+export const OfferSavingsPreview = ({ promotionId }: OfferSavingsPreviewProps): JSX.Element => {
+  const [loadPreview, { called, data, error, loading }] = usePromotionOfferSavingsPreviewLazyQuery({
+    fetchPolicy: "network-only",
+    notifyOnNetworkStatusChange: true,
+  });
+  const onPreview = (): void => {
+    if (promotionId) {
+      void loadPreview({ variables: { id: promotionId } });
+    }
+  };
+
+  return (
+    <OfferSavingsPreviewView
+      called={called}
+      loading={loading}
+      error={Boolean(error)}
+      preview={data?.promotion?.offerSavingsPreview}
+      promotionId={promotionId}
+      onPreview={onPreview}
+    />
+  );
+};

--- a/src/discounts/queries.ts
+++ b/src/discounts/queries.ts
@@ -152,6 +152,39 @@ export const promotionDetails = gql`
   }
 `;
 
+export const promotionOfferSavingsPreview = gql`
+  query PromotionOfferSavingsPreview($id: ID!) {
+    promotion(id: $id) {
+      id
+      offerSavingsPreview {
+        offerCount
+        channelCount
+        offers {
+          productId
+          productName
+          channelSlug
+          originalPrice {
+            amount
+            currency
+          }
+          promotionalPrice {
+            amount
+            currency
+          }
+          savingsAmount {
+            amount
+            currency
+          }
+        }
+        warnings {
+          code
+          message
+        }
+      }
+    }
+  }
+`;
+
 export const ruleConditionsSelectedOptionsDetails = gql`
   query RuleConditionsSelectedOptionsDetails(
     $categoriesIds: [ID!]

--- a/src/graphql/fabbrica.generated.ts
+++ b/src/graphql/fabbrica.generated.ts
@@ -523,6 +523,9 @@ import type {
   MoveProductInput,
   Mutation,
   NameTranslationInput,
+  OfferPreviewItem,
+  OfferPreviewWarning,
+  OfferSavingsPreview,
   Order,
   OrderAddNote,
   OrderAddNoteInput,
@@ -17951,6 +17954,138 @@ export type OptionalObjectWithAttributes = OptionalPage | OptionalProduct | Opti
 
 export type OptionalObjectWithMetadata = OptionalAddress | OptionalApp | OptionalAttribute | OptionalCategory | OptionalChannel | OptionalCheckout | OptionalCheckoutLine | OptionalCollection | OptionalFulfillment | OptionalGiftCard | OptionalInvoice | OptionalMenu | OptionalMenuItem | OptionalOrder | OptionalOrderLine | OptionalPage | OptionalPageType | OptionalPayment | OptionalProduct | OptionalProductMedia | OptionalProductType | OptionalProductVariant | OptionalPromotion | OptionalSale | OptionalShippingMethod | OptionalShippingMethodType | OptionalShippingZone | OptionalShop | OptionalTaxClass | OptionalTaxConfiguration | OptionalTransactionItem | OptionalUser | OptionalVoucher | OptionalWarehouse;
 
+/**
+ * A job advertisement price preview for one channel.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OptionalOfferPreviewItem = {
+  __typename?: 'OfferPreviewItem';
+  /**
+ * Slug of the active EUR publication channel.
+ *
+ * Added in Saleor 3.23.
+ */
+  channelSlug?: OfferPreviewItem['channelSlug'] | undefined;
+  /**
+ * Standard EUR listing price before this campaign.
+ *
+ * Added in Saleor 3.23.
+ */
+  originalPrice?: OptionalMoney | undefined;
+  /**
+ * ID of the matching product (job advertisement).
+ *
+ * Added in Saleor 3.23.
+ */
+  productId?: OfferPreviewItem['productId'] | undefined;
+  /**
+ * Name of the matching product (job advertisement).
+ *
+ * Added in Saleor 3.23.
+ */
+  productName?: OfferPreviewItem['productName'] | undefined;
+  /**
+ * EUR listing price after this campaign.
+ *
+ * Added in Saleor 3.23.
+ */
+  promotionalPrice?: OptionalMoney | undefined;
+  /**
+ * EUR savings produced by this campaign.
+ *
+ * Added in Saleor 3.23.
+ */
+  savingsAmount?: OptionalMoney | undefined;
+};
+
+/**
+ * Define factory for {@link OfferPreviewItem} model.
+ *
+ * @param options
+ * @returns factory {@link OfferPreviewItemFactoryInterface}
+ */
+export const defineOfferPreviewItemFactory: DefineTypeFactoryInterface<
+  OptionalOfferPreviewItem,
+  {}
+> = defineTypeFactory;
+
+/**
+ * A non-fatal campaign preview warning.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OptionalOfferPreviewWarning = {
+  __typename?: 'OfferPreviewWarning';
+  /**
+ * Stable warning code for programmatic handling.
+ *
+ * Added in Saleor 3.23.
+ */
+  code?: OfferPreviewWarning['code'] | undefined;
+  /**
+ * Operator-facing explanation of the preview warning.
+ *
+ * Added in Saleor 3.23.
+ */
+  message?: OfferPreviewWarning['message'] | undefined;
+};
+
+/**
+ * Define factory for {@link OfferPreviewWarning} model.
+ *
+ * @param options
+ * @returns factory {@link OfferPreviewWarningFactoryInterface}
+ */
+export const defineOfferPreviewWarningFactory: DefineTypeFactoryInterface<
+  OptionalOfferPreviewWarning,
+  {}
+> = defineTypeFactory;
+
+/**
+ * Read-only pricing preview for a hiring campaign.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OptionalOfferSavingsPreview = {
+  __typename?: 'OfferSavingsPreview';
+  /**
+ * Number of active EUR channels represented in returned offers.
+ *
+ * Added in Saleor 3.23.
+ */
+  channelCount?: OfferSavingsPreview['channelCount'] | undefined;
+  /**
+ * Total number of matching product and channel pairs.
+ *
+ * Added in Saleor 3.23.
+ */
+  offerCount?: OfferSavingsPreview['offerCount'] | undefined;
+  /**
+ * Matching job advertisement previews, capped at 100 entries.
+ *
+ * Added in Saleor 3.23.
+ */
+  offers?: OptionalOfferPreviewItem[] | undefined;
+  /**
+ * Non-fatal limitations or empty-state explanations.
+ *
+ * Added in Saleor 3.23.
+ */
+  warnings?: OptionalOfferPreviewWarning[] | undefined;
+};
+
+/**
+ * Define factory for {@link OfferSavingsPreview} model.
+ *
+ * @param options
+ * @returns factory {@link OfferSavingsPreviewFactoryInterface}
+ */
+export const defineOfferSavingsPreviewFactory: DefineTypeFactoryInterface<
+  OptionalOfferSavingsPreview,
+  {}
+> = defineTypeFactory;
+
 /** Represents an order in the shop. */
 export type OptionalOrder = {
   __typename?: 'Order';
@@ -27691,6 +27826,14 @@ export type OptionalPromotion = {
   metafields?: Promotion['metafields'] | undefined;
   /** Name of the promotion. */
   name?: Promotion['name'] | undefined;
+  /**
+ * Preview matching published job advertisements in active EUR channels. Returns at most 100 offer entries and does not activate the promotion.
+ *
+ * Added in Saleor 3.23.
+ *
+ * Requires one of the following permissions: MANAGE_DISCOUNTS.
+ */
+  offerSavingsPreview?: OptionalOfferSavingsPreview | undefined;
   /** List of private metadata items. Requires staff permissions to access. */
   privateMetadata?: OptionalMetadataItem[] | undefined;
   /**

--- a/src/graphql/fabbricaTypes.generated.ts
+++ b/src/graphql/fabbricaTypes.generated.ts
@@ -16786,6 +16786,105 @@ export type ObjectWithMetadataPrivateMetafieldsArgs = {
   keys: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
+/**
+ * A job advertisement price preview for one channel.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OfferPreviewItem = {
+  __typename: 'OfferPreviewItem';
+  /**
+   * Slug of the active EUR publication channel.
+   *
+   * Added in Saleor 3.23.
+   */
+  channelSlug: Scalars['String']['output'];
+  /**
+   * Standard EUR listing price before this campaign.
+   *
+   * Added in Saleor 3.23.
+   */
+  originalPrice: Money;
+  /**
+   * ID of the matching product (job advertisement).
+   *
+   * Added in Saleor 3.23.
+   */
+  productId: Scalars['ID']['output'];
+  /**
+   * Name of the matching product (job advertisement).
+   *
+   * Added in Saleor 3.23.
+   */
+  productName: Scalars['String']['output'];
+  /**
+   * EUR listing price after this campaign.
+   *
+   * Added in Saleor 3.23.
+   */
+  promotionalPrice: Money;
+  /**
+   * EUR savings produced by this campaign.
+   *
+   * Added in Saleor 3.23.
+   */
+  savingsAmount: Money;
+};
+
+/**
+ * A non-fatal campaign preview warning.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OfferPreviewWarning = {
+  __typename: 'OfferPreviewWarning';
+  /**
+   * Stable warning code for programmatic handling.
+   *
+   * Added in Saleor 3.23.
+   */
+  code: Scalars['String']['output'];
+  /**
+   * Operator-facing explanation of the preview warning.
+   *
+   * Added in Saleor 3.23.
+   */
+  message: Scalars['String']['output'];
+};
+
+/**
+ * Read-only pricing preview for a hiring campaign.
+ *
+ * Added in Saleor 3.23.
+ */
+export type OfferSavingsPreview = {
+  __typename: 'OfferSavingsPreview';
+  /**
+   * Number of active EUR channels represented in returned offers.
+   *
+   * Added in Saleor 3.23.
+   */
+  channelCount: Scalars['Int']['output'];
+  /**
+   * Total number of matching product and channel pairs.
+   *
+   * Added in Saleor 3.23.
+   */
+  offerCount: Scalars['Int']['output'];
+  /**
+   * Matching job advertisement previews, capped at 100 entries.
+   *
+   * Added in Saleor 3.23.
+   */
+  offers: Array<OfferPreviewItem>;
+  /**
+   * Non-fatal limitations or empty-state explanations.
+   *
+   * Added in Saleor 3.23.
+   */
+  warnings: Array<OfferPreviewWarning>;
+};
+
 /** Represents an order in the shop. */
 export type Order = Node & ObjectWithMetadata & {
   __typename: 'Order';
@@ -24240,6 +24339,14 @@ export type Promotion = Node & ObjectWithMetadata & {
   metafields: Maybe<Scalars['Metadata']['output']>;
   /** Name of the promotion. */
   name: Scalars['String']['output'];
+  /**
+   * Preview matching published job advertisements in active EUR channels. Returns at most 100 offer entries and does not activate the promotion.
+   *
+   * Added in Saleor 3.23.
+   *
+   * Requires one of the following permissions: MANAGE_DISCOUNTS.
+   */
+  offerSavingsPreview: OfferSavingsPreview;
   /** List of private metadata items. Requires staff permissions to access. */
   privateMetadata: Array<MetadataItem>;
   /**

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -8897,6 +8897,66 @@ export function usePromotionDetailsLazyQuery(baseOptions?: ApolloReactHooks.Lazy
 export type PromotionDetailsQueryHookResult = ReturnType<typeof usePromotionDetailsQuery>;
 export type PromotionDetailsLazyQueryHookResult = ReturnType<typeof usePromotionDetailsLazyQuery>;
 export type PromotionDetailsQueryResult = Apollo.QueryResult<Types.PromotionDetailsQuery, Types.PromotionDetailsQueryVariables>;
+export const PromotionOfferSavingsPreviewDocument = gql`
+    query PromotionOfferSavingsPreview($id: ID!) {
+  promotion(id: $id) {
+    id
+    offerSavingsPreview {
+      offerCount
+      channelCount
+      offers {
+        productId
+        productName
+        channelSlug
+        originalPrice {
+          amount
+          currency
+        }
+        promotionalPrice {
+          amount
+          currency
+        }
+        savingsAmount {
+          amount
+          currency
+        }
+      }
+      warnings {
+        code
+        message
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __usePromotionOfferSavingsPreviewQuery__
+ *
+ * To run a query within a React component, call `usePromotionOfferSavingsPreviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePromotionOfferSavingsPreviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePromotionOfferSavingsPreviewQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function usePromotionOfferSavingsPreviewQuery(baseOptions: ApolloReactHooks.QueryHookOptions<Types.PromotionOfferSavingsPreviewQuery, Types.PromotionOfferSavingsPreviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<Types.PromotionOfferSavingsPreviewQuery, Types.PromotionOfferSavingsPreviewQueryVariables>(PromotionOfferSavingsPreviewDocument, options);
+      }
+export function usePromotionOfferSavingsPreviewLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<Types.PromotionOfferSavingsPreviewQuery, Types.PromotionOfferSavingsPreviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<Types.PromotionOfferSavingsPreviewQuery, Types.PromotionOfferSavingsPreviewQueryVariables>(PromotionOfferSavingsPreviewDocument, options);
+        }
+export type PromotionOfferSavingsPreviewQueryHookResult = ReturnType<typeof usePromotionOfferSavingsPreviewQuery>;
+export type PromotionOfferSavingsPreviewLazyQueryHookResult = ReturnType<typeof usePromotionOfferSavingsPreviewLazyQuery>;
+export type PromotionOfferSavingsPreviewQueryResult = Apollo.QueryResult<Types.PromotionOfferSavingsPreviewQuery, Types.PromotionOfferSavingsPreviewQueryVariables>;
 export const RuleConditionsSelectedOptionsDetailsDocument = gql`
     query RuleConditionsSelectedOptionsDetails($categoriesIds: [ID!], $collectionsIds: [ID!], $productsIds: [ID!], $variantsIds: [ID!]) {
   categories(first: 100, where: {ids: $categoriesIds}) {

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -3228,6 +3228,27 @@ export type ObjectWithMetadataFieldPolicy = {
 	privateMetafield?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetafields?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type OfferPreviewItemKeySpecifier = ('channelSlug' | 'originalPrice' | 'productId' | 'productName' | 'promotionalPrice' | 'savingsAmount' | OfferPreviewItemKeySpecifier)[];
+export type OfferPreviewItemFieldPolicy = {
+	channelSlug?: FieldPolicy<any> | FieldReadFunction<any>,
+	originalPrice?: FieldPolicy<any> | FieldReadFunction<any>,
+	productId?: FieldPolicy<any> | FieldReadFunction<any>,
+	productName?: FieldPolicy<any> | FieldReadFunction<any>,
+	promotionalPrice?: FieldPolicy<any> | FieldReadFunction<any>,
+	savingsAmount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type OfferPreviewWarningKeySpecifier = ('code' | 'message' | OfferPreviewWarningKeySpecifier)[];
+export type OfferPreviewWarningFieldPolicy = {
+	code?: FieldPolicy<any> | FieldReadFunction<any>,
+	message?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type OfferSavingsPreviewKeySpecifier = ('channelCount' | 'offerCount' | 'offers' | 'warnings' | OfferSavingsPreviewKeySpecifier)[];
+export type OfferSavingsPreviewFieldPolicy = {
+	channelCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	offerCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	offers?: FieldPolicy<any> | FieldReadFunction<any>,
+	warnings?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type OrderKeySpecifier = ('actions' | 'authorizeStatus' | 'availableCollectionPoints' | 'availableShippingMethods' | 'billingAddress' | 'canFinalize' | 'channel' | 'chargeStatus' | 'checkoutId' | 'collectionPointName' | 'created' | 'customerNote' | 'deliveryMethod' | 'discount' | 'discountName' | 'discounts' | 'displayGrossPrices' | 'errors' | 'events' | 'externalReference' | 'fulfillments' | 'giftCards' | 'grantedRefunds' | 'id' | 'invoices' | 'isPaid' | 'isShippingRequired' | 'languageCode' | 'languageCodeEnum' | 'lines' | 'metadata' | 'metafield' | 'metafields' | 'number' | 'origin' | 'original' | 'paymentStatus' | 'paymentStatusDisplay' | 'payments' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'redirectUrl' | 'shippingAddress' | 'shippingMethod' | 'shippingMethodName' | 'shippingMethods' | 'shippingPrice' | 'shippingTaxClass' | 'shippingTaxClassMetadata' | 'shippingTaxClassName' | 'shippingTaxClassPrivateMetadata' | 'shippingTaxRate' | 'status' | 'statusDisplay' | 'subtotal' | 'taxExemption' | 'token' | 'total' | 'totalAuthorizePending' | 'totalAuthorized' | 'totalBalance' | 'totalCancelPending' | 'totalCanceled' | 'totalCaptured' | 'totalChargePending' | 'totalCharged' | 'totalGrantedRefund' | 'totalRefundPending' | 'totalRefunded' | 'totalRemainingGrant' | 'trackingClientId' | 'transactions' | 'translatedDiscountName' | 'undiscountedShippingPrice' | 'undiscountedTotal' | 'updatedAt' | 'user' | 'userEmail' | 'voucher' | 'voucherCode' | 'weight' | OrderKeySpecifier)[];
 export type OrderFieldPolicy = {
 	actions?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -5169,7 +5190,7 @@ export type ProductVariantUpdatedFieldPolicy = {
 	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
 	version?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PromotionKeySpecifier = ('createdAt' | 'description' | 'endDate' | 'events' | 'id' | 'metadata' | 'metafield' | 'metafields' | 'name' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'rules' | 'startDate' | 'translation' | 'type' | 'updatedAt' | PromotionKeySpecifier)[];
+export type PromotionKeySpecifier = ('createdAt' | 'description' | 'endDate' | 'events' | 'id' | 'metadata' | 'metafield' | 'metafields' | 'name' | 'offerSavingsPreview' | 'privateMetadata' | 'privateMetafield' | 'privateMetafields' | 'rules' | 'startDate' | 'translation' | 'type' | 'updatedAt' | PromotionKeySpecifier)[];
 export type PromotionFieldPolicy = {
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -5180,6 +5201,7 @@ export type PromotionFieldPolicy = {
 	metafield?: FieldPolicy<any> | FieldReadFunction<any>,
 	metafields?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
+	offerSavingsPreview?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetadata?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetafield?: FieldPolicy<any> | FieldReadFunction<any>,
 	privateMetafields?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -8908,6 +8930,18 @@ export type StrictTypedTypePolicies = {
 	ObjectWithMetadata?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | ObjectWithMetadataKeySpecifier | (() => undefined | ObjectWithMetadataKeySpecifier),
 		fields?: ObjectWithMetadataFieldPolicy,
+	},
+	OfferPreviewItem?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | OfferPreviewItemKeySpecifier | (() => undefined | OfferPreviewItemKeySpecifier),
+		fields?: OfferPreviewItemFieldPolicy,
+	},
+	OfferPreviewWarning?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | OfferPreviewWarningKeySpecifier | (() => undefined | OfferPreviewWarningKeySpecifier),
+		fields?: OfferPreviewWarningFieldPolicy,
+	},
+	OfferSavingsPreview?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | OfferSavingsPreviewKeySpecifier | (() => undefined | OfferSavingsPreviewKeySpecifier),
+		fields?: OfferSavingsPreviewFieldPolicy,
 	},
 	Order?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | OrderKeySpecifier | (() => undefined | OrderKeySpecifier),

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -11311,6 +11311,13 @@ export type PromotionDetailsQueryVariables = Exact<{
 
 export type PromotionDetailsQuery = { __typename: 'Query', promotion: { __typename: 'Promotion', id: string, name: string, type: PromotionTypeEnum | null, description: unknown | null, startDate: any, endDate: any | null, rules: Array<{ __typename: 'PromotionRule', id: string, name: string | null, description: unknown | null, giftIds: Array<string> | null, rewardType: RewardTypeEnum | null, rewardValueType: RewardValueTypeEnum | null, rewardValue: any | null, cataloguePredicate: unknown | null, orderPredicate: unknown | null, channels: Array<{ __typename: 'Channel', id: string, isActive: boolean, name: string, slug: string, currencyCode: string, defaultCountry: { __typename: 'CountryDisplay', code: string, country: string } }> | null }> | null } | null };
 
+export type PromotionOfferSavingsPreviewQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type PromotionOfferSavingsPreviewQuery = { __typename: 'Query', promotion: { __typename: 'Promotion', id: string, offerSavingsPreview: { __typename: 'OfferSavingsPreview', offerCount: number, channelCount: number, offers: Array<{ __typename: 'OfferPreviewItem', productId: string, productName: string, channelSlug: string, originalPrice: { __typename: 'Money', amount: number, currency: string }, promotionalPrice: { __typename: 'Money', amount: number, currency: string }, savingsAmount: { __typename: 'Money', amount: number, currency: string } }>, warnings: Array<{ __typename: 'OfferPreviewWarning', code: string, message: string }> } } | null };
+
 export type RuleConditionsSelectedOptionsDetailsQueryVariables = Exact<{
   categoriesIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   collectionsIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;


### PR DESCRIPTION
## Context

Promotion operators need a read-only way to inspect which job advertisements a campaign affects and how Saleor Core prices those offers before activation. Without this preview, operators cannot verify the current listing price, campaign price, employer savings, or publication channel from the promotion detail page.

## Root cause

The dashboard did not query or render the Core `Promotion.offerSavingsPreview` field. The initial implementation also referenced generated GraphQL symbols that were not synchronized with the checked-in schema and generated client, which caused TypeScript compilation failures. Its first test setup replaced the entire generated GraphQL module and used a Jest helper unavailable in the repository's installed type definitions.

## Changes

- add the `PromotionOfferSavingsPreview` query and synchronize the main schema plus generated GraphQL hooks, operation types, type policies, and fixtures;
- add a lazy, network-only preview card to promotion details with loading, error, empty, warning, summary, and bounded-list states;
- render all monetary values directly from Core without frontend price calculations;
- add focused component tests and Storybook states using a narrow locale/theme wrapper and Jest-compatible mocks;
- extract translated messages and add user-facing documentation and a patch changeset.

## User impact

Operators can request a fresh pricing preview on demand and review up to the backend's documented 100 offer entries without activating the promotion. Failed requests remain retryable, empty campaigns are explained, and large result sets stay within a scrollable card.

## Validation

- `graphql-codegen --config codegen-main.ts` — passed
- `graphql-codegen --config codegen-staging.ts` — passed
- focused Jest suite for `OfferSavingsPreview.test.tsx` — 5 tests passed
- production Vite build with local Sentry upload disabled — passed
- ESLint auto-fix — passed with 0 errors; existing repository warnings remain
- Prettier on changed files — passed
- message extraction — passed
- changeset validation — passed
- Knip — completed; existing repository findings remain and none point to the new preview
- changed-file TypeScript diagnostic filter — no errors in the preview, discount query, or regenerated GraphQL files
- `git diff --check` — passed
