### PR TITLE
refactor: migrate Material-UI Card to macaw-ui-next DashboardCard

### DIFF
--- a/src/components/CardTitle/CardTitle.stories.tsx
+++ b/src/components/CardTitle/CardTitle.stories.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@material-ui/core";
+import { Box } from "@saleor/macaw-ui-next";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ComponentType } from "react";
 import { fn } from "storybook/test";
@@ -11,9 +11,9 @@ const meta: Meta<typeof CardTitle> = {
   component: CardTitle,
   decorators: [
     (Story: ComponentType) => (
-      <Card style={{ maxWidth: 640 }}>
+      <Box backgroundColor="default1" __maxWidth={640}>
         <Story />
-      </Card>
+      </Box>
     ),
   ],
   args: {

--- a/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxChannelsPage.tsx
@@ -4,7 +4,7 @@ import {
   TopNavDestinationIcon,
   topNavDestinationMessages,
 } from "@dashboard/components/AppLayout/TopNav";
-import { CardTitle } from "@dashboard/components/CardTitle/CardTitle";
+import { DashboardCard } from "@dashboard/components/Card";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton/ConfirmButton";
 import Form from "@dashboard/components/Form/Form";
 import Grid from "@dashboard/components/Grid/Grid";
@@ -24,7 +24,7 @@ import { TaxCountryDialog } from "@dashboard/taxes/components/TaxCountryDialog/T
 import TaxPageTitle from "@dashboard/taxes/components/TaxPageTitle/TaxPageTitle";
 import { taxesMessages } from "@dashboard/taxes/messages";
 import { isLastElement } from "@dashboard/taxes/utils/utils";
-import { Card, CardContent, Divider } from "@material-ui/core";
+import { Divider } from "@material-ui/core";
 import { List, ListHeader, ListItem, ListItemCell, PageTab, PageTabs } from "@saleor/macaw-ui";
 import { Box, Button, Skeleton } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -203,11 +203,12 @@ const TaxChannelsPage = (props: TaxChannelsPageProps) => {
                       strategyChoicesLoading={loading}
                     />
                     <VerticalSpacer spacing={3} />
-                    <Card>
-                      <CardTitle
-                        className={classes.toolbarMargin}
-                        title={intl.formatMessage(taxesMessages.countryExceptions)}
-                        toolbar={
+                    <DashboardCard>
+                      <DashboardCard.Header>
+                        <DashboardCard.Title>
+                          {intl.formatMessage(taxesMessages.countryExceptions)}
+                        </DashboardCard.Title>
+                        <DashboardCard.Toolbar>
                           <Button
                             data-test-id="add-country-button"
                             variant="secondary"
@@ -215,12 +216,12 @@ const TaxChannelsPage = (props: TaxChannelsPageProps) => {
                           >
                             <FormattedMessage {...taxesMessages.addCountryLabel} />
                           </Button>
-                        }
-                      />
+                        </DashboardCard.Toolbar>
+                      </DashboardCard.Header>
                       {countryExceptions?.length === 0 ? (
-                        <CardContent>
+                        <DashboardCard.Content>
                           <FormattedMessage {...taxesMessages.noExceptionsForChannel} />
-                        </CardContent>
+                        </DashboardCard.Content>
                       ) : (
                         <List gridTemplate={["1fr 500px 1fr 1fr"]}>
                           <ListHeader>
@@ -268,7 +269,7 @@ const TaxChannelsPage = (props: TaxChannelsPageProps) => {
                           )) ?? <Skeleton />}
                         </List>
                       )}
-                    </Card>
+                    </DashboardCard>
                   </div>
                 </Grid>
 

--- a/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
+++ b/src/taxes/pages/TaxChannelsPage/TaxSettingsCard/TaxSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { CardTitle } from "@dashboard/components/CardTitle/CardTitle";
+import { DashboardCard } from "@dashboard/components/Card";
 import ControlledCheckbox from "@dashboard/components/ControlledCheckbox";
 import Grid from "@dashboard/components/Grid/Grid";
 import { Select } from "@dashboard/components/Select/Select";
@@ -6,15 +6,7 @@ import { type TaxConfigurationUpdateInput } from "@dashboard/graphql";
 import { type FormChange } from "@dashboard/hooks/useForm";
 import { LegacyFlowWarning } from "@dashboard/taxes/components/LegacyFlowWarning";
 import { taxesMessages } from "@dashboard/taxes/messages";
-import {
-  Card,
-  CardContent,
-  Divider,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Typography,
-} from "@material-ui/core";
+import { Divider, FormControlLabel, Radio, RadioGroup, Typography } from "@material-ui/core";
 import { type Option } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -38,9 +30,13 @@ const TaxSettingsCard = ({
   const classes = useStyles();
 
   return (
-    <Card>
-      <CardTitle title={intl.formatMessage(taxesMessages.defaultSettings)} />
-      <CardContent>
+    <DashboardCard>
+      <DashboardCard.Header>
+        <DashboardCard.Title>
+          {intl.formatMessage(taxesMessages.defaultSettings)}
+        </DashboardCard.Title>
+      </DashboardCard.Header>
+      <DashboardCard.Content>
         <Typography className={classes.supportHeader}>
           <FormattedMessage {...taxesMessages.chargeTaxesHeader} />
         </Typography>
@@ -70,9 +66,9 @@ const TaxSettingsCard = ({
             />
           </div>
         </div>
-      </CardContent>
+      </DashboardCard.Content>
       <Divider />
-      <CardContent data-test-id="entered-rendered-prices-section">
+      <DashboardCard.Content data-test-id="entered-rendered-prices-section">
         <Grid variant="uniform">
           <RadioGroup
             value={values.pricesEnteredWithTax}
@@ -113,8 +109,8 @@ const TaxSettingsCard = ({
             />
           </div>
         </Grid>
-      </CardContent>
-    </Card>
+      </DashboardCard.Content>
+    </DashboardCard>
   );
 };
 

--- a/src/taxes/pages/TaxChannelsPage/styles.ts
+++ b/src/taxes/pages/TaxChannelsPage/styles.ts
@@ -27,11 +27,6 @@ export const useStyles = makeStyles(
       display: "grid",
       gridTemplateColumns: "1fr 500px 1fr 1fr",
     },
-    toolbarMargin: {
-      "&:last-child": {
-        marginRight: 0,
-      },
-    },
   }),
   { name: "TaxChannelsPage" },
 );

--- a/src/taxes/pages/TaxClassesPage/TaxClassesPage.tsx
+++ b/src/taxes/pages/TaxClassesPage/TaxClassesPage.tsx
@@ -3,7 +3,7 @@ import {
   TopNavDestinationIcon,
   topNavDestinationMessages,
 } from "@dashboard/components/AppLayout/TopNav";
-import { CardTitle } from "@dashboard/components/CardTitle/CardTitle";
+import { DashboardCard } from "@dashboard/components/Card";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton/ConfirmButton";
 import Grid from "@dashboard/components/Grid/Grid";
 import { DetailPageLayout } from "@dashboard/components/Layouts/Detail";
@@ -27,7 +27,6 @@ import { type TaxClassesPageFormData } from "@dashboard/taxes/types";
 import { useAutofocus } from "@dashboard/taxes/utils/useAutofocus";
 import { getFormErrors } from "@dashboard/utils/errors";
 import getTaxesErrorMessage from "@dashboard/utils/errors/taxes";
-import { Card, CardContent } from "@material-ui/core";
 import { PageTab, PageTabs } from "@saleor/macaw-ui";
 import { Box, Input } from "@saleor/macaw-ui-next";
 import { useEffect, useMemo, useState } from "react";
@@ -135,9 +134,13 @@ const TaxClassesPage = (props: TaxClassesPageProps) => {
                   />
                   {currentTaxClass && (
                     <div>
-                      <Card>
-                        <CardTitle title={intl.formatMessage(taxesMessages.generalInformation)} />
-                        <CardContent>
+                      <DashboardCard>
+                        <DashboardCard.Header>
+                          <DashboardCard.Title>
+                            {intl.formatMessage(taxesMessages.generalInformation)}
+                          </DashboardCard.Title>
+                        </DashboardCard.Header>
+                        <DashboardCard.Content>
                           <Input
                             value={data?.name}
                             onChange={change}
@@ -149,22 +152,26 @@ const TaxClassesPage = (props: TaxClassesPageProps) => {
                             aria-invalid={!!formErrors.name}
                             helperText={getTaxesErrorMessage(formErrors.name, intl)}
                           />
-                        </CardContent>
-                      </Card>
+                        </DashboardCard.Content>
+                      </DashboardCard>
                       <VerticalSpacer spacing={3} />
-                      <Card>
-                        <CardTitle title={intl.formatMessage(taxesMessages.taxClassRates)} />
+                      <DashboardCard>
+                        <DashboardCard.Header>
+                          <DashboardCard.Title>
+                            {intl.formatMessage(taxesMessages.taxClassRates)}
+                          </DashboardCard.Title>
+                        </DashboardCard.Header>
                         {currentTaxClass?.countries.length === 0 ? (
-                          <CardContent className={classes.supportText}>
+                          <DashboardCard.Content className={classes.supportText}>
                             <FormattedMessage
                               {...taxesMessages.noRatesInTaxClass}
                               values={{
                                 tab: <b>{intl.formatMessage(taxesMessages.countriesSection)}</b>,
                               }}
                             />
-                          </CardContent>
+                          </DashboardCard.Content>
                         ) : (
-                          <CardContent>
+                          <DashboardCard.Content>
                             <ResponsiveTable
                               search={{
                                 placeholder: intl.formatMessage(taxesMessages.searchTaxCountries),
@@ -209,9 +216,9 @@ const TaxClassesPage = (props: TaxClassesPageProps) => {
                                 ))}
                               </TableBody>
                             </ResponsiveTable>
-                          </CardContent>
+                          </DashboardCard.Content>
                         )}
-                      </Card>
+                      </DashboardCard>
                       <VerticalSpacer spacing={3} />
                       <Metadata data={data} onChange={handlers.changeMetadata} />
                     </div>


### PR DESCRIPTION
Removes the last `Card`/`CardContent` imports from @material-ui/core in src/. The tax pages now follow the convention already set by their migrated sibling TaxCountriesPage.

`toolbarMargin` in TaxChannelsPage styles is dropped — it only existed to correct MUI CardHeader action spacing, which DashboardCard.Toolbar handles.

CardTitle itself still wraps MUI CardHeader; it is shared widely and left for a separate change.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
