### PR TITLE
Give each attribute dropdown its own option cache so lists stay put

### DIFF
--- a/.changeset/attribute-dropdown-cache.md
+++ b/.changeset/attribute-dropdown-cache.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Attribute dropdowns on products, variants, and models now keep their own option lists.
+
+Opening one field no longer empties or swaps another field’s values, and the list stays put after blur. Typing filters immediately; the network request stays debounced. Creating a value shows a plus so it reads as an action, not another choice.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -13384,6 +13384,10 @@
     "context": "variant pricing channel status description when product is unpublished",
     "string": "The product is not published on this channel yet."
   },
+  "mQib3Y": {
+    "context": "placeholder for attribute dropdown combobox",
+    "string": "Search values"
+  },
   "mSCZd4": {
     "context": "Webhook details asynchronous events",
     "string": "Asynchronous"

--- a/src/components/Attributes/Attributes.tsx
+++ b/src/components/Attributes/Attributes.tsx
@@ -19,6 +19,7 @@ import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import { DashboardCard } from "../Card";
 import { AttributeListItem } from "./AttributeListItem";
 import { type AttributeRowHandlers, type VariantAttributeScope } from "./types";
+import { resolveByAttributeId, resolveFetchMoreByAttributeId } from "./utils";
 
 export interface AttributeInputData {
   inputType: AttributeInputTypeEnum;
@@ -35,11 +36,17 @@ export type AttributeInput = FormsetAtomicData<
   string[],
   AttributeValuesMetadata[]
 >;
-interface AttributesProps extends AttributeRowHandlers {
+export type AttributeValueChoices =
+  | AttributeValueFragment[]
+  | ((attributeId: string) => AttributeValueFragment[]);
+
+export type AttributeValueFetchMore = FetchMoreProps | ((attributeId: string) => FetchMoreProps);
+
+interface AttributesProps extends Omit<AttributeRowHandlers, "fetchMoreAttributeValues"> {
   attributes: AttributeInput[];
-  attributeValues: AttributeValueFragment[];
+  attributeValues: AttributeValueChoices;
   fetchAttributeValues: (query: string, attributeId: string) => void;
-  fetchMoreAttributeValues: FetchMoreProps;
+  fetchMoreAttributeValues: AttributeValueFetchMore;
   onAttributeSelectBlur: () => void;
   disabled: boolean;
   loading: boolean;
@@ -104,12 +111,22 @@ export const Attributes = ({
                     {attributes.map(attribute => (
                       <React.Fragment key={attribute.id}>
                         <AttributeListItem
+                          {...props}
                           attribute={attribute}
                           errors={errors}
-                          attributeValues={attributeValues}
+                          attributeValues={resolveByAttributeId(attributeValues, attribute.id)}
+                          fetchMoreAttributeValues={
+                            resolveFetchMoreByAttributeId(
+                              props.fetchMoreAttributeValues,
+                              attribute.id,
+                            ) ?? {
+                              hasMore: false,
+                              loading: false,
+                              onFetchMore: () => undefined,
+                            }
+                          }
                           onAttributeSelectBlur={onAttributeSelectBlur}
                           richTextGetters={richTextGetters}
-                          {...props}
                         />
                       </React.Fragment>
                     ))}

--- a/src/components/Attributes/DropdownRow.test.tsx
+++ b/src/components/Attributes/DropdownRow.test.tsx
@@ -1,5 +1,6 @@
 import {
   AttributeInputTypeEnum,
+  type AttributeValueDetailsFragment,
   type AttributeValueFragment,
   ProductErrorCode,
   type ProductErrorWithAttributesFragment,
@@ -64,7 +65,7 @@ const mockAttribute: AttributeInput = {
   value: [],
 };
 
-const mockAttributeValues: AttributeValueFragment[] = [
+const mockAttributeValues: AttributeValueDetailsFragment[] = [
   {
     __typename: "AttributeValue",
     id: "val-1",
@@ -76,6 +77,8 @@ const mockAttributeValues: AttributeValueFragment[] = [
     dateTime: null,
     file: null,
     value: null,
+    plainText: null,
+    richText: null,
   },
   {
     __typename: "AttributeValue",
@@ -88,6 +91,8 @@ const mockAttributeValues: AttributeValueFragment[] = [
     dateTime: null,
     file: null,
     value: null,
+    plainText: null,
+    richText: null,
   },
 ];
 
@@ -200,6 +205,70 @@ describe("DropdownRow", () => {
 
     // Assert
     expect(screen.getByText("Invalid attribute value")).toBeInTheDocument();
+  });
+
+  it("should show type choices when search results are empty", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const attributeWithSeed: AttributeInput = {
+      ...mockAttribute,
+      data: {
+        ...mockAttribute.data,
+        values: mockAttributeValues,
+      },
+    };
+
+    // Act
+    render(
+      <DropdownRow
+        attribute={attributeWithSeed}
+        attributeValues={[]}
+        disabled={false}
+        error={undefined as any}
+        onChange={mockOnChange}
+        fetchAttributeValues={mockFetchAttributeValues}
+        fetchMoreAttributeValues={mockFetchMoreAttributeValues}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+
+    // Assert
+    expect(screen.getByText("Red")).toBeInTheDocument();
+    expect(screen.getByText("Blue")).toBeInTheDocument();
+  });
+
+  it("should filter type choices locally while typing", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const attributeWithSeed: AttributeInput = {
+      ...mockAttribute,
+      data: {
+        ...mockAttribute.data,
+        values: mockAttributeValues,
+      },
+    };
+
+    render(
+      <DropdownRow
+        attribute={attributeWithSeed}
+        attributeValues={[]}
+        disabled={false}
+        error={undefined as any}
+        onChange={mockOnChange}
+        fetchAttributeValues={mockFetchAttributeValues}
+        fetchMoreAttributeValues={mockFetchMoreAttributeValues}
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox");
+
+    await user.click(combobox);
+    await user.type(combobox, "bl");
+
+    // Assert
+    expect(screen.getByText("Blue")).toBeInTheDocument();
+    expect(screen.queryByText("Red")).not.toBeInTheDocument();
   });
 
   it("should filter out attribute values with null slug", async () => {

--- a/src/components/Attributes/DropdownRow.tsx
+++ b/src/components/Attributes/DropdownRow.tsx
@@ -4,18 +4,27 @@ import {
   getErrorMessage,
   getSingleDisplayValue,
 } from "@dashboard/components/Attributes/utils";
+import { isAddNewValueOption } from "@dashboard/components/Combobox/utils";
 import {
   type AttributeValueFragment,
   type PageErrorWithAttributesFragment,
   type ProductErrorWithAttributesFragment,
 } from "@dashboard/graphql";
 import { DynamicCombobox, type Option } from "@saleor/macaw-ui-next";
-import { useState } from "react";
-import { useIntl } from "react-intl";
+import { useMemo, useState } from "react";
+import { defineMessages, useIntl } from "react-intl";
 
 import { type AttributeInput } from "./Attributes";
 import { type AttributeRowHandlers } from "./types";
 import { useAttributeDropdown } from "./useAttributeDropdown";
+
+const messages = defineMessages({
+  searchValues: {
+    id: "mQib3Y",
+    defaultMessage: "Search values",
+    description: "placeholder for attribute dropdown combobox",
+  },
+});
 
 type DropdownRowProps = Pick<
   AttributeRowHandlers,
@@ -26,6 +35,33 @@ type DropdownRowProps = Pick<
   disabled: boolean;
   error: ProductErrorWithAttributesFragment | PageErrorWithAttributesFragment;
   onAttributeSelectBlur?: () => void;
+};
+
+const toOptions = (values: Array<Pick<AttributeValueFragment, "name" | "slug">>): Option[] =>
+  values
+    .filter((value): value is typeof value & { slug: string } => value.slug !== null)
+    .map(value => ({
+      value: value.slug,
+      label: value.name ?? value.slug,
+    }));
+
+const mergeOptions = (seed: Option[], remote: Option[]): Option[] => {
+  const byValue = new Map<string, Option>();
+
+  seed.forEach(option => byValue.set(option.value, option));
+  remote.forEach(option => byValue.set(option.value, option));
+
+  return Array.from(byValue.values());
+};
+
+const filterOptions = (options: Option[], query: string): Option[] => {
+  const normalized = query.trim().toLocaleLowerCase();
+
+  if (!normalized) {
+    return options;
+  }
+
+  return options.filter(option => option.label.toLocaleLowerCase().includes(normalized));
 };
 
 export const DropdownRow = ({
@@ -39,6 +75,7 @@ export const DropdownRow = ({
   onAttributeSelectBlur,
 }: DropdownRowProps): JSX.Element => {
   const intl = useIntl();
+  const fieldId = `attribute:${attribute.label}`;
   const [inputValue, setInputValue] = useState("");
   const [selectedValue, setSelectedValue] = useState<Option | null>(
     attribute.value[0]
@@ -63,12 +100,11 @@ export const DropdownRow = ({
     fetchMore: fetchMoreAttributeValues,
   });
 
-  const options: Option[] = attributeValues
-    .filter(value => value.slug !== null)
-    .map(value => ({
-      value: value.slug as string,
-      label: value.name ?? value.slug ?? "",
-    }));
+  const options = useMemo(() => {
+    const merged = mergeOptions(toOptions(attribute.data.values), toOptions(attributeValues));
+
+    return filterOptions(merged, inputValue);
+  }, [attribute.data.values, attributeValues, inputValue]);
 
   const handleOnChange = (option: Option | null) => {
     if (!option) {
@@ -83,13 +119,17 @@ export const DropdownRow = ({
     setSelectedValue(transformedOption);
     onChange(attribute.id, transformedOption.value);
 
-    if (option.label.includes(customValueLabel)) {
+    if (isAddNewValueOption(option, customValueLabel)) {
       setInputValue("");
     }
   };
 
   return (
-    <BasicAttributeRow label={attribute.label} {...getAttributeRowLabelProps(attribute)}>
+    <BasicAttributeRow
+      id={fieldId}
+      label={attribute.label}
+      {...getAttributeRowLabelProps(attribute)}
+    >
       <DynamicCombobox
         size="small"
         disabled={disabled}
@@ -97,9 +137,10 @@ export const DropdownRow = ({
         value={selectedValue}
         error={!!error}
         helperText={getErrorMessage(error, intl)}
-        name={`attribute:${attribute.label}`}
-        id={`attribute:${attribute.label}`}
+        name={fieldId}
+        id={fieldId}
         label=""
+        placeholder={intl.formatMessage(messages.searchValues)}
         onChange={handleOnChange}
         onInputValueChange={value => {
           setInputValue(value);
@@ -108,7 +149,7 @@ export const DropdownRow = ({
         onFocus={handleFocus}
         onBlur={onAttributeSelectBlur}
         onScrollEnd={handleFetchMore}
-        loading={fetchMoreAttributeValues?.hasMore || fetchMoreAttributeValues?.loading}
+        loading={!!fetchMoreAttributeValues?.loading}
       />
     </BasicAttributeRow>
   );

--- a/src/components/Attributes/SwatchRow.tsx
+++ b/src/components/Attributes/SwatchRow.tsx
@@ -42,29 +42,35 @@ export const SwatchRow = ({
 
   const { handleFetchMore, handleFocus, handleInputChange } = useComboboxHandlers({
     fetchOptions: query => fetchAttributeValues(query, attribute.id),
-    alwaysFetchOnFocus: false,
+    alwaysFetchOnFocus: true,
     fetchMore: fetchMoreAttributeValues,
   });
 
-  const options = useMemo(
-    () =>
-      attributeValues.flatMap(attributeValue => {
-        if (!attributeValue.name || !attributeValue.slug) {
-          return [];
-        }
+  const options = useMemo(() => {
+    const bySlug = new Map<string, (typeof attributeValues)[number]>();
 
-        const swatch = getAttributeSwatchData(attributeValue);
+    [...attribute.data.values, ...attributeValues].forEach(attributeValue => {
+      if (attributeValue.slug) {
+        bySlug.set(attributeValue.slug, attributeValue);
+      }
+    });
 
-        return [
-          {
-            label: attributeValue.name,
-            value: attributeValue.slug,
-            startAdornment: swatch ? <DatagridSwatchPreview {...swatch} /> : null,
-          },
-        ];
-      }),
-    [attributeValues],
-  );
+    return Array.from(bySlug.values()).flatMap(attributeValue => {
+      if (!attributeValue.name || !attributeValue.slug) {
+        return [];
+      }
+
+      const swatch = getAttributeSwatchData(attributeValue);
+
+      return [
+        {
+          label: attributeValue.name,
+          value: attributeValue.slug,
+          startAdornment: swatch ? <DatagridSwatchPreview {...swatch} /> : null,
+        },
+      ];
+    });
+  }, [attribute.data.values, attributeValues]);
 
   return (
     <BasicAttributeRow label={attribute.label} {...getAttributeRowLabelProps(attribute)}>
@@ -92,7 +98,7 @@ export const SwatchRow = ({
         onInputValueChange={handleInputChange}
         onFocus={handleFocus}
         onScrollEnd={handleFetchMore}
-        loading={fetchMoreAttributeValues?.hasMore || fetchMoreAttributeValues?.loading}
+        loading={!!fetchMoreAttributeValues?.loading}
       />
     </BasicAttributeRow>
   );

--- a/src/components/Attributes/useAttributeDropdown.test.tsx
+++ b/src/components/Attributes/useAttributeDropdown.test.tsx
@@ -65,6 +65,7 @@ describe("useAttributeDropdown", () => {
       expect(result.current.customValueOption).toHaveLength(1);
       expect(result.current.customValueOption[0].value).toBe("orange");
       expect(result.current.customValueOption[0].label).toContain("Add new value");
+      expect(result.current.customValueOption[0].startAdornment).toBeTruthy();
     });
 
     it("should hide 'Add new value' option when user types the already selected value", () => {
@@ -252,7 +253,7 @@ describe("useAttributeDropdown", () => {
       expect(mockFetchOptions).toHaveBeenCalledWith(DEFAULT_INITIAL_SEARCH_DATA.query);
     });
 
-    it("should only fetch once on multiple focus calls", () => {
+    it("should refetch on every focus so reopen after blur still has options", () => {
       // Arrange
       const { result } = renderHook(() =>
         useAttributeDropdown({
@@ -268,7 +269,8 @@ describe("useAttributeDropdown", () => {
       result.current.handleFocus();
 
       // Assert
-      expect(mockFetchOptions).toHaveBeenCalledTimes(1);
+      expect(mockFetchOptions).toHaveBeenCalledTimes(3);
+      expect(mockFetchOptions).toHaveBeenCalledWith(DEFAULT_INITIAL_SEARCH_DATA.query);
     });
   });
 

--- a/src/components/Attributes/useAttributeDropdown.tsx
+++ b/src/components/Attributes/useAttributeDropdown.tsx
@@ -1,8 +1,10 @@
+import { AddNewValueAdornment } from "@dashboard/components/Combobox/components/AddNewValueAdornment";
+import { isAddNewValueOption } from "@dashboard/components/Combobox/utils";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";
 import useDebounce from "@dashboard/hooks/useDebounce";
 import { type FetchMoreProps } from "@dashboard/types";
 import { type Option } from "@saleor/macaw-ui-next";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { defineMessages, useIntl } from "react-intl";
 
 const messages = defineMessages({
@@ -31,7 +33,6 @@ export const useAttributeDropdown = ({
   fetchMore,
 }: UseAttributeDropdownProps) => {
   const intl = useIntl();
-  const mounted = useRef(false);
 
   const fetchOptionsCallback = useCallback(
     (value: string) => {
@@ -52,10 +53,8 @@ export const useAttributeDropdown = ({
   };
 
   const handleFocus = () => {
-    if (!mounted.current) {
-      mounted.current = true;
-      fetchOptions(DEFAULT_INITIAL_SEARCH_DATA.query);
-    }
+    // Refetch on every focus so a reopen after blur still has remote options.
+    fetchOptions(DEFAULT_INITIAL_SEARCH_DATA.query);
   };
 
   const customValueLabel = intl.formatMessage(messages.addNewValue, {
@@ -75,12 +74,13 @@ export const useAttributeDropdown = ({
         {
           label: customValueLabel,
           value: inputValue,
+          startAdornment: <AddNewValueAdornment />,
         },
       ]
     : [];
 
   const transformCustomValue = (option: Option): Option => {
-    if (option.label.includes(customValueLabel)) {
+    if (isAddNewValueOption(option, customValueLabel)) {
       return { label: option.value, value: option.value };
     }
 

--- a/src/components/Attributes/utils.test.ts
+++ b/src/components/Attributes/utils.test.ts
@@ -1,4 +1,20 @@
-import { getTruncatedTextValue } from "./utils";
+import { getTruncatedTextValue, resolveByAttributeId } from "./utils";
+
+describe("resolveByAttributeId", () => {
+  it("should call a lookup function with the attribute id", () => {
+    // Arrange
+    const getChoices = (attributeId: string) => (attributeId === "attr-1" ? [{ slug: "red" }] : []);
+
+    // Act / Assert
+    expect(resolveByAttributeId(getChoices, "attr-1")).toEqual([{ slug: "red" }]);
+    expect(resolveByAttributeId(getChoices, "attr-2")).toEqual([]);
+  });
+
+  it("should return an empty list when the value is missing", () => {
+    // Arrange / Act / Assert
+    expect(resolveByAttributeId(undefined, "attr-1")).toEqual([]);
+  });
+});
 
 describe("getTruncatedTextValue", () => {
   it("should truncate the value if it is longer than the specified length", () => {

--- a/src/components/Attributes/utils.ts
+++ b/src/components/Attributes/utils.ts
@@ -7,6 +7,7 @@ import {
   type PageErrorWithAttributesFragment,
   type ProductErrorWithAttributesFragment,
 } from "@dashboard/graphql";
+import { type FetchMoreProps } from "@dashboard/types";
 import { getProductErrorMessage } from "@dashboard/utils/errors";
 import getPageErrorMessage from "@dashboard/utils/errors/page";
 import { getEntityUrl } from "@dashboard/utils/maps";
@@ -91,11 +92,34 @@ export function getMultiChoices(values: AttributeValueFragment[]): Option[] {
   }));
 }
 
+export function resolveByAttributeId<T>(
+  value: T[] | ((attributeId: string) => T[]) | undefined,
+  attributeId: string,
+): T[] {
+  if (typeof value === "function") {
+    return value(attributeId);
+  }
+
+  return value ?? [];
+}
+
+export function resolveFetchMoreByAttributeId(
+  value: FetchMoreProps | ((attributeId: string) => FetchMoreProps) | undefined,
+  attributeId: string,
+): FetchMoreProps | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return typeof value === "function" ? value(attributeId) : value;
+}
+
 export function getSingleDisplayValue(
   attribute: AttributeInput,
   attributeValues: AttributeValueFragment[],
 ): string {
   return (
+    attribute.data.selectedValues?.find(value => value.slug === attribute.value[0])?.name ||
     attributeValues.find(value => value.slug === attribute.value[0])?.name ||
     attribute.data.values.find(value => value.slug === attribute.value[0])?.name ||
     attribute.value[0] ||

--- a/src/components/Combobox/components/AddNewValueAdornment.tsx
+++ b/src/components/Combobox/components/AddNewValueAdornment.tsx
@@ -1,0 +1,16 @@
+import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
+import { Box } from "@saleor/macaw-ui-next";
+import { Plus } from "lucide-react";
+
+export const AddNewValueAdornment = (): JSX.Element => (
+  <Box
+    as="span"
+    display="flex"
+    alignItems="center"
+    paddingRight={2}
+    aria-hidden
+    data-test-id="add-new-value-icon"
+  >
+    <Plus size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+  </Box>
+);

--- a/src/components/Combobox/components/Multiselect.tsx
+++ b/src/components/Combobox/components/Multiselect.tsx
@@ -11,7 +11,7 @@ import { useIntl } from "react-intl";
 
 import { useCombbobxCustomOption } from "../hooks/useCombbobxCustomOption";
 import { useComboboxHandlers } from "../hooks/useComboboxHandlers";
-import { toWithCustomValues } from "../utils";
+import { isAddNewValueOption, toWithCustomValues } from "../utils";
 
 type MultiselectProps = Omit<DynamicMultiselectProps<Option>, "onChange"> & {
   options: Option[];
@@ -60,7 +60,7 @@ const MultiselectRoot = forwardRef<HTMLInputElement, MultiselectProps>(
       selectedValue: selectedValues,
     });
     const handleOnChange = (values: Option[]) => {
-      const hasCustomValue = values.find(value => value.label.includes(customValueLabel));
+      const hasCustomValue = values.find(value => isAddNewValueOption(value, customValueLabel));
       const valuesWithCustom = values.map(toWithCustomValues(customValueLabel));
 
       onChange({

--- a/src/components/Combobox/hooks/useCombbobxCustomOption.tsx
+++ b/src/components/Combobox/hooks/useCombbobxCustomOption.tsx
@@ -1,6 +1,7 @@
 import { type Option } from "@saleor/macaw-ui-next";
 import { useIntl } from "react-intl";
 
+import { AddNewValueAdornment } from "../components/AddNewValueAdornment";
 import { messages } from "../messages";
 
 export const useCombbobxCustomOption = ({
@@ -25,6 +26,7 @@ export const useCombbobxCustomOption = ({
         {
           label: customValueLabel,
           value: query,
+          startAdornment: <AddNewValueAdornment />,
         },
       ]
     : [];

--- a/src/components/Combobox/utils.test.ts
+++ b/src/components/Combobox/utils.test.ts
@@ -1,0 +1,32 @@
+import { isAddNewValueOption, toWithCustomValues } from "./utils";
+
+describe("isAddNewValueOption", () => {
+  it("should match the create row by exact label", () => {
+    // Arrange
+    const addNewValueLabel = "Add new value: This is a test";
+
+    // Act / Assert
+    expect(isAddNewValueOption({ label: "Add new value: This is a test" }, addNewValueLabel)).toBe(
+      true,
+    );
+    expect(isAddNewValueOption({ label: "This is a test" }, addNewValueLabel)).toBe(false);
+  });
+});
+
+describe("toWithCustomValues", () => {
+  it("should strip the create-row prefix only on an exact label match", () => {
+    // Arrange
+    const addNewValueLabel = "Add new value: Gold";
+    const transform = toWithCustomValues(addNewValueLabel);
+
+    // Act / Assert
+    expect(transform({ label: addNewValueLabel, value: "Gold" })).toEqual({
+      label: "Gold",
+      value: "Gold",
+    });
+    expect(transform({ label: "Not Gold", value: "not-gold" })).toEqual({
+      label: "Not Gold",
+      value: "not-gold",
+    });
+  });
+});

--- a/src/components/Combobox/utils.ts
+++ b/src/components/Combobox/utils.ts
@@ -1,7 +1,12 @@
 import { type Option } from "@saleor/macaw-ui-next";
 
+export const isAddNewValueOption = (
+  option: Pick<Option, "label">,
+  addNewValueLabel: string,
+): boolean => option.label === addNewValueLabel;
+
 export const toWithCustomValues = (addNewValueLabel: string) => (value: Option) => {
-  if (value.label.includes(addNewValueLabel)) {
+  if (isAddNewValueOption(value, addNewValueLabel)) {
     return { label: value.value, value: value.value };
   }
 

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -13,7 +13,12 @@ import {
 import AssignAttributeValueDialog, {
   type AssignAttributeValueDialogFilterChangeMap,
 } from "@dashboard/components/AssignAttributeValueDialog";
-import { type AttributeInput, Attributes } from "@dashboard/components/Attributes";
+import {
+  type AttributeInput,
+  Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
+} from "@dashboard/components/Attributes";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
@@ -31,7 +36,6 @@ import {
   type PageDetailsFragment,
   type PageErrorWithAttributesFragment,
   PermissionEnum,
-  type SearchAttributeValuesQuery,
   type SearchCategoriesQuery,
   type SearchCollectionsQuery,
   type SearchPagesQuery,
@@ -72,7 +76,7 @@ interface PageDetailsPageProps {
   allowEmptySlug?: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
   selectedPageType?: PageDetailsFragment["pageType"];
-  attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
+  attributeValues: AttributeValueChoices;
   onRemove: () => void;
   onShowMetadata?: () => void;
   onSubmit: (data: PageSubmitData) => SubmitPromise;
@@ -89,7 +93,7 @@ interface PageDetailsPageProps {
   fetchReferenceCollections?: (data: string) => void;
   fetchMoreReferenceCollections?: FetchMoreProps;
   fetchAttributeValues: (query: string, attributeId: string) => void;
-  fetchMoreAttributeValues?: FetchMoreProps;
+  fetchMoreAttributeValues?: AttributeValueFetchMore;
   onCloseDialog: () => void;
   onSelectPageType?: (pageTypeId: string) => void;
   onAttributeSelectBlur: () => void;

--- a/src/modeling/views/PageCreate.tsx
+++ b/src/modeling/views/PageCreate.tsx
@@ -87,9 +87,9 @@ const PageCreate = ({ params }: PageCreateProps) => {
     variables: DEFAULT_INITIAL_SEARCH_DATA,
   });
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
   const { data: selectedPageType } = usePageTypeQuery({
@@ -99,7 +99,7 @@ const PageCreate = ({ params }: PageCreateProps) => {
     },
     skip: !selectedPageTypeId,
   });
-  const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+  const attributeValues = getAttributeValues;
   const [uploadFile, uploadFileOpts] = useFileUploadMutation({});
   const [pageCreate, pageCreateOpts] = usePageCreateMutation({
     disableErrorHandling: true,
@@ -244,11 +244,7 @@ const PageCreate = ({ params }: PageCreateProps) => {
     loading: searchCollectionsOpts.loading,
     onFetchMore: loadMoreCollections,
   };
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
   const fetchMoreReferencePages = getSearchFetchMoreProps(searchPagesOpts, loadMorePages);
   const fetchMoreReferenceProducts = getSearchFetchMoreProps(searchProductsOpts, loadMoreProducts);
   const errors = getMutationErrors(pageCreateOpts) as PageErrorWithAttributesFragment[];

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -178,12 +178,12 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     result: searchCategoriesOpts,
   } = useReferenceCategorySearch(refAttr);
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
-  const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+  const attributeValues = getAttributeValues;
   const fetchMoreReferencePages = {
     hasMore: searchPagesOpts.data?.search?.pageInfo?.hasNextPage,
     loading: searchPagesOpts.loading,
@@ -204,11 +204,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     loading: searchCollectionsOpts.loading,
     onFetchMore: loadMoreCollections,
   };
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
 
   const onFilterChange = useAssignAttributeValueDialogFilterChangeHandlers({
     refetchProducts: searchProductsOpts.refetch,

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -14,7 +14,12 @@ import {
 import AssignAttributeValueDialog, {
   type AssignAttributeValueDialogFilterChangeMap,
 } from "@dashboard/components/AssignAttributeValueDialog";
-import { type AttributeInput, Attributes } from "@dashboard/components/Attributes";
+import {
+  type AttributeInput,
+  Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
+} from "@dashboard/components/Attributes";
 import ChannelsAvailabilityCard from "@dashboard/components/ChannelsAvailabilityCard";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
@@ -28,7 +33,6 @@ import {
   type ProductChannelListingErrorFragment,
   type ProductErrorWithAttributesFragment,
   type ProductTypeQuery,
-  type SearchAttributeValuesQuery,
   type SearchCategoriesQuery,
   type SearchCollectionsQuery,
   type SearchPagesQuery,
@@ -67,12 +71,12 @@ interface ProductCreatePageProps {
   currentChannels: ChannelData[];
   collections: RelayToFlat<SearchCollectionsQuery["search"]>;
   categories: RelayToFlat<SearchCategoriesQuery["search"]>;
-  attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
+  attributeValues: AttributeValueChoices;
   loading: boolean;
   fetchMoreCategories: FetchMoreProps;
   fetchMoreCollections: FetchMoreProps;
   fetchMoreProductTypes: FetchMoreProps;
-  fetchMoreAttributeValues?: FetchMoreProps;
+  fetchMoreAttributeValues?: AttributeValueFetchMore;
   initial?: Partial<ProductCreateFormData>;
   productTypes?: RelayToFlat<SearchProductTypesQuery["search"]>;
   referencePages?: RelayToFlat<SearchPagesQuery["search"]>;

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -16,7 +16,12 @@ import { type TopNavMenuItem } from "@dashboard/components/AppLayout/TopNav/Menu
 import AssignAttributeValueDialog, {
   type AssignAttributeValueDialogFilterChangeMap,
 } from "@dashboard/components/AssignAttributeValueDialog";
-import { type AttributeInput, Attributes } from "@dashboard/components/Attributes";
+import {
+  type AttributeInput,
+  Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
+} from "@dashboard/components/Attributes";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
@@ -41,7 +46,6 @@ import {
   type ProductErrorWithAttributesFragment,
   type ProductFragment,
   type RefreshLimitsQuery,
-  type SearchAttributeValuesQuery,
   type SearchCategoriesQuery,
   type SearchCollectionsQuery,
   type SearchPagesQuery,
@@ -113,7 +117,7 @@ interface ProductUpdatePageProps {
   errors: UseProductUpdateHandlerError[];
   collections: RelayToFlat<SearchCollectionsQuery["search"]>;
   categories: RelayToFlat<SearchCategoriesQuery["search"]>;
-  attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
+  attributeValues: AttributeValueChoices;
   disabled: boolean;
   fetchMoreCategories: FetchMoreProps;
   fetchMoreCollections: FetchMoreProps;
@@ -148,7 +152,7 @@ interface ProductUpdatePageProps {
   fetchMoreReferenceProducts?: FetchMoreProps;
   fetchMoreReferenceCategories?: FetchMoreProps;
   fetchMoreReferenceCollections?: FetchMoreProps;
-  fetchMoreAttributeValues?: FetchMoreProps;
+  fetchMoreAttributeValues?: AttributeValueFetchMore;
   isSimpleProduct: boolean;
   fetchCategories: (query: string) => void;
   fetchCollections: (query: string) => void;

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -15,6 +15,8 @@ import AssignAttributeValueDialog, {
 import {
   type AttributeInput,
   Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
   VariantAttributeScope,
 } from "@dashboard/components/Attributes";
 import { DashboardCard } from "@dashboard/components/Card";
@@ -30,7 +32,6 @@ import { Savebar } from "@dashboard/components/Savebar";
 import {
   type ProductErrorWithAttributesFragment,
   type ProductVariantCreateDataQuery,
-  type SearchAttributeValuesQuery,
   type SearchCategoriesQuery,
   type SearchCollectionsQuery,
   type SearchPagesQuery,
@@ -104,7 +105,7 @@ interface ProductVariantCreatePageProps {
   referenceProducts?: RelayToFlat<SearchProductsQuery["search"]>;
   referenceCategories?: RelayToFlat<SearchCategoriesQuery["search"]>;
   referenceCollections?: RelayToFlat<SearchCollectionsQuery["search"]>;
-  attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
+  attributeValues: AttributeValueChoices;
   onSubmit: (data: ProductVariantCreateData) => SubmitPromise;
   onVariantClick: (variantId: string) => void;
   onVariantReorder: (move: VariantReorderMove) => void;
@@ -120,7 +121,7 @@ interface ProductVariantCreatePageProps {
   fetchMoreReferenceProducts?: FetchMoreProps;
   fetchMoreReferenceCategories?: FetchMoreProps;
   fetchMoreReferenceCollections?: FetchMoreProps;
-  fetchMoreAttributeValues?: FetchMoreProps;
+  fetchMoreAttributeValues?: AttributeValueFetchMore;
   onCloseDialog: () => void;
   onAttributeSelectBlur: () => void;
   fetchMoreWarehouses: () => void;

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -18,6 +18,8 @@ import AssignAttributeValueDialog, {
 import {
   type AttributeInput,
   Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
   VariantAttributeScope,
 } from "@dashboard/components/Attributes";
 import CardSpacer from "@dashboard/components/CardSpacer";
@@ -34,7 +36,6 @@ import {
   type ProductChannelListingErrorFragment,
   type ProductErrorWithAttributesFragment,
   type ProductVariantFragment,
-  type SearchAttributeValuesQuery,
   type SearchCategoriesQuery,
   type SearchCollectionsQuery,
   type SearchPagesQuery,
@@ -125,12 +126,12 @@ interface ProductVariantPageProps {
   referenceProducts?: RelayToFlat<SearchProductsQuery["search"]>;
   referenceCategories?: RelayToFlat<SearchCategoriesQuery["search"]>;
   referenceCollections?: RelayToFlat<SearchCollectionsQuery["search"]>;
-  attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
+  attributeValues: AttributeValueChoices;
   fetchMoreReferencePages?: FetchMoreProps;
   fetchMoreReferenceProducts?: FetchMoreProps;
   fetchMoreReferenceCategories?: FetchMoreProps;
   fetchMoreReferenceCollections?: FetchMoreProps;
-  fetchMoreAttributeValues?: FetchMoreProps;
+  fetchMoreAttributeValues?: AttributeValueFetchMore;
   fetchReferencePages?: (data: string) => void;
   fetchReferenceProducts?: (data: string) => void;
   fetchReferenceCategories?: (data: string) => void;

--- a/src/products/components/ProductVariantPage/VariantAttributesSection.tsx
+++ b/src/products/components/ProductVariantPage/VariantAttributesSection.tsx
@@ -2,13 +2,14 @@ import {
   type AttributeInput,
   type AttributeRowHandlers,
   Attributes,
+  type AttributeValueChoices,
+  type AttributeValueFetchMore,
 } from "@dashboard/components/Attributes";
 import { DashboardCard } from "@dashboard/components/Card";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import Link from "@dashboard/components/Link";
 import {
-  type AttributeValueFragment,
   type PageErrorWithAttributesFragment,
   type ProductErrorWithAttributesFragment,
 } from "@dashboard/graphql";
@@ -18,7 +19,8 @@ import { CircleHelp } from "lucide-react";
 import { type ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
-interface VariantAttributesSectionProps extends AttributeRowHandlers {
+interface VariantAttributesSectionProps
+  extends Omit<AttributeRowHandlers, "fetchMoreAttributeValues"> {
   title: ReactNode;
   attributes: AttributeInput[];
   /** Total count of all variant attributes (selection + non-selection) */
@@ -26,7 +28,8 @@ interface VariantAttributesSectionProps extends AttributeRowHandlers {
   selectionAttributesExist: boolean;
   /** Whether the product type supports variant attributes */
   hasVariants: boolean;
-  attributeValues: AttributeValueFragment[];
+  attributeValues: AttributeValueChoices;
+  fetchMoreAttributeValues: AttributeValueFetchMore;
   productTypeName: string;
   productTypeUrl: string;
   loading: boolean;

--- a/src/products/views/ProductCreate/ProductCreate.tsx
+++ b/src/products/views/ProductCreate/ProductCreate.tsx
@@ -112,9 +112,9 @@ const ProductCreateView = ({ params }: ProductCreateProps) => {
     variables: DEFAULT_INITIAL_SEARCH_DATA,
   });
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
   const [updateMetadata] = useUpdateMetadataMutation({});
@@ -304,11 +304,7 @@ const ProductCreateView = ({ params }: ProductCreateProps) => {
     searchReferenceCollectionsOpts,
     loadMoreReferenceCollections,
   );
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
   const loading =
     uploadFileOpts.loading ||
     productCreateOpts.loading ||
@@ -350,7 +346,7 @@ const ProductCreateView = ({ params }: ProductCreateProps) => {
         currentChannels={currentChannels}
         categories={mapEdgesToItems(searchCategoriesOpts?.data?.search) || []}
         collections={mapEdgesToItems(searchCollectionsOpts?.data?.search) || []}
-        attributeValues={mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute?.choices) ?? []}
+        attributeValues={getAttributeValues}
         loading={loading}
         channelsErrors={channelsErrors}
         errors={errors}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -88,9 +88,9 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     variables: DEFAULT_INITIAL_SEARCH_DATA,
   });
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
   const { data, loading, refetch } = useProductDetailsQuery({
@@ -401,7 +401,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   const categories = mapEdgesToItems(searchCategoriesOpts?.data?.search) || [];
   const referenceCategories = mapEdgesToItems(searchReferenceCategoriesOpts?.data?.search) || [];
   const collections = mapEdgesToItems(searchCollectionsOpts?.data?.search) || [];
-  const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+  const attributeValues = getAttributeValues;
   const fetchMoreCollections = getSearchFetchMoreProps(searchCollectionsOpts, loadMoreCollections);
   const fetchMoreCategories = getSearchFetchMoreProps(searchCategoriesOpts, loadMoreCategories);
   const fetchMoreReferenceCategories = getSearchFetchMoreProps(
@@ -414,11 +414,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   );
   const fetchMoreReferencePages = getSearchFetchMoreProps(searchPagesOpts, loadMorePages);
   const fetchMoreReferenceProducts = getSearchFetchMoreProps(searchProductsOpts, loadMoreProducts);
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
   const { taxClasses, fetchMoreTaxClasses } = useTaxClassFetchMore();
 
   if (product === null) {

--- a/src/products/views/ProductVariant/ProductVariant.tsx
+++ b/src/products/views/ProductVariant/ProductVariant.tsx
@@ -256,9 +256,9 @@ const ProductVariant = ({ variantId, params }: ProductUpdateProps) => {
     result: searchCollectionsOpts,
   } = useReferenceCollectionSearch(refAttr);
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
   const onFilterChange = useAssignAttributeValueDialogFilterChangeHandlers({
@@ -288,12 +288,8 @@ const ProductVariant = ({ variantId, params }: ProductUpdateProps) => {
     loading: searchCollectionsOpts.loading,
     onFetchMore: loadMoreCollections,
   };
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
-  const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
+  const attributeValues = getAttributeValues;
 
   if (variant === null) {
     return <NotFoundPage backHref={productUrl(productId)} />;

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -226,9 +226,9 @@ const ProductVariant = ({ productId, params }: ProductVariantCreateProps) => {
     referenceWhereConstraints: getReferenceWhereConstraints(initialConstraints),
   });
   const {
-    loadMore: loadMoreAttributeValues,
+    getChoices: getAttributeValues,
+    getFetchMore: getFetchMoreAttributeValues,
     search: searchAttributeValues,
-    result: searchAttributeValuesOpts,
     reset: searchAttributeReset,
   } = useAttributeValueSearchHandler(DEFAULT_INITIAL_SEARCH_DATA);
   const fetchMoreReferencePages = {
@@ -251,12 +251,8 @@ const ProductVariant = ({ productId, params }: ProductVariantCreateProps) => {
     loading: searchCollectionsOpts.loading,
     onFetchMore: loadMoreCollections,
   };
-  const fetchMoreAttributeValues = {
-    hasMore: !!searchAttributeValuesOpts.data?.attribute?.choices?.pageInfo?.hasNextPage,
-    loading: !!searchAttributeValuesOpts.loading,
-    onFetchMore: loadMoreAttributeValues,
-  };
-  const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
+  const fetchMoreAttributeValues = getFetchMoreAttributeValues;
+  const attributeValues = getAttributeValues;
   const disableForm =
     productLoading ||
     uploadFileOpts.loading ||

--- a/src/utils/handlers/attributeValueSearchHandler.test.ts
+++ b/src/utils/handlers/attributeValueSearchHandler.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+
+import useAttributeValueSearchHandler from "./attributeValueSearchHandler";
+
+const mockSearch = jest.fn();
+const mockLoadMore = jest.fn();
+let mockResult = {
+  data: {
+    attribute: {
+      id: "attr-1",
+      choices: {
+        edges: [{ node: { id: "v1", name: "Red", slug: "red" } }],
+        pageInfo: { hasNextPage: false },
+      },
+    },
+  },
+  loading: false,
+};
+
+jest.mock("@dashboard/searches/useAttributeValueSearch", () => ({
+  __esModule: true,
+  default: () => ({
+    loadMore: mockLoadMore,
+    search: mockSearch,
+    result: mockResult,
+  }),
+}));
+
+describe("useAttributeValueSearchHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResult = {
+      data: {
+        attribute: {
+          id: "attr-1",
+          choices: {
+            edges: [{ node: { id: "v1", name: "Red", slug: "red" } }],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      },
+      loading: false,
+    };
+  });
+
+  const renderSearchHandler = () =>
+    renderHook(() =>
+      useAttributeValueSearchHandler({
+        id: "attr-1",
+        first: 20,
+        query: "",
+      }),
+    );
+
+  it("should cache choices per attribute and keep them after reset", () => {
+    // Arrange
+    const { result } = renderSearchHandler();
+
+    // Act
+    act(() => {
+      result.current.search("", "attr-1");
+    });
+
+    // Assert
+    expect(result.current.getChoices("attr-1")).toEqual([{ id: "v1", name: "Red", slug: "red" }]);
+    expect(result.current.getChoices("attr-2")).toEqual([]);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.getChoices("attr-1")).toEqual([{ id: "v1", name: "Red", slug: "red" }]);
+    expect(result.current.getFetchMore("attr-1").hasMore).toBe(false);
+  });
+
+  it("should not write another attribute's payload into the active cache", () => {
+    // Arrange — result still belongs to attr-1 while we search attr-2
+    const { result } = renderSearchHandler();
+
+    act(() => {
+      result.current.search("", "attr-2");
+    });
+
+    // Assert
+    expect(result.current.getChoices("attr-2")).toEqual([]);
+    expect(result.current.getChoices("attr-1")).toEqual([]);
+  });
+});

--- a/src/utils/handlers/attributeValueSearchHandler.ts
+++ b/src/utils/handlers/attributeValueSearchHandler.ts
@@ -4,18 +4,26 @@ import {
 } from "@dashboard/graphql";
 import { type UseSearchResult } from "@dashboard/hooks/makeSearch";
 import useAttributeValueSearch from "@dashboard/searches/useAttributeValueSearch";
-import { useEffect, useState } from "react";
+import { type FetchMoreProps } from "@dashboard/types";
+import { mapEdgesToItems } from "@dashboard/utils/maps";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface AttributeValueSearchHandlerState {
   id: string | null;
   query: string;
 }
 
+export type AttributeValueChoice = NonNullable<
+  NonNullable<NonNullable<SearchAttributeValuesQuery["attribute"]>["choices"]>["edges"]
+>[number]["node"];
+
 interface UseAttributeValueSearchHandler
   extends Omit<
     UseSearchResult<SearchAttributeValuesQuery, SearchAttributeValuesQueryVariables>,
     "search"
   > {
+  getChoices: (attributeId: string) => AttributeValueChoice[];
+  getFetchMore: (attributeId: string) => FetchMoreProps;
   reset: () => void;
   search: (query: string, id: string | null) => void;
 }
@@ -27,6 +35,9 @@ function useAttributeValueSearchHandler(
     id: null,
     query: variables.query,
   });
+  const [choicesById, setChoicesById] = useState<Record<string, AttributeValueChoice[]>>({});
+  const [hasMoreById, setHasMoreById] = useState<Record<string, boolean>>({});
+  const lastCacheSignatureRef = useRef<string | null>(null);
   const { loadMore, search, result } = useAttributeValueSearch({
     variables: {
       ...variables,
@@ -34,6 +45,7 @@ function useAttributeValueSearchHandler(
     },
     skip: !state.id,
   });
+
   const handleSearch = (query: string, id: string | null) => {
     if (query === "" || query !== state.query) {
       search(query);
@@ -46,25 +58,60 @@ function useAttributeValueSearchHandler(
       });
     }
   };
-  const reset = () => setState(prevState => ({ ...prevState, id: null }));
 
-  useEffect(() => {
-    if (state.id) {
-      search("");
-    }
-  }, [state.id]);
+  const activeAttributeId = state.id;
+  const resultAttributeId = result.data?.attribute?.id;
+  const cacheSignature =
+    activeAttributeId && resultAttributeId === activeAttributeId
+      ? `${activeAttributeId}:${state.query}:${result.data?.attribute?.choices?.pageInfo?.endCursor ?? ""}:${result.data?.attribute?.choices?.edges?.length ?? 0}`
+      : null;
+
+  // Adjust cache during render when this field's payload changes. Do not use
+  // previousData for another attribute — that would leak Color into Size.
+  if (activeAttributeId && cacheSignature && cacheSignature !== lastCacheSignatureRef.current) {
+    lastCacheSignatureRef.current = cacheSignature;
+    setChoicesById(previous => ({
+      ...previous,
+      [activeAttributeId]: mapEdgesToItems(result.data?.attribute?.choices) ?? [],
+    }));
+    setHasMoreById(previous => ({
+      ...previous,
+      [activeAttributeId]: !!result.data?.attribute?.choices?.pageInfo?.hasNextPage,
+    }));
+  }
+
+  useEffect(
+    function searchWhenAttributeChanges() {
+      if (state.id) {
+        search("");
+      }
+    },
+    [state.id],
+  );
+
+  const getChoices = useCallback(
+    (attributeId: string): AttributeValueChoice[] => choicesById[attributeId] ?? [],
+    [choicesById],
+  );
+
+  const getFetchMore = useCallback(
+    (attributeId: string): FetchMoreProps => ({
+      hasMore: !!hasMoreById[attributeId],
+      loading: state.id === attributeId && !!result.loading,
+      onFetchMore: loadMore,
+    }),
+    [hasMoreById, loadMore, result.loading, state.id],
+  );
 
   return {
+    getChoices,
+    getFetchMore,
     query: state.query,
     loadMore,
     search: handleSearch,
-    reset,
-    result: state.id
-      ? result
-      : {
-          ...result,
-          data: undefined,
-        },
+    // Blur must not drop cached choices. Each dropdown reads getChoices(id).
+    reset: () => undefined,
+    result,
   };
 }
 


### PR DESCRIPTION
Attribute dropdowns on products, variants, and models now keep their own option lists.

Opening one field no longer empties or swaps another field’s values, and the list stays put after blur. Typing filters immediately; the network request stays debounced. Creating a value shows a plus so it reads as an action, not another choice.