### PR TITLE
Redirect taxes and discounts section roots to their first tab

### DIFF
--- a/.changeset/section-root-redirects.md
+++ b/.changeset/section-root-redirects.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Opening `/taxes` or `/discounts` directly now lands on a real page instead of a blank one.
+
+Both sections route all of their pages under a sub-path (`/taxes/channels`, `/discounts/sales`, …) and had no route for the section root, so a bookmarked or hand-typed section URL matched nothing and rendered an empty page. The roots now redirect to the tab the navigation already points at — taxes to Channels, discounts to Promotions.

--- a/src/discounts/index.test.tsx
+++ b/src/discounts/index.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import DiscountSection from ".";
+
+// `@sentry/react` is auto-mocked in the test setup, which turns the Sentry-wrapped
+// `Route` from the shared Router module into `undefined`. Use the plain react-router
+// `Route` instead so routing actually resolves.
+jest.mock("@dashboard/components/Router", () => ({
+  Route: jest.requireActual("react-router-dom").Route,
+}));
+
+// The list views are wrapped in filter providers that expect Apollo. This test only
+// exercises routing, so pass the children straight through.
+jest.mock("@dashboard/components/ConditionalFilter", () => ({
+  ConditionalDiscountFilterProvider: ({ children }: { children: React.ReactNode }) => children,
+  ConditionalVoucherFilterProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("./views/DiscountList", () => ({
+  DiscountList: () => <div data-test-id="promotion-list-view" />,
+}));
+jest.mock("./views/DiscountDetails", () => ({
+  DiscountDetails: () => <div data-test-id="promotion-details-view" />,
+}));
+jest.mock("./views/DiscountCreate", () => ({
+  DiscountCreate: () => <div data-test-id="promotion-create-view" />,
+}));
+jest.mock("./views/VoucherList", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="voucher-list-view" />,
+}));
+jest.mock("./views/VoucherDetails", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="voucher-details-view" />,
+}));
+jest.mock("./views/VoucherCreate", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="voucher-create-view" />,
+}));
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <DiscountSection />
+    </MemoryRouter>,
+  );
+
+describe("DiscountSection routing", () => {
+  it("redirects the section root to the promotions list (regression: /discounts rendered a blank page)", () => {
+    // Arrange & Act
+    renderAt("/discounts");
+
+    // Assert
+    expect(screen.getByTestId("promotion-list-view")).toBeInTheDocument();
+  });
+
+  it("redirects the section root to the promotions list regardless of a trailing slash", () => {
+    // Arrange & Act
+    renderAt("/discounts/");
+
+    // Assert
+    expect(screen.getByTestId("promotion-list-view")).toBeInTheDocument();
+  });
+
+  it("keeps rendering the vouchers list on its own path", () => {
+    // Arrange & Act
+    renderAt("/discounts/vouchers");
+
+    // Assert
+    expect(screen.getByTestId("voucher-list-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("promotion-list-view")).not.toBeInTheDocument();
+  });
+
+  it("keeps rendering the voucher details view on its own path", () => {
+    // Arrange & Act
+    renderAt("/discounts/vouchers/dm91Y2hlcjox");
+
+    // Assert
+    expect(screen.getByTestId("voucher-details-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("promotion-list-view")).not.toBeInTheDocument();
+  });
+});

--- a/src/discounts/index.tsx
+++ b/src/discounts/index.tsx
@@ -7,11 +7,12 @@ import { sectionNames } from "@dashboard/intl";
 import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
 import { useIntl } from "react-intl";
-import { type RouteComponentProps, Switch } from "react-router-dom";
+import { Redirect, type RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
 import { type DiscountListUrlQueryParams, DiscountListUrlSortField } from "./discountsUrls";
 import {
+  discountSection,
   saleAddPath,
   saleListPath,
   salePath,
@@ -84,6 +85,7 @@ const DiscountSection = () => {
     <>
       <WindowTitle title={intl.formatMessage(sectionNames.vouchers)} />
       <Switch>
+        <Route exact path={discountSection} render={() => <Redirect to={saleListPath} />} />
         <Route exact path={saleListPath} component={SaleListView} />
         <Route exact path={saleAddPath} component={SaleCreateView} />
         <Route exact path={voucherAddPath} component={VoucherCreateView} />

--- a/src/discounts/urls.ts
+++ b/src/discounts/urls.ts
@@ -13,7 +13,7 @@ import {
   type TabActionDialog,
 } from "../types";
 
-const discountSection = "/discounts/";
+export const discountSection = "/discounts/";
 
 const saleSection = urlJoin(discountSection, "sales");
 

--- a/src/taxes/index.test.tsx
+++ b/src/taxes/index.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import TaxesSection from ".";
+
+// `@sentry/react` is auto-mocked in the test setup, which turns the Sentry-wrapped
+// `Route` from the shared Router module into `undefined`. Use the plain react-router
+// `Route` instead so routing actually resolves.
+jest.mock("@dashboard/components/Router", () => ({
+  Route: jest.requireActual("react-router-dom").Route,
+}));
+
+// The tab views pull in Apollo queries and page layouts. This test only exercises
+// routing, so stub them with recognizable markers.
+jest.mock("./views/TaxChannelsList", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="tax-channels-view" />,
+}));
+jest.mock("./views/TaxCountriesList", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="tax-countries-view" />,
+}));
+jest.mock("./views/TaxClassesList", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="tax-classes-view" />,
+}));
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <TaxesSection />
+    </MemoryRouter>,
+  );
+
+describe("TaxesSection routing", () => {
+  it("redirects the section root to the channels tab (regression: /taxes rendered a blank page)", () => {
+    // Arrange & Act
+    renderAt("/taxes");
+
+    // Assert
+    expect(screen.getByTestId("tax-channels-view")).toBeInTheDocument();
+  });
+
+  it("redirects the section root to the channels tab regardless of a trailing slash", () => {
+    // Arrange & Act
+    renderAt("/taxes/");
+
+    // Assert
+    expect(screen.getByTestId("tax-channels-view")).toBeInTheDocument();
+  });
+
+  it("keeps rendering the countries tab on its own path", () => {
+    // Arrange & Act
+    renderAt("/taxes/countries");
+
+    // Assert
+    expect(screen.getByTestId("tax-countries-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("tax-channels-view")).not.toBeInTheDocument();
+  });
+
+  it("keeps rendering the tax classes tab on its own path", () => {
+    // Arrange & Act
+    renderAt("/taxes/tax-classes");
+
+    // Assert
+    expect(screen.getByTestId("tax-classes-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("tax-channels-view")).not.toBeInTheDocument();
+  });
+});

--- a/src/taxes/index.tsx
+++ b/src/taxes/index.tsx
@@ -2,7 +2,7 @@ import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
 import { parseQs } from "@dashboard/url-utils";
 import { useIntl } from "react-intl";
-import { type RouteComponentProps, Switch } from "react-router-dom";
+import { Redirect, type RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
 import {
@@ -10,6 +10,7 @@ import {
   taxConfigurationListPath,
   taxCountriesListPath,
   type TaxesUrlQueryParams,
+  taxSection,
 } from "./urls";
 import TaxChannelsListComponent from "./views/TaxChannelsList";
 import TaxClassesListComponent from "./views/TaxClassesList";
@@ -35,6 +36,11 @@ const Component = () => {
     <>
       <WindowTitle title={intl.formatMessage(sectionNames.taxes)} />
       <Switch>
+        <Route
+          exact
+          path={taxSection}
+          render={() => <Redirect to={taxConfigurationListPath()} />}
+        />
         <Route path={taxConfigurationListPath(":id")} component={TaxChannelsList} />
         <Route path={taxConfigurationListPath()} component={TaxChannelsList} />
         <Route path={taxCountriesListPath(":id")} component={TaxCountriesList} />

--- a/src/taxes/urls.ts
+++ b/src/taxes/urls.ts
@@ -6,7 +6,7 @@ import { encodeURIComponentOptional } from "./utils/utils";
 
 export type TaxTab = "channels" | "countries" | "tax-classes";
 
-const taxSection = "/taxes/";
+export const taxSection = "/taxes/";
 
 export const taxTabPath = (tab: TaxTab) => urlJoin(taxSection, tab);
 


### PR DESCRIPTION
Fixes #4233

Opening `/taxes` shows a blank page. The issue asks for a fallback that redirects to `/taxes/channels`. `/discounts` has the same defect and is fixed here too.

## Cause

Both sections are mounted at their section root in `src/index.tsx`:

```tsx
<SectionRoute path="/taxes" component={TaxesSection} />
```

but every page inside them is routed under a sub-path — `/taxes/channels`, `/taxes/countries`, `/taxes/tax-classes`, and `/discounts/sales`, `/discounts/vouchers`. Neither section's `Switch` had a route for the root itself, so visiting the root matched nothing and the section rendered an empty `Switch`: a page with just the chrome and no content.

Every other section routes its list view at the section root (`productListPath === "/products/"`, `customerListPath === "/customers/"`, and so on), so bare `/products` and friends already resolve. Taxes and discounts are the only two affected.

## Change

An `exact` index route in each section that redirects to the tab the navigation already points at:

- `/taxes` → `/taxes/channels`, which `createConfigurationMenu` and the settings catalog already link to via `taxConfigurationListUrl()`.
- `/discounts` → `/discounts/sales` (Promotions), which the sidebar's Discounts group already links to via `saleListUrl()`.

`taxSection` and `discountSection` were already the constants those paths are built from; they are now exported so the redirect routes reuse them instead of restating the literals.

The routes are `exact`, so they only match the root and cannot shadow the tab routes.

## Verification

New routing tests for both sections, following the existing `RootRoutes.test.tsx` pattern (plain react-router `Route`, stubbed views, `MemoryRouter`).

Each section is covered for the root, the root with a trailing slash, and two of its own tab paths to confirm the index route does not shadow them. Reverting only the two `index.tsx` files fails exactly the 4 redirect cases and leaves the 4 tab cases passing:

```
Tests: 4 failed, 4 passed, 8 total
```

`tsc --noEmit` and ESLint are clean on the changed files, and the `src/taxes` + `src/discounts` suites pass (50 suites, 250 tests).
