### PR TITLE
fix: stop deleting file attribute values before object updates

### DIFF
--- a/.changeset/file-attribute-permission-fix.md
+++ b/.changeset/file-attribute-permission-fix.md
@@ -5,5 +5,5 @@
 Fixed replacing or clearing a file attribute value failing with a permission
 error for users without attribute-management permissions. The dashboard no
 longer calls `attributeValueDelete` before saving products, variants, and
-models — TODO - concrete Saleor 3.23.x version and maybe 3.22.x too cleans up the detached file value as part of the update
-itself, and on older versions the update still succeeds.
+models — Saleor 3.23.30 and above clean up the detached file value as part of the
+update itself, and on older versions the update still succeeds.

--- a/.changeset/file-attribute-permission-fix.md
+++ b/.changeset/file-attribute-permission-fix.md
@@ -1,0 +1,9 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed replacing or clearing a file attribute value failing with a permission
+error for users without attribute-management permissions. The dashboard no
+longer calls `attributeValueDelete` before saving products, variants, and
+models — TODO - concrete Saleor 3.23.x version and maybe 3.22.x too cleans up the detached file value as part of the update
+itself, and on older versions the update still succeeds.

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -2,9 +2,7 @@ import { type FetchResult } from "@apollo/client";
 import { type AttributeInput, type AttributeInputData } from "@dashboard/components/Attributes";
 import {
   AttributeEntityTypeEnum,
-  type AttributeErrorFragment,
   AttributeInputTypeEnum,
-  type AttributeValueDeleteMutation,
   type AttributeValueFragment,
   type AttributeValueInput,
   type FileUploadMutation,
@@ -207,28 +205,6 @@ export function getSelectedAttributeValues(
   }
 }
 
-export const isFileValueUnused = (
-  attributesWithNewFileValue: FormsetData<null, File>,
-  existingAttribute:
-    | PageSelectedAttributeFragment
-    | ProductFragment["attributes"][0]
-    | SelectedVariantAttributeFragment,
-) => {
-  if (existingAttribute.attribute.inputType !== AttributeInputTypeEnum.FILE) {
-    return false;
-  }
-
-  if (existingAttribute.values.length === 0) {
-    return false;
-  }
-
-  const modifiedAttribute = attributesWithNewFileValue.find(
-    dataAttribute => dataAttribute.id === existingAttribute.attribute.id,
-  );
-
-  return !!modifiedAttribute;
-};
-
 export const mergeFileUploadErrors = (
   uploadFilesResult: Array<FetchResult<FileUploadMutation>>,
 ): UploadErrorFragment[] =>
@@ -241,19 +217,6 @@ export const mergeFileUploadErrors = (
 
     return errors;
   }, [] as UploadErrorFragment[]);
-
-export const mergeAttributeValueDeleteErrors = (
-  deleteAttributeValuesResult: Array<FetchResult<AttributeValueDeleteMutation>>,
-): AttributeErrorFragment[] =>
-  deleteAttributeValuesResult.reduce((errors, deleteValueResult) => {
-    const deleteErrors = deleteValueResult?.data?.attributeValueDelete?.errors;
-
-    if (deleteErrors) {
-      return [...errors, ...deleteErrors];
-    }
-
-    return errors;
-  }, [] as AttributeErrorFragment[]);
 
 export const mergeChoicesWithValues = (
   attribute:

--- a/src/attributes/utils/handlers.test.ts
+++ b/src/attributes/utils/handlers.test.ts
@@ -3,15 +3,10 @@ import {
   createAttributeMultiChangeHandler,
   createAttributeReferenceAdditionalDataHandler,
   createAttributeReferenceChangeHandler,
-  handleDeleteMultipleAttributeValues,
   prepareAttributesInput,
 } from "@dashboard/attributes/utils/handlers";
 import { type AttributeInput, type AttributeInputData } from "@dashboard/components/Attributes";
-import {
-  AttributeInputTypeEnum,
-  type AttributeValueDetailsFragment,
-  type ProductFragment,
-} from "@dashboard/graphql";
+import { AttributeInputTypeEnum, type AttributeValueDetailsFragment } from "@dashboard/graphql";
 import { type FormsetData, type UseFormsetOutput } from "@dashboard/hooks/useFormset";
 
 const multipleValueAttributes: FormsetData<AttributeInputData, string[]> = [
@@ -864,55 +859,6 @@ describe("createAttributeChangeHandler", () => {
     expect(formset.change).toHaveBeenCalledTimes(1);
     expect(formset.change).toHaveBeenCalledWith("attr-1", ["val-1"]);
     expect(trigger).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("handleDeleteMultipleAttributeValues", () => {
-  it("should return empty array when no attributes", async () => {
-    // Arrange
-    const trigger = jest.fn();
-
-    // Act
-    const result = await handleDeleteMultipleAttributeValues([], undefined, trigger);
-
-    // Assert
-    expect(result).toEqual([]);
-    expect(trigger).toHaveBeenCalledTimes(0);
-  });
-
-  it("should call deleteAttributeValue when new attribute with file match existing one", async () => {
-    // Arrange
-    const deleteAttributeValue = jest.fn(() => Promise.resolve("val-1")) as any;
-    const attributesWithNewFileValue = [
-      {
-        id: "attr-1",
-      },
-    ] as FormsetData<null, File>;
-
-    const attributes = [
-      {
-        attribute: {
-          id: "attr-1",
-          inputType: AttributeInputTypeEnum.FILE,
-        },
-        values: [
-          {
-            id: "val-1",
-          },
-        ],
-      },
-    ] as Array<ProductFragment["attributes"][0]>;
-
-    // Act
-    const result = await handleDeleteMultipleAttributeValues(
-      attributesWithNewFileValue,
-      attributes,
-      deleteAttributeValue,
-    );
-
-    // Assert
-    expect(result).toEqual(["val-1"]);
-    expect(deleteAttributeValue).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/attributes/utils/handlers.test.ts
+++ b/src/attributes/utils/handlers.test.ts
@@ -629,8 +629,14 @@ describe("Sending only changed attributes", () => {
         ],
       });
 
-      // Files are deleted by using AttributeValueDetele mutation
-      expect(result).toEqual([]);
+      // `file: null` detaches the value; core deletes the orphaned row itself
+      expect(result).toEqual([
+        {
+          id: ATTR_ID,
+          contentType: undefined,
+          file: null,
+        },
+      ]);
     });
     it("adds new image (null -> img)", () => {
       const attribute = createFileAttribute("bob.jpg");
@@ -700,7 +706,7 @@ describe("Sending only changed attributes", () => {
         {
           id: ATTR_ID,
           contentType: undefined,
-          file: undefined,
+          file: null,
         },
       ]);
     });

--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -3,14 +3,9 @@ import { type AttributeInput, type AttributeInputData } from "@dashboard/compone
 import {
   AttributeEntityTypeEnum,
   AttributeInputTypeEnum,
-  type AttributeValueDeleteMutation,
-  type AttributeValueDeleteMutationVariables,
   type AttributeValueInput,
   type FileUploadMutation,
   type FileUploadMutationVariables,
-  type PageSelectedAttributeFragment,
-  type ProductFragment,
-  type ProductVariantDetailsQuery,
 } from "@dashboard/graphql";
 import {
   type FormsetAdditionalDataChange,
@@ -25,7 +20,7 @@ import { move, toggle } from "@dashboard/utils/lists";
 import isEqual from "lodash/isEqual";
 import uniqBy from "lodash/uniqBy";
 
-import { getFileValuesToUploadFromAttributes, isFileValueUnused } from "./data";
+import { getFileValuesToUploadFromAttributes } from "./data";
 
 export function createAttributeChangeHandler(
   attributesFormData: UseFormsetOutput<AttributeInputData>,
@@ -424,36 +419,3 @@ export const handleUploadMultipleFiles = async (
       }),
     ),
   );
-
-export const handleDeleteMultipleAttributeValues = async (
-  attributesWithNewFileValue: FormsetData<null, File>,
-  attributes:
-    | Array<
-        | PageSelectedAttributeFragment
-        | ProductFragment["attributes"][0]
-        | NonNullable<ProductVariantDetailsQuery["productVariant"]>["nonSelectionAttributes"][0]
-      >
-    | undefined,
-  deleteAttributeValue: (
-    variables: AttributeValueDeleteMutationVariables,
-  ) => Promise<FetchResult<AttributeValueDeleteMutation>>,
-) => {
-  if (!attributes) {
-    return [];
-  }
-
-  return Promise.all(
-    attributes.map(existingAttribute => {
-      const fileValueUnused = isFileValueUnused(attributesWithNewFileValue, existingAttribute);
-
-      if (fileValueUnused) {
-        return deleteAttributeValue({
-          id: existingAttribute.values[0].id,
-          firstValues: 20,
-        });
-      }
-
-      return undefined;
-    }),
-  );
-};

--- a/src/attributes/utils/handlers.ts
+++ b/src/attributes/utils/handlers.ts
@@ -292,9 +292,9 @@ export const prepareAttributesInput = ({
     if (inputType === AttributeInputTypeEnum.FILE) {
       const fileInput = getFileInput(attr, updatedFileAttributes);
 
-      if (fileInput.file || attr.data.isRequired) {
-        attrInput.push(fileInput);
-      }
+      // A cleared file must still be sent as `file: null` — an attribute
+      // omitted from the update input is left untouched server-side.
+      attrInput.push({ ...fileInput, file: fileInput.file ?? null });
 
       return attrInput;
     }

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -1,11 +1,9 @@
 // @ts-strict-ignore
 import {
   getAttributesAfterFileAttributesUpdate,
-  mergeAttributeValueDeleteErrors,
   mergeFileUploadErrors,
 } from "@dashboard/attributes/utils/data";
 import {
-  handleDeleteMultipleAttributeValues,
   handleUploadMultipleFiles,
   prepareAttributesInput,
 } from "@dashboard/attributes/utils/handlers";
@@ -22,7 +20,6 @@ import {
   type PageErrorFragment,
   type PageInput,
   type UploadErrorFragment,
-  useAttributeValueDeleteMutation,
   useFileUploadMutation,
   usePageDetailsQuery,
   usePageRemoveMutation,
@@ -100,7 +97,6 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
   const [pageUpdate, pageUpdateOpts] = usePageUpdateMutation({
     disableErrorHandling: true,
   });
-  const [deleteAttributeValue, deleteAttributeValueOpts] = useAttributeValueDeleteMutation({});
   const [pageRemove, pageRemoveOpts] = usePageRemoveMutation({
     onCompleted: data => {
       if (data.pageDelete.errors.length === 0) {
@@ -121,11 +117,6 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
       data.attributesWithNewFileValue,
       variables => uploadFile({ variables }),
     );
-    const deleteAttributeValuesResult = await handleDeleteMultipleAttributeValues(
-      data.attributesWithNewFileValue,
-      pageDetails?.data?.page?.attributes,
-      variables => deleteAttributeValue({ variables }),
-    );
     const updatedFileAttributes = getAttributesAfterFileAttributesUpdate(
       data.attributesWithNewFileValue,
       uploadFilesResult,
@@ -141,7 +132,6 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     errors = [
       ...errors,
       ...mergeFileUploadErrors(uploadFilesResult),
-      ...mergeAttributeValueDeleteErrors(deleteAttributeValuesResult),
       ...updateResult.data.pageUpdate.errors,
     ];
 
@@ -218,12 +208,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     <>
       <WindowTitle title={maybe(() => pageDetails.data.page.title)} />
       <PageDetailsPage
-        loading={
-          pageDetails.loading ||
-          pageUpdateOpts.loading ||
-          uploadFileOpts.loading ||
-          deleteAttributeValueOpts.loading
-        }
+        loading={pageDetails.loading || pageUpdateOpts.loading || uploadFileOpts.loading}
         errors={pageUpdateOpts.data?.pageUpdate.errors || []}
         saveButtonBarState={pageUpdateOpts.status}
         page={pageDetails.data?.page}

--- a/src/products/views/ProductUpdate/handlers/useProductUpdateHandler.ts
+++ b/src/products/views/ProductUpdate/handlers/useProductUpdateHandler.ts
@@ -1,12 +1,6 @@
 // @ts-strict-ignore
-import {
-  mergeAttributeValueDeleteErrors,
-  mergeFileUploadErrors,
-} from "@dashboard/attributes/utils/data";
-import {
-  handleDeleteMultipleAttributeValues,
-  handleUploadMultipleFiles,
-} from "@dashboard/attributes/utils/handlers";
+import { mergeFileUploadErrors } from "@dashboard/attributes/utils/data";
+import { handleUploadMultipleFiles } from "@dashboard/attributes/utils/handlers";
 import {
   type AttributeErrorFragment,
   ErrorPolicyEnum,
@@ -17,7 +11,6 @@ import {
   type ProductFragment,
   type ProductVariantBulkCreateInput,
   type UploadErrorFragment,
-  useAttributeValueDeleteMutation,
   useFileUploadMutation,
   useProductChannelListingUpdateMutation,
   useProductUpdateMutation,
@@ -96,7 +89,6 @@ export function useProductUpdateHandler(
   const [uploadFile] = useFileUploadMutation();
   const [updateProduct] = useProductUpdateMutation();
   const [updateChannels] = useProductChannelListingUpdateMutation();
-  const [deleteAttributeValue] = useAttributeValueDeleteMutation();
   const clearSaveSteps = () => setSaveSteps([]);
   const sendMutations = async (
     data: ProductUpdateSubmitData,
@@ -113,15 +105,7 @@ export function useProductUpdateHandler(
       data.attributesWithNewFileValue,
       variables => uploadFile({ variables }),
     );
-    const deleteAttributeValuesResult = await handleDeleteMultipleAttributeValues(
-      data.attributesWithNewFileValue,
-      product?.attributes,
-      variables => deleteAttributeValue({ variables }),
-    );
-    const fileErrors = [
-      ...mergeFileUploadErrors(uploadFilesResult),
-      ...mergeAttributeValueDeleteErrors(deleteAttributeValuesResult),
-    ];
+    const fileErrors = mergeFileUploadErrors(uploadFilesResult);
 
     if (hasFileAttributeWork) {
       steps = setProductSaveStepStatus(steps, "files", fileErrors.length > 0 ? "error" : "success");

--- a/src/products/views/ProductVariant/ProductVariant.tsx
+++ b/src/products/views/ProductVariant/ProductVariant.tsx
@@ -2,11 +2,9 @@
 import placeholderImg from "@assets/images/placeholder255x255.png";
 import {
   getAttributesAfterFileAttributesUpdate,
-  mergeAttributeValueDeleteErrors,
   mergeFileUploadErrors,
 } from "@dashboard/attributes/utils/data";
 import {
-  handleDeleteMultipleAttributeValues,
   handleUploadMultipleFiles,
   prepareAttributesInput,
 } from "@dashboard/attributes/utils/handlers";
@@ -19,7 +17,6 @@ import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";
 import {
   type ProductErrorWithAttributesFragment,
-  useAttributeValueDeleteMutation,
   useFileUploadMutation,
   useProductVariantDetailsQuery,
   useProductVariantReorderMutation,
@@ -130,7 +127,6 @@ const ProductVariant = ({ variantId, params }: ProductUpdateProps) => {
       setErrors(data.productVariantUpdate.errors);
     },
   });
-  const [deleteAttributeValue, deleteAttributeValueOpts] = useAttributeValueDeleteMutation({});
   const { handleSubmitChannels, updateChannelsOpts } = useSubmitChannels();
 
   const variant = data?.productVariant;
@@ -161,17 +157,11 @@ const ProductVariant = ({ variantId, params }: ProductUpdateProps) => {
     updateVariantOpts.loading ||
     assignMediaOpts.loading ||
     unassignMediaOpts.loading ||
-    reorderProductVariantsOpts.loading ||
-    deleteAttributeValueOpts.loading;
+    reorderProductVariantsOpts.loading;
   const handleUpdate = async (data: ProductVariantUpdateSubmitData) => {
     const uploadFilesResult = await handleUploadMultipleFiles(
       data.attributesWithNewFileValue,
       variables => uploadFile({ variables }),
-    );
-    const deleteAttributeValuesResult = await handleDeleteMultipleAttributeValues(
-      data.attributesWithNewFileValue,
-      variant?.nonSelectionAttributes,
-      variables => deleteAttributeValue({ variables }),
     );
     const updatedFileAttributes = getAttributesAfterFileAttributesUpdate(
       data.attributesWithNewFileValue,
@@ -206,7 +196,6 @@ const ProductVariant = ({ variantId, params }: ProductUpdateProps) => {
 
     return [
       ...mergeFileUploadErrors(uploadFilesResult),
-      ...mergeAttributeValueDeleteErrors(deleteAttributeValuesResult),
       ...(result.data?.productVariantStocksCreate.errors ?? []),
       ...(result.data?.productVariantStocksDelete.errors ?? []),
       ...(result.data?.productVariantStocksUpdate.errors ?? []),


### PR DESCRIPTION
Core will be taking care of this instead of the Dashboard, starting from `3.23.30`.