### PR TITLE
ci: build PR test deployments with staging schema

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -143,6 +143,8 @@ jobs:
           IS_CLOUD_INSTANCE: true
           ENABLED_SERVICE_NAME_HEADER: true
           ONBOARDING_USER_JOINED_DATE_THRESHOLD: ${{ vars.STAGING_ONBOARDING_USER_JOINED_DATE_THRESHOLD }}
+          # PR test envs run core unstable/unreleased main, so build against the staging schema
+          FF_USE_STAGING_SCHEMA: true
         run: pnpm run build
 
       - name: Upload Build


### PR DESCRIPTION
PR test envs run core unstable/unreleased main, so the released schema breaks against them.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
