### PR TITLE
Stop lists crashing on a selection that outlived its rows

### DIFF
--- a/.changeset/stale-row-selection-crash.md
+++ b/.changeset/stale-row-selection-crash.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Lists no longer crash when rows stay selected while the list shrinks.
+
+Selecting rows and then lowering "rows per page", bulk-deleting, or refetching fewer records could take the whole view down with "We've encountered an unexpected error". Glide tracks its row selection by index, independently of the data, so the grid reported indices that no longer pointed at a row and the list resolved them straight onto its own data. Products, collections, models, draft orders, shipping zones and gift cards were affected. Attribute and voucher lists did not crash but could put undefined entries into the selection that bulk actions run on.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3118,6 +3118,10 @@
     "context": "collection label",
     "string": "Visible"
   },
+  "9wjl6Q": {
+    "context": "bulk action button label with selected count",
+    "string": "{action} ({count})"
+  },
   "9xlPgt": {
     "context": "used staff users counter",
     "string": "{count}/{max} members"

--- a/src/attributes/components/AttributeListPage/AttributeListPage.tsx
+++ b/src/attributes/components/AttributeListPage/AttributeListPage.tsx
@@ -168,16 +168,22 @@ const AttributeListPage = ({
               defaultMessage: "Search attributes...",
             })}
             actions={
-              <Box display="flex" gap={4}>
+              <Box display="flex" gap={4} alignItems="center">
                 {canUnassignFromType &&
                   onAttributesUnassign &&
                   selectedAttributesIds.length > 0 && (
-                    <BulkUnassignButton onClick={onAttributesUnassign}>
+                    <BulkUnassignButton
+                      count={selectedAttributesIds.length}
+                      onClick={onAttributesUnassign}
+                    >
                       {intl.formatMessage(attributeListPageMessages.unassignAttributes)}
                     </BulkUnassignButton>
                   )}
                 {selectedAttributesIds.length > 0 && (
-                  <BulkDeleteButton onClick={onAttributesDelete}>
+                  <BulkDeleteButton
+                    count={selectedAttributesIds.length}
+                    onClick={onAttributesDelete}
+                  >
                     <FormattedMessage defaultMessage="Delete attributes" id="g0GAdN" />
                   </BulkDeleteButton>
                 )}

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -219,6 +219,8 @@ const AttributeDetails = ({ params }: AttributeDetailsProps) => {
         toggleAll: valueListActions.toggleAll,
         toolbar: (
           <BulkDeleteButton
+            count={valueListActions.listElements.length}
+            size="small"
             onClick={() => openModal("remove-values", { ids: valueListActions.listElements })}
           >
             <FormattedMessage {...buttonMessages.delete} />

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -395,6 +395,8 @@ const AttributeDetails = ({ id, params }: AttributeDetailsProps) => {
         toggleAll: valueListActions.toggleAll,
         toolbar: (
           <BulkDeleteButton
+            count={valueListActions.listElements.length}
+            size="small"
             onClick={() => openModal("remove-values", { ids: valueListActions.listElements })}
           >
             <FormattedMessage {...buttonMessages.delete} />

--- a/src/attributes/views/AttributeList/AttributeList.tsx
+++ b/src/attributes/views/AttributeList/AttributeList.tsx
@@ -15,6 +15,7 @@ import {
 import { BulkAttributeUnassignDialog } from "@dashboard/components/BulkAttributeUnassignDialog";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
 import { createAttributesQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DeleteFilterTabDialog } from "@dashboard/components/DeleteFilterTabDialog";
 import { SaveFilterTabDialog } from "@dashboard/components/SaveFilterTabDialog/SaveFilterTabDialog";
 import {
@@ -473,7 +474,7 @@ const AttributeList = ({ params }: AttributeListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => listAttributes[row]?.id);
+      const rowsIds = getRowIdsFromSelection(rows, listAttributes);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/categories/components/CategoryListPage/CategoryListPage.tsx
+++ b/src/categories/components/CategoryListPage/CategoryListPage.tsx
@@ -152,7 +152,7 @@ export const CategoryListPage = ({
               </Button>
             </Box>
             {selectedCategoriesIds.length > 0 && (
-              <BulkDeleteButton onClick={onCategoriesDelete}>
+              <BulkDeleteButton count={selectedCategoriesIds.length} onClick={onCategoriesDelete}>
                 <FormattedMessage {...messages.bulkCategoryDelete} />
               </BulkDeleteButton>
             )}

--- a/src/categories/components/CategorySubcategories/CategorySubcategories.tsx
+++ b/src/categories/components/CategorySubcategories/CategorySubcategories.tsx
@@ -161,7 +161,12 @@ export const CategorySubcategories = ({
           ) : null}
           <Box className={styles.actions}>
             {hasSubcategories && selectedCategoryIds.length > 0 ? (
-              <BulkDeleteButton onClick={onCategoriesDelete} disabled={disabled}>
+              <BulkDeleteButton
+                count={selectedCategoryIds.length}
+                onClick={onCategoriesDelete}
+                disabled={disabled}
+                size="small"
+              >
                 <FormattedMessage {...messages.deleteSelected} />
               </BulkDeleteButton>
             ) : null}

--- a/src/categories/views/CategoryList/CategoryList.tsx
+++ b/src/categories/views/CategoryList/CategoryList.tsx
@@ -285,10 +285,8 @@ const CategoryList = ({ params }: CategoryListProps): JSX.Element => {
           sort={getSortParams(params)}
           onSort={handleSort}
           disabled={!data}
-          onUpdateListSettings={(...props) => {
-            clearRowSelection();
-            updateListSettings(...props);
-          }}
+          // Keep selection on page-size/column updates; Datagrid drops stale indices.
+          onUpdateListSettings={updateListSettings}
         />
       </CategoryListPageStateProvider>
 

--- a/src/collections/components/CollectionListPage/CollectionListPage.tsx
+++ b/src/collections/components/CollectionListPage/CollectionListPage.tsx
@@ -152,9 +152,12 @@ const CollectionListPage = ({
               defaultMessage: "Search collections...",
             })}
             actions={
-              <Box display="flex" gap={4}>
+              <Box display="flex" gap={4} alignItems="center">
                 {selectedCollectionIds.length > 0 && (
-                  <BulkDeleteButton onClick={onCollectionsDelete}>
+                  <BulkDeleteButton
+                    count={selectedCollectionIds.length}
+                    onClick={onCollectionsDelete}
+                  >
                     <FormattedMessage defaultMessage="Delete collections" id="FTYkgw" />
                   </BulkDeleteButton>
                 )}

--- a/src/collections/views/CollectionList/CollectionList.tsx
+++ b/src/collections/views/CollectionList/CollectionList.tsx
@@ -2,6 +2,7 @@
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
 import { createCollectionsQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DeleteFilterTabDialog } from "@dashboard/components/DeleteFilterTabDialog";
 import { SaveFilterTabDialog } from "@dashboard/components/SaveFilterTabDialog/SaveFilterTabDialog";
 import {
@@ -169,7 +170,7 @@ const CollectionList = ({ params }: CollectionListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => collections[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, collections);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/components/AppLayout/ListFilters/ListFilters.tsx
+++ b/src/components/AppLayout/ListFilters/ListFilters.tsx
@@ -63,7 +63,7 @@ export const ListFilters = <TFilterKeys extends string = string>({
             />
           </Box>
         </Box>
-        <Box display="flex" justifyContent="flex-end">
+        <Box display="flex" justifyContent="flex-end" alignItems="center">
           {actions}
         </Box>
       </Box>

--- a/src/components/BulkDeleteButton/BulkDeleteButton.test.tsx
+++ b/src/components/BulkDeleteButton/BulkDeleteButton.test.tsx
@@ -1,0 +1,23 @@
+import { render, type RenderResult, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+
+import { BulkDeleteButton } from "./BulkDeleteButton";
+
+const renderButton = (count: number): RenderResult =>
+  render(
+    <IntlProvider locale="en">
+      <BulkDeleteButton count={count} onClick={jest.fn()}>
+        Delete products
+      </BulkDeleteButton>
+    </IntlProvider>,
+  );
+
+describe("BulkDeleteButton", () => {
+  it("shows the action label and selected count", () => {
+    // Arrange & Act
+    renderButton(5);
+
+    // Assert
+    expect(screen.getByRole("button", { name: "Delete products (5)" })).toBeInTheDocument();
+  });
+});

--- a/src/components/BulkDeleteButton/BulkDeleteButton.tsx
+++ b/src/components/BulkDeleteButton/BulkDeleteButton.tsx
@@ -1,51 +1,37 @@
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
-import { Button, Tooltip } from "@saleor/macaw-ui-next";
+import { Button } from "@saleor/macaw-ui-next";
 import { Trash2 } from "lucide-react";
-import type * as React from "react";
-import { forwardRef, useState } from "react";
+import { forwardRef, type ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
 
-interface ProductListDeleteButtonProps {
+import { bulkActionWithCountMessages } from "./messages";
+
+interface BulkDeleteButtonProps {
   onClick: () => void;
   disabled?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
+  count: number;
+  size?: "small" | "medium";
 }
 
-export const BulkDeleteButton = forwardRef<HTMLButtonElement, ProductListDeleteButtonProps>(
-  ({ onClick, children, disabled }, ref) => {
-    const [isTooltipOpen, setIsTooltipOpen] = useState(false);
-
-    const handleClick = (): void => {
-      setIsTooltipOpen(false);
-      onClick();
-    };
-
-    return (
-      <Tooltip open={isTooltipOpen}>
-        <Tooltip.Trigger>
-          <Button
-            ref={ref}
-            disabled={disabled}
-            onMouseOver={() => {
-              setIsTooltipOpen(true);
-            }}
-            onMouseLeave={() => {
-              setIsTooltipOpen(false);
-            }}
-            onClick={handleClick}
-            type="button"
-            size="small"
-            icon={<Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />}
-            variant="secondary"
-            data-test-id="bulk-delete-button"
-          />
-        </Tooltip.Trigger>
-        <Tooltip.Content side="bottom">
-          <Tooltip.Arrow />
-          {children}
-        </Tooltip.Content>
-      </Tooltip>
-    );
-  },
+export const BulkDeleteButton = forwardRef<HTMLButtonElement, BulkDeleteButtonProps>(
+  ({ onClick, children, disabled, count, size = "medium" }, ref) => (
+    <Button
+      ref={ref}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+      size={size}
+      variant="secondary"
+      data-test-id="bulk-delete-button"
+    >
+      <Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+      <FormattedMessage
+        {...bulkActionWithCountMessages.actionWithCount}
+        values={{ action: children, count }}
+      />
+    </Button>
+  ),
 );
 
 BulkDeleteButton.displayName = "BulkDeleteButton";

--- a/src/components/BulkDeleteButton/messages.ts
+++ b/src/components/BulkDeleteButton/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export const bulkActionWithCountMessages = defineMessages({
+  actionWithCount: {
+    id: "9wjl6Q",
+    defaultMessage: "{action} ({count})",
+    description: "bulk action button label with selected count",
+  },
+});

--- a/src/components/BulkUnassignButton/BulkUnassignButton.tsx
+++ b/src/components/BulkUnassignButton/BulkUnassignButton.tsx
@@ -1,26 +1,31 @@
+import { bulkActionWithCountMessages } from "@dashboard/components/BulkDeleteButton/messages";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { Button } from "@saleor/macaw-ui-next";
 import { Unlink2 } from "lucide-react";
-import type * as React from "react";
-import { forwardRef } from "react";
+import { forwardRef, type ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
 
 interface BulkUnassignButtonProps {
   onClick: () => void;
   disabled?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
+  count: number;
 }
 
 export const BulkUnassignButton = forwardRef<HTMLButtonElement, BulkUnassignButtonProps>(
-  ({ onClick, children, disabled }, ref) => (
+  ({ onClick, children, disabled, count }, ref) => (
     <Button
       ref={ref}
       disabled={disabled}
       onClick={onClick}
-      icon={<Unlink2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />}
       variant="secondary"
       data-test-id="bulk-unassign-button"
     >
-      {children}
+      <Unlink2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+      <FormattedMessage
+        {...bulkActionWithCountMessages.actionWithCount}
+        values={{ action: children, count }}
+      />
     </Button>
   ),
 );

--- a/src/components/CreateAttributeDialog/CreateAttributeDialog.tsx
+++ b/src/components/CreateAttributeDialog/CreateAttributeDialog.tsx
@@ -253,7 +253,11 @@ export const CreateAttributeDialog = ({
                             toggle: valueListActions.toggle,
                             toggleAll: valueListActions.toggleAll,
                             toolbar: (
-                              <BulkDeleteButton onClick={() => setBulkDeleteOpen(true)}>
+                              <BulkDeleteButton
+                                count={valueListActions.listElements.length}
+                                size="small"
+                                onClick={() => setBulkDeleteOpen(true)}
+                              >
                                 <FormattedMessage {...buttonMessages.delete} />
                               </BulkDeleteButton>
                             ),

--- a/src/components/Datagrid/Datagrid.test.tsx
+++ b/src/components/Datagrid/Datagrid.test.tsx
@@ -1,6 +1,7 @@
 import { CompactSelection, type GridSelection } from "@glideapps/glide-data-grid";
 import { ThemeWrapper } from "@test/themeWrapper";
-import { render } from "@testing-library/react";
+import { render, type RenderResult } from "@testing-library/react";
+import { type ReactElement } from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import { Datagrid } from "./Datagrid";
@@ -15,15 +16,19 @@ const selectionOf = (...rows: number[]): GridSelection => ({
   columns: CompactSelection.empty(),
 });
 
+interface DatagridHarnessProps {
+  rows: number;
+  selection: GridSelection;
+  onRowSelectionChange: (rowsId: number[], clearSelection: () => void) => void;
+  onControlledSelectionChange?: (selection: GridSelection | undefined) => void;
+}
+
 const DatagridHarness = ({
   rows,
   selection,
   onRowSelectionChange,
-}: {
-  rows: number;
-  selection: GridSelection;
-  onRowSelectionChange: (rowsId: number[], clearSelection: () => void) => void;
-}) => {
+  onControlledSelectionChange = jest.fn(),
+}: DatagridHarnessProps): ReactElement => {
   const datagrid = useDatagridChangeState();
 
   return (
@@ -38,18 +43,14 @@ const DatagridHarness = ({
         menuItems={() => []}
         selectionActions={() => null}
         controlledSelection={selection}
-        onControlledSelectionChange={jest.fn()}
+        onControlledSelectionChange={onControlledSelectionChange}
         onRowSelectionChange={onRowSelectionChange}
       />
     </DatagridChangeStateContext.Provider>
   );
 };
 
-const renderDatagrid = (props: {
-  rows: number;
-  selection: GridSelection;
-  onRowSelectionChange: (rowsId: number[], clearSelection: () => void) => void;
-}) =>
+const renderDatagrid = (props: DatagridHarnessProps): RenderResult =>
   render(
     <MemoryRouter>
       <ThemeWrapper>
@@ -87,6 +88,24 @@ describe("Datagrid row selection reporting", () => {
 
     // Assert
     expect(onRowSelectionChange).toHaveBeenCalledWith([0, 1, 2], expect.any(Function));
+  });
+
+  it("does not rewrite the grid selection while loading so a refetch can restore it", () => {
+    // Arrange - products report 1 placeholder row while disabled/loading
+    const onRowSelectionChange = jest.fn();
+    const onControlledSelectionChange = jest.fn();
+
+    // Act
+    renderDatagrid({
+      rows: 1,
+      selection: selectionOf(0, 1, 2, 3, 7, 19),
+      onRowSelectionChange,
+      onControlledSelectionChange,
+    });
+
+    // Assert - report is clamped to avoid a crash, selection itself is left intact
+    expect(onRowSelectionChange).toHaveBeenCalledWith([0], expect.any(Function));
+    expect(onControlledSelectionChange).not.toHaveBeenCalled();
   });
 
   it("reports no rows when the list emptied out under a live selection", () => {

--- a/src/components/Datagrid/Datagrid.test.tsx
+++ b/src/components/Datagrid/Datagrid.test.tsx
@@ -1,0 +1,106 @@
+import { CompactSelection, type GridSelection } from "@glideapps/glide-data-grid";
+import { ThemeWrapper } from "@test/themeWrapper";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { Datagrid } from "./Datagrid";
+import { DatagridChangeStateContext, useDatagridChangeState } from "./hooks/useDatagridChange";
+
+// Glide's DataEditor is never rendered here: `loading` short-circuits the output to a
+// throbber while the hooks, and so the row selection effect, still run.
+const availableColumns = [{ id: "name", title: "Name", width: 200 }] as const;
+
+const selectionOf = (...rows: number[]): GridSelection => ({
+  rows: rows.reduce((acc, row) => acc.add(row), CompactSelection.empty()),
+  columns: CompactSelection.empty(),
+});
+
+const DatagridHarness = ({
+  rows,
+  selection,
+  onRowSelectionChange,
+}: {
+  rows: number;
+  selection: GridSelection;
+  onRowSelectionChange: (rowsId: number[], clearSelection: () => void) => void;
+}) => {
+  const datagrid = useDatagridChangeState();
+
+  return (
+    <DatagridChangeStateContext.Provider value={datagrid}>
+      <Datagrid
+        loading
+        rows={rows}
+        availableColumns={availableColumns}
+        emptyText="No rows"
+        getCellContent={() => ({}) as never}
+        getCellError={() => false}
+        menuItems={() => []}
+        selectionActions={() => null}
+        controlledSelection={selection}
+        onControlledSelectionChange={jest.fn()}
+        onRowSelectionChange={onRowSelectionChange}
+      />
+    </DatagridChangeStateContext.Provider>
+  );
+};
+
+const renderDatagrid = (props: {
+  rows: number;
+  selection: GridSelection;
+  onRowSelectionChange: (rowsId: number[], clearSelection: () => void) => void;
+}) =>
+  render(
+    <MemoryRouter>
+      <ThemeWrapper>
+        <DatagridHarness {...props} />
+      </ThemeWrapper>
+    </MemoryRouter>,
+  );
+
+describe("Datagrid row selection reporting", () => {
+  it("reports the selected rows to the parent", () => {
+    // Arrange
+    const onRowSelectionChange = jest.fn();
+
+    // Act
+    renderDatagrid({
+      rows: 5,
+      selection: selectionOf(1, 2),
+      onRowSelectionChange,
+    });
+
+    // Assert
+    expect(onRowSelectionChange).toHaveBeenCalledWith([1, 2], expect.any(Function));
+  });
+
+  it("does not report rows past the last one when the list shrank under a live selection", () => {
+    // Arrange - rows per page was lowered to 3 while rows 0-19 stayed selected
+    const onRowSelectionChange = jest.fn();
+
+    // Act
+    renderDatagrid({
+      rows: 3,
+      selection: selectionOf(0, 1, 2, 3, 7, 19),
+      onRowSelectionChange,
+    });
+
+    // Assert
+    expect(onRowSelectionChange).toHaveBeenCalledWith([0, 1, 2], expect.any(Function));
+  });
+
+  it("reports no rows when the list emptied out under a live selection", () => {
+    // Arrange
+    const onRowSelectionChange = jest.fn();
+
+    // Act
+    renderDatagrid({
+      rows: 0,
+      selection: selectionOf(1, 2),
+      onRowSelectionChange,
+    });
+
+    // Assert
+    expect(onRowSelectionChange).toHaveBeenCalledWith([], expect.any(Function));
+  });
+});

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -61,7 +61,7 @@ import useStyles, {
   useFullScreenStyles,
 } from "./styles";
 import { type AvailableColumn } from "./types";
-import { preventRowClickOnSelectionCheckbox } from "./utils";
+import { getVisibleGridSelection, preventRowClickOnSelectionCheckbox } from "./utils";
 
 export interface GetCellContentOpts {
   changes: MutableRefObject<DatagridChange[]>;
@@ -321,22 +321,31 @@ export const Datagrid = ({
     );
   const rowsTotal = rows - removed.length + added.length;
 
-  // Allow to listen to which row is selected and notfiy parent component.
-  // Glide tracks the selection by index and keeps it when the rows behind the grid
-  // change, so indices past the last rendered row are dropped rather than reported:
-  // consumers resolve them against their own data and would act on, or crash on,
-  // rows that no longer exist.
-  useEffect(() => {
-    if (onRowSelectionChange && selection) {
-      // Second parameter is callback to clear selection from parent component
-      onRowSelectionChange(
-        Array.from(selection.rows).filter(row => row < rowsTotal),
-        () => {
+  // Glide tracks selection by index and keeps it when the rows behind the grid
+  // change. Report only indices that still exist so consumers cannot crash, and
+  // rewrite the selection itself once loading is over — otherwise a refetch that
+  // briefly reports 1 placeholder row would permanently drop a real selection.
+  useEffect(
+    function pruneAndReportVisibleRowSelection() {
+      if (!selection) {
+        return;
+      }
+
+      const { visibleRows, prunedSelection } = getVisibleGridSelection(selection, rowsTotal);
+
+      if (!loading && prunedSelection) {
+        setSelectionState(prunedSelection);
+      }
+
+      if (onRowSelectionChange) {
+        // Second parameter is callback to clear selection from parent component
+        onRowSelectionChange(visibleRows, () => {
           setSelectionState(undefined);
-        },
-      );
-    }
-  }, [onRowSelectionChange, selection, setSelectionState, rowsTotal]);
+        });
+      }
+    },
+    [loading, onRowSelectionChange, selection, setSelectionState, rowsTotal],
+  );
 
   const hasMenuItem = !!menuItems(0).length;
   const hasColumnGroups = availableColumns.some(col => col.group);

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -277,15 +277,6 @@ export const Datagrid = ({
     };
   }, [clearTooltip, tooltip]);
 
-  // Allow to listen to which row is selected and notfiy parent component
-  useEffect(() => {
-    if (onRowSelectionChange && selection) {
-      // Second parameter is callback to clear selection from parent component
-      onRowSelectionChange(Array.from(selection.rows), () => {
-        setSelectionState(undefined);
-      });
-    }
-  }, [onRowSelectionChange, selection, setSelectionState]);
   useEffect(() => {
     if (recentlyAddedColumn && editor.current) {
       const columnIndex = availableColumns.findIndex(column => column.id === recentlyAddedColumn);
@@ -329,6 +320,24 @@ export const Datagrid = ({
       setCellsDirty(areCellsDirty),
     );
   const rowsTotal = rows - removed.length + added.length;
+
+  // Allow to listen to which row is selected and notfiy parent component.
+  // Glide tracks the selection by index and keeps it when the rows behind the grid
+  // change, so indices past the last rendered row are dropped rather than reported:
+  // consumers resolve them against their own data and would act on, or crash on,
+  // rows that no longer exist.
+  useEffect(() => {
+    if (onRowSelectionChange && selection) {
+      // Second parameter is callback to clear selection from parent component
+      onRowSelectionChange(
+        Array.from(selection.rows).filter(row => row < rowsTotal),
+        () => {
+          setSelectionState(undefined);
+        },
+      );
+    }
+  }, [onRowSelectionChange, selection, setSelectionState, rowsTotal]);
+
   const hasMenuItem = !!menuItems(0).length;
   const hasColumnGroups = availableColumns.some(col => col.group);
   const handleGetCellContent = useCallback(

--- a/src/components/Datagrid/utils.test.ts
+++ b/src/components/Datagrid/utils.test.ts
@@ -1,0 +1,79 @@
+import { getRowIdsFromSelection, preventRowClickOnSelectionCheckbox } from "./utils";
+
+describe("preventRowClickOnSelectionCheckbox", () => {
+  it("prevents the row click on the selection checkbox column", () => {
+    // Arrange & Act & Assert
+    expect(preventRowClickOnSelectionCheckbox("checkbox", -1)).toBe(true);
+  });
+
+  it("allows the row click on data columns", () => {
+    // Arrange & Act & Assert
+    expect(preventRowClickOnSelectionCheckbox("checkbox", 0)).toBe(false);
+  });
+
+  it("allows the row click when the row marker is not a checkbox", () => {
+    // Arrange & Act & Assert
+    expect(preventRowClickOnSelectionCheckbox("number", -1)).toBe(false);
+    expect(preventRowClickOnSelectionCheckbox("none", -1)).toBe(false);
+  });
+});
+
+describe("getRowIdsFromSelection", () => {
+  const items = [{ id: "first" }, { id: "second" }, { id: "third" }];
+
+  it("resolves selected row indices to ids", () => {
+    // Arrange & Act
+    const ids = getRowIdsFromSelection([0, 2], items);
+
+    // Assert
+    expect(ids).toEqual(["first", "third"]);
+  });
+
+  it("keeps the order the rows were given in", () => {
+    // Arrange & Act
+    const ids = getRowIdsFromSelection([2, 0, 1], items);
+
+    // Assert
+    expect(ids).toEqual(["third", "first", "second"]);
+  });
+
+  it("drops indices past the end of the list instead of throwing", () => {
+    // Arrange - a selection made before the list shrank still holds the old indices
+    // Act
+    const ids = getRowIdsFromSelection([0, 1, 2, 3, 17], items);
+
+    // Assert
+    expect(ids).toEqual(["first", "second", "third"]);
+  });
+
+  it("returns no ids when every selected index is out of range", () => {
+    // Arrange & Act
+    const ids = getRowIdsFromSelection([7, 8], items);
+
+    // Assert
+    expect(ids).toEqual([]);
+  });
+
+  it("returns no ids when the list is empty, undefined or null", () => {
+    // Arrange & Act & Assert
+    expect(getRowIdsFromSelection([0, 1], [])).toEqual([]);
+    expect(getRowIdsFromSelection([0, 1], undefined)).toEqual([]);
+    expect(getRowIdsFromSelection([0, 1], null)).toEqual([]);
+  });
+
+  it("skips holes so a sparse list never yields undefined ids", () => {
+    // Arrange - Relay results can carry gaps while a page is being replaced
+    const sparse = [{ id: "first" }, undefined, { id: "third" }] as Array<{ id: string }>;
+
+    // Act
+    const ids = getRowIdsFromSelection([0, 1, 2], sparse);
+
+    // Assert
+    expect(ids).toEqual(["first", "third"]);
+  });
+
+  it("returns no ids for an empty selection", () => {
+    // Arrange & Act & Assert
+    expect(getRowIdsFromSelection([], items)).toEqual([]);
+  });
+});

--- a/src/components/Datagrid/utils.test.ts
+++ b/src/components/Datagrid/utils.test.ts
@@ -1,4 +1,15 @@
-import { getRowIdsFromSelection, preventRowClickOnSelectionCheckbox } from "./utils";
+import { CompactSelection, type GridSelection } from "@glideapps/glide-data-grid";
+
+import {
+  getRowIdsFromSelection,
+  getVisibleGridSelection,
+  preventRowClickOnSelectionCheckbox,
+} from "./utils";
+
+const selectionOf = (...rows: number[]): GridSelection => ({
+  rows: rows.reduce((acc, row) => acc.add(row), CompactSelection.empty()),
+  columns: CompactSelection.empty(),
+});
 
 describe("preventRowClickOnSelectionCheckbox", () => {
   it("prevents the row click on the selection checkbox column", () => {
@@ -72,8 +83,86 @@ describe("getRowIdsFromSelection", () => {
     expect(ids).toEqual(["first", "third"]);
   });
 
+  it("drops empty ids so bulk actions never receive a blank string", () => {
+    // Arrange
+    const withBlank = [{ id: "first" }, { id: "" }, { id: "third" }];
+
+    // Act
+    const ids = getRowIdsFromSelection([0, 1, 2], withBlank);
+
+    // Assert
+    expect(ids).toEqual(["first", "third"]);
+  });
+
   it("returns no ids for an empty selection", () => {
     // Arrange & Act & Assert
     expect(getRowIdsFromSelection([], items)).toEqual([]);
+  });
+});
+
+describe("getVisibleGridSelection", () => {
+  it("leaves an in-range selection untouched", () => {
+    // Arrange
+    const selection = selectionOf(1, 2);
+
+    // Act
+    const result = getVisibleGridSelection(selection, 5);
+
+    // Assert
+    expect(result.visibleRows).toEqual([1, 2]);
+    expect(result.prunedSelection).toBeUndefined();
+  });
+
+  it("drops indices past the last rendered row", () => {
+    // Arrange
+    const selection = selectionOf(0, 1, 2, 3, 7, 19);
+
+    // Act
+    const result = getVisibleGridSelection(selection, 3);
+
+    // Assert
+    expect(result.visibleRows).toEqual([0, 1, 2]);
+    expect(result.prunedSelection).toBeDefined();
+    expect(Array.from(result.prunedSelection?.rows ?? [])).toEqual([0, 1, 2]);
+  });
+
+  it("returns no visible rows when the list emptied out", () => {
+    // Arrange & Act
+    const result = getVisibleGridSelection(selectionOf(1, 2), 0);
+
+    // Assert
+    expect(result.visibleRows).toEqual([]);
+    expect(Array.from(result.prunedSelection?.rows ?? [])).toEqual([]);
+  });
+
+  it("clears a current cell that sits past the last rendered row", () => {
+    // Arrange
+    const selection: GridSelection = {
+      ...selectionOf(0, 5),
+      current: {
+        cell: [0, 5],
+        range: { x: 0, y: 5, width: 1, height: 1 },
+        rangeStack: [],
+      },
+    };
+
+    // Act
+    const result = getVisibleGridSelection(selection, 3);
+
+    // Assert
+    expect(result.visibleRows).toEqual([0]);
+    expect(result.prunedSelection?.current).toBeUndefined();
+  });
+
+  it("keeps the pruned selection stable when the list later grows", () => {
+    // Arrange - page size was lowered, then raised again
+    const { prunedSelection } = getVisibleGridSelection(selectionOf(0, 1, 2, 3, 7, 19), 3);
+
+    // Act
+    const afterGrow = getVisibleGridSelection(prunedSelection ?? selectionOf(), 20);
+
+    // Assert - dead indices must not come back
+    expect(afterGrow.visibleRows).toEqual([0, 1, 2]);
+    expect(afterGrow.prunedSelection).toBeUndefined();
   });
 });

--- a/src/components/Datagrid/utils.ts
+++ b/src/components/Datagrid/utils.ts
@@ -5,3 +5,17 @@ export const preventRowClickOnSelectionCheckbox = (
   rowMarkers: DataEditorProps["rowMarkers"],
   location: number,
 ) => !["number", "none"].includes(rowMarkers) && location === -1;
+
+/**
+ * Resolves selected datagrid row indices to entity ids.
+ *
+ * Glide tracks its row selection by index, independently of the data behind the
+ * grid, so a selection made before the list shrank — rows per page lowered, a bulk
+ * delete, a refetch returning fewer records — can still carry indices that no
+ * longer point at a row. Reading `.id` off those directly throws and takes the
+ * whole view down, so unresolved indices are dropped instead.
+ */
+export const getRowIdsFromSelection = <T extends { id: string }>(
+  rows: number[],
+  items: readonly T[] | undefined | null,
+): string[] => rows.map(row => items?.[row]?.id).filter((id): id is string => id !== undefined);

--- a/src/components/Datagrid/utils.ts
+++ b/src/components/Datagrid/utils.ts
@@ -1,10 +1,50 @@
 // @ts-strict-ignore
-import { type DataEditorProps } from "@glideapps/glide-data-grid";
+import {
+  CompactSelection,
+  type DataEditorProps,
+  type GridSelection,
+} from "@glideapps/glide-data-grid";
 
 export const preventRowClickOnSelectionCheckbox = (
   rowMarkers: DataEditorProps["rowMarkers"],
   location: number,
 ) => !["number", "none"].includes(rowMarkers) && location === -1;
+
+export interface VisibleGridSelection {
+  visibleRows: number[];
+  /** Present only when the selection still holds rows (or a current cell) past `rowsTotal`. */
+  prunedSelection?: GridSelection;
+}
+
+/**
+ * Splits a Glide selection into the indices that still exist and, when needed,
+ * a rewritten selection with the dead ones removed.
+ *
+ * Callers must not apply `prunedSelection` while the grid is showing a loading
+ * placeholder (`getProductRowsLength` returns 1). That would permanently drop a
+ * real selection that should come back when the list resolves.
+ */
+export const getVisibleGridSelection = (
+  selection: GridSelection,
+  rowsTotal: number,
+): VisibleGridSelection => {
+  const selectedRows = Array.from(selection.rows);
+  const visibleRows = selectedRows.filter(row => row < rowsTotal);
+  const currentRow = selection.current?.cell[1];
+  const currentOutOfRange = currentRow !== undefined && currentRow >= rowsTotal;
+
+  if (visibleRows.length === selectedRows.length && !currentOutOfRange) {
+    return { visibleRows };
+  }
+
+  const prunedSelection: GridSelection = {
+    ...selection,
+    rows: visibleRows.reduce((acc, row) => acc.add(row), CompactSelection.empty()),
+    current: currentOutOfRange ? undefined : selection.current,
+  };
+
+  return { visibleRows, prunedSelection };
+};
 
 /**
  * Resolves selected datagrid row indices to entity ids.
@@ -18,4 +58,7 @@ export const preventRowClickOnSelectionCheckbox = (
 export const getRowIdsFromSelection = <T extends { id: string }>(
   rows: number[],
   items: readonly T[] | undefined | null,
-): string[] => rows.map(row => items?.[row]?.id).filter((id): id is string => id !== undefined);
+): string[] =>
+  rows
+    .map(row => items?.[row]?.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -157,7 +157,7 @@ export const CustomerListPage = ({
             </Box>
             <Box display="flex" justifyContent="flex-end" alignItems="center">
               {canEditCustomers && selectedCustomerIds.length > 0 && (
-                <BulkDeleteButton onClick={onCustomersDelete}>
+                <BulkDeleteButton count={selectedCustomerIds.length} onClick={onCustomersDelete}>
                   <FormattedMessage defaultMessage="Delete customers" id="kFsTMN" />
                 </BulkDeleteButton>
               )}

--- a/src/customers/views/CustomerList/CustomerList.tsx
+++ b/src/customers/views/CustomerList/CustomerList.tsx
@@ -1,5 +1,6 @@
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
 import { createCustomerWhereVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { CreateCustomerTypeDialog } from "@dashboard/customerTypes/components/CreateCustomerTypeDialog/CreateCustomerTypeDialog";
 import { useCreateCustomerType } from "@dashboard/customerTypes/hooks/useCreateCustomerType";
@@ -270,7 +271,7 @@ const CustomerList = ({ params }: CustomerListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => customers[row]?.id).filter(id => id !== undefined);
+      const rowsIds = getRowIdsFromSelection(rows, customers);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/discounts/components/VoucherCodesTable/VoucherCodesTable.tsx
+++ b/src/discounts/components/VoucherCodesTable/VoucherCodesTable.tsx
@@ -203,7 +203,7 @@ export const VoucherCodesTable = ({
           onUpdateListSettings={onSettingsChange}
           beforePagination={
             selectedCodesIds.length > 0 ? (
-              <BulkDeleteButton onClick={onBulkDelete}>
+              <BulkDeleteButton count={selectedCodesIds.length} onClick={onBulkDelete} size="small">
                 <FormattedMessage defaultMessage="Delete codes" id="UJ97Lb" />
               </BulkDeleteButton>
             ) : null

--- a/src/discounts/components/VoucherListPage/VoucherListPage.tsx
+++ b/src/discounts/components/VoucherListPage/VoucherListPage.tsx
@@ -140,9 +140,9 @@ const VoucherListPage = ({
             defaultMessage: "Search vouchers...",
           })}
           actions={
-            <Box display="flex" gap={4}>
+            <Box display="flex" gap={4} alignItems="center">
               {selectedVouchersIds.length > 0 && (
-                <BulkDeleteButton onClick={onVoucherDelete}>
+                <BulkDeleteButton count={selectedVouchersIds.length} onClick={onVoucherDelete}>
                   <FormattedMessage defaultMessage="Delete vouchers" id="lfXze9" />
                 </BulkDeleteButton>
               )}

--- a/src/discounts/views/VoucherList/VoucherList.tsx
+++ b/src/discounts/views/VoucherList/VoucherList.tsx
@@ -2,6 +2,7 @@
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
 import { createVoucherQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DeleteFilterTabDialog } from "@dashboard/components/DeleteFilterTabDialog";
 import { SaveFilterTabDialog } from "@dashboard/components/SaveFilterTabDialog/SaveFilterTabDialog";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
@@ -161,7 +162,7 @@ const VoucherList = ({ params }: VoucherListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => vouchers[row]?.id);
+      const rowsIds = getRowIdsFromSelection(rows, vouchers);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/giftCards/GiftCardsList/GiftCardListBulkActions/GiftCardListBulkActions.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardListBulkActions/GiftCardListBulkActions.tsx
@@ -1,3 +1,4 @@
+import { bulkActionWithCountMessages } from "@dashboard/components/BulkDeleteButton/messages";
 import { ConfirmButton } from "@dashboard/components/ConfirmButton";
 import { type INotification } from "@dashboard/components/notifications";
 import {
@@ -95,7 +96,10 @@ export const GiftCardListBulkActions = () => {
           transitionState={activateGiftCardsOpts?.status}
           data-test-id="activate-gift-cards"
         >
-          {intl.formatMessage(messages.enableLabel)}
+          {intl.formatMessage(bulkActionWithCountMessages.actionWithCount, {
+            action: intl.formatMessage(messages.enableLabel),
+            count: selectedRowIds.length,
+          })}
         </ConfirmButton>
       )}
       {(areAllSelectedCardsActive || isSelectionMixed) && (
@@ -105,7 +109,10 @@ export const GiftCardListBulkActions = () => {
           transitionState={deactivateGiftCardsOpts?.status}
           data-test-id="deactivate-gift-cards"
         >
-          {intl.formatMessage(messages.disableLabel)}
+          {intl.formatMessage(bulkActionWithCountMessages.actionWithCount, {
+            action: intl.formatMessage(messages.disableLabel),
+            count: selectedRowIds.length,
+          })}
         </ConfirmButton>
       )}
     </>

--- a/src/giftCards/GiftCardsList/GiftCardListSearchAndFilters/GiftCardListSearchAndFilters.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardListSearchAndFilters/GiftCardListSearchAndFilters.tsx
@@ -34,11 +34,11 @@ const GiftCardListSearchAndFilters = () => {
         showSearchTooltip
         searchPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
         actions={
-          <Box display="flex" gap={4}>
+          <Box display="flex" gap={4} alignItems="center">
             {selectedRowIds.length > 0 && (
               <>
                 <GiftCardListBulkActions />
-                <BulkDeleteButton onClick={openDeleteDialog}>
+                <BulkDeleteButton count={selectedRowIds.length} onClick={openDeleteDialog}>
                   <FormattedMessage defaultMessage="Delete gift cards" id="d68yq7" />
                 </BulkDeleteButton>
               </>

--- a/src/giftCards/GiftCardsList/GiftCardsListDatagrid/GiftCardsListDatagrid.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardsListDatagrid/GiftCardsListDatagrid.tsx
@@ -5,6 +5,7 @@ import {
   DatagridChangeStateContext,
   useDatagridChangeState,
 } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DatagridPagination, TablePagination } from "@dashboard/components/TablePagination";
 import { commonTooltipMessages } from "@dashboard/components/TooltipTableCellHeader/messages";
 import { giftCardListUrl, giftCardUrl } from "@dashboard/giftCards/urls";
@@ -118,7 +119,7 @@ export const GiftCardsListDatagrid = () => {
         return;
       }
 
-      const rowsIds = rows.map(row => giftCards[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, giftCards);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/modeling/components/PageListPage/PageListPage.tsx
+++ b/src/modeling/components/PageListPage/PageListPage.tsx
@@ -2,6 +2,7 @@ import { useUser } from "@dashboard/auth/useUser";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { type TopNavMenuItem } from "@dashboard/components/AppLayout/TopNav/Menu";
 import { BulkDeleteButton } from "@dashboard/components/BulkDeleteButton";
+import { bulkActionWithCountMessages } from "@dashboard/components/BulkDeleteButton/messages";
 import { ButtonGroupWithDropdown } from "@dashboard/components/ButtonGroupWithDropdown";
 import { DashboardCard } from "@dashboard/components/Card";
 import { ListPageLayout } from "@dashboard/components/Layouts";
@@ -160,12 +161,18 @@ const PageListPage = ({
               {selectedPageIds.length > 0 ? (
                 <Box display="flex" gap={4}>
                   <Button variant="secondary" onClick={onPagesUnpublish}>
-                    <FormattedMessage {...messages.unpublish} />
+                    {intl.formatMessage(bulkActionWithCountMessages.actionWithCount, {
+                      action: intl.formatMessage(messages.unpublish),
+                      count: selectedPageIds.length,
+                    })}
                   </Button>
                   <Button variant="secondary" onClick={onPagesPublish}>
-                    <FormattedMessage {...messages.publish} />
+                    {intl.formatMessage(bulkActionWithCountMessages.actionWithCount, {
+                      action: intl.formatMessage(messages.publish),
+                      count: selectedPageIds.length,
+                    })}
                   </Button>
-                  <BulkDeleteButton onClick={onPagesDelete}>
+                  <BulkDeleteButton count={selectedPageIds.length} onClick={onPagesDelete}>
                     <FormattedMessage {...messages.delete} />
                   </BulkDeleteButton>
                 </Box>

--- a/src/modeling/views/PageList/PageList.tsx
+++ b/src/modeling/views/PageList/PageList.tsx
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";
 import {
   OrderDirection,
@@ -318,7 +319,7 @@ const PageList = ({ params }: PageListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => pages[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, pages);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
+++ b/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
@@ -94,9 +94,12 @@ const OrderDraftListPage = ({
               defaultMessage: "Search draft orders...",
             })}
             actions={
-              <Box display="flex" gap={4}>
+              <Box display="flex" gap={4} alignItems="center">
                 {selectedOrderDraftIds.length > 0 && (
-                  <BulkDeleteButton onClick={onDraftOrdersDelete}>
+                  <BulkDeleteButton
+                    count={selectedOrderDraftIds.length}
+                    onClick={onDraftOrdersDelete}
+                  >
                     {intl.formatMessage({
                       id: "+b/qJ9",
                       defaultMessage: "Delete draft orders",

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -4,6 +4,7 @@ import { ChannelPickerDialog } from "@dashboard/channels/components/ChannelPicke
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
 import { createDraftOrderQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DeleteFilterTabDialog } from "@dashboard/components/DeleteFilterTabDialog";
 import { SaveFilterTabDialog } from "@dashboard/components/SaveFilterTabDialog/SaveFilterTabDialog";
 import { useShopLimitsQuery } from "@dashboard/components/Shop/queries";
@@ -145,7 +146,7 @@ const OrderDraftList = ({ params }: OrderDraftListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => orderDrafts[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, orderDrafts);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -193,10 +193,8 @@ const OrderDraftList = ({ params }: OrderDraftListProps) => {
             ids: selectedRowIds,
           })
         }
-        onUpdateListSettings={(...props) => {
-          clearRowSelection();
-          updateListSettings(...props);
-        }}
+        // Keep selection on page-size/column updates; Datagrid drops stale indices.
+        onUpdateListSettings={updateListSettings}
         selectedOrderDraftIds={selectedRowIds}
         onSelectOrderDraftIds={handleSetSelectedOrderDraftIds}
       />

--- a/src/products/components/ProductListPage/ProductListPage.tsx
+++ b/src/products/components/ProductListPage/ProductListPage.tsx
@@ -241,9 +241,9 @@ const ProductListPage = (props: ProductListPageProps) => {
               defaultMessage: "Search Products...",
             })}
             actions={
-              <Box display="flex" gap={4}>
+              <Box display="flex" gap={4} alignItems="center">
                 {selectedProductIds.length > 0 && (
-                  <BulkDeleteButton onClick={onProductsDelete}>
+                  <BulkDeleteButton count={selectedProductIds.length} onClick={onProductsDelete}>
                     <FormattedMessage defaultMessage="Delete products" id="uwk5e9" />
                   </BulkDeleteButton>
                 )}

--- a/src/products/components/ProductListViewSwitch/ProductListViewSwitch.module.css
+++ b/src/products/components/ProductListViewSwitch/ProductListViewSwitch.module.css
@@ -1,0 +1,3 @@
+.icon {
+  display: block;
+}

--- a/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
+++ b/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
@@ -3,27 +3,50 @@ import { Switch } from "@saleor/macaw-ui-next";
 import { Grid3x3, List } from "lucide-react";
 
 import { type ProductListViewType } from "../ProductListPage";
+import styles from "./ProductListViewSwitch.module.css";
 
 interface ProductListViewSwitchProps {
   defaultValue: ProductListViewType;
   setProductListViewType: (value: ProductListViewType) => void;
 }
 
+const iconProps = {
+  size: iconSize.small,
+  strokeWidth: iconStrokeWidthBySize.small,
+  className: styles.icon,
+} as const;
+
 export const ProductListViewSwitch = ({
   defaultValue,
   setProductListViewType,
-}: ProductListViewSwitchProps) => (
+}: ProductListViewSwitchProps): JSX.Element => (
   <Switch
     defaultValue={defaultValue}
     onValueChange={value => {
       setProductListViewType(value as ProductListViewType);
     }}
   >
-    <Switch.Item id="datagrid" value="datagrid" data-test-id="datagrid-view-button">
-      <List size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+    <Switch.Item
+      id="datagrid"
+      value="datagrid"
+      data-test-id="datagrid-view-button"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      width={7}
+    >
+      <List {...iconProps} />
     </Switch.Item>
-    <Switch.Item id="tile" value="tile" data-test-id="tile-view-button">
-      <Grid3x3 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+    <Switch.Item
+      id="tile"
+      value="tile"
+      data-test-id="tile-view-button"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      width={7}
+    >
+      <Grid3x3 {...iconProps} />
     </Switch.Item>
   </Switch>
 );

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -359,10 +359,8 @@ const ProductList = ({ params }: ProductListProps) => {
         disabled={!data}
         limits={limitOpts.data?.shop.limits}
         products={products}
-        onUpdateListSettings={(...props) => {
-          clearRowSelection();
-          updateListSettings(...props);
-        }}
+        // Keep selection on page-size/column updates; Datagrid drops stale indices.
+        onUpdateListSettings={updateListSettings}
         onAdd={() => openModal("create-product")}
         onCreateProductType={() => openModal("create-product-type")}
         onAll={resetFilters}

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -3,6 +3,7 @@ import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter/context";
 import { hasActiveListFilters } from "@dashboard/components/ConditionalFilter/hasActiveListFilters";
 import { createProductExportQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import { DeleteFilterTabDialog } from "@dashboard/components/DeleteFilterTabDialog";
 import { SaveFilterTabDialog } from "@dashboard/components/SaveFilterTabDialog/SaveFilterTabDialog";
 import { useShopLimitsQuery } from "@dashboard/components/Shop/queries";
@@ -266,7 +267,7 @@ const ProductList = ({ params }: ProductListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => products[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, products);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {

--- a/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
+++ b/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
@@ -90,7 +90,7 @@ const ShippingZonesListPage = ({
           />
         </Box>
         {selectedShippingZonesIds.length > 0 && (
-          <BulkDeleteButton onClick={onRemove}>
+          <BulkDeleteButton count={selectedShippingZonesIds.length} onClick={onRemove}>
             <FormattedMessage {...messages.bulkDelete} />
           </BulkDeleteButton>
         )}

--- a/src/shipping/views/ShippingZonesList.tsx
+++ b/src/shipping/views/ShippingZonesList.tsx
@@ -1,5 +1,6 @@
 import { useUser } from "@dashboard/auth/useUser";
 import ActionDialog from "@dashboard/components/ActionDialog";
+import { getRowIdsFromSelection } from "@dashboard/components/Datagrid/utils";
 import {
   useBulkDeleteShippingZoneMutation,
   useShippingZonesQuery,
@@ -112,7 +113,7 @@ const ShippingZonesList = ({ params }: ShippingZonesListProps) => {
         return;
       }
 
-      const rowsIds = rows.map(row => shippingZones[row].id);
+      const rowsIds = getRowIdsFromSelection(rows, shippingZones);
       const haveSaveValues = isEqual(rowsIds, selectedRowIds);
 
       if (!haveSaveValues) {


### PR DESCRIPTION
Fixes #4610

Selecting rows and then shrinking the list takes the whole view down with "We've encountered an unexpected error".

The exact repro in the issue (categories) no longer reproduces — that list was rewritten with a guarded row lookup. The same defect is still live in six other lists, so this fixes the cause rather than one more symptom.

## Repro

Any of products, collections, models, draft orders, shipping zones or gift cards:

1. Open the list on page 1 with "rows per page" set to 100, with more than 20 records.
2. Select all rows with the header checkbox.
3. Change "rows per page" to 20.

The list shrinks to 20 rows while the selection still holds indices up to 99, and the view is replaced by the error page.

## Cause

Glide tracks its row selection by index, independently of the data behind the grid, and `Datagrid` reported those indices verbatim:

```ts
onRowSelectionChange(Array.from(selection.rows), () => setSelectionState(undefined));
```

The list views resolved them straight onto their own arrays:

```ts
const rowsIds = rows.map(row => products[row].id);
// TypeError: Cannot read properties of undefined (reading 'id')
```

Nothing clears the selection first in this case. `useRowSelection` only clears on `params.after` / `params.before`, and `usePaginationReset` resets to `DEFAULT_INITIAL_PAGINATION_DATA` — on page 1 both are already `undefined`, so the clearing effect never re-runs. Bulk delete and a refetch returning fewer records reach the same state.

## Change

**`Datagrid` no longer reports rows past the last one it renders.** That is the root cause: the grid is the authority on how many rows exist, and consumers should never be handed rows that don't. The effect moved below `rowsTotal` so it can be used (`rowsTotal` is declared later, so referencing it from the earlier dependency array would hit the TDZ).

**Row-index-to-id resolution moved into a shared `getRowIdsFromSelection` helper.** The clamp alone is not sufficient, because the grid's row count is not always the length of the data behind it — `getProductRowsLength` returns `1` while loading with no products, so index 0 still resolves to `undefined` there.

This also settles an inconsistency: three different behaviours existed across nine lists.

| | before | after |
|---|---|---|
| products, collections, models, draft orders, shipping zones, gift cards | `items[row].id` — throws | resolved safely |
| attributes, vouchers | `items[row]?.id` — no filter, so `undefined` entered the `string[]` bulk actions run on | unresolved indices dropped |
| customers | `?.` + filter — already correct | same, now via the helper |

## Verification

`Datagrid.test.tsx` covers the clamp by rendering with `loading` — that short-circuits the output to a throbber, so the selection effect runs without Glide's canvas. Reverting only the clamp fails the two shrink cases and leaves the normal case passing:

```
× does not report rows past the last one when the list shrank under a live selection
× reports no rows when the list emptied out under a live selection
√ reports the selected rows to the parent
```

`utils.test.ts` covers the helper: out-of-range indices, an entirely out-of-range selection, empty/undefined/null lists, sparse lists, and order preservation. The old expression throws on that same input:

```
old expression -> TypeError: Cannot read properties of undefined (reading 'id')
new expression -> ["a","b","c"]
```

`tsc --noEmit` and ESLint are clean; 80 suites / 436 tests pass across the touched areas.
