### PR TITLE
refactor: replace JSX.Element return types with React.ReactNode

### DIFF
--- a/src/attributes/components/AssignedAttributesCard/AssignedAttributesBulkDeleteButton.tsx
+++ b/src/attributes/components/AssignedAttributesCard/AssignedAttributesBulkDeleteButton.tsx
@@ -11,7 +11,7 @@ interface AssignedAttributesBulkDeleteButtonProps {
 export const AssignedAttributesBulkDeleteButton = ({
   onClick,
   label,
-}: AssignedAttributesBulkDeleteButtonProps): JSX.Element => (
+}: AssignedAttributesBulkDeleteButtonProps): React.ReactNode => (
   <Button
     data-test-id="bulk-delete-button"
     variant="tertiary"

--- a/src/attributes/components/AssignedAttributesCard/AssignedAttributesCard.tsx
+++ b/src/attributes/components/AssignedAttributesCard/AssignedAttributesCard.tsx
@@ -78,7 +78,7 @@ export const AssignedAttributesCard = ({
   onAttributeCreate,
   onAttributeReorder,
   onAttributeUnassign,
-}: AssignedAttributesCardProps): JSX.Element => {
+}: AssignedAttributesCardProps): React.ReactNode => {
   const intl = useIntl();
   const { items: orderedAttributes, onSortEnd } = useOptimisticListReorder(
     attributes,

--- a/src/attributes/components/AttributeAssignedTypesCard/AttributeAssignedTypesCard.test.tsx
+++ b/src/attributes/components/AttributeAssignedTypesCard/AttributeAssignedTypesCard.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { AttributeAssignedTypesCard } from "./AttributeAssignedTypesCard";
 
-const RouterWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const RouterWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <Wrapper>{children}</Wrapper>
   </MemoryRouter>

--- a/src/attributes/components/AttributeAssignedTypesCard/AttributeAssignedTypesCard.tsx
+++ b/src/attributes/components/AttributeAssignedTypesCard/AttributeAssignedTypesCard.tsx
@@ -33,7 +33,7 @@ interface UsageTypeRowProps {
   roles?: AssignedTypeRole[];
 }
 
-const UsageTypeRow = ({ name, href, roles }: UsageTypeRowProps): JSX.Element => {
+const UsageTypeRow = ({ name, href, roles }: UsageTypeRowProps): React.ReactNode => {
   const intl = useIntl();
 
   return (
@@ -71,7 +71,7 @@ interface UsageListProps {
   showRoles: boolean;
 }
 
-const UsageList = ({ types, getTypeUrl, showRoles }: UsageListProps): JSX.Element => (
+const UsageList = ({ types, getTypeUrl, showRoles }: UsageListProps): React.ReactNode => (
   <Box as="ul" className={styles.list} data-test-id="attribute-usage-list">
     {types.map(type => (
       <UsageTypeRow
@@ -97,7 +97,7 @@ interface UsageCardSkeletonProps {
   showRolePills: boolean;
 }
 
-const UsageCardSkeleton = ({ showRolePills }: UsageCardSkeletonProps): JSX.Element => (
+const UsageCardSkeleton = ({ showRolePills }: UsageCardSkeletonProps): React.ReactNode => (
   <Box as="ul" className={styles.list} data-test-id="attribute-usage-card-skeleton">
     {USAGE_SKELETON_ROW_WIDTHS.map(width => (
       <Box as="li" key={width} className={styles.listItem}>
@@ -115,7 +115,7 @@ const UsageEmptyState = ({
   hintMessage,
   linkMessage,
   href,
-}: UsageEmptyStateProps): JSX.Element => (
+}: UsageEmptyStateProps): React.ReactNode => (
   <Box display="flex" flexDirection="column" gap={2}>
     <Text size={3} color="default2">
       <FormattedMessage {...message} />
@@ -142,7 +142,7 @@ export const AttributeAssignedTypesCard = ({
   variantTypes,
   modelTypes,
   modelTypesListHasMore = false,
-}: AttributeAssignedTypesCardProps): JSX.Element => {
+}: AttributeAssignedTypesCardProps): React.ReactNode => {
   const intl = useIntl();
   const isProductAttribute = attributeType === AttributeTypeEnum.PRODUCT_TYPE;
   const productUsage = mergeProductAssignedTypeUsage(productTypes, variantTypes);

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -68,7 +68,7 @@ interface AttributeDetailsProps
   variant?: "card" | "embedded";
 }
 
-const AttributeDetails = (props: AttributeDetailsProps): JSX.Element => {
+const AttributeDetails = (props: AttributeDetailsProps): React.ReactNode => {
   const {
     canChangeType,
     errors,

--- a/src/attributes/components/AttributeListTableSkeleton/AttributeListTableSkeleton.tsx
+++ b/src/attributes/components/AttributeListTableSkeleton/AttributeListTableSkeleton.tsx
@@ -12,7 +12,7 @@ interface AttributeListTableSkeletonRowsProps {
 export const AttributeListTableSkeletonRows = ({
   rowCount = 3,
   variantColumn,
-}: AttributeListTableSkeletonRowsProps): JSX.Element => (
+}: AttributeListTableSkeletonRowsProps): React.ReactNode => (
   <>
     {Array.from({ length: rowCount }, (_, index) => (
       <TableRow key={index} className={tableStyles.row}>

--- a/src/attributes/components/AttributeOrganization/AttributeOrganization.tsx
+++ b/src/attributes/components/AttributeOrganization/AttributeOrganization.tsx
@@ -41,7 +41,7 @@ const ClassTile = ({
   tileRef: (node: HTMLElement | null) => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
   onSelect: (value: AttributeTypeEnum) => void;
-}): JSX.Element => {
+}): React.ReactNode => {
   const Icon = option.icon;
 
   return (
@@ -89,7 +89,7 @@ const AttributeOrganization = ({
   data,
   disabled,
   onChange,
-}: AttributeOrganizationProps): JSX.Element => {
+}: AttributeOrganizationProps): React.ReactNode => {
   const intl = useIntl();
   const tileRefs = useRef<Partial<Record<AttributeTypeEnum, HTMLElement | null>>>({});
   const value = data.type ?? AttributeTypeEnum.PRODUCT_TYPE;

--- a/src/attributes/components/AttributePage/AttributePage.topNav.test.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.topNav.test.tsx
@@ -31,7 +31,7 @@ const staffUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/attributes/components/AttributePage/Title.test.tsx
+++ b/src/attributes/components/AttributePage/Title.test.tsx
@@ -40,7 +40,7 @@ const mockUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/attributes/components/AttributeProperties/AttributeProperties.stories.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.stories.tsx
@@ -19,7 +19,7 @@ const AttributePropertiesPlayground = ({
   initial,
 }: {
   initial: Partial<AttributePageFormData>;
-}): JSX.Element => {
+}): React.ReactNode => {
   const [data, setData] = useState<AttributePageFormData>({
     ...getAttributePageInitialForm(),
     ...initial,

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -28,7 +28,7 @@ const AttributeProperties = ({
   errors,
   disabled,
   onChange,
-}: AttributePropertiesProps): JSX.Element => {
+}: AttributePropertiesProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["storefrontSearchPosition"], errors);
   // filterableInStorefront and storefrontSearchPosition are removed from the API in 3.24

--- a/src/attributes/components/AttributeReferenceTypesSection/AttributeReferenceTypesSection.tsx
+++ b/src/attributes/components/AttributeReferenceTypesSection/AttributeReferenceTypesSection.tsx
@@ -28,7 +28,7 @@ export const AttributeReferenceTypesSection = ({
   onChange,
   options,
   value,
-}: AttributeReferenceTypesSectionProps): JSX.Element => {
+}: AttributeReferenceTypesSectionProps): React.ReactNode => {
   const intl = useIntl();
   const label =
     entityType === AttributeEntityTypeEnum.PAGE

--- a/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
+++ b/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
@@ -66,7 +66,7 @@ const AttributeValueEditForm = ({
   onClose,
   onSubmit,
   onSubmitMany,
-}: AttributeValueEditFormProps): JSX.Element => {
+}: AttributeValueEditFormProps): React.ReactNode => {
   const intl = useIntl();
   const { pendingPaste, handlePaste, keepAsOneName, clearPendingPaste } = useAttributeValuePaste({
     disabled,
@@ -235,7 +235,7 @@ export const AttributeValueEditDialog = ({
   onSubmitMany,
   open,
   inputType,
-}: AttributeValueEditDialogProps): JSX.Element => {
+}: AttributeValueEditDialogProps): React.ReactNode => {
   const isSubmittingRef = useRef(false);
   const isSwatch = inputType === AttributeInputTypeEnum.SWATCH;
   const isAdd = attributeValue === null;

--- a/src/attributes/components/AttributeValueInlineAdd/AttributeValueInlineAdd.tsx
+++ b/src/attributes/components/AttributeValueInlineAdd/AttributeValueInlineAdd.tsx
@@ -73,7 +73,7 @@ export const AttributeValueInlineAdd = ({
   onAdd,
   onAddMany,
   variant = "tableFooter",
-}: AttributeValueInlineAddProps): JSX.Element => {
+}: AttributeValueInlineAddProps): React.ReactNode => {
   const intl = useIntl();
   const [form, setForm] = useState<AttributeValueEditDialogFormData>(emptyForm);
   const isSwatch = inputType === AttributeInputTypeEnum.SWATCH;

--- a/src/attributes/components/AttributeValuePasteProposal/AttributeValuePasteProposal.tsx
+++ b/src/attributes/components/AttributeValuePasteProposal/AttributeValuePasteProposal.tsx
@@ -16,7 +16,7 @@ export const AttributeValuePasteProposal = ({
   values,
   onAdd,
   onKeepAsOne,
-}: AttributeValuePasteProposalProps): JSX.Element => (
+}: AttributeValuePasteProposalProps): React.ReactNode => (
   <Box className={styles.pasteProposal} data-test-id="attribute-value-paste-proposal">
     <Text size={2} fontWeight="medium">
       <FormattedMessage

--- a/src/attributes/components/AttributeValueRequiredCell/AttributeValueRequiredCell.tsx
+++ b/src/attributes/components/AttributeValueRequiredCell/AttributeValueRequiredCell.tsx
@@ -10,7 +10,7 @@ interface AttributeValueRequiredCellProps {
 
 export const AttributeValueRequiredCell = ({
   valueRequired,
-}: AttributeValueRequiredCellProps): JSX.Element => (
+}: AttributeValueRequiredCellProps): React.ReactNode => (
   <Text size={2} color={valueRequired ? "default1" : "default2"} data-test-id="value-required">
     {valueRequired ? (
       <FormattedMessage {...messages.required} />

--- a/src/attributes/components/SwatchPreview/SwatchPreview.tsx
+++ b/src/attributes/components/SwatchPreview/SwatchPreview.tsx
@@ -22,7 +22,7 @@ export const SwatchPreview = ({
   imageUrl,
   size = 40,
   shape = "rounded",
-}: SwatchPreviewProps): JSX.Element => {
+}: SwatchPreviewProps): React.ReactNode => {
   const hasImage = Boolean(imageUrl);
   const hasColor = Boolean(color);
   const isEmpty = !hasImage && !hasColor;

--- a/src/categories/components/CategoryListDatagrid/CategoryListDatagrid.tsx
+++ b/src/categories/components/CategoryListDatagrid/CategoryListDatagrid.tsx
@@ -110,7 +110,7 @@ export const CategoryListDatagrid = ({
   onLoadMoreSubcategories,
   hidePagination = false,
   variant = "default",
-}: CategoryListDatagridProps): JSX.Element => {
+}: CategoryListDatagridProps): React.ReactNode => {
   const isSidebar = variant === "sidebar";
   const containerRef = useRef<HTMLDivElement>(null);
   const [sidebarColumnWidths, setSidebarColumnWidths] = useState(DEFAULT_SIDEBAR_COLUMN_WIDTHS);

--- a/src/categories/components/CategoryListPage/CategoryListPage.tsx
+++ b/src/categories/components/CategoryListPage/CategoryListPage.tsx
@@ -54,7 +54,7 @@ export const CategoryListPage = ({
   onCreateCategory,
   hasPresetsChanged,
   ...listProps
-}: CategoryTableProps): JSX.Element => {
+}: CategoryTableProps): React.ReactNode => {
   const {
     rows,
     selectedCategoriesIds,

--- a/src/categories/components/CategoryListPage/categoryListPageState.tsx
+++ b/src/categories/components/CategoryListPage/categoryListPageState.tsx
@@ -31,7 +31,7 @@ interface CategoryListPageStateProviderProps extends PropsWithChildren {
 export const CategoryListPageStateProvider = ({
   children,
   value,
-}: CategoryListPageStateProviderProps): JSX.Element => {
+}: CategoryListPageStateProviderProps): React.ReactNode => {
   const [store] = useState(() => {
     const initialStore = createStore();
 

--- a/src/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/src/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -60,7 +60,7 @@ export const CategoryProducts = ({
   categoryId,
   params,
   disabled,
-}: CategoryProductsProps): JSX.Element => {
+}: CategoryProductsProps): React.ReactNode => {
   const navigate = useNavigator();
   const [openModal, closeModal] = createDialogActionHandlers<
     CategoryUrlDialog,

--- a/src/categories/components/CategorySubcategories/CategorySubcategories.tsx
+++ b/src/categories/components/CategorySubcategories/CategorySubcategories.tsx
@@ -45,7 +45,7 @@ export const CategorySubcategories = ({
   setClearDatagridRowSelectionCallback,
   settings,
   onUpdateListSettings,
-}: CategorySubcategoriesProps): JSX.Element => {
+}: CategorySubcategoriesProps): React.ReactNode => {
   const client = useApolloClient();
   const location = useLocation();
   const [storedExpandedIds, setStoredExpandedIds] = useState<string[]>([]);

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -107,7 +107,7 @@ export const CategoryUpdatePage = ({
   onUpdateListSettings,
   onShowMetadata,
   onCreateSubcategory,
-}: CategoryUpdatePageProps): JSX.Element => {
+}: CategoryUpdatePageProps): React.ReactNode => {
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const navigate = useNavigator();

--- a/src/categories/components/CreateCategoryDialog/CreateCategoryDialog.tsx
+++ b/src/categories/components/CreateCategoryDialog/CreateCategoryDialog.tsx
@@ -61,7 +61,7 @@ export const CreateCategoryDialog = ({
   errors: apiErrors,
   onClose,
   onSubmit,
-}: CreateCategoryDialogProps): JSX.Element => {
+}: CreateCategoryDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [submitErrors, setSubmitErrors] = useState<ProductErrorFragment[]>([]);
   // Ignore Apollo's last mutation result until this open session submits again.

--- a/src/categories/views/CategoryList/CategoryList.tsx
+++ b/src/categories/views/CategoryList/CategoryList.tsx
@@ -58,7 +58,7 @@ interface CategoryListProps {
   params: CategoryListUrlQueryParams;
 }
 
-const CategoryList = ({ params }: CategoryListProps): JSX.Element => {
+const CategoryList = ({ params }: CategoryListProps): React.ReactNode => {
   const client = useApolloClient();
   const location = useLocation();
   const navigate = useNavigator();

--- a/src/channels/components/CurrencyCodeCombobox/CurrencyCodeCombobox.stories.tsx
+++ b/src/channels/components/CurrencyCodeCombobox/CurrencyCodeCombobox.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof CurrencyCodeCombobox>;
 
-const CurrencyCodeComboboxPlayground = (): JSX.Element => {
+const CurrencyCodeComboboxPlayground = (): React.ReactNode => {
   const [value, setValue] = useState("PLN");
 
   return (

--- a/src/channels/components/CurrencyCodeCombobox/CurrencyCodeCombobox.tsx
+++ b/src/channels/components/CurrencyCodeCombobox/CurrencyCodeCombobox.tsx
@@ -32,7 +32,7 @@ export const CurrencyCodeCombobox = ({
   value,
   onChange,
   "data-test-id": dataTestId,
-}: CurrencyCodeComboboxProps): JSX.Element => {
+}: CurrencyCodeComboboxProps): React.ReactNode => {
   const intl = useIntl();
   // Macaw fires onChange(null) while syncing inputValue on mount/remount. Ignore that
   // so country→currency autosuggest is not immediately cleared.

--- a/src/collections/components/CollectionProducts/ProductsTable.tsx
+++ b/src/collections/components/CollectionProducts/ProductsTable.tsx
@@ -61,7 +61,7 @@ const areAllChecked = (products: Product[], selected: number) => {
   return selected !== 0;
 };
 
-const ProductsTableEmpty = (): JSX.Element => (
+const ProductsTableEmpty = (): React.ReactNode => (
   <Box padding={4} data-test-id="products-empty-state">
     <Placeholder
       icon={
@@ -88,7 +88,7 @@ const ProductsTableBody = ({
   reorderable,
   draggable,
   wrapRows,
-}: ProductsTableBodyProps): JSX.Element => {
+}: ProductsTableBodyProps): React.ReactNode => {
   const allChecked = areAllChecked(products, selected);
 
   return (
@@ -199,7 +199,7 @@ const ProductsTableBody = ({
   );
 };
 
-const ProductsTableStatic = (props: ProductsTableProps): JSX.Element => {
+const ProductsTableStatic = (props: ProductsTableProps): React.ReactNode => {
   const { products } = props;
 
   if (products.length === 0) {
@@ -217,7 +217,7 @@ const ProductsTableStatic = (props: ProductsTableProps): JSX.Element => {
   );
 };
 
-const ProductsTableReorderable = (props: ProductsTableProps): JSX.Element => {
+const ProductsTableReorderable = (props: ProductsTableProps): React.ReactNode => {
   const { products, paginationState } = props;
   const { items, sensors, isSaving, handleDragEnd, handleDragCancel } = useProductDrag({
     products,
@@ -253,7 +253,7 @@ const ProductsTableReorderable = (props: ProductsTableProps): JSX.Element => {
 export const ProductsTable = ({
   reorderable = true,
   ...props
-}: ProductsTableProps): JSX.Element => {
+}: ProductsTableProps): React.ReactNode => {
   if (!reorderable) {
     return <ProductsTableStatic {...props} reorderable={false} />;
   }

--- a/src/collections/components/CreateCollectionDialog/CreateCollectionDialog.tsx
+++ b/src/collections/components/CreateCollectionDialog/CreateCollectionDialog.tsx
@@ -56,7 +56,7 @@ export const CreateCollectionDialog = ({
   errors: apiErrors,
   onClose,
   onSubmit,
-}: CreateCollectionDialogProps): JSX.Element => {
+}: CreateCollectionDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [submitErrors, setSubmitErrors] = useState<CollectionErrorFragment[]>([]);
   // Ignore Apollo's last mutation result until this open session submits again.

--- a/src/components/AppLayout/ContextualLinks/ContextualHelpIcon.tsx
+++ b/src/components/AppLayout/ContextualLinks/ContextualHelpIcon.tsx
@@ -19,7 +19,7 @@ export const ContextualHelpIcon = ({
   label,
   analyticsType,
   dataTestId,
-}: ContextualHelpIconProps): JSX.Element => {
+}: ContextualHelpIconProps): React.ReactNode => {
   const { trackEvent } = useAnalytics();
 
   return (

--- a/src/components/AppLayout/ListFilters/components/ExpressionFilters.tsx
+++ b/src/components/AppLayout/ListFilters/components/ExpressionFilters.tsx
@@ -12,7 +12,7 @@ import styles from "./ExpressionFilters.module.css";
 
 const EXPRESSION_FILTERS_PANEL_ID = "expression-filters-panel";
 
-export const ExpressionFilters = (): JSX.Element => {
+export const ExpressionFilters = (): React.ReactNode => {
   const { formatMessage } = useIntl();
   const { valueProvider, containerState, filterWindow } = useConditionalFilterContext();
   const handleToggle = (): void => {

--- a/src/components/AppLayout/ListFilters/components/SearchInput.tsx
+++ b/src/components/AppLayout/ListFilters/components/SearchInput.tsx
@@ -11,7 +11,7 @@ const SearchInput = ({
   onSearchChange,
   placeholder,
   showSearchTooltip = false,
-}: SearchInputProps): JSX.Element => (
+}: SearchInputProps): React.ReactNode => (
   <ListSearchInput
     initialSearch={initialSearch}
     placeholder={placeholder}

--- a/src/components/AppLayout/TopNav/Menu.test.tsx
+++ b/src/components/AppLayout/TopNav/Menu.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 
 import { Menu, type TopNavMenuItem } from "./Menu";
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/components/AssignListCard/AssignListCard.tsx
+++ b/src/components/AssignListCard/AssignListCard.tsx
@@ -59,7 +59,7 @@ export const AssignListCard = ({
   "data-test-id": dataTestId,
   rowTestId = "assign-list-row",
   rowLinkTestId = (id: string): string => `${id}-link`,
-}: AssignListCardProps): JSX.Element => {
+}: AssignListCardProps): React.ReactNode => {
   const hasItems = items.length > 0;
 
   return (

--- a/src/components/AssignPickerBackfillExhausted/AssignPickerBackfillExhausted.tsx
+++ b/src/components/AssignPickerBackfillExhausted/AssignPickerBackfillExhausted.tsx
@@ -23,7 +23,7 @@ export const AssignPickerBackfillExhaustedRow = ({
   message,
   buttonLabel,
   onLoadMore,
-}: AssignPickerBackfillExhaustedProps): JSX.Element => (
+}: AssignPickerBackfillExhaustedProps): React.ReactNode => (
   <TableRow>
     <TableCell colSpan={colSpan} className={styles.cell}>
       <Box

--- a/src/components/AssignPickerListEmptyState/AssignPickerListEmptyState.tsx
+++ b/src/components/AssignPickerListEmptyState/AssignPickerListEmptyState.tsx
@@ -10,7 +10,7 @@ interface AssignPickerListEmptyStateProps {
 
 export const AssignPickerListEmptyState = ({
   children,
-}: AssignPickerListEmptyStateProps): JSX.Element => (
+}: AssignPickerListEmptyStateProps): React.ReactNode => (
   <Box
     className={styles.container}
     display="flex"
@@ -32,7 +32,7 @@ interface AssignPickerListEmptyStateRowProps {
 export const AssignPickerListEmptyStateRow = ({
   colSpan = 3,
   children,
-}: AssignPickerListEmptyStateRowProps): JSX.Element => (
+}: AssignPickerListEmptyStateRowProps): React.ReactNode => (
   <TableRow>
     <TableCell colSpan={colSpan} className={styles.cell}>
       <AssignPickerListEmptyState>{children}</AssignPickerListEmptyState>

--- a/src/components/AssignPickerListLoading/AssignPickerListLoading.tsx
+++ b/src/components/AssignPickerListLoading/AssignPickerListLoading.tsx
@@ -4,7 +4,7 @@ import { Box } from "@saleor/macaw-ui-next";
 
 import styles from "./AssignPickerListPlaceholder.module.css";
 
-export const AssignPickerListLoading = (): JSX.Element => (
+export const AssignPickerListLoading = (): React.ReactNode => (
   <Box
     className={styles.container}
     display="flex"
@@ -22,7 +22,7 @@ interface AssignPickerListLoadingRowProps {
 
 export const AssignPickerListLoadingRow = ({
   colSpan = 3,
-}: AssignPickerListLoadingRowProps): JSX.Element => (
+}: AssignPickerListLoadingRowProps): React.ReactNode => (
   <TableRow>
     <TableCell colSpan={colSpan} className={styles.cell}>
       <AssignPickerListLoading />

--- a/src/components/AssignProductDialog/AssignProductDialog.tsx
+++ b/src/components/AssignProductDialog/AssignProductDialog.tsx
@@ -46,7 +46,7 @@ export interface AssignProductDialogProps
   initialConstraints?: InitialConstraints;
 }
 
-export const AssignProductDialog = (props: AssignProductDialogProps): JSX.Element => {
+export const AssignProductDialog = (props: AssignProductDialogProps): React.ReactNode => {
   const {
     selectionMode = "multiple",
     excludedFilters,

--- a/src/components/AssignShippingZoneDialog/AssignShippingZoneDialog.tsx
+++ b/src/components/AssignShippingZoneDialog/AssignShippingZoneDialog.tsx
@@ -28,7 +28,7 @@ export const AssignShippingZoneDialog = ({
   open,
   onClose,
   ...fetchMoreProps
-}: AssignShippingZoneDialogProps): JSX.Element => {
+}: AssignShippingZoneDialogProps): React.ReactNode => {
   const intl = useIntl();
 
   const { query, onQueryChange, resetQuery } = useModalSearchWithFilters({

--- a/src/components/AssignWarehouseDialog/AssignWarehouseDialog.tsx
+++ b/src/components/AssignWarehouseDialog/AssignWarehouseDialog.tsx
@@ -32,7 +32,7 @@ export const AssignWarehouseDialog = ({
   open,
   onClose,
   ...fetchMoreProps
-}: AssignWarehouseDialogProps): JSX.Element => {
+}: AssignWarehouseDialogProps): React.ReactNode => {
   const intl = useIntl();
 
   const { query, onQueryChange, resetQuery } = useModalSearchWithFilters({

--- a/src/components/AssignableListTable/AssignableListCard.stories.tsx
+++ b/src/components/AssignableListTable/AssignableListCard.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof AssignableListCard> = {
 export default meta;
 type Story = StoryObj<typeof AssignableListCard>;
 
-const TablePlaceholder = (): JSX.Element => (
+const TablePlaceholder = (): React.ReactNode => (
   <Text size={3} color="default2" padding={6} display="block">
     Table heading + rows live here. Hover a row to reveal delete.
   </Text>

--- a/src/components/AssignableListTable/AssignableListCard.test.tsx
+++ b/src/components/AssignableListTable/AssignableListCard.test.tsx
@@ -15,7 +15,7 @@ const paginatorValue = {
   loadPreviousPage: jest.fn(),
 };
 
-const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const TestWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <Wrapper>
     <PaginatorContext.Provider value={paginatorValue}>{children}</PaginatorContext.Provider>
   </Wrapper>

--- a/src/components/AssignableListTable/AssignableListCard.tsx
+++ b/src/components/AssignableListTable/AssignableListCard.tsx
@@ -31,7 +31,7 @@ export const AssignableListCard = ({
   children,
   footer,
   "data-test-id": dataTestId,
-}: AssignableListCardProps): JSX.Element => (
+}: AssignableListCardProps): React.ReactNode => (
   <DetailSettingsCard
     title={title}
     subtitle={subtitle}

--- a/src/components/AssignableListTable/AssignableListPagination.test.tsx
+++ b/src/components/AssignableListTable/AssignableListPagination.test.tsx
@@ -13,7 +13,7 @@ const paginatorValue = {
   loadPreviousPage: jest.fn(),
 };
 
-const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const TestWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <Wrapper>
     <PaginatorContext.Provider value={paginatorValue}>{children}</PaginatorContext.Provider>
   </Wrapper>

--- a/src/components/AssignableListTable/AssignableListPagination.tsx
+++ b/src/components/AssignableListTable/AssignableListPagination.tsx
@@ -64,7 +64,7 @@ export const AssignableListPagination = ({
   inset = "card",
   paddingLeft,
   beforePagination,
-}: AssignableListPaginationProps): JSX.Element => {
+}: AssignableListPaginationProps): React.ReactNode => {
   const intl = useIntl();
   const { hasNextPage, hasPreviousPage, loadNextPage, loadPreviousPage } = usePaginatorContext();
   const currentRowNumber = String(numberOfRows);

--- a/src/components/AssignableListTable/AssignableListTable.tsx
+++ b/src/components/AssignableListTable/AssignableListTable.tsx
@@ -103,7 +103,7 @@ export const AssignableListTable = <T extends { id: string }>({
   "data-test-id": dataTestId = "assignable-list-table",
   leadingInset = ASSIGNABLE_LIST_TABLE_LEADING_INSET,
   density = "compact",
-}: AssignableListTableProps<T>): JSX.Element => {
+}: AssignableListTableProps<T>): React.ReactNode => {
   const intl = useIntl();
   const showSelection = selection === "checkbox";
   const showRowActions = showSelection && Boolean(onUnassign);
@@ -314,7 +314,7 @@ export const AssignableListCell = ({
   children: ReactNode;
   truncate?: boolean;
   align?: "start" | "end";
-}): JSX.Element => (
+}): React.ReactNode => (
   <GridTable.Cell
     __height="inherit"
     padding={0}
@@ -338,7 +338,7 @@ export const AssignableListLinkCell = ({
   /** Full label for native browser tooltip when the cell truncates. */
   title?: string;
   children: ReactNode;
-}): JSX.Element => (
+}): React.ReactNode => (
   <GridTable.Cell __height="inherit" padding={0} className={styles.truncateCell}>
     <Link href={href} inline={false} className={styles.cellLink} title={title}>
       <Box className={styles.cellContent}>{children}</Box>

--- a/src/components/AttributeClass/AttributeClass.tsx
+++ b/src/components/AttributeClass/AttributeClass.tsx
@@ -79,7 +79,7 @@ export const AttributeClassDisplay = ({
   color = "default2",
   "data-test-id": dataTestId = "attribute-class-display",
   title,
-}: AttributeClassProps): JSX.Element => {
+}: AttributeClassProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!attributeType) {
@@ -123,7 +123,7 @@ export const AttributeClassDisplay = ({
   );
 };
 
-export const ClickableAttributeClass = (props: AttributeClassProps): JSX.Element => {
+export const ClickableAttributeClass = (props: AttributeClassProps): React.ReactNode => {
   const { attributeType } = props;
   const intl = useIntl();
   const userPermissions = useUserPermissions();

--- a/src/components/AttributeInputTypeIcon/AttributeInputTypeIcon.tsx
+++ b/src/components/AttributeInputTypeIcon/AttributeInputTypeIcon.tsx
@@ -16,7 +16,7 @@ export const AttributeInputTypeIcon = ({
   inputType,
   size = "small",
   hasUnit = false,
-}: AttributeInputTypeIconProps): JSX.Element => {
+}: AttributeInputTypeIconProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/components/AttributeInputTypeIcon/AttributeLabelIcon.tsx
+++ b/src/components/AttributeInputTypeIcon/AttributeLabelIcon.tsx
@@ -18,7 +18,7 @@ export const AttributeLabelIcon = ({
   icon,
   size = "small",
   ariaLabel,
-}: AttributeLabelIconProps): JSX.Element => {
+}: AttributeLabelIconProps): React.ReactNode => {
   const pixelSize = attributeInputTypeIconPixelSize[size];
 
   return (

--- a/src/components/AttributeInputTypeIcon/AttributeNameWithTypeIcon.tsx
+++ b/src/components/AttributeInputTypeIcon/AttributeNameWithTypeIcon.tsx
@@ -14,7 +14,7 @@ export const AttributeNameWithTypeIcon = ({
   name,
   inputType,
   secondary,
-}: AttributeNameWithTypeIconProps): JSX.Element => (
+}: AttributeNameWithTypeIconProps): React.ReactNode => (
   <Box display="flex" flexDirection="column" gap={0.5} minWidth={0}>
     <Box display="flex" alignItems="center" gap={1} minWidth={0}>
       {name}

--- a/src/components/Attributes/AttributeRow.tsx
+++ b/src/components/Attributes/AttributeRow.tsx
@@ -43,7 +43,7 @@ const AttributeRow = ({
   fetchMoreAttributeValues,
   onAttributeSelectBlur,
   richTextGetters,
-}: AttributeRowProps): JSX.Element => {
+}: AttributeRowProps): React.ReactNode => {
   const intl = useIntl();
   const labelProps = getAttributeRowLabelProps(attribute);
   const referenceIcons = useModelReferenceIcons(attribute);

--- a/src/components/Attributes/DatagridSwatchPreview.tsx
+++ b/src/components/Attributes/DatagridSwatchPreview.tsx
@@ -24,7 +24,7 @@ export const DatagridSwatchPreview = ({
   fileUrl,
   size = DATAGRID_SWATCH_SIZE,
   placement = "option",
-}: DatagridSwatchPreviewProps): JSX.Element => (
+}: DatagridSwatchPreviewProps): React.ReactNode => (
   <span
     aria-hidden
     className={clsx(styles.adornment, placement === "input" && styles.adornmentInput)}

--- a/src/components/Attributes/DropdownRow.tsx
+++ b/src/components/Attributes/DropdownRow.tsx
@@ -69,7 +69,7 @@ export const DropdownRow = ({
   fetchAttributeValues,
   fetchMoreAttributeValues,
   onAttributeSelectBlur,
-}: DropdownRowProps): JSX.Element => {
+}: DropdownRowProps): React.ReactNode => {
   const intl = useIntl();
   const fieldId = `attribute:${attribute.label}`;
   const [inputValue, setInputValue] = useState("");

--- a/src/components/Attributes/SwatchRow.tsx
+++ b/src/components/Attributes/SwatchRow.tsx
@@ -32,7 +32,7 @@ export const SwatchRow = ({
   disabled,
   error,
   onChange,
-}: SwatchRowProps): JSX.Element => {
+}: SwatchRowProps): React.ReactNode => {
   const intl = useIntl();
   const selectedValueSlug = attribute.value[0];
   const value = selectedValueSlug

--- a/src/components/ButtonGroupWithDropdown/ButtonGroupWithDropdown.tsx
+++ b/src/components/ButtonGroupWithDropdown/ButtonGroupWithDropdown.tsx
@@ -59,7 +59,7 @@ export const ButtonGroupWithDropdown = ({
   size,
   className,
   ...boxProps
-}: ButtonGroupWithDropdownProps): JSX.Element => {
+}: ButtonGroupWithDropdownProps): React.ReactNode => {
   const showSeparator = pinnedOptions.length > 0 && options.length > 0;
   const chevronSize = size === "small" ? iconSize.small : iconSize.medium;
   const chevronStroke = size === "small" ? iconStrokeWidthBySize.small : iconStrokeWidth;

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -47,7 +47,7 @@ export const Callout = ({
   children,
   className,
   "data-test-id": dataTestId,
-}: CalloutProps): JSX.Element => {
+}: CalloutProps): React.ReactNode => {
   const { Icon, className: typeClassName } = calloutVariants[type];
   const rootClassName = [styles.callout, typeClassName, className].filter(Boolean).join(" ");
 

--- a/src/components/Channel/Channel.tsx
+++ b/src/components/Channel/Channel.tsx
@@ -95,7 +95,7 @@ export const ChannelDisplay = ({
   inline = false,
   "data-test-id": dataTestId = "channel-display",
   title,
-}: ChannelProps): JSX.Element => {
+}: ChannelProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!channel) {
@@ -143,7 +143,7 @@ export const ChannelDisplay = ({
   return content;
 };
 
-export const ClickableChannel = (props: ChannelLinkProps): JSX.Element => {
+export const ClickableChannel = (props: ChannelLinkProps): React.ReactNode => {
   const { channel } = props;
   const intl = useIntl();
   const userPermissions = useUserPermissions();
@@ -176,7 +176,7 @@ export const ClickableChannel = (props: ChannelLinkProps): JSX.Element => {
   );
 };
 
-export const ChannelDetailsLink = ({ onClick, ...props }: ChannelLinkProps): JSX.Element => {
+export const ChannelDetailsLink = ({ onClick, ...props }: ChannelLinkProps): React.ReactNode => {
   const { channel } = props;
   const intl = useIntl();
 

--- a/src/components/Combobox/components/AddNewValueAdornment.tsx
+++ b/src/components/Combobox/components/AddNewValueAdornment.tsx
@@ -2,7 +2,7 @@ import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { Box } from "@saleor/macaw-ui-next";
 import { Plus } from "lucide-react";
 
-export const AddNewValueAdornment = (): JSX.Element => (
+export const AddNewValueAdornment = (): React.ReactNode => (
   <Box
     as="span"
     display="flex"

--- a/src/components/ConditionalFilter/FiltersArea.test.tsx
+++ b/src/components/ConditionalFilter/FiltersArea.test.tsx
@@ -29,7 +29,7 @@ jest.mock("./useTranslate", () => ({
 }));
 
 jest.mock("./UI", () => {
-  const Footer = ({ children }: { children: ReactNode }): JSX.Element => <div>{children}</div>;
+  const Footer = ({ children }: { children: ReactNode }): React.ReactNode => <div>{children}</div>;
   const Button = ({
     children,
     ...props
@@ -39,13 +39,13 @@ jest.mock("./UI", () => {
     disabled?: boolean;
     variant?: string;
     "data-test-id"?: string;
-  }): JSX.Element => (
+  }): React.ReactNode => (
     <button type="button" {...props}>
       {children}
     </button>
   );
   const Filters = Object.assign(
-    ({ children }: { children: ReactNode }): JSX.Element => <div>{children}</div>,
+    ({ children }: { children: ReactNode }): React.ReactNode => <div>{children}</div>,
     {
       Footer,
       AddRowButton: Button,

--- a/src/components/ConditionalFilter/LoadingFiltersArea.tsx
+++ b/src/components/ConditionalFilter/LoadingFiltersArea.tsx
@@ -9,7 +9,7 @@ interface LoadingFiltersAreaProps {
 
 export const LoadingFiltersArea = ({
   layout = "popover",
-}: LoadingFiltersAreaProps): JSX.Element => {
+}: LoadingFiltersAreaProps): React.ReactNode => {
   const isPopover = layout === "popover";
   const isPanel = layout === "panel";
 

--- a/src/components/ConditionalFilter/UI/ConstraintReasonHint.stories.tsx
+++ b/src/components/ConditionalFilter/UI/ConstraintReasonHint.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof ConstraintReasonHint>;
 
-const FilterRowChrome = ({ fields }: { fields: string[] }): JSX.Element => (
+const FilterRowChrome = ({ fields }: { fields: string[] }): React.ReactNode => (
   <Box
     __width="560px"
     padding={4}

--- a/src/components/ConditionalFilter/UI/Filters.tsx
+++ b/src/components/ConditionalFilter/UI/Filters.tsx
@@ -18,7 +18,7 @@ export const Filters = ({
   locale,
   error,
   layout = "popover",
-}: FiltersProps): JSX.Element => {
+}: FiltersProps): React.ReactNode => {
   const errorsByRowIndex = createErrorLookup(error);
   const isInline = isFlatFilterLayout(layout);
   const columnGap = isInline ? 3 : 2;

--- a/src/components/ConditionalFilter/UI/Footer.tsx
+++ b/src/components/ConditionalFilter/UI/Footer.tsx
@@ -59,7 +59,7 @@ export const ClearButton = ({ children, disabled, ...props }: ButtonProps) => {
   );
 };
 
-export const CloseButton = ({ children, ...props }: ButtonProps): JSX.Element => (
+export const CloseButton = ({ children, ...props }: ButtonProps): React.ReactNode => (
   <Button variant="tertiary" {...props}>
     {children}
   </Button>

--- a/src/components/ConditionalFilter/UI/NoValue.tsx
+++ b/src/components/ConditionalFilter/UI/NoValue.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "@saleor/macaw-ui-next";
 
-export const NoValue = ({ locale }: { locale: Record<string, string> }): JSX.Element => (
+export const NoValue = ({ locale }: { locale: Record<string, string> }): React.ReactNode => (
   <Box
     display="flex"
     justifyContent="center"

--- a/src/components/ConditionalFilter/UI/ProductReferenceMultiselect.stories.tsx
+++ b/src/components/ConditionalFilter/UI/ProductReferenceMultiselect.stories.tsx
@@ -46,7 +46,7 @@ export default meta;
 
 type Story = StoryObj<typeof ProductReferenceMultiselect>;
 
-const ProductReferenceMultiselectPlayground = (): JSX.Element => {
+const ProductReferenceMultiselectPlayground = (): React.ReactNode => {
   const [value, setValue] = useState<RightOperatorOption[]>([options[0]]);
   const selected: MultiselectOperator = {
     conditionValue: { type: "multiselect", label: "in", value: "input-2" },

--- a/src/components/ConditionalFilter/UI/ProductReferenceMultiselect.tsx
+++ b/src/components/ConditionalFilter/UI/ProductReferenceMultiselect.tsx
@@ -44,7 +44,7 @@ export const ProductReferenceMultiselect = ({
   helperText,
   disabled,
   layout,
-}: ProductReferenceMultiselectProps): JSX.Element => {
+}: ProductReferenceMultiselectProps): React.ReactNode => {
   const [query, setQuery] = useState("");
   const options = includeSelectedComboboxOptions(selected.options ?? [], selected.value);
   const listItems = filterProductReferenceOptions(options, query);

--- a/src/components/ConditionalFilter/UI/RangeInputWrapper.tsx
+++ b/src/components/ConditionalFilter/UI/RangeInputWrapper.tsx
@@ -16,7 +16,7 @@ export const RangeInputWrapper = ({
   children,
   inline = false,
   compact = "date",
-}: RangeInputWrapperProps): JSX.Element => (
+}: RangeInputWrapperProps): React.ReactNode => (
   <Box
     className={clsx(styles.root, inline && styles.inline)}
     data-range-layout={inline ? "inline" : "stack"}

--- a/src/components/ConditionalFilter/UI/Root.tsx
+++ b/src/components/ConditionalFilter/UI/Root.tsx
@@ -32,7 +32,7 @@ export const Root = ({
     noValueText: "Click button below to start filtering",
   },
   error,
-}: ExperimentalFiltersProps): JSX.Element => {
+}: ExperimentalFiltersProps): React.ReactNode => {
   const { emitter } = useEventEmitter({
     onChange,
   });

--- a/src/components/ConditionalFilter/UI/Row.tsx
+++ b/src/components/ConditionalFilter/UI/Row.tsx
@@ -44,7 +44,7 @@ export const RowComponent = ({
   emitter,
   error,
   layout = "popover",
-}: RowProps): JSX.Element => {
+}: RowProps): React.ReactNode => {
   const constrain = getItemConstraint(item.constraint);
   const reasonLabels = getConstraintReasonLabels(item, rows);
   const isAttribute = item.isAttribute;

--- a/src/components/ConditionalFilter/UI/SwatchAttributeMultiselect.stories.tsx
+++ b/src/components/ConditionalFilter/UI/SwatchAttributeMultiselect.stories.tsx
@@ -42,7 +42,7 @@ export default meta;
 
 type Story = StoryObj<typeof SwatchAttributeMultiselect>;
 
-const SwatchAttributeMultiselectPlayground = (): JSX.Element => {
+const SwatchAttributeMultiselectPlayground = (): React.ReactNode => {
   const [value, setValue] = useState<RightOperatorOption[]>([options[0]]);
   const selected: MultiselectOperator = {
     conditionValue: { type: "multiselect", label: "in", value: "input-2" },

--- a/src/components/ConditionalFilter/UI/SwatchAttributeMultiselect.tsx
+++ b/src/components/ConditionalFilter/UI/SwatchAttributeMultiselect.tsx
@@ -42,7 +42,7 @@ export const SwatchAttributeMultiselect = ({
   helperText,
   disabled,
   layout,
-}: SwatchAttributeMultiselectProps): JSX.Element => {
+}: SwatchAttributeMultiselectProps): React.ReactNode => {
   const [query, setQuery] = useState("");
   const options = includeSelectedComboboxOptions(selected.options ?? [], selected.value);
   const listItems = filterProductReferenceOptions(options, query);

--- a/src/components/ConditionalFilter/UI/VariantReferenceMultiselect.stories.tsx
+++ b/src/components/ConditionalFilter/UI/VariantReferenceMultiselect.stories.tsx
@@ -53,7 +53,7 @@ export default meta;
 
 type Story = StoryObj<typeof VariantReferenceMultiselect>;
 
-const VariantReferenceMultiselectPlayground = (): JSX.Element => {
+const VariantReferenceMultiselectPlayground = (): React.ReactNode => {
   const [value, setValue] = useState<RightOperatorOption[]>([options[0], options[2]]);
   const selected: MultiselectOperator = {
     conditionValue: { type: "multiselect", label: "in", value: "input-2" },

--- a/src/components/ConditionalFilter/UI/VariantReferenceMultiselect.tsx
+++ b/src/components/ConditionalFilter/UI/VariantReferenceMultiselect.tsx
@@ -50,7 +50,7 @@ export const VariantReferenceMultiselect = ({
   helperText,
   disabled,
   layout,
-}: VariantReferenceMultiselectProps): JSX.Element => {
+}: VariantReferenceMultiselectProps): React.ReactNode => {
   const [query, setQuery] = useState("");
   const options = includeSelectedComboboxOptions(selected.options ?? [], selected.value);
   const variantOptions = filterVariantReferenceOptions(

--- a/src/components/CopyableText/CopyableText.tsx
+++ b/src/components/CopyableText/CopyableText.tsx
@@ -11,7 +11,7 @@ interface CopyableTextProps {
   children?: ReactNode;
 }
 
-export const CopyableText = ({ text, children }: CopyableTextProps): JSX.Element => {
+export const CopyableText = ({ text, children }: CopyableTextProps): React.ReactNode => {
   const intl = useIntl();
   const [copied, copy] = useClipboard();
   const [showCopyButton, setShowCopyButton] = useState(false);

--- a/src/components/CountryList/CountryList.tsx
+++ b/src/components/CountryList/CountryList.tsx
@@ -49,7 +49,7 @@ export const CountryList = ({
   errorMessage,
   onCountryAssign,
   onCountryUnassign,
-}: CountryListProps): JSX.Element => {
+}: CountryListProps): React.ReactNode => {
   const intl = useIntl();
   const sortedCountries = useMemo(
     () =>

--- a/src/components/CreateAttributeDialog/CreateAttributeDialog.test.tsx
+++ b/src/components/CreateAttributeDialog/CreateAttributeDialog.test.tsx
@@ -112,7 +112,7 @@ jest.mock(
   }),
 );
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/components/CustomerType/CustomerType.tsx
+++ b/src/components/CustomerType/CustomerType.tsx
@@ -82,7 +82,7 @@ export const CustomerTypeDisplay = ({
   color = "default2",
   "data-test-id": dataTestId = "customer-type-display",
   title,
-}: CustomerTypeProps): JSX.Element => {
+}: CustomerTypeProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!customerType) {
@@ -116,7 +116,7 @@ export const CustomerTypeDisplay = ({
   );
 };
 
-export const ClickableCustomerType = (props: CustomerTypeProps): JSX.Element => {
+export const ClickableCustomerType = (props: CustomerTypeProps): React.ReactNode => {
   const { customerType, href } = props;
   const intl = useIntl();
   const userPermissions = useUserPermissions();

--- a/src/components/Date/MerchantDate.tsx
+++ b/src/components/Date/MerchantDate.tsx
@@ -197,7 +197,7 @@ interface MerchantDateProps {
 // row date), each tick of `useCurrentDate` re-allocates a few Intl formatters.
 // Worth introducing a memoized formatter cache keyed by (locale, options) at
 // that point. Single-instance usage in headers is fine.
-export const MerchantDate = ({ kind, date, now }: MerchantDateProps): JSX.Element => {
+export const MerchantDate = ({ kind, date, now }: MerchantDateProps): React.ReactNode => {
   const intl = useIntl();
   const liveNow = useCurrentDate();
   const referenceNow = now ?? new Date(liveNow);

--- a/src/components/DeletableItem/DeletableItem.tsx
+++ b/src/components/DeletableItem/DeletableItem.tsx
@@ -15,7 +15,7 @@ const DeletableItem = ({
   id,
   disabled = false,
   label,
-}: DeletableItemProps): JSX.Element => {
+}: DeletableItemProps): React.ReactNode => {
   const handleDelete = () => {
     if (!disabled) {
       onDelete(id);

--- a/src/components/DetailGroupBox/DetailGroupBox.tsx
+++ b/src/components/DetailGroupBox/DetailGroupBox.tsx
@@ -37,7 +37,7 @@ export const DetailGroupBox = ({
   marginTop,
   triggerButtonTestId,
   variant = "primary",
-}: DetailGroupBoxProps): JSX.Element => {
+}: DetailGroupBoxProps): React.ReactNode => {
   const [expanded, setExpanded] = useState<string | undefined>(
     defaultExpanded ? groupId : undefined,
   );

--- a/src/components/DetailPageContent/DetailPageContent.tsx
+++ b/src/components/DetailPageContent/DetailPageContent.tsx
@@ -20,7 +20,7 @@ export const DetailPageContent = ({
   children,
   className,
   ...rest
-}: DetailPageContentProps): JSX.Element => (
+}: DetailPageContentProps): React.ReactNode => (
   <Box
     className={clsx(styles.root, className)}
     display="flex"

--- a/src/components/DetailPageSectionLayout/DetailPageSectionLayout.tsx
+++ b/src/components/DetailPageSectionLayout/DetailPageSectionLayout.tsx
@@ -24,7 +24,7 @@ interface DetailPageSectionLayoutProps {
 export const DetailPageSectionLayout = ({
   nav,
   children,
-}: DetailPageSectionLayoutProps): JSX.Element => (
+}: DetailPageSectionLayoutProps): React.ReactNode => (
   <Box className={styles.root} display="flex" gap={4} paddingTop={6} paddingBottom={6}>
     <Box
       display={{ mobile: "none", tablet: "block", desktop: "block" }}

--- a/src/components/DetailSettingToggleRow/DetailSettingToggleRow.tsx
+++ b/src/components/DetailSettingToggleRow/DetailSettingToggleRow.tsx
@@ -28,7 +28,7 @@ export const DetailSettingToggleRow = ({
   testId,
   notice,
   children,
-}: DetailSettingToggleRowProps): JSX.Element => {
+}: DetailSettingToggleRowProps): React.ReactNode => {
   const toggle = () => {
     if (!disabled) {
       onPressedChange(!pressed);
@@ -80,6 +80,8 @@ export const DetailSettingToggleRow = ({
   );
 };
 
-export const DetailSettingNestedField = ({ children }: { children: ReactNode }): JSX.Element => (
-  <Box className={styles.nestedField}>{children}</Box>
-);
+export const DetailSettingNestedField = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactNode => <Box className={styles.nestedField}>{children}</Box>;

--- a/src/components/DetailSettingsCard/DetailSettingsCard.tsx
+++ b/src/components/DetailSettingsCard/DetailSettingsCard.tsx
@@ -20,7 +20,7 @@ interface DetailSettingsCardProps {
   "data-test-id"?: string;
 }
 
-export const DetailSettingsOptionalLabel = (): JSX.Element => (
+export const DetailSettingsOptionalLabel = (): React.ReactNode => (
   <Text as="span" size={2} color="default2" fontWeight="regular">
     <FormattedMessage {...commonMessages.optionalField} />
   </Text>
@@ -37,14 +37,14 @@ export const DetailSettingsCardTitle = ({
 }: {
   children: ReactNode;
   optional?: boolean;
-}): JSX.Element => (
+}): React.ReactNode => (
   <Box display="inline-flex" alignItems="baseline" gap={2} flexWrap="wrap" as="span">
     <Box as="span">{children}</Box>
     {optional ? <DetailSettingsOptionalLabel /> : null}
   </Box>
 );
 
-export const DetailSettingsCardIntro = ({ children }: { children: ReactNode }): JSX.Element => (
+export const DetailSettingsCardIntro = ({ children }: { children: ReactNode }): React.ReactNode => (
   <Box className={styles.intro}>{children}</Box>
 );
 
@@ -56,7 +56,7 @@ export const DetailSettingsCard = ({
   children,
   contentFlush = false,
   "data-test-id": dataTestId,
-}: DetailSettingsCardProps): JSX.Element => (
+}: DetailSettingsCardProps): React.ReactNode => (
   <Box className={styles.card} data-test-id={dataTestId}>
     <Box className={clsx(styles.header, headerEnd && styles.headerWithEnd)}>
       <Box className={styles.headerMain}>

--- a/src/components/DragHandle/DragHandle.tsx
+++ b/src/components/DragHandle/DragHandle.tsx
@@ -22,7 +22,7 @@ export const DragHandle = ({
   className,
   cursor = "grab",
   ...props
-}: DragHandleProps): JSX.Element => (
+}: DragHandleProps): React.ReactNode => (
   <GripVertical
     className={clsx(styles.root, cursorClassName[cursor], className)}
     size={iconSize.small}

--- a/src/components/EmptyImage/index.tsx
+++ b/src/components/EmptyImage/index.tsx
@@ -2,7 +2,7 @@ import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { Box } from "@saleor/macaw-ui-next";
 import { Image } from "lucide-react";
 
-export const EmptyImage = (): JSX.Element => (
+export const EmptyImage = (): React.ReactNode => (
   <Box
     __width="31px"
     __height="31px"

--- a/src/components/EntityBackgroundImageField/EntityBackgroundImageField.stories.tsx
+++ b/src/components/EntityBackgroundImageField/EntityBackgroundImageField.stories.tsx
@@ -23,7 +23,7 @@ const StatefulField = ({
 }: {
   disabled?: boolean;
   image: EntityBackgroundImage | null | undefined;
-}): JSX.Element => {
+}): React.ReactNode => {
   const [alt, setAlt] = useState(image?.alt ?? "");
 
   return (

--- a/src/components/EntityBackgroundImageField/EntityBackgroundImageField.tsx
+++ b/src/components/EntityBackgroundImageField/EntityBackgroundImageField.tsx
@@ -73,7 +73,7 @@ const BackgroundImagePreview = ({
   testIds,
   onImageDelete,
   onUploadPreviewLoaded,
-}: BackgroundImagePreviewProps): JSX.Element => {
+}: BackgroundImagePreviewProps): React.ReactNode => {
   const intl = useIntl();
   const showDelete = hasSavedImage && !disabled && !isUploading;
 
@@ -143,7 +143,7 @@ export const EntityBackgroundImageField = ({
   onImageDelete,
   onImageUpload,
   onUploadPreviewLoaded,
-}: EntityBackgroundImageFieldProps): JSX.Element => {
+}: EntityBackgroundImageFieldProps): React.ReactNode => {
   const intl = useIntl();
   const hasSavedImage = image != null;
   const hasPendingUpload = Boolean(uploadPreviewUrl);

--- a/src/components/FixedAtCreationField/FixedAtCreationField.tsx
+++ b/src/components/FixedAtCreationField/FixedAtCreationField.tsx
@@ -20,7 +20,7 @@ export const FixedAtCreationField = ({
   label,
   name,
   value,
-}: FixedAtCreationFieldProps): JSX.Element => (
+}: FixedAtCreationFieldProps): React.ReactNode => (
   <Input
     data-test-id={dataTestId}
     disabled

--- a/src/components/Form/ExitFormDialog.tsx
+++ b/src/components/Form/ExitFormDialog.tsx
@@ -20,7 +20,7 @@ const ExitFormDialog = ({
   onClose,
   isOpen,
   description,
-}: ExitFormDialogProps): JSX.Element => {
+}: ExitFormDialogProps): React.ReactNode => {
   const intl = useIntl();
   // Ignore-changes calls onLeave, which sets `open` false. Modal onChange(false) must not
   // also run onClose ("keep editing") — that clears the pending navigation target.

--- a/src/components/InsetSegmentedControl/InsetSegmentedControl.tsx
+++ b/src/components/InsetSegmentedControl/InsetSegmentedControl.tsx
@@ -86,7 +86,7 @@ export const InsetSegmentedControl = <T extends string>({
   "aria-label": ariaLabel,
   className,
   "data-test-id": dataTestId,
-}: InsetSegmentedControlProps<T>): JSX.Element => {
+}: InsetSegmentedControlProps<T>): React.ReactNode => {
   const sizeStyles = SIZE_STYLES[size];
 
   return (

--- a/src/components/KpiCard/KpiCard.test.tsx
+++ b/src/components/KpiCard/KpiCard.test.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, type ReactNode } from "react";
 
 import { KpiCard } from "./KpiCard";
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/components/KpiCard/KpiCard.tsx
+++ b/src/components/KpiCard/KpiCard.tsx
@@ -30,7 +30,7 @@ const deltaTextColor = {
   neutral: "default2",
 } as const;
 
-const DeltaIcon = ({ trend }: { trend: KpiDelta["trend"] }): JSX.Element => {
+const DeltaIcon = ({ trend }: { trend: KpiDelta["trend"] }): React.ReactNode => {
   if (trend === "up") {
     return <TrendingUp size={12} />;
   }
@@ -58,7 +58,7 @@ export const KpiCard = ({
   active,
   onSelect,
   dataTestId,
-}: KpiCardProps): JSX.Element => {
+}: KpiCardProps): React.ReactNode => {
   if (loading) {
     return (
       <Box

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -21,7 +21,7 @@ interface LinkProps
   state?: LinkState;
 }
 
-export const Link = (props: LinkProps): JSX.Element => {
+export const Link = (props: LinkProps): React.ReactNode => {
   const {
     className,
     children,

--- a/src/components/ListSearchInput/ListSearchInput.tsx
+++ b/src/components/ListSearchInput/ListSearchInput.tsx
@@ -17,7 +17,7 @@ export const ListSearchInput = ({
   placeholder,
   onSearchChange,
   showTooltip = true,
-}: ListSearchInputProps): JSX.Element => {
+}: ListSearchInputProps): React.ReactNode => {
   const [search, setSearch] = useState(initialSearch);
 
   useEffect(

--- a/src/components/MicrocopyLink.tsx
+++ b/src/components/MicrocopyLink.tsx
@@ -7,7 +7,7 @@ interface MicrocopyLinkProps {
   children: ReactNode;
 }
 
-export function MicrocopyLink({ to, children }: MicrocopyLinkProps): JSX.Element {
+export function MicrocopyLink({ to, children }: MicrocopyLinkProps): React.ReactNode {
   return (
     <Link to={to} style={{ textDecoration: "none" }}>
       <Text

--- a/src/components/ModalFilters/ModalFilters.tsx
+++ b/src/components/ModalFilters/ModalFilters.tsx
@@ -33,7 +33,7 @@ const getLockedValueOptions = (element: FilterElement): ItemOption[] =>
 
 /** Renders a locked value with the canonical read-only type component so the
  * restriction hint matches how model/product types appear in detail page headers. */
-const LockedValue = ({ field, option }: { field: string; option: ItemOption }): JSX.Element => {
+const LockedValue = ({ field, option }: { field: string; option: ItemOption }): React.ReactNode => {
   if (field === "pageTypes") {
     return <ModelTypeDisplay modelType={{ id: option.value, name: option.label }} />;
   }
@@ -49,7 +49,7 @@ const LockedValue = ({ field, option }: { field: string; option: ItemOption }): 
   );
 };
 
-const LockedRestrictionHint = ({ elements }: { elements: FilterElement[] }): JSX.Element => {
+const LockedRestrictionHint = ({ elements }: { elements: FilterElement[] }): React.ReactNode => {
   const { formatMessage } = useIntl();
 
   return (

--- a/src/components/ModelType/ModelType.tsx
+++ b/src/components/ModelType/ModelType.tsx
@@ -70,7 +70,7 @@ export const ModelTypeDisplay = ({
   color = "default2",
   "data-test-id": dataTestId = "model-type-display",
   title,
-}: ModelTypeProps): JSX.Element => {
+}: ModelTypeProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!modelType) {
@@ -113,7 +113,7 @@ export const ModelTypeDisplay = ({
   );
 };
 
-export const ClickableModelType = (props: ModelTypeProps): JSX.Element => {
+export const ClickableModelType = (props: ModelTypeProps): React.ReactNode => {
   const { modelType } = props;
   const intl = useIntl();
   const userPermissions = useUserPermissions();

--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -11,7 +11,7 @@ interface PlaceholderProps {
 
 // Note: `borderStyle: "dashed"` lives in a CSS module because
 // macaw-ui-next's `borderStyle` sprinkle only ships `"none" | "solid"`.
-export const Placeholder = ({ children, icon }: PlaceholderProps): JSX.Element => (
+export const Placeholder = ({ children, icon }: PlaceholderProps): React.ReactNode => (
   <Box
     className={styles.placeholder}
     borderRadius={4}

--- a/src/components/ProductType/ProductType.tsx
+++ b/src/components/ProductType/ProductType.tsx
@@ -71,7 +71,7 @@ export const ProductTypeDisplay = ({
   color = "default2",
   "data-test-id": dataTestId = "product-type-display",
   title,
-}: ProductTypeProps): JSX.Element => {
+}: ProductTypeProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!productType) {
@@ -105,7 +105,7 @@ export const ProductTypeDisplay = ({
   );
 };
 
-export const ClickableProductType = (props: ProductTypeProps): JSX.Element => {
+export const ClickableProductType = (props: ProductTypeProps): React.ReactNode => {
   const { productType } = props;
   const intl = useIntl();
   const userPermissions = useUserPermissions();

--- a/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
+++ b/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
@@ -30,7 +30,7 @@ export const SaveFilterTabDialog = ({
   onClose,
   onSubmit,
   open,
-}: SaveFilterTabDialogProps): JSX.Element => {
+}: SaveFilterTabDialogProps): React.ReactNode => {
   const intl = useIntl();
   const isSubmittingRef = useRef(false);
 

--- a/src/components/Settings/SettingsFieldStack.tsx
+++ b/src/components/Settings/SettingsFieldStack.tsx
@@ -9,7 +9,10 @@ interface SettingsFieldStackProps {
 /**
  * Stack of form fields inside a SettingsSection, with consistent padding.
  */
-export const SettingsFieldStack = ({ children, intro }: SettingsFieldStackProps): JSX.Element => {
+export const SettingsFieldStack = ({
+  children,
+  intro,
+}: SettingsFieldStackProps): React.ReactNode => {
   return (
     <Box paddingX={6} paddingY={5} display="flex" flexDirection="column" gap={4}>
       {intro}

--- a/src/components/Settings/SettingsHubLayout.tsx
+++ b/src/components/Settings/SettingsHubLayout.tsx
@@ -24,7 +24,7 @@ export const SettingsHubLayout = ({
   backHrefIcon,
   backHrefTitle,
   children,
-}: SettingsHubLayoutProps): JSX.Element => {
+}: SettingsHubLayoutProps): React.ReactNode => {
   useScrollToSettingsHash();
 
   return (

--- a/src/components/Settings/SettingsLinkCard.tsx
+++ b/src/components/Settings/SettingsLinkCard.tsx
@@ -26,7 +26,7 @@ export const SettingsLinkCard = ({
   ownership,
   id,
   "data-test-id": dataTestId,
-}: SettingsLinkCardProps): JSX.Element => {
+}: SettingsLinkCardProps): React.ReactNode => {
   return (
     <Link to={to} className={styles.link} data-test-id={dataTestId} id={id}>
       <Box

--- a/src/components/Settings/SettingsOwnershipChip.tsx
+++ b/src/components/Settings/SettingsOwnershipChip.tsx
@@ -14,7 +14,9 @@ interface SettingsOwnershipChipProps {
  * Ownership pill used on every SettingsSection / SettingsLinkCard.
  * Shop and Channel share this component so padding and placement stay consistent.
  */
-export const SettingsOwnershipChip = ({ ownership }: SettingsOwnershipChipProps): JSX.Element => {
+export const SettingsOwnershipChip = ({
+  ownership,
+}: SettingsOwnershipChipProps): React.ReactNode => {
   const Icon = ownership === "shop" ? Store : Globe;
   const isShop = ownership === "shop";
 

--- a/src/components/Settings/SettingsPageContent.tsx
+++ b/src/components/Settings/SettingsPageContent.tsx
@@ -19,7 +19,7 @@ export const SettingsPageContent = ({
   title,
   description,
   children,
-}: SettingsPageContentProps): JSX.Element => {
+}: SettingsPageContentProps): React.ReactNode => {
   const hasAside = title != null || description != null;
 
   return (

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -27,7 +27,7 @@ export const SettingsSection = ({
   children,
   id,
   "data-test-id": dataTestId,
-}: SettingsSectionProps): JSX.Element => {
+}: SettingsSectionProps): React.ReactNode => {
   return (
     <Box
       as="section"

--- a/src/components/Settings/SettingsToggleRow.tsx
+++ b/src/components/Settings/SettingsToggleRow.tsx
@@ -37,7 +37,7 @@ export const SettingsToggleRow = ({
   onCheckedChange,
   id,
   "data-test-id": dataTestId,
-}: SettingsToggleRowProps): JSX.Element => {
+}: SettingsToggleRowProps): React.ReactNode => {
   const handleRowClick = (event: MouseEvent): void => {
     if (disabled || isInteractiveTarget(event.target)) {
       return;

--- a/src/components/Sidebar/SidebarIconSlot.tsx
+++ b/src/components/Sidebar/SidebarIconSlot.tsx
@@ -2,7 +2,7 @@ import { Box } from "@saleor/macaw-ui-next";
 
 const SIDEBAR_ICON_SLOT_SIZE = 20;
 
-export const SidebarIconSlot = ({ children }: { children: React.ReactNode }): JSX.Element => (
+export const SidebarIconSlot = ({ children }: { children: React.ReactNode }): React.ReactNode => (
   <Box
     color="default2"
     display="flex"

--- a/src/components/Sidebar/menu/CustomersSidebarMenu.stories.tsx
+++ b/src/components/Sidebar/menu/CustomersSidebarMenu.stories.tsx
@@ -21,7 +21,7 @@ const CustomersSidebarMenu = ({
   customerTypes,
   pinnedIds,
   selectedTypeIds,
-}: CustomersSidebarMenuProps): JSX.Element => {
+}: CustomersSidebarMenuProps): React.ReactNode => {
   const children = [
     ...createCustomerTypeMenuItems({
       customerTypes,

--- a/src/components/Sidebar/user/ThemeSwitcher.tsx
+++ b/src/components/Sidebar/user/ThemeSwitcher.tsx
@@ -3,7 +3,7 @@ import { type DefaultTheme, Text } from "@saleor/macaw-ui-next";
 import { Moon, Sun } from "lucide-react";
 import { FormattedMessage } from "react-intl";
 
-export const ThemeSwitcher = ({ theme }: { theme: DefaultTheme }): JSX.Element => {
+export const ThemeSwitcher = ({ theme }: { theme: DefaultTheme }): React.ReactNode => {
   if (theme === "defaultLight") {
     return (
       <>

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -3,7 +3,11 @@ import "./skeleton.css";
 import { Box, type SkeletonProps } from "@saleor/macaw-ui-next";
 import { type ComponentProps } from "react";
 
-export const Skeleton = ({ className, borderRadius = 2, ...props }: SkeletonProps): JSX.Element => (
+export const Skeleton = ({
+  className,
+  borderRadius = 2,
+  ...props
+}: SkeletonProps): React.ReactNode => (
   <Box
     {...(props as ComponentProps<typeof Box>)}
     borderRadius={borderRadius}

--- a/src/components/SortableTable/SortableHandle.tsx
+++ b/src/components/SortableTable/SortableHandle.tsx
@@ -31,7 +31,7 @@ export const SortableHandle = ({
   isSorting = false,
   attributes,
   listeners,
-}: SortableHandleProps): JSX.Element => (
+}: SortableHandleProps): React.ReactNode => (
   <TableCell className={clsx(styles.cell, disabled && styles.disabled)} onClick={stopRowNavigation}>
     <div
       className={styles.handle}

--- a/src/components/SortableTable/SortableTableBody.tsx
+++ b/src/components/SortableTable/SortableTableBody.tsx
@@ -80,7 +80,7 @@ export const SortableTableBody = ({
   className,
   onSortEnd,
   ...props
-}: SortableTableBodyComponentProps): JSX.Element => {
+}: SortableTableBodyComponentProps): React.ReactNode => {
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
   const [overlayMetrics, setOverlayMetrics] = useState<OverlayMetrics | null>(null);
   const suppressClickAfterDrag = useSuppressClickAfterDrag();

--- a/src/components/SortableTable/SortableTableRow.tsx
+++ b/src/components/SortableTable/SortableTableRow.tsx
@@ -49,7 +49,7 @@ const SortableTableRowView = ({
   setRowNodeRef,
   style,
   ...props
-}: SortableTableRowViewProps): JSX.Element => {
+}: SortableTableRowViewProps): React.ReactNode => {
   const { disabled, isSorting } = useSortableContext();
 
   return (
@@ -76,7 +76,7 @@ const SortableTableRowView = ({
   );
 };
 
-const SortableTableRowDnd = (props: SortableTableRowProps): JSX.Element => {
+const SortableTableRowDnd = (props: SortableTableRowProps): React.ReactNode => {
   const { disabled } = useSortableContext();
   const sortableId = props.id ?? props.index;
 
@@ -108,7 +108,7 @@ const SortableTableRowDnd = (props: SortableTableRowProps): JSX.Element => {
   );
 };
 
-export const SortableTableRow = ({ overlay, ...props }: SortableTableRowProps): JSX.Element => {
+export const SortableTableRow = ({ overlay, ...props }: SortableTableRowProps): React.ReactNode => {
   if (overlay) {
     return <SortableTableRowView {...props} overlay />;
   }

--- a/src/components/SubMenu/SubMenu.tsx
+++ b/src/components/SubMenu/SubMenu.tsx
@@ -17,7 +17,7 @@ interface SubMenuProps {
  * Title + description action menu (e.g. Add code).
  * Typography matches DetailSettingToggleRow: title size 3 medium, hint size 2 default2.
  */
-export const SubMenu = ({ menuItems }: SubMenuProps): JSX.Element => (
+export const SubMenu = ({ menuItems }: SubMenuProps): React.ReactNode => (
   <List padding={1} __minWidth="100%">
     {menuItems.map(({ id, title, description, icon, onClick }) => (
       <List.Item

--- a/src/components/TableRowLink/TableRowLinkCheckbox.tsx
+++ b/src/components/TableRowLink/TableRowLinkCheckbox.tsx
@@ -19,7 +19,7 @@ export const TableRowLinkCheckbox = ({
   disabled,
   onCheckedChange,
   "data-test-id": dataTestId,
-}: TableRowLinkCheckboxProps): JSX.Element => (
+}: TableRowLinkCheckboxProps): React.ReactNode => (
   <Box
     display="flex"
     alignItems="center"

--- a/src/components/Timeline/TimelineDateGroupHeader.tsx
+++ b/src/components/Timeline/TimelineDateGroupHeader.tsx
@@ -12,7 +12,7 @@ interface TimelineDateGroupHeaderProps {
 export const TimelineDateGroupHeader = ({
   groupKey,
   isSoleGroup = false,
-}: TimelineDateGroupHeaderProps): JSX.Element => {
+}: TimelineDateGroupHeaderProps): React.ReactNode => {
   const intl = useIntl();
 
   const getLabel = (key: string): string => {

--- a/src/components/Timeline/TimelineStem.tsx
+++ b/src/components/Timeline/TimelineStem.tsx
@@ -13,7 +13,7 @@ export const TimelineStem = ({
   top,
   bottom,
   "data-test-id": dataTestId,
-}: TimelineStemProps): JSX.Element => (
+}: TimelineStemProps): React.ReactNode => (
   <Box
     as="span"
     className={styles.stem}

--- a/src/configuration/ConfigurationSettingsSearch.tsx
+++ b/src/configuration/ConfigurationSettingsSearch.tsx
@@ -11,7 +11,7 @@ import styles from "./ConfigurationSettingsSearch.module.css";
 
 const CONFIGURATION_SETTINGS_LISTBOX_ID = "configuration-settings-search-listbox";
 
-const KindBadge = ({ kind }: { kind: ResolvedSettingsCatalogEntry["kind"] }): JSX.Element => {
+const KindBadge = ({ kind }: { kind: ResolvedSettingsCatalogEntry["kind"] }): React.ReactNode => {
   switch (kind) {
     case "hub":
       return (
@@ -59,7 +59,7 @@ export const ConfigurationSettingsSearchToolbar = ({
   onQueryChange,
   onKeyDown,
   activeOptionId,
-}: ConfigurationSettingsSearchToolbarProps): JSX.Element => {
+}: ConfigurationSettingsSearchToolbarProps): React.ReactNode => {
   const intl = useIntl();
   const hasQuery = query.trim().length > 0;
 
@@ -109,7 +109,7 @@ export const ConfigurationSettingsSearchResults = ({
   query,
   activeIndex,
   onActiveIndexChange,
-}: ConfigurationSettingsSearchResultsProps): JSX.Element => {
+}: ConfigurationSettingsSearchResultsProps): React.ReactNode => {
   const listRef = useRef<HTMLUListElement | null>(null);
 
   useEffect(

--- a/src/customerTypes/components/CreateCustomerTypeDialog/CreateCustomerTypeDialog.tsx
+++ b/src/customerTypes/components/CreateCustomerTypeDialog/CreateCustomerTypeDialog.tsx
@@ -38,7 +38,7 @@ export const CreateCustomerTypeDialog = ({
   errors: apiErrors,
   onClose,
   onSubmit,
-}: CreateCustomerTypeDialogProps): JSX.Element => {
+}: CreateCustomerTypeDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [submitErrors, setSubmitErrors] = useState<CustomerTypeCreateErrorFragment[]>([]);
   const [showApiErrors, setShowApiErrors] = useState(false);

--- a/src/customerTypes/components/CustomerTypeAttributes/CustomerTypeAttributes.tsx
+++ b/src/customerTypes/components/CustomerTypeAttributes/CustomerTypeAttributes.tsx
@@ -28,7 +28,7 @@ export const CustomerTypeAttributes = ({
   onAttributeReorder,
   onAttributeUnassign,
   ...listActions
-}: CustomerTypeAttributesProps): JSX.Element => {
+}: CustomerTypeAttributesProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/customerTypes/components/CustomerTypeDetails/CustomerTypeDetails.tsx
+++ b/src/customerTypes/components/CustomerTypeDetails/CustomerTypeDetails.tsx
@@ -25,7 +25,7 @@ export const CustomerTypeDetails = ({
   isDefault = false,
   errors = [],
   onChange,
-}: CustomerTypeDetailsProps): JSX.Element => {
+}: CustomerTypeDetailsProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name", "slug"], errors);
 

--- a/src/customerTypes/components/CustomerTypeDetailsPage/CustomerTypeDetailsPage.topNav.test.tsx
+++ b/src/customerTypes/components/CustomerTypeDetailsPage/CustomerTypeDetailsPage.topNav.test.tsx
@@ -22,7 +22,7 @@ jest.mock("../CustomerTypeDetails/CustomerTypeDetails", () => ({
   CustomerTypeDetails: () => <div data-test-id="customer-type-details-mock" />,
 }));
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <ThemeWrapper>{children}</ThemeWrapper>
   </MemoryRouter>

--- a/src/customerTypes/components/CustomerTypeDetailsPage/Title.test.tsx
+++ b/src/customerTypes/components/CustomerTypeDetailsPage/Title.test.tsx
@@ -9,7 +9,7 @@ const customerType = {
   isDefault: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeWrapper>{children}</ThemeWrapper>
 );
 

--- a/src/customers/components/CustomerAddresses/CustomerAddresses.tsx
+++ b/src/customers/components/CustomerAddresses/CustomerAddresses.tsx
@@ -24,7 +24,7 @@ interface AddressBlockProps {
   address: NonNullable<CustomerDetailsFragment["defaultBillingAddress"]>;
 }
 
-const AddressBlock = ({ label, address }: AddressBlockProps): JSX.Element => {
+const AddressBlock = ({ label, address }: AddressBlockProps): React.ReactNode => {
   const intl = useIntl();
   const [copied, copy] = useClipboard();
   const copyAriaLabel = intl.formatMessage(buttonMessages.copyToClipboard);
@@ -61,7 +61,7 @@ const CustomerAddresses = ({
   customer,
   disabled,
   manageAddressHref,
-}: CustomerAddressesProps): JSX.Element => {
+}: CustomerAddressesProps): React.ReactNode => {
   const billing = customer?.defaultBillingAddress ?? null;
   const shipping = customer?.defaultShippingAddress ?? null;
   const sameAddress = billing && shipping && billing.id === shipping.id;

--- a/src/customers/components/CustomerAttributesCard/CustomerAttributesCard.tsx
+++ b/src/customers/components/CustomerAttributesCard/CustomerAttributesCard.tsx
@@ -59,7 +59,7 @@ export const CustomerAttributesCard = ({
   disabled,
   error,
   onChange,
-}: CustomerAttributesCardProps): JSX.Element => {
+}: CustomerAttributesCardProps): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const userPermissions = useUserPermissions();

--- a/src/customers/components/CustomerDetailsPage/Title.test.tsx
+++ b/src/customers/components/CustomerDetailsPage/Title.test.tsx
@@ -45,7 +45,7 @@ const mockUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -64,7 +64,7 @@ export const CustomerListPage = ({
   tabCounts,
   onTabChange,
   ...customerListProps
-}: CustomerListPageProps): JSX.Element => {
+}: CustomerListPageProps): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const canEditCustomers = useCanEditCustomers();

--- a/src/customers/components/CustomerOrders/CustomerOrders.tsx
+++ b/src/customers/components/CustomerOrders/CustomerOrders.tsx
@@ -29,14 +29,14 @@ interface CustomerOrdersProps {
   viewAllHref: string;
 }
 
-const OrderStatusPill = ({ status }: { status: OrderStatus }): JSX.Element => {
+const OrderStatusPill = ({ status }: { status: OrderStatus }): React.ReactNode => {
   const intl = useIntl();
   const { localized, status: color } = transformOrderStatus(status, intl);
 
   return <Pill label={localized} color={color} data-test-id="customer-order-status" />;
 };
 
-export const CustomerOrders = ({ orders, viewAllHref }: CustomerOrdersProps): JSX.Element => {
+export const CustomerOrders = ({ orders, viewAllHref }: CustomerOrdersProps): React.ReactNode => {
   return (
     <AssignableListCard
       data-test-id="customer-orders"

--- a/src/customers/components/CustomerOverview/CustomerOverview.stories.tsx
+++ b/src/customers/components/CustomerOverview/CustomerOverview.stories.tsx
@@ -112,7 +112,7 @@ const OverviewProviders = ({
   children: ReactNode;
   permissions?: PermissionEnum[];
   kpiContext?: ReturnType<typeof withKpiContext>;
-}): JSX.Element => (
+}): React.ReactNode => (
   <UserContext.Provider value={staffContext(permissions)}>
     <TimezoneProvider value="America/New_York">
       <CustomerDetailsContext.Provider value={kpiContext}>

--- a/src/customers/components/CustomerOverview/CustomerOverview.tsx
+++ b/src/customers/components/CustomerOverview/CustomerOverview.tsx
@@ -32,7 +32,7 @@ interface CustomerOverviewProps {
 const ICON_SIZE = 16;
 const EMPTY_VALUE = "—";
 
-export const CustomerOverview = ({ customer }: CustomerOverviewProps): JSX.Element => {
+export const CustomerOverview = ({ customer }: CustomerOverviewProps): React.ReactNode => {
   const intl = useIntl();
   const { locale } = useLocale();
   const { effectiveKpiChannelId, kpiChannels, setKpiChannelId } = useCustomerDetails();

--- a/src/customers/components/CustomerOverview/CustomerOverviewMoneyBreakdownTooltip.tsx
+++ b/src/customers/components/CustomerOverview/CustomerOverviewMoneyBreakdownTooltip.tsx
@@ -18,7 +18,7 @@ interface MoneyTooltipRowProps {
   locale: string;
 }
 
-const MoneyTooltipRow = ({ label, money, locale }: MoneyTooltipRowProps): JSX.Element => (
+const MoneyTooltipRow = ({ label, money, locale }: MoneyTooltipRowProps): React.ReactNode => (
   <Box className={styles.moneyTooltipRow}>
     <Text size={2} color="default2" className={styles.moneyTooltipLabel}>
       {label}
@@ -36,7 +36,7 @@ export const CustomerOverviewMoneyBreakdownTooltip = ({
   locale,
   shipping,
   refunded,
-}: CustomerOverviewMoneyBreakdownTooltipProps): JSX.Element => (
+}: CustomerOverviewMoneyBreakdownTooltipProps): React.ReactNode => (
   <Box className={styles.moneyTooltip}>
     <Text size={2} color="default2">
       <FormattedMessage

--- a/src/customers/components/CustomerTypeCard/ChangeCustomerTypeDialog.tsx
+++ b/src/customers/components/CustomerTypeCard/ChangeCustomerTypeDialog.tsx
@@ -17,7 +17,7 @@ export const ChangeCustomerTypeDialog = ({
   typeName,
   onClose,
   onConfirm,
-}: ChangeCustomerTypeDialogProps): JSX.Element => (
+}: ChangeCustomerTypeDialogProps): React.ReactNode => (
   <DashboardModal onChange={onClose} open={open}>
     {open ? (
       <DashboardModal.Content size="xs" data-test-id="change-customer-type-dialog">

--- a/src/customers/components/CustomerTypeTabs/CustomerTypeTabs.tsx
+++ b/src/customers/components/CustomerTypeTabs/CustomerTypeTabs.tsx
@@ -35,7 +35,7 @@ export const CustomerTypeTabs = ({
   counts,
   onTabChange,
   rightSlot,
-}: CustomerTypeTabsProps): JSX.Element => (
+}: CustomerTypeTabsProps): React.ReactNode => (
   <ModelTypeTabs
     pageTypes={customerTypes}
     selectedIds={selectedIds}

--- a/src/discounts/components/DiscountCategories/DiscountCategories.tsx
+++ b/src/discounts/components/DiscountCategories/DiscountCategories.tsx
@@ -37,7 +37,7 @@ export const DiscountCategories = ({
   numberOfRows = PAGINATE_BY,
   onUpdateListSettings,
   embedded = false,
-}: DiscountCategoriesProps): JSX.Element => {
+}: DiscountCategoriesProps): React.ReactNode => {
   const intl = useIntl();
 
   const body = (

--- a/src/discounts/components/DiscountCollections/DiscountCollections.tsx
+++ b/src/discounts/components/DiscountCollections/DiscountCollections.tsx
@@ -37,7 +37,7 @@ export const DiscountCollections = ({
   numberOfRows = PAGINATE_BY,
   onUpdateListSettings,
   embedded = false,
-}: DiscountCollectionsProps): JSX.Element => {
+}: DiscountCollectionsProps): React.ReactNode => {
   const intl = useIntl();
 
   const body = (

--- a/src/discounts/components/DiscountDates/DiscountDates.tsx
+++ b/src/discounts/components/DiscountDates/DiscountDates.tsx
@@ -38,7 +38,7 @@ const DiscountDatesFields = <ErrorCode,>({
   formErrors,
   onChange,
   onBlur,
-}: Omit<DiscountDatesProps<ErrorCode>, "unwrapped">): JSX.Element => {
+}: Omit<DiscountDatesProps<ErrorCode>, "unwrapped">): React.ReactNode => {
   const intl = useIntl();
   const apiErrors = getFormErrors(["startDate", "endDate"], errors);
 
@@ -180,7 +180,7 @@ const DiscountDatesFields = <ErrorCode,>({
 export const DiscountDates = <ErrorCode,>({
   unwrapped = false,
   ...props
-}: DiscountDatesProps<ErrorCode>): JSX.Element => {
+}: DiscountDatesProps<ErrorCode>): React.ReactNode => {
   const fields: ReactNode = <DiscountDatesFields {...props} />;
 
   if (unwrapped) {

--- a/src/discounts/components/DiscountDates/DiscountDatesWithController.tsx
+++ b/src/discounts/components/DiscountDates/DiscountDatesWithController.tsx
@@ -15,7 +15,7 @@ interface DiscountDatesWithControllerProps<ErrorCode> {
 export const DiscountDatesWithController = <ErrorCode,>({
   disabled,
   errors,
-}: DiscountDatesWithControllerProps<ErrorCode>): JSX.Element => {
+}: DiscountDatesWithControllerProps<ErrorCode>): React.ReactNode => {
   const { formState } = useFormContext<DiscoutFormData>();
   const { field } = useController<DiscoutFormData, "dates">({
     name: "dates",

--- a/src/discounts/components/DiscountDetailsPage/Title.tsx
+++ b/src/discounts/components/DiscountDetailsPage/Title.tsx
@@ -10,7 +10,7 @@ interface DiscountDetailsTitleProps {
   data: PromotionDetailsFragment | undefined | null;
 }
 
-export const DiscountDetailsTitle = ({ data }: DiscountDetailsTitleProps): JSX.Element => {
+export const DiscountDetailsTitle = ({ data }: DiscountDetailsTitleProps): React.ReactNode => {
   const intl = useIntl();
 
   if (!data) {

--- a/src/discounts/components/DiscountProducts/DiscountProducts.tsx
+++ b/src/discounts/components/DiscountProducts/DiscountProducts.tsx
@@ -55,7 +55,7 @@ export const DiscountProducts = ({
   numberOfRows = PAGINATE_BY,
   onUpdateListSettings,
   embedded = false,
-}: SaleProductsProps): JSX.Element => {
+}: SaleProductsProps): React.ReactNode => {
   const intl = useIntl();
   // Product.channelListings is behind MANAGE_PRODUCTS and simply absent otherwise, so drop the
   // column instead of filling every row with a placeholder.

--- a/src/discounts/components/DiscountRules/DiscountRules.test.tsx
+++ b/src/discounts/components/DiscountRules/DiscountRules.test.tsx
@@ -42,7 +42,7 @@ jest.mock("./hooks/useGraphQLPlayground", () => ({
 }));
 jest.setTimeout(30000); // Timeout was increased because of error throw in update test when run all tests
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => {
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => {
   return (
     <MemoryRouter>
       <MockedProvider

--- a/src/discounts/components/DiscountRules/componenets/RuleForm/components/RuleConditions/RuleConditions.tsx
+++ b/src/discounts/components/DiscountRules/componenets/RuleForm/components/RuleConditions/RuleConditions.tsx
@@ -20,7 +20,7 @@ interface RuleConditionsProps {
 export const RuleConditions = ({
   hasSelectedChannels,
   openPlayground,
-}: RuleConditionsProps): JSX.Element => {
+}: RuleConditionsProps): React.ReactNode => {
   const intl = useIntl();
   const { discountType, disabled } = useDiscountRulesContext();
   const conditionNames = useConditionNames(discountType);

--- a/src/discounts/components/DiscountRules/componenets/RuleFormModal/RuleFormModal.tsx
+++ b/src/discounts/components/DiscountRules/componenets/RuleFormModal/RuleFormModal.tsx
@@ -30,7 +30,7 @@ export const RuleFormModal = ({
   initialFormValues,
   onClose,
   onSubmit,
-}: RuleFormModalProps): JSX.Element => {
+}: RuleFormModalProps): React.ReactNode => {
   const intl = useIntl();
   const isSubmittingRef = useRef(false);
   const { discountType } = useDiscountRulesContext();

--- a/src/discounts/components/DiscountRules/componenets/RulesList/components/RuleListContainer/RuleListContainer.tsx
+++ b/src/discounts/components/DiscountRules/componenets/RulesList/components/RuleListContainer/RuleListContainer.tsx
@@ -6,6 +6,6 @@ interface RuleListContainerProps {
   children: ReactNode;
 }
 
-export const RuleListContainer = ({ children }: RuleListContainerProps): JSX.Element => (
+export const RuleListContainer = ({ children }: RuleListContainerProps): React.ReactNode => (
   <div className={styles.grid}>{children}</div>
 );

--- a/src/discounts/components/DiscountSavebar/DiscountSavebar.tsx
+++ b/src/discounts/components/DiscountSavebar/DiscountSavebar.tsx
@@ -26,7 +26,7 @@ export const DiscountSavebar = ({
   onCancel,
   submitButtonState,
   composition = EMPTY_PROMOTION_SAVE_COMPOSITION,
-}: DiscountSavebarProps): JSX.Element => {
+}: DiscountSavebarProps): React.ReactNode => {
   const intl = useIntl();
   const hasUnsavedChanges = hasPromotionSaveComposition(composition);
   const isSaveDisabled = disabled || !hasUnsavedChanges;

--- a/src/discounts/components/DiscountScheduleCard/DiscountScheduleCard.tsx
+++ b/src/discounts/components/DiscountScheduleCard/DiscountScheduleCard.tsx
@@ -47,7 +47,7 @@ export const DiscountScheduleCard = <ErrorCode,>({
   statusTestId,
   fieldsTestId,
   skeletonTestId,
-}: DiscountScheduleCardProps<ErrorCode>): JSX.Element => {
+}: DiscountScheduleCardProps<ErrorCode>): React.ReactNode => {
   const intl = useIntl();
   const phase = getVoucherSchedulePhase(data);
   const statusMessage =

--- a/src/discounts/components/DiscountVariants/DiscountVariants.tsx
+++ b/src/discounts/components/DiscountVariants/DiscountVariants.tsx
@@ -50,7 +50,7 @@ export const DiscountVariants = ({
   numberOfRows = PAGINATE_BY,
   onUpdateListSettings,
   embedded = false,
-}: SaleVariantsProps): JSX.Element => {
+}: SaleVariantsProps): React.ReactNode => {
   const intl = useIntl();
   const variants = getLoadableList(discountVariants) as DiscountVariantRow[] | undefined;
 

--- a/src/discounts/components/VoucherBulkDeleteDialog/VoucherBulkDeleteDialog.tsx
+++ b/src/discounts/components/VoucherBulkDeleteDialog/VoucherBulkDeleteDialog.tsx
@@ -22,7 +22,7 @@ export const VoucherBulkDeleteDialog = ({
   onClose,
   onConfirm,
   open,
-}: VoucherBulkDeleteDialogProps): JSX.Element => {
+}: VoucherBulkDeleteDialogProps): React.ReactNode => {
   const isSubmitting = confirmButtonState === "loading";
 
   const handleClose = (): void => {

--- a/src/discounts/components/VoucherCatalogueSection/VoucherCatalogueSection.tsx
+++ b/src/discounts/components/VoucherCatalogueSection/VoucherCatalogueSection.tsx
@@ -95,7 +95,7 @@ export const VoucherCatalogueSection = ({
   collectionListToolbar,
   productListToolbar,
   variantListToolbar,
-}: VoucherCatalogueSectionProps): JSX.Element => {
+}: VoucherCatalogueSectionProps): React.ReactNode => {
   const intl = useIntl();
   const catalogueErrorMessage = formatVoucherCatalogueErrorMessage(errors, intl);
   const categoriesCount = tabItemsCount.categories ?? 0;

--- a/src/discounts/components/VoucherCatalogueUnassignDialog/VoucherCatalogueUnassignDialog.tsx
+++ b/src/discounts/components/VoucherCatalogueUnassignDialog/VoucherCatalogueUnassignDialog.tsx
@@ -108,7 +108,7 @@ export const VoucherCatalogueUnassignDialog = ({
   onClose,
   onConfirm,
   open,
-}: VoucherCatalogueUnassignDialogProps): JSX.Element => {
+}: VoucherCatalogueUnassignDialogProps): React.ReactNode => {
   const isSubmitting = confirmButtonState === "loading";
 
   const handleClose = (): void => {

--- a/src/discounts/components/VoucherChannelAvailabilityCard/VoucherChannelAvailabilityCard.tsx
+++ b/src/discounts/components/VoucherChannelAvailabilityCard/VoucherChannelAvailabilityCard.tsx
@@ -37,7 +37,7 @@ export const VoucherChannelAvailabilityCard = ({
   managePermissions,
   onManageClick,
   scheduleData,
-}: VoucherChannelAvailabilityCardProps): JSX.Element => {
+}: VoucherChannelAvailabilityCardProps): React.ReactNode => {
   const intl = useIntl();
   const localizeDate = useDateLocalize();
   const sortedChannels = useMemo(

--- a/src/discounts/components/VoucherCodes/VoucherCodes.tsx
+++ b/src/discounts/components/VoucherCodes/VoucherCodes.tsx
@@ -22,6 +22,6 @@ export interface VoucherCodesProps {
   onCustomCodeGenerate: (code: string) => void;
 }
 
-export const VoucherCodes = (props: VoucherCodesProps): JSX.Element => (
+export const VoucherCodes = (props: VoucherCodesProps): React.ReactNode => (
   <VoucherCodesCard {...props} />
 );

--- a/src/discounts/components/VoucherCodesAddButton/VoucherCodesAddButton.tsx
+++ b/src/discounts/components/VoucherCodesAddButton/VoucherCodesAddButton.tsx
@@ -19,7 +19,7 @@ export const VoucherCodesAddButton = ({
   onMultiCodesGenerate,
   onSingleCodesGenerate,
   disabled = false,
-}: VoucherCodesAddButtonProps): JSX.Element => {
+}: VoucherCodesAddButtonProps): React.ReactNode => {
   const [isSubMenuOpen, setSubMenuOpen] = useState(false);
   const intl = useIntl();
   const handleMultipleCodesGenerate = useCallback(() => {

--- a/src/discounts/components/VoucherCodesCard/VoucherCodesCard.tsx
+++ b/src/discounts/components/VoucherCodesCard/VoucherCodesCard.tsx
@@ -52,7 +52,7 @@ export const VoucherCodesCard = ({
   settings,
   onSettingsChange,
   errors = [],
-}: VoucherCodesCardProps): JSX.Element => {
+}: VoucherCodesCardProps): React.ReactNode => {
   const intl = useIntl();
   const { pageInfo, ...paginationValues } = voucherCodesPagination;
   const [openModal, setOpenModal] = useState<VoucherCodesUrlDialog | null>(null);

--- a/src/discounts/components/VoucherCodesTable/VoucherCodesTable.tsx
+++ b/src/discounts/components/VoucherCodesTable/VoucherCodesTable.tsx
@@ -47,7 +47,7 @@ export const VoucherCodesTable = ({
   onBulkDelete,
   settings,
   onSettingsChange,
-}: VoucherCodesTableProps): JSX.Element => {
+}: VoucherCodesTableProps): React.ReactNode => {
   const intl = useIntl();
   const rows: VoucherCodeRow[] | undefined = useMemo(() => {
     if (loading && codes.length === 0) {

--- a/src/discounts/components/VoucherDeleteDialog/VoucherDeleteDialog.tsx
+++ b/src/discounts/components/VoucherDeleteDialog/VoucherDeleteDialog.tsx
@@ -23,7 +23,7 @@ export const VoucherDeleteDialog = ({
   onConfirm,
   open,
   voucherCode,
-}: VoucherDeleteDialogProps): JSX.Element => {
+}: VoucherDeleteDialogProps): React.ReactNode => {
   const isSubmitting = confirmButtonState === "loading";
 
   const handleClose = (): void => {

--- a/src/discounts/components/VoucherDiscountSection/VoucherDiscountSection.tsx
+++ b/src/discounts/components/VoucherDiscountSection/VoucherDiscountSection.tsx
@@ -52,7 +52,7 @@ export const VoucherDiscountSectionSkeleton = ({
   variant = "unknown",
 }: {
   variant?: VoucherDiscountSkeletonVariant;
-}): JSX.Element => {
+}): React.ReactNode => {
   const isShipping = variant === "shipping";
 
   return (
@@ -103,7 +103,7 @@ export const VoucherDiscountSection = ({
   onChange,
   onChannelChange,
   onChannelsChange,
-}: VoucherDiscountSectionProps): JSX.Element => {
+}: VoucherDiscountSectionProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["discountType", "discountValue", "type"], errors);
   const isShipping = isShippingVoucher(data);

--- a/src/discounts/components/VoucherDiscountSection/VoucherDiscountSubsectionHeader.tsx
+++ b/src/discounts/components/VoucherDiscountSection/VoucherDiscountSubsectionHeader.tsx
@@ -10,7 +10,7 @@ interface VoucherDiscountSubsectionHeaderProps {
 export const VoucherDiscountSubsectionHeader = ({
   title,
   hint,
-}: VoucherDiscountSubsectionHeaderProps): JSX.Element => (
+}: VoucherDiscountSubsectionHeaderProps): React.ReactNode => (
   <Box display="flex" flexDirection="column" gap={1}>
     <Text size={3} fontWeight="medium" as="h3" margin={0}>
       {title}

--- a/src/discounts/components/VoucherDiscountSection/VoucherFixedAmountChannelList.tsx
+++ b/src/discounts/components/VoucherDiscountSection/VoucherFixedAmountChannelList.tsx
@@ -50,7 +50,7 @@ export const VoucherFixedAmountChannelList = ({
   amountKind = "fixed",
   onChannelChange,
   onChannelsChange,
-}: VoucherFixedAmountChannelListProps): JSX.Element => {
+}: VoucherFixedAmountChannelListProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["discountValue"], errors);
   const isPercentage = amountKind === "percentage";

--- a/src/discounts/components/VoucherDiscountSection/VoucherScopeTile.tsx
+++ b/src/discounts/components/VoucherDiscountSection/VoucherScopeTile.tsx
@@ -30,7 +30,7 @@ export const VoucherScopeTile = ({
   disabled,
   onSelect,
   "data-test-id": dataTestId,
-}: VoucherScopeTileProps): JSX.Element => (
+}: VoucherScopeTileProps): React.ReactNode => (
   <Box
     as="button"
     type="button"

--- a/src/discounts/components/VoucherLimits/VoucherLimits.stories.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.stories.tsx
@@ -60,7 +60,7 @@ const InteractiveLimits = ({
   initialData,
 }: {
   initialData: VoucherDetailsPageFormData;
-}): JSX.Element => {
+}): React.ReactNode => {
   const [data, setData] = useState(initialData);
 
   return (

--- a/src/discounts/components/VoucherLimits/VoucherLimits.tsx
+++ b/src/discounts/components/VoucherLimits/VoucherLimits.tsx
@@ -24,7 +24,7 @@ const LockedSettingNotice = ({
 }: {
   children: ReactNode;
   "data-test-id"?: string;
-}): JSX.Element => (
+}): React.ReactNode => (
   <div className={styles.lockedNotice} data-test-id={dataTestId} role="status">
     <Lock
       className={styles.lockedNoticeIcon}

--- a/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
+++ b/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
@@ -39,7 +39,7 @@ export const VoucherRequirements = ({
   onChange,
   onChannelChange,
   onChannelsChange,
-}: VoucherRequirementsProps): JSX.Element => {
+}: VoucherRequirementsProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["minSpent", "minCheckoutItemsQuantity"], errors);
   const minimalOrderValueText = intl.formatMessage({

--- a/src/discounts/components/VoucherScheduleCard/VoucherScheduleCard.tsx
+++ b/src/discounts/components/VoucherScheduleCard/VoucherScheduleCard.tsx
@@ -21,7 +21,7 @@ export const VoucherScheduleCard = ({
   disabled,
   loading = false,
   onChange,
-}: VoucherScheduleCardProps): JSX.Element => (
+}: VoucherScheduleCardProps): React.ReactNode => (
   <DiscountScheduleCard
     data={data}
     errors={errors}

--- a/src/extensions/components/ResolveAppId/ResolveAppId.tsx
+++ b/src/extensions/components/ResolveAppId/ResolveAppId.tsx
@@ -13,7 +13,7 @@ type ResolutionState =
   | { status: "notInstalled" }
   | { status: "failed" };
 
-const Centered = ({ children }: { children: ReactNode }): JSX.Element => (
+const Centered = ({ children }: { children: ReactNode }): React.ReactNode => (
   <Box display="flex" justifyContent="center" alignItems="center" padding={12}>
     {children}
   </Box>
@@ -38,7 +38,7 @@ const buildAppIdUrl = (
   );
 };
 
-const RedirectFromIdentifier = ({ identifier }: { identifier: string }): JSX.Element => {
+const RedirectFromIdentifier = ({ identifier }: { identifier: string }): React.ReactNode => {
   const location = useLocation();
   const { resolveAppIdFromIdentifier } = useAppNavigation();
   const [state, setState] = useState<ResolutionState>({ status: "resolving" });
@@ -105,7 +105,7 @@ interface ResolveAppIdProps {
  * An identifier is resolved once and replaced with the ID form, so everything
  * rendered below this component only ever sees an app ID.
  */
-export const ResolveAppId = ({ segment, children }: ResolveAppIdProps): JSX.Element => {
+export const ResolveAppId = ({ segment, children }: ResolveAppIdProps): React.ReactNode => {
   if (isAppGlobalId(segment)) {
     return <>{children(segment)}</>;
   }

--- a/src/extensions/preferences/ExtensionPreferenceStateControl.tsx
+++ b/src/extensions/preferences/ExtensionPreferenceStateControl.tsx
@@ -22,7 +22,7 @@ export const ExtensionPreferenceStateControl = ({
   value,
   disabled,
   onChange,
-}: ExtensionPreferenceStateControlProps): JSX.Element => {
+}: ExtensionPreferenceStateControlProps): React.ReactNode => {
   const intl = useIntl();
   const shown = isWidgetShown(value);
   const pinned = isWidgetPinned(value);

--- a/src/extensions/preferences/ExtensionPreferencesSection.tsx
+++ b/src/extensions/preferences/ExtensionPreferencesSection.tsx
@@ -22,7 +22,7 @@ import { useExtensionPreferences } from "./useExtensionPreferences";
 import { getWidgetLocationHref, isWidgetMount, widgetMountMessages } from "./widgetMountLabel";
 import { isWidgetShown } from "./widgetPreferenceState";
 
-export const ExtensionPreferencesSection = (): JSX.Element => {
+export const ExtensionPreferencesSection = (): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const userPermissions = useUserPermissions();

--- a/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/TokenCreateDialog.tsx
+++ b/src/extensions/views/EditCustomExtension/components/TokenCreateDialog/TokenCreateDialog.tsx
@@ -33,7 +33,7 @@ export const TokenCreateDialog = ({
   token,
   onClose,
   onCreate,
-}: TokenCreateDialogProps): JSX.Element => {
+}: TokenCreateDialogProps): React.ReactNode => {
   const intl = useIntl();
   const isSubmittingRef = useRef(false);
   const step: TokenCreateStep = token ? "summary" : "form";

--- a/src/giftCards/GiftCardSettings/GiftCardExpirySettingsCard/GiftCardExpirySettingsCard.tsx
+++ b/src/giftCards/GiftCardSettings/GiftCardExpirySettingsCard/GiftCardExpirySettingsCard.tsx
@@ -26,7 +26,7 @@ export const GiftCardExpirySettingsCard = ({
   disabled,
   errors,
   onChange,
-}: GiftCardExpirySettingsCardProps): JSX.Element => {
+}: GiftCardExpirySettingsCardProps): React.ReactNode => {
   const intl = useIntl();
 
   const handleToggle = (checked: boolean) => {

--- a/src/giftCards/GiftCardSettings/GiftCardSettingsPage.tsx
+++ b/src/giftCards/GiftCardSettings/GiftCardSettingsPage.tsx
@@ -51,7 +51,7 @@ const getGiftCardSettingsExit = (
   };
 };
 
-export const GiftCardSettingsPage = (): JSX.Element => {
+export const GiftCardSettingsPage = (): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const notify = useNotifier();

--- a/src/giftCards/GiftCardUpdate/GiftCardAssignedCustomerCard/GiftCardAssignedCustomerCard.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardAssignedCustomerCard/GiftCardAssignedCustomerCard.tsx
@@ -10,7 +10,7 @@ import { GIFT_CARD_DETAILS_QUERY } from "../queries";
 import { GiftCardAssignedCustomerCardView } from "./GiftCardAssignedCustomerCardView";
 import { giftCardAssignedCustomerCardMessages as messages } from "./messages";
 
-export const GiftCardAssignedCustomerCard = (): JSX.Element => {
+export const GiftCardAssignedCustomerCard = (): React.ReactNode => {
   const intl = useIntl();
   const notify = useNotifier();
   const { giftCard, loading } = useGiftCardDetails();

--- a/src/giftCards/GiftCardUpdate/GiftCardAssignedCustomerCard/GiftCardAssignedCustomerCardView.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardAssignedCustomerCard/GiftCardAssignedCustomerCardView.tsx
@@ -32,7 +32,7 @@ export const GiftCardAssignedCustomerCardView = ({
   removing = false,
   onAssign,
   onRemove,
-}: GiftCardAssignedCustomerCardViewProps): JSX.Element => {
+}: GiftCardAssignedCustomerCardViewProps): React.ReactNode => {
   const items = useMemo(() => {
     if (!giftCard) {
       return [];

--- a/src/giftCards/GiftCardUpdate/GiftCardBalanceCard/GiftCardBalanceCard.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardBalanceCard/GiftCardBalanceCard.tsx
@@ -2,7 +2,7 @@ import useGiftCardDetails from "../providers/GiftCardDetailsProvider/hooks/useGi
 import useGiftCardUpdateDialogs from "../providers/GiftCardUpdateDialogsProvider/hooks/useGiftCardUpdateDialogs";
 import { GiftCardBalanceCardView } from "./GiftCardBalanceCardView";
 
-export const GiftCardBalanceCard = (): JSX.Element => {
+export const GiftCardBalanceCard = (): React.ReactNode => {
   const { loading, giftCard } = useGiftCardDetails();
   const { openSetBalanceDialog } = useGiftCardUpdateDialogs();
 

--- a/src/giftCards/GiftCardUpdate/GiftCardBalanceCard/GiftCardBalanceCardView.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardBalanceCard/GiftCardBalanceCardView.tsx
@@ -28,7 +28,7 @@ export const GiftCardBalanceCardView = ({
   giftCard,
   loading = false,
   onSetBalance,
-}: GiftCardBalanceCardViewProps): JSX.Element => {
+}: GiftCardBalanceCardViewProps): React.ReactNode => {
   const intl = useIntl();
   const { locale } = useLocale();
   const localizeDate = useDateLocalize();

--- a/src/giftCards/GiftCardUpdate/GiftCardHistory/GiftCardHistory.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardHistory/GiftCardHistory.tsx
@@ -23,7 +23,7 @@ interface FormData {
  * Open (non-carded) activity section — sits last in DetailPageContent.
  * Timeline chrome is self-spacing; avoid wrapping in DetailSettingsCard / DetailGroupBox.
  */
-export const GiftCardHistory = (): JSX.Element => {
+export const GiftCardHistory = (): React.ReactNode => {
   const intl = useIntl();
   const notify = useNotifier();
   const { giftCard } = useGiftCardDetails();

--- a/src/giftCards/GiftCardUpdate/GiftCardHistory/GiftCardTimelineEvent.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardHistory/GiftCardTimelineEvent.tsx
@@ -228,7 +228,7 @@ export const GiftCardTimelineEvent = ({
   date,
   event,
   isLastInGroup,
-}: GiftCardTimelineEventProps): JSX.Element => {
+}: GiftCardTimelineEventProps): React.ReactNode => {
   const intl = useIntl();
   const icon = event.type ? giftCardEventIconMap[event.type] : undefined;
   const actor = resolveActor(event);

--- a/src/giftCards/GiftCardUpdate/GiftCardProvenanceCard/GiftCardProvenanceCard.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardProvenanceCard/GiftCardProvenanceCard.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import useGiftCardDetails from "../providers/GiftCardDetailsProvider/hooks/useGiftCardDetails";
 import { GiftCardProvenanceCardView } from "./GiftCardProvenanceCardView";
 
-export const GiftCardProvenanceCard = (): JSX.Element => {
+export const GiftCardProvenanceCard = (): React.ReactNode => {
   const { giftCard, loading } = useGiftCardDetails();
   const { data: channelsData } = useChannelsQuery({
     skip: !giftCard?.boughtInChannel,

--- a/src/giftCards/GiftCardUpdate/GiftCardProvenanceCard/GiftCardProvenanceCardView.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardProvenanceCard/GiftCardProvenanceCardView.tsx
@@ -47,7 +47,7 @@ export const GiftCardProvenanceCardView = ({
   giftCard,
   loading = false,
   channel = null,
-}: GiftCardProvenanceCardViewProps): JSX.Element => {
+}: GiftCardProvenanceCardViewProps): React.ReactNode => {
   const intl = useIntl();
   const localizeDate = useDateLocalize();
 

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -9,7 +9,7 @@ import useGiftCardUpdateForm from "../providers/GiftCardUpdateFormProvider/hooks
 import styles from "./GiftCardUpdateDetailsCard.module.css";
 import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 
-export const GiftCardUpdateDetailsCard = (): JSX.Element => {
+export const GiftCardUpdateDetailsCard = (): React.ReactNode => {
   const intl = useIntl();
   const { loading } = useGiftCardDetails();
   const {

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdateExpirySelect/GiftCardUpdateExpirySelect.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdateExpirySelect/GiftCardUpdateExpirySelect.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { giftCardExpirySelectMessages as messages } from "./messages";
 
-export const GiftCardUpdateExpirySelect = (): JSX.Element => {
+export const GiftCardUpdateExpirySelect = (): React.ReactNode => {
   const intl = useIntl();
   const {
     change,

--- a/src/giftCards/GiftCardsList/GiftCardListPage.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardListPage.tsx
@@ -10,7 +10,7 @@ import { useGiftCardListDialogs } from "./providers/GiftCardListDialogsProvider/
 import { useGiftCardList } from "./providers/GiftCardListProvider/GiftCardListProvider";
 import { GiftCardListActionParamsEnum } from "./types";
 
-export const GiftCardListPage = (): JSX.Element => {
+export const GiftCardListPage = (): React.ReactNode => {
   const { params, onPresetSave, onPresetDelete, getPresetNameToDelete } = useGiftCardList();
   const { onClose } = useGiftCardListDialogs();
 

--- a/src/giftCards/GiftCardsList/GiftCardListSearchAndFilters/GiftCardListSearchAndFilters.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardListSearchAndFilters/GiftCardListSearchAndFilters.tsx
@@ -8,7 +8,7 @@ import { useGiftCardListDialogs } from "../providers/GiftCardListDialogsProvider
 import { useGiftCardList } from "../providers/GiftCardListProvider/GiftCardListProvider";
 import { giftCardListSearchAndFiltersMessages as messages } from "./messages";
 
-const GiftCardListSearchAndFilters = (): JSX.Element => {
+const GiftCardListSearchAndFilters = (): React.ReactNode => {
   const intl = useIntl();
 
   const { params, handleSearchChange, selectedRowIds } = useGiftCardList();

--- a/src/home/HomeEmptyState.tsx
+++ b/src/home/HomeEmptyState.tsx
@@ -47,7 +47,7 @@ const messages = defineMessages({
   },
 });
 
-export const HomeEmptyState = (): JSX.Element => {
+export const HomeEmptyState = (): React.ReactNode => {
   const intl = useIntl();
   const videoRef = useRef<HTMLVideoElement>(null);
   const pulseLink = getPulsePromotionLink(IS_CLOUD_INSTANCE);

--- a/src/icons/GraphqlIcon.tsx
+++ b/src/icons/GraphqlIcon.tsx
@@ -10,7 +10,7 @@ const graphqlStrokeWidth = getNavigationCustomIconStrokeWidth(GRAPHQL_VIEWBOX_WI
 const graphqlVertexRadius = 2.25;
 const graphqlIconOpacity = 0.95;
 
-export const GraphqlIcon = (): JSX.Element => (
+export const GraphqlIcon = (): React.ReactNode => (
   <Box __opacity={graphqlIconOpacity}>
     <svg
       width={navigationLucideIconProps.size}

--- a/src/icons/Modeling.tsx
+++ b/src/icons/Modeling.tsx
@@ -53,7 +53,7 @@ const ModelingIconPaths = ({ strokeWidth }: { strokeWidth: number }) => (
   </>
 );
 
-export const ModelingIcon = (): JSX.Element => (
+export const ModelingIcon = (): React.ReactNode => (
   <svg
     width={navigationLucideIconProps.size}
     height={navigationLucideIconProps.size}
@@ -65,7 +65,7 @@ export const ModelingIcon = (): JSX.Element => (
   </svg>
 );
 
-export const ConfigurationModelingIcon = (): JSX.Element => (
+export const ConfigurationModelingIcon = (): React.ReactNode => (
   <svg
     width={configurationLucideIconProps.size}
     height={configurationLucideIconProps.size}
@@ -77,7 +77,7 @@ export const ConfigurationModelingIcon = (): JSX.Element => (
   </svg>
 );
 
-export const TopNavModelingIcon = (): JSX.Element => (
+export const TopNavModelingIcon = (): React.ReactNode => (
   <svg
     width={topNavLucideIconProps.size}
     height={topNavLucideIconProps.size}

--- a/src/icons/PaperSignIcon.tsx
+++ b/src/icons/PaperSignIcon.tsx
@@ -28,7 +28,7 @@ interface PaperSignIconProps {
   size?: number;
 }
 
-export const PaperSignIcon = ({ size = iconSize.small }: PaperSignIconProps): JSX.Element => (
+export const PaperSignIcon = ({ size = iconSize.small }: PaperSignIconProps): React.ReactNode => (
   <svg
     width={size}
     height={size}

--- a/src/icons/RefundedIcon.tsx
+++ b/src/icons/RefundedIcon.tsx
@@ -13,7 +13,7 @@ export const RefundedIcon = ({
   className?: string;
   color?: string;
   strokeWidth?: number;
-}): JSX.Element => (
+}): React.ReactNode => (
   <svg
     width={size}
     height={size}

--- a/src/icons/createNavigationLucideIcon.tsx
+++ b/src/icons/createNavigationLucideIcon.tsx
@@ -5,20 +5,20 @@ import {
 } from "@dashboard/components/icons";
 import { type LucideIcon } from "lucide-react";
 
-export const createNavigationLucideIcon = (Icon: LucideIcon): (() => JSX.Element) => {
-  const NavigationLucideIcon = (): JSX.Element => <Icon {...navigationLucideIconProps} />;
+export const createNavigationLucideIcon = (Icon: LucideIcon): (() => React.ReactNode) => {
+  const NavigationLucideIcon = (): React.ReactNode => <Icon {...navigationLucideIconProps} />;
 
   return NavigationLucideIcon;
 };
 
-export const createConfigurationLucideIcon = (Icon: LucideIcon): (() => JSX.Element) => {
-  const ConfigurationLucideIcon = (): JSX.Element => <Icon {...configurationLucideIconProps} />;
+export const createConfigurationLucideIcon = (Icon: LucideIcon): (() => React.ReactNode) => {
+  const ConfigurationLucideIcon = (): React.ReactNode => <Icon {...configurationLucideIconProps} />;
 
   return ConfigurationLucideIcon;
 };
 
-export const createTopNavLucideIcon = (Icon: LucideIcon): (() => JSX.Element) => {
-  const TopNavLucideIcon = (): JSX.Element => <Icon {...topNavLucideIconProps} />;
+export const createTopNavLucideIcon = (Icon: LucideIcon): (() => React.ReactNode) => {
+  const TopNavLucideIcon = (): React.ReactNode => <Icon {...topNavLucideIconProps} />;
 
   return TopNavLucideIcon;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,7 +127,7 @@ const handleLegacyTheming = (): void => {
 
 handleLegacyTheming();
 
-const App = (): JSX.Element => (
+const App = (): React.ReactNode => (
   <ApolloProvider client={apolloClient}>
     <Router>
       {/* @ts-expect-error legacy types */}

--- a/src/modelTypes/components/CreateModelTypeDialog/CreateModelTypeDialog.tsx
+++ b/src/modelTypes/components/CreateModelTypeDialog/CreateModelTypeDialog.tsx
@@ -38,7 +38,7 @@ export const CreateModelTypeDialog = ({
   errors: apiErrors,
   onClose,
   onSubmit,
-}: CreateModelTypeDialogProps): JSX.Element => {
+}: CreateModelTypeDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [submitErrors, setSubmitErrors] = useState<PageErrorFragment[]>([]);
   const [showApiErrors, setShowApiErrors] = useState(false);

--- a/src/modelTypes/components/PageTypeAttributes/PageTypeAttributes.tsx
+++ b/src/modelTypes/components/PageTypeAttributes/PageTypeAttributes.tsx
@@ -28,7 +28,7 @@ const PageTypeAttributes = ({
   onAttributeReorder,
   onAttributeUnassign,
   ...listActions
-}: PageTypeAttributesProps): JSX.Element => {
+}: PageTypeAttributesProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/modelTypes/components/PageTypeDetails/PageTypeDetails.tsx
+++ b/src/modelTypes/components/PageTypeDetails/PageTypeDetails.tsx
@@ -26,7 +26,7 @@ const PageTypeDetails = ({
   errors = [],
   onChange,
   onIconChange,
-}: PageTypeDetailsProps): JSX.Element => {
+}: PageTypeDetailsProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name"], errors);
 

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
@@ -29,7 +29,7 @@ jest.mock("../PageTypeDetails/PageTypeDetails", () => ({
   default: () => <div data-test-id="page-type-details-mock" />,
 }));
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <ThemeProvider>{children}</ThemeProvider>
   </MemoryRouter>

--- a/src/modelTypes/components/PageTypeDetailsPage/Title.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/Title.test.tsx
@@ -8,7 +8,7 @@ const pageType = {
   name: "Blog",
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
@@ -30,7 +30,7 @@ const staffUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/modeling/components/PageDetailsPage/Title.test.tsx
+++ b/src/modeling/components/PageDetailsPage/Title.test.tsx
@@ -38,7 +38,7 @@ const mockUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/navigationPins/components/NavigationPinList.tsx
+++ b/src/navigationPins/components/NavigationPinList.tsx
@@ -26,7 +26,7 @@ export const NavigationPinList = ({
   emptyMessage,
   disabled,
   onRemove,
-}: NavigationPinListProps): JSX.Element => {
+}: NavigationPinListProps): React.ReactNode => {
   const intl = useIntl();
   const { items, hasResolved } = useNavigationPinListItems(pins);
 

--- a/src/navigationPins/components/NavigationPinsCard.tsx
+++ b/src/navigationPins/components/NavigationPinsCard.tsx
@@ -25,7 +25,7 @@ const pinIcon = <Pin size={iconSize.small} strokeWidth={iconStrokeWidth} />;
  * organization-pinned — the models page hides its button in that case — and to free a
  * slot occupied by a deleted model type.
  */
-export const NavigationPinsCard = (): JSX.Element => {
+export const NavigationPinsCard = (): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const notify = useNotifier();

--- a/src/notificationsSettings/components/DisableStaffEmailsDialog/DisableStaffEmailsDialog.stories.tsx
+++ b/src/notificationsSettings/components/DisableStaffEmailsDialog/DisableStaffEmailsDialog.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
 
 export default meta;
 
-export const Default = (): JSX.Element => {
+export const Default = (): React.ReactNode => {
   const [open, setOpen] = useState(true);
 
   return (

--- a/src/notificationsSettings/components/DisableStaffEmailsDialog/DisableStaffEmailsDialog.tsx
+++ b/src/notificationsSettings/components/DisableStaffEmailsDialog/DisableStaffEmailsDialog.tsx
@@ -20,7 +20,7 @@ export const DisableStaffEmailsDialog = ({
   confirmButtonState,
   onClose,
   onConfirm,
-}: DisableStaffEmailsDialogProps): JSX.Element => {
+}: DisableStaffEmailsDialogProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/notificationsSettings/components/EmailNotificationsPage/EmailNotificationsPage.tsx
+++ b/src/notificationsSettings/components/EmailNotificationsPage/EmailNotificationsPage.tsx
@@ -50,7 +50,7 @@ export const EmailNotificationsPage = ({
   onNotificationChange,
   onSmtpFieldChange,
   onSubmit,
-}: EmailNotificationsPageProps): JSX.Element => {
+}: EmailNotificationsPageProps): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const formId = "staff-emails-form";

--- a/src/notificationsSettings/components/NotificationsHubPage/NotificationsHubPage.tsx
+++ b/src/notificationsSettings/components/NotificationsHubPage/NotificationsHubPage.tsx
@@ -13,7 +13,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { notificationsMessages } from "../../messages";
 
-export const NotificationsHubPage = (): JSX.Element => {
+export const NotificationsHubPage = (): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/notificationsSettings/components/StaffEmailsSettingsCard/StaffEmailsSettingsCard.stories.tsx
+++ b/src/notificationsSettings/components/StaffEmailsSettingsCard/StaffEmailsSettingsCard.stories.tsx
@@ -34,7 +34,7 @@ const initialFormState: EmailNotificationsFormState = {
   otherFields: {},
 };
 
-export const CloudDefaultDelivery = (): JSX.Element => {
+export const CloudDefaultDelivery = (): React.ReactNode => {
   const [deliveryMode, setDeliveryMode] = useState<StaffEmailDeliveryMode>("default");
   const [formState, setFormState] = useState<EmailNotificationsFormState>(initialFormState);
 

--- a/src/notificationsSettings/components/StaffEmailsSettingsCard/StaffEmailsSettingsCard.tsx
+++ b/src/notificationsSettings/components/StaffEmailsSettingsCard/StaffEmailsSettingsCard.tsx
@@ -105,7 +105,7 @@ export const StaffEmailsSettingsCard = ({
   onActiveChange,
   onDeliveryModeChange,
   onSmtpFieldChange,
-}: StaffEmailsSettingsCardProps): JSX.Element => {
+}: StaffEmailsSettingsCardProps): React.ReactNode => {
   const intl = useIntl();
   const smtpValues = ensureSmtpFieldDefaults(formState.otherFields);
   const tlsSslError = smtpFieldErrors.use_tls || smtpFieldErrors.use_ssl || undefined;
@@ -291,7 +291,7 @@ export const StaffMessagesSettingsCard = ({
   deliveryMode,
   disabled,
   onNotificationChange,
-}: StaffMessagesSettingsCardProps): JSX.Element => {
+}: StaffMessagesSettingsCardProps): React.ReactNode => {
   const intl = useIntl();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const lockCustomCopy = IS_CLOUD_INSTANCE && deliveryMode === "default";
@@ -423,7 +423,7 @@ const NotificationEmailEditor = ({
   expanded,
   onToggle,
   onChange,
-}: NotificationEmailEditorProps): JSX.Element => {
+}: NotificationEmailEditorProps): React.ReactNode => {
   const intl = useIntl();
   const templateRef = useRef<HTMLTextAreaElement | null>(null);
   const effectiveTemplateMode = lockCustomCopy ? "default" : values.templateMode;

--- a/src/notificationsSettings/components/StaffOrderAlertRecipientsCard/StaffOrderAlertRecipientsCard.stories.tsx
+++ b/src/notificationsSettings/components/StaffOrderAlertRecipientsCard/StaffOrderAlertRecipientsCard.stories.tsx
@@ -32,7 +32,7 @@ const initialRecipients: StaffOrderAlertRecipient[] = [
   },
 ];
 
-export const WithRecipients = (): JSX.Element => {
+export const WithRecipients = (): React.ReactNode => {
   const [recipients, setRecipients] = useState(initialRecipients);
 
   return (
@@ -50,7 +50,7 @@ export const WithRecipients = (): JSX.Element => {
   );
 };
 
-export const Empty = (): JSX.Element => (
+export const Empty = (): React.ReactNode => (
   <Box padding={6} __maxWidth="48rem">
     <StaffOrderAlertRecipientsCard
       recipients={[]}

--- a/src/notificationsSettings/components/StaffOrderAlertRecipientsCard/StaffOrderAlertRecipientsCard.tsx
+++ b/src/notificationsSettings/components/StaffOrderAlertRecipientsCard/StaffOrderAlertRecipientsCard.tsx
@@ -55,7 +55,7 @@ export const StaffOrderAlertRecipientsCard = ({
   staffEmailsEnabled,
   onAssign,
   onRemove,
-}: StaffOrderAlertRecipientsCardProps): JSX.Element => {
+}: StaffOrderAlertRecipientsCardProps): React.ReactNode => {
   const intl = useIntl();
   const hasRecipients = recipients.length > 0;
   const assignButton = canManageStaff ? (
@@ -154,7 +154,7 @@ interface RecipientRowProps {
   onRemove: (id: string) => void;
 }
 
-const RecipientRow = ({ recipient, disabled, onRemove }: RecipientRowProps): JSX.Element => {
+const RecipientRow = ({ recipient, disabled, onRemove }: RecipientRowProps): React.ReactNode => {
   const name = recipientDisplayName(recipient);
   const hint = recipientHint(recipient);
   const href = recipient.userId ? staffMemberDetailsUrl(recipient.userId) : undefined;

--- a/src/notificationsSettings/components/SwitchToDefaultDeliveryDialog/SwitchToDefaultDeliveryDialog.stories.tsx
+++ b/src/notificationsSettings/components/SwitchToDefaultDeliveryDialog/SwitchToDefaultDeliveryDialog.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
 
 export default meta;
 
-export const Default = (): JSX.Element => {
+export const Default = (): React.ReactNode => {
   const [open, setOpen] = useState(true);
 
   return (

--- a/src/notificationsSettings/components/SwitchToDefaultDeliveryDialog/SwitchToDefaultDeliveryDialog.tsx
+++ b/src/notificationsSettings/components/SwitchToDefaultDeliveryDialog/SwitchToDefaultDeliveryDialog.tsx
@@ -26,7 +26,7 @@ export const SwitchToDefaultDeliveryDialog = ({
   onClose,
   onConfirm,
   onDownloadBackup,
-}: SwitchToDefaultDeliveryDialogProps): JSX.Element => {
+}: SwitchToDefaultDeliveryDialogProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/notificationsSettings/route.tsx
+++ b/src/notificationsSettings/route.tsx
@@ -9,7 +9,7 @@ import { NotificationsHubView } from "@dashboard/notificationsSettings/views/Not
 import { StaffEmailsView } from "@dashboard/notificationsSettings/views/StaffEmails";
 import { Switch } from "react-router-dom";
 
-export const NotificationsSettingsRoute = (): JSX.Element => (
+export const NotificationsSettingsRoute = (): React.ReactNode => (
   <Switch>
     <Route exact path={notificationsSettingsPath} component={NotificationsHubView} />
     <Route exact path={notificationsStaffEmailsPath} component={StaffEmailsView} />

--- a/src/notificationsSettings/views/CustomerEmailsRedirect.tsx
+++ b/src/notificationsSettings/views/CustomerEmailsRedirect.tsx
@@ -12,7 +12,7 @@ import { notificationsMessages } from "../messages";
  * Opens the installed SMTP app (customer emails). If not installed, sends merchants
  * to Explore Extensions in this Dashboard — not the public App Store.
  */
-export const CustomerEmailsRedirectView = (): JSX.Element => {
+export const CustomerEmailsRedirectView = (): React.ReactNode => {
   const navigate = useNavigator();
   const { navigateToApp } = useAppNavigation();
   const redirected = useRef(false);

--- a/src/notificationsSettings/views/NotificationsHub.tsx
+++ b/src/notificationsSettings/views/NotificationsHub.tsx
@@ -1,5 +1,5 @@
 import { NotificationsHubPage } from "@dashboard/notificationsSettings/components/NotificationsHubPage/NotificationsHubPage";
 
-export const NotificationsHubView = (): JSX.Element => {
+export const NotificationsHubView = (): React.ReactNode => {
   return <NotificationsHubPage />;
 };

--- a/src/notificationsSettings/views/StaffEmails.tsx
+++ b/src/notificationsSettings/views/StaffEmails.tsx
@@ -42,7 +42,7 @@ const scrollToStaffDelivery = (): void => {
   scrollToDetailSection(settingsHashes.notificationsDelivery);
 };
 
-export const StaffEmailsView = (): JSX.Element => {
+export const StaffEmailsView = (): React.ReactNode => {
   const intl = useIntl();
   const notify = useNotifier();
   const { data, loading } = usePluginQuery({

--- a/src/orders/components/OrderCaptureDialog/OrderCaptureDialog.tsx
+++ b/src/orders/components/OrderCaptureDialog/OrderCaptureDialog.tsx
@@ -67,7 +67,7 @@ export const OrderCaptureDialog = ({
   errors = [],
   onClose,
   onSubmit,
-}: OrderCaptureDialogProps): JSX.Element => {
+}: OrderCaptureDialogProps): React.ReactNode => {
   const intl = useIntl();
 
   const currency = orderTotal.currency;

--- a/src/orders/components/OrderCardTitle/ClipboardCopyIcon.tsx
+++ b/src/orders/components/OrderCardTitle/ClipboardCopyIcon.tsx
@@ -5,7 +5,7 @@ interface ClipboardCopyIconProps {
   hasBeenClicked: boolean;
 }
 
-export const ClipboardCopyIcon = ({ hasBeenClicked }: ClipboardCopyIconProps): JSX.Element => {
+export const ClipboardCopyIcon = ({ hasBeenClicked }: ClipboardCopyIconProps): React.ReactNode => {
   const className = sprinkles({ color: "default2" });
 
   return hasBeenClicked ? (

--- a/src/orders/components/OrderCardTitle/OrderCardDatagridSeparator.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardDatagridSeparator.tsx
@@ -1,5 +1,5 @@
 import styles from "./OrderCardTitle.module.css";
 
-export const OrderCardDatagridSeparator = (): JSX.Element => (
+export const OrderCardDatagridSeparator = (): React.ReactNode => (
   <hr className={styles.datagridSeparator} aria-hidden />
 );

--- a/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
+++ b/src/orders/components/OrderCardTitle/OrderCardTitle.tsx
@@ -44,7 +44,7 @@ export const OrderCardTitle = ({
   restockWarehouseId,
   backgroundColor = "default1",
   hasToolbarMenu = false,
-}: OrderCardTitleProps): JSX.Element => {
+}: OrderCardTitleProps): React.ReactNode => {
   const intl = useIntl();
   const sourceWarehouseVariant =
     status === FulfillmentStatus.CANCELED ? "shippedFrom" : "fulfilledFrom";

--- a/src/orders/components/OrderCardTitle/TrackingNumberDisplay.tsx
+++ b/src/orders/components/OrderCardTitle/TrackingNumberDisplay.tsx
@@ -14,7 +14,7 @@ interface TrackingNumberDisplayProps {
 export const TrackingNumberDisplay = ({
   trackingNumber,
   separator = ", ",
-}: TrackingNumberDisplayProps): JSX.Element => {
+}: TrackingNumberDisplayProps): React.ReactNode => {
   const intl = useIntl();
   const [copied, copy] = useClipboard();
   const [showCopyButton, setShowCopyButton] = useState(false);

--- a/src/orders/components/OrderCardTitle/UnderlineLink.tsx
+++ b/src/orders/components/OrderCardTitle/UnderlineLink.tsx
@@ -9,13 +9,13 @@ export const UnderlineLink = ({
   children,
   textProps,
   ...props
-}: UnderlineLinkProps): JSX.Element => (
+}: UnderlineLinkProps): React.ReactNode => (
   <Link {...props}>
     <UnderlineText {...textProps}>{children}</UnderlineText>
   </Link>
 );
 
-const UnderlineText = ({ children, ...props }: TextProps): JSX.Element => (
+const UnderlineText = ({ children, ...props }: TextProps): React.ReactNode => (
   <Text
     as="span"
     textDecoration="underline"

--- a/src/orders/components/OrderCardTitle/WarehouseInfo.tsx
+++ b/src/orders/components/OrderCardTitle/WarehouseInfo.tsx
@@ -25,7 +25,7 @@ export const WarehouseInfo = ({
   warehouseId,
   separator = ", ",
   variant = "fulfilledFrom",
-}: WarehouseInfoProps): JSX.Element => {
+}: WarehouseInfoProps): React.ReactNode => {
   const intl = useIntl();
   const message = warehouseMessageByVariant[variant];
 

--- a/src/orders/components/OrderChannelSettingsMatrix/OrderChannelSettingsMatrix.tsx
+++ b/src/orders/components/OrderChannelSettingsMatrix/OrderChannelSettingsMatrix.tsx
@@ -56,7 +56,7 @@ const HeaderWithHelp = ({
   tooltip,
   tooltipContent,
   id,
-}: HeaderWithHelpProps): JSX.Element => {
+}: HeaderWithHelpProps): React.ReactNode => {
   const intl = useIntl();
 
   return (
@@ -88,7 +88,7 @@ const HeaderWithHelp = ({
   );
 };
 
-const AutoConfirmTooltip = (): JSX.Element => {
+const AutoConfirmTooltip = (): React.ReactNode => {
   const intl = useIntl();
   const unfulfilledStatus = transformOrderStatus(OrderStatus.UNFULFILLED, intl);
   const unconfirmedStatus = transformOrderStatus(OrderStatus.UNCONFIRMED, intl);
@@ -134,7 +134,7 @@ const MatrixCheckbox = ({
   disabled?: boolean;
   testId: string;
   onCheckedChange: (checked: boolean) => void;
-}): JSX.Element => (
+}): React.ReactNode => (
   <Box className={styles.matrixControl}>
     <Checkbox
       checked={checked}
@@ -151,7 +151,7 @@ export const OrderChannelSettingsMatrix = ({
   dirtyChannelIds,
   disabled,
   onChannelChange,
-}: OrderChannelSettingsMatrixProps): JSX.Element => {
+}: OrderChannelSettingsMatrixProps): React.ReactNode => {
   const intl = useIntl();
   const [searchQuery, setSearchQuery] = useState("");
   const [hideInactive, setHideInactive] = useState(false);

--- a/src/orders/components/OrderCheckoutStockSettings/OrderCheckoutStockSettings.tsx
+++ b/src/orders/components/OrderCheckoutStockSettings/OrderCheckoutStockSettings.tsx
@@ -18,7 +18,7 @@ export const OrderCheckoutStockSettings = ({
   data,
   disabled,
   onChange,
-}: OrderCheckoutStockSettingsProps): JSX.Element => {
+}: OrderCheckoutStockSettingsProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.tsx
@@ -14,7 +14,7 @@ export const OrderFulfillProductCellContent = ({
   productName,
   attributesCaption,
   children,
-}: OrderFulfillProductCellContentProps): JSX.Element => {
+}: OrderFulfillProductCellContentProps): React.ReactNode => {
   const { elementRef: productNameRef, isOverflowing: isProductNameOverflowing } =
     useOverflowDetection<HTMLDivElement>();
   const { elementRef: attributesRef, isOverflowing: isAttributesOverflowing } =

--- a/src/orders/components/OrderGrantRefundPage/components/ProductCard.stories.tsx
+++ b/src/orders/components/OrderGrantRefundPage/components/ProductCard.stories.tsx
@@ -61,7 +61,7 @@ const GrantRefundDecorator = ({
 }: {
   children: ReactNode;
   reasonReferenceTypeId?: string;
-}): JSX.Element => (
+}): React.ReactNode => (
   <GrantRefundContext.Provider
     value={{
       state,

--- a/src/orders/components/OrderLineExpandedPanel/OrderLineExpandedPanel.tsx
+++ b/src/orders/components/OrderLineExpandedPanel/OrderLineExpandedPanel.tsx
@@ -29,7 +29,7 @@ import { OrderLineGrantedRefundRow } from "./OrderLineGrantedRefundRow";
 
 const cancelableStatuses = [FulfillmentStatus.FULFILLED, FulfillmentStatus.WAITING_FOR_APPROVAL];
 
-const MetadataDot = (): JSX.Element => (
+const MetadataDot = (): React.ReactNode => (
   <span className={styles.metadataDot} aria-hidden="true">
     ·
   </span>

--- a/src/orders/components/OrderLineExpandedPanel/OrderLineGrantedRefundRow.tsx
+++ b/src/orders/components/OrderLineExpandedPanel/OrderLineGrantedRefundRow.tsx
@@ -17,7 +17,7 @@ import { Link } from "react-router-dom";
 import { messages } from "./messages";
 import styles from "./OrderLineExpandedPanel.module.css";
 
-const MetadataDot = (): JSX.Element => (
+const MetadataDot = (): React.ReactNode => (
   <span className={styles.metadataDot} aria-hidden="true">
     ·
   </span>
@@ -36,7 +36,7 @@ export const OrderLineGrantedRefundRow = ({
   entry,
   orderId,
   locale,
-}: OrderLineGrantedRefundRowProps): JSX.Element => {
+}: OrderLineGrantedRefundRowProps): React.ReactNode => {
   const intl = useIntl();
   const canEdit = canEditLineGrantedRefund(entry.status);
   const statusLabel = getGrantedRefundStatusMessage(entry.status, intl);

--- a/src/orders/components/OrderLineGroupBottomSeparator/OrderLineGroupBottomSeparator.tsx
+++ b/src/orders/components/OrderLineGroupBottomSeparator/OrderLineGroupBottomSeparator.tsx
@@ -1,6 +1,6 @@
 import { Box, type vars } from "@saleor/macaw-ui-next";
 
-const OrderLineGroupBottomSeparator = (): JSX.Element => (
+const OrderLineGroupBottomSeparator = (): React.ReactNode => (
   <Box
     backgroundColor="default1"
     width="100%"
@@ -19,7 +19,7 @@ interface OrderLineGroupEndProps {
 export const OrderLineGroupEnd = ({
   showBottomSeparator,
   backgroundColor,
-}: OrderLineGroupEndProps): JSX.Element =>
+}: OrderLineGroupEndProps): React.ReactNode =>
   showBottomSeparator ? (
     <OrderLineGroupBottomSeparator />
   ) : (

--- a/src/orders/components/OrderLineRowActions/OrderLineRowActions.tsx
+++ b/src/orders/components/OrderLineRowActions/OrderLineRowActions.tsx
@@ -22,7 +22,7 @@ export const OrderLineRowActions = ({
   onShowMetadata,
   disabled,
   intl,
-}: OrderLineRowActionsProps): JSX.Element => {
+}: OrderLineRowActionsProps): React.ReactNode => {
   const classes = useStyles({ showMetadataButton: true });
   const hasLineActionsMenu = menuItems.length > 1;
   const productMenuItem = menuItems[0];

--- a/src/orders/components/OrderReturnsRefundsSettingsCard/OrderReturnsRefundsSettingsCard.tsx
+++ b/src/orders/components/OrderReturnsRefundsSettingsCard/OrderReturnsRefundsSettingsCard.tsx
@@ -4,7 +4,7 @@ import { sectionNames } from "@dashboard/intl";
 import { refundsSettingsPath } from "@dashboard/refundsSettings/urls";
 import { FormattedMessage, useIntl } from "react-intl";
 
-export const OrderReturnsRefundsSettingsCard = (): JSX.Element => {
+export const OrderReturnsRefundsSettingsCard = (): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -152,7 +152,7 @@ const OrderSettingsForm = ({
   channels,
   onSubmit,
   disabled,
-}: OrderSettingsFormProps): JSX.Element => {
+}: OrderSettingsFormProps): React.ReactNode => {
   const props = useOrderSettingsForm(shop, channels, onSubmit, disabled);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {

--- a/src/orders/components/OrderTransactionsSection/OrderTransactionsSection.tsx
+++ b/src/orders/components/OrderTransactionsSection/OrderTransactionsSection.tsx
@@ -36,7 +36,7 @@ export const OrderTransactionsSection = ({
   onPaymentVoid,
   onAddManualTransaction,
   onRefundAdd,
-}: OrderTransactionsSectionProps): JSX.Element => {
+}: OrderTransactionsSectionProps): React.ReactNode => {
   const filteredPayments = useMemo(() => getFilteredPayments(order), [order]);
 
   const hasAnyTransactions = [order?.transactions, filteredPayments, order?.giftCards].some(

--- a/src/orders/components/ReasonReferenceModal/ReasonReferenceModal.tsx
+++ b/src/orders/components/ReasonReferenceModal/ReasonReferenceModal.tsx
@@ -31,7 +31,7 @@ export const ReasonReferenceModal = ({
   referenceModelTypeId,
   onClose,
   onConfirm,
-}: ReasonReferenceModalProps): JSX.Element => {
+}: ReasonReferenceModalProps): React.ReactNode => {
   const intl = useIntl();
   const [tempReason, setTempReason] = useState(reason);
   const [tempReference, setTempReference] = useState(reasonReference);

--- a/src/orders/components/RefundTransferFailureInfo/RefundTransferFailureInfo.tsx
+++ b/src/orders/components/RefundTransferFailureInfo/RefundTransferFailureInfo.tsx
@@ -9,7 +9,7 @@ interface RefundTransferFailureInfoProps {
 export const RefundTransferFailureInfo = ({
   message,
   testId = "refund-transfer-failure-info",
-}: RefundTransferFailureInfoProps): JSX.Element => (
+}: RefundTransferFailureInfoProps): React.ReactNode => (
   <Tooltip>
     <Tooltip.Trigger>
       <Box display="flex" cursor="pointer" padding={1} flexShrink="0" data-test-id={testId}>

--- a/src/productTypes/components/CreateProductTypeDialog/CreateProductTypeDialog.tsx
+++ b/src/productTypes/components/CreateProductTypeDialog/CreateProductTypeDialog.tsx
@@ -41,7 +41,7 @@ export const CreateProductTypeDialog = ({
   errors: apiErrors,
   onClose,
   onSubmit,
-}: CreateProductTypeDialogProps): JSX.Element => {
+}: CreateProductTypeDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [submitErrors, setSubmitErrors] = useState<ProductErrorFragment[]>([]);
   const [showApiErrors, setShowApiErrors] = useState(false);

--- a/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -26,7 +26,7 @@ const ProductTypeAttributes = ({
   onAttributeReorder,
   onAttributeUnassign,
   ...listActions
-}: ProductTypeAttributesProps): JSX.Element => {
+}: ProductTypeAttributesProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
+++ b/src/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
@@ -27,7 +27,7 @@ const ProductTypeDetails = ({
   disabled,
   errors,
   onChange,
-}: ProductTypeDetailsProps): JSX.Element => {
+}: ProductTypeDetailsProps): React.ReactNode => {
   const intl = useIntl();
   const nameInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
@@ -37,7 +37,7 @@ jest.mock("../ProductTypeVariantAttributes/ProductTypeVariantAttributes", () => 
   default: () => <div data-test-id="product-type-variant-attributes-mock" />,
 }));
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <ThemeProvider>{children}</ThemeProvider>
   </MemoryRouter>

--- a/src/productTypes/components/ProductTypeDetailsPage/Title.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/Title.test.tsx
@@ -8,7 +8,7 @@ const productType = {
   name: "E-books",
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/productTypes/components/ProductTypeKindTiles/ProductTypeKindTiles.tsx
+++ b/src/productTypes/components/ProductTypeKindTiles/ProductTypeKindTiles.tsx
@@ -37,7 +37,7 @@ const KindTile = ({
   tileRef: (node: HTMLElement | null) => void;
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
   onSelect: (value: ProductTypeKindEnum) => void;
-}): JSX.Element => {
+}): React.ReactNode => {
   const Icon = option.icon;
 
   return (
@@ -85,7 +85,7 @@ export const ProductTypeKindTiles = ({
   value,
   disabled,
   onChange,
-}: ProductTypeKindTilesProps): JSX.Element => {
+}: ProductTypeKindTilesProps): React.ReactNode => {
   const intl = useIntl();
   const tileRefs = useRef<Partial<Record<ProductTypeKindEnum, HTMLElement | null>>>({});
   const options: KindOption[] = [

--- a/src/productTypes/components/ProductTypePdpSchematic/ProductTypePdpSchematic.tsx
+++ b/src/productTypes/components/ProductTypePdpSchematic/ProductTypePdpSchematic.tsx
@@ -52,7 +52,7 @@ const OptionPlaceholders = ({
 }: {
   name: string;
   sampleValue: string | null;
-}): JSX.Element => {
+}): React.ReactNode => {
   const useSwatches = isColorAttributeName(name);
 
   return (
@@ -72,7 +72,11 @@ const OptionPlaceholders = ({
   );
 };
 
-const OptionRows = ({ attributes }: { attributes: PdpSchematicNamedAttribute[] }): JSX.Element => (
+const OptionRows = ({
+  attributes,
+}: {
+  attributes: PdpSchematicNamedAttribute[];
+}): React.ReactNode => (
   <>
     {attributes.map(attribute => (
       <Box key={attribute.id} className={styles.optionRow} data-test-id="pdp-schematic-option">
@@ -85,7 +89,7 @@ const OptionRows = ({ attributes }: { attributes: PdpSchematicNamedAttribute[] }
   </>
 );
 
-const SampleValue = ({ value }: { value: string | null }): JSX.Element =>
+const SampleValue = ({ value }: { value: string | null }): React.ReactNode =>
   value ? (
     <Text as="span" className={styles.specValue}>
       {value}
@@ -118,7 +122,7 @@ const LegendItem = ({
   titleClassName: string;
   title: ReactNode;
   body: ReactNode;
-}): JSX.Element => (
+}): React.ReactNode => (
   <Box as="li" className={styles.legendItem} data-schematic-region={region}>
     <Box className={styles.legendLeading} aria-hidden>
       <Box className={clsx(styles.legendIcon, iconClassName)} />
@@ -134,7 +138,7 @@ const LegendItem = ({
   </Box>
 );
 
-const SchematicLoadingRegions = (): JSX.Element => (
+const SchematicLoadingRegions = (): React.ReactNode => (
   <>
     <Box className={clsx(styles.region, styles.regionOptions)}>
       <Text as="span" className={styles.regionLabel}>
@@ -163,7 +167,7 @@ const SchematicLoadingRegions = (): JSX.Element => (
   </>
 );
 
-const SchematicLoadingSpecs = (): JSX.Element => (
+const SchematicLoadingSpecs = (): React.ReactNode => (
   <>
     {Array.from({ length: 2 }, (_, index) => (
       <Box key={index} className={styles.specRow} aria-hidden>
@@ -181,7 +185,7 @@ export const ProductTypePdpSchematic = ({
   selectedVariantAttributeIds,
   onDismiss,
   loading = false,
-}: ProductTypePdpSchematicProps): JSX.Element => {
+}: ProductTypePdpSchematicProps): React.ReactNode => {
   const intl = useIntl();
   const { theme } = useTheme();
   const { optionAttributes, badgeAttributes, specAttributes } = getPdpSchematicModel({

--- a/src/productTypes/components/ProductTypeVariantAttributes/ProductTypeVariantAttributes.tsx
+++ b/src/productTypes/components/ProductTypeVariantAttributes/ProductTypeVariantAttributes.tsx
@@ -77,7 +77,7 @@ const VariantSelectionSwitch = ({
   disabled: boolean;
   disabledReason?: string;
   onPressedChange: (next: boolean) => void;
-}): JSX.Element => {
+}): React.ReactNode => {
   const toggle = (): void => {
     if (!disabled) {
       onPressedChange(!pressed);

--- a/src/products/components/CreateProductDialog/CreateProductDialog.tsx
+++ b/src/products/components/CreateProductDialog/CreateProductDialog.tsx
@@ -57,7 +57,7 @@ export const CreateProductDialog = ({
   onClose,
   onCreateProductType,
   onSubmit,
-}: CreateProductDialogProps): JSX.Element => {
+}: CreateProductDialogProps): React.ReactNode => {
   const intl = useIntl();
   const [selectedOption, setSelectedOption] = useState<ProductTypeChoice | null>(null);
   const [query, setQuery] = useState("");

--- a/src/products/components/ProductExportDialog/ProductExportDialog.tsx
+++ b/src/products/components/ProductExportDialog/ProductExportDialog.tsx
@@ -78,7 +78,7 @@ export const ProductExportDialog = ({
   hasListFilters,
   warehouses,
   ...fetchMoreProps
-}: ProductExportDialogProps): JSX.Element => {
+}: ProductExportDialogProps): React.ReactNode => {
   const [step, { next, prev, set: setStep }] = useWizard(ProductExportStep.INFO, [
     ProductExportStep.INFO,
     ProductExportStep.SETTINGS,

--- a/src/products/components/ProductExternalMediaDialog/ProductExternalMediaDialog.tsx
+++ b/src/products/components/ProductExternalMediaDialog/ProductExternalMediaDialog.tsx
@@ -27,7 +27,7 @@ export const ProductExternalMediaDialog = ({
   open,
   onClose,
   onSubmit,
-}: ProductExternalMediaDialogProps): JSX.Element => {
+}: ProductExternalMediaDialogProps): React.ReactNode => {
   const intl = useIntl();
   const urlInputRef = useRef<HTMLInputElement>(null);
   const isSubmittingRef = useRef(false);

--- a/src/products/components/ProductListPagination/ProductListPagination.test.tsx
+++ b/src/products/components/ProductListPagination/ProductListPagination.test.tsx
@@ -14,7 +14,7 @@ const paginatorValue = {
   loadPreviousPage: jest.fn(),
 };
 
-const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const TestWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <Wrapper>
     <MemoryRouter>
       <PaginatorContext.Provider value={paginatorValue}>{children}</PaginatorContext.Provider>

--- a/src/products/components/ProductListPagination/ProductListPagination.tsx
+++ b/src/products/components/ProductListPagination/ProductListPagination.tsx
@@ -16,7 +16,7 @@ export const ProductListPagination = ({
   settings,
   disabled,
   onUpdateListSettings,
-}: ProductListPaginationProps): JSX.Element => {
+}: ProductListPaginationProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
+++ b/src/products/components/ProductListViewSwitch/ProductListViewSwitch.tsx
@@ -33,7 +33,7 @@ const messages = defineMessages({
 export const ProductListViewSwitch = ({
   defaultValue,
   setProductListViewType,
-}: ProductListViewSwitchProps): JSX.Element => {
+}: ProductListViewSwitchProps): React.ReactNode => {
   const intl = useIntl();
   const listViewLabel = intl.formatMessage(messages.listView);
   const gridViewLabel = intl.formatMessage(messages.gridView);

--- a/src/products/components/ProductMedia/ProductMedia.test.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.test.tsx
@@ -24,7 +24,7 @@ const uploadSuccessResult = (mediaId: string): FetchResult<ProductMediaCreateMut
   },
 });
 
-const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const TestWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <Wrapper>{children}</Wrapper>
   </MemoryRouter>

--- a/src/products/components/ProductUpdatePage/Title.test.tsx
+++ b/src/products/components/ProductUpdatePage/Title.test.tsx
@@ -40,7 +40,7 @@ const mockUser: UserFragment = {
   restrictedAccessToChannels: false,
 };
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <MemoryRouter>
     <UserContext.Provider
       value={{

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -65,7 +65,7 @@ export const ProductVariantPrice = ({
   listedInChannelsCount,
   availableChannelsCount,
   disabledMessage,
-}: ProductVariantPriceProps): JSX.Element => {
+}: ProductVariantPriceProps): React.ReactNode => {
   const intl = useIntl();
   const channelApiErrors = errors.filter(
     (error): error is ProductChannelListingErrorFragment => "channels" in error,

--- a/src/refundsSettings/components/RefundsSettingsPage/ReasonModelsPreview.tsx
+++ b/src/refundsSettings/components/RefundsSettingsPage/ReasonModelsPreview.tsx
@@ -21,7 +21,7 @@ export const ReasonModelsPreview = ({
   previewTitle,
   emptyModelsLabel,
   createModelLabel,
-}: ReasonModelsPreviewProps): JSX.Element => {
+}: ReasonModelsPreviewProps): React.ReactNode => {
   const { data: exampleModelData, loading } = useModelsOfTypeQuery({
     variables: {
       pageTypeId,

--- a/src/refundsSettings/components/RefundsSettingsPage/ReasonSettingsSection.tsx
+++ b/src/refundsSettings/components/RefundsSettingsPage/ReasonSettingsSection.tsx
@@ -41,7 +41,7 @@ export const ReasonSettingsSection = ({
   onChange,
   loading,
   disabled = false,
-}: ReasonSettingsSectionProps): JSX.Element => {
+}: ReasonSettingsSectionProps): React.ReactNode => {
   const selectedTypeLabel = modelTypesOptions.find(option => option.value === value)?.label;
 
   return (

--- a/src/refundsSettings/components/RefundsSettingsPage/RefundsSettingsPage.tsx
+++ b/src/refundsSettings/components/RefundsSettingsPage/RefundsSettingsPage.tsx
@@ -37,7 +37,7 @@ export const RefundsSettingsPage = ({
   refundReasonReferenceType,
   returnReasonReferenceType,
   saveButtonBarState,
-}: RefundsSettingsPageProps): JSX.Element => {
+}: RefundsSettingsPageProps): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
 

--- a/src/refundsSettings/views/RefundsSettings.tsx
+++ b/src/refundsSettings/views/RefundsSettings.tsx
@@ -21,7 +21,7 @@ import { submitRefundsSettingsForm } from "@dashboard/refundsSettings/components
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 
-export const RefundsSettings = (): JSX.Element => {
+export const RefundsSettings = (): React.ReactNode => {
   const intl = useIntl();
   const notify = useNotifier();
   const formId = useRef(Symbol("refunds-settings-form")).current;

--- a/src/refundsSettings/views/index.tsx
+++ b/src/refundsSettings/views/index.tsx
@@ -3,7 +3,7 @@ import { sectionNames } from "@dashboard/intl";
 import { RefundsSettings } from "@dashboard/refundsSettings/views/RefundsSettings";
 import { useIntl } from "react-intl";
 
-export const RefundsSettingsView = (): JSX.Element => {
+export const RefundsSettingsView = (): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/ripples/components/RippleVideoAnnouncement/RippleVideoAnnouncement.tsx
+++ b/src/ripples/components/RippleVideoAnnouncement/RippleVideoAnnouncement.tsx
@@ -29,7 +29,7 @@ const ActionLink = ({
 }: {
   action: RippleVideoAnnouncementAction;
   children: ReactNode;
-}): JSX.Element => {
+}): React.ReactNode => {
   if (action.external) {
     return (
       <Link href={action.href} target="_blank" rel="noopener noreferrer" inline={false}>

--- a/src/shipping/components/OrderValue/OrderValue.tsx
+++ b/src/shipping/components/OrderValue/OrderValue.tsx
@@ -47,7 +47,7 @@ const OrderValue = ({
   disabled,
   onChannelChange,
   onChannelsReplace,
-}: OrderValueProps): JSX.Element => {
+}: OrderValueProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormChannelErrors(
     ["maximumOrderPrice", "minimumOrderPrice"],

--- a/src/shipping/components/PricingCard/PricingCard.tsx
+++ b/src/shipping/components/PricingCard/PricingCard.tsx
@@ -46,7 +46,7 @@ const PricingCard = ({
   onFocusChannelComplete,
   onChange,
   onChannelsReplace,
-}: PricingCardProps): JSX.Element => {
+}: PricingCardProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormChannelErrors(["price"], errors as ChannelError[]);
   const sortedChannels = useMemo(() => sortChannelShippingDataByName(channels), [channels]);

--- a/src/shipping/components/ShippingMethodChannelsEmptyPlaceholder/ShippingMethodChannelsEmptyPlaceholder.tsx
+++ b/src/shipping/components/ShippingMethodChannelsEmptyPlaceholder/ShippingMethodChannelsEmptyPlaceholder.tsx
@@ -11,7 +11,7 @@ const messages = defineMessages({
   },
 });
 
-export const ShippingMethodChannelsEmptyPlaceholder = (): JSX.Element => (
+export const ShippingMethodChannelsEmptyPlaceholder = (): React.ReactNode => (
   <Placeholder
     icon={<Lock size={iconSize.medium} strokeWidth={iconStrokeWidthBySize.medium} aria-hidden />}
   >

--- a/src/shipping/components/ShippingZoneDetailsPage/Title.test.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/Title.test.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, type ReactNode } from "react";
 
 import { ShippingZoneDetailsTitle } from "./Title";
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/shipping/components/ShippingZoneRates/AlignedChannelPrice.tsx
+++ b/src/shipping/components/ShippingZoneRates/AlignedChannelPrice.tsx
@@ -15,7 +15,7 @@ const getDecimalSeparator = (locale: string): string => {
   return parts.find(part => part.type === "decimal")?.value ?? ".";
 };
 
-export const AlignedChannelPrice = ({ money }: AlignedChannelPriceProps): JSX.Element => {
+export const AlignedChannelPrice = ({ money }: AlignedChannelPriceProps): React.ReactNode => {
   const { locale } = useLocale();
   const decimalSeparator = useMemo(() => getDecimalSeparator(locale), [locale]);
   const formatted = formatMoneyAmount(money, locale);

--- a/src/shipping/components/ShippingZoneRates/ShippingZoneRateChannelTable.tsx
+++ b/src/shipping/components/ShippingZoneRates/ShippingZoneRateChannelTable.tsx
@@ -33,7 +33,7 @@ export const ShippingZoneRateChannelTable = ({
   variant,
   disabled,
   getRateChannelSetupHref,
-}: ShippingZoneRateChannelTableProps): JSX.Element => {
+}: ShippingZoneRateChannelTableProps): React.ReactNode => {
   const intl = useIntl();
   const [query, setQuery] = useState("");
   const filteredChannels = useMemo(

--- a/src/shipping/components/ShippingZoneRatesPage/Title.test.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/Title.test.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, type ReactNode } from "react";
 
 import { ShippingMethodDetailsTitle } from "./Title";
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ThemeProvider>{children}</ThemeProvider>
 );
 

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.test.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.test.tsx
@@ -17,7 +17,7 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
-const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const Wrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <ApolloMockedProvider>
     <MemoryRouter>
       <IntlProvider defaultLocale="en" locale="en">

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -99,7 +99,7 @@ export const SiteSettingsPage = ({
   saveButtonBarState,
   shop,
   onSubmit,
-}: SiteSettingsPageProps): JSX.Element => {
+}: SiteSettingsPageProps): React.ReactNode => {
   const intl = useIntl();
   const navigate = useNavigator();
   const [displayCountry, setDisplayCountry] = useStateFromProps(

--- a/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.tsx
@@ -22,7 +22,7 @@ export const StoreDetailsFields = ({
   disabled,
   errors,
   onChange,
-}: StoreDetailsFieldsProps): JSX.Element => {
+}: StoreDetailsFieldsProps): React.ReactNode => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name", "description"], errors);
 
@@ -60,7 +60,7 @@ export const StoreDetailsCard = ({
   disabled,
   errors,
   onChange,
-}: StoreDetailsCardProps): JSX.Element => {
+}: StoreDetailsCardProps): React.ReactNode => {
   const intl = useIntl();
 
   return (

--- a/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
+++ b/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
@@ -49,7 +49,7 @@ export const StaffAddMemberDialog = ({
   onConfirm,
   onSearchChange,
   open,
-}: StaffAddMemberDialogProps): JSX.Element => {
+}: StaffAddMemberDialogProps): React.ReactNode => {
   const dialogErrors = useModalDialogErrors(errors, open);
   const intl = useIntl();
   const formErrors = getFormErrors(["firstName", "lastName", "email"], dialogErrors);

--- a/src/staff/components/StaffMetadataDialog/StaffMetadataDialog.tsx
+++ b/src/staff/components/StaffMetadataDialog/StaffMetadataDialog.tsx
@@ -16,7 +16,7 @@ export const StaffMetadataDialog = ({
   onClose,
   open,
   staffMember,
-}: StaffMetadataDialogProps): JSX.Element => {
+}: StaffMetadataDialogProps): React.ReactNode => {
   const intl = useIntl();
   const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
     initialData: staffMember ?? undefined,

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.test.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.test.tsx
@@ -7,7 +7,7 @@ import { IntlProvider } from "react-intl";
 
 import { StaffPasswordResetDialog } from "./StaffPasswordResetDialog";
 
-const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+const TestWrapper = ({ children }: { children: ReactNode }): React.ReactNode => (
   <IntlProvider defaultLocale="en" locale="en">
     <ThemeProvider>{children}</ThemeProvider>
   </IntlProvider>

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -18,7 +18,7 @@ const FORM_ID = "staff-password-reset";
 
 const normalizeEmail = (value: string): string => value.trim().toLowerCase();
 
-export const StaffPasswordResetDialog = ({ open, onClose }: DialogProps): JSX.Element => {
+export const StaffPasswordResetDialog = ({ open, onClose }: DialogProps): React.ReactNode => {
   const intl = useIntl();
   const [email, setEmail] = useState("");
   const notify = useNotifier();

--- a/src/staff/components/StaffPreferences/StaffPreferences.tsx
+++ b/src/staff/components/StaffPreferences/StaffPreferences.tsx
@@ -12,7 +12,7 @@ interface StaffPreferencesProps {
 export const StaffPreferences = ({
   locale,
   onLocaleChange,
-}: StaffPreferencesProps): JSX.Element => {
+}: StaffPreferencesProps): React.ReactNode => {
   const intl = useIntl();
   const handleLocaleChange = async (nextLocale: Locale): Promise<void> => {
     if (!nextLocale) {

--- a/src/staff/components/StaffProperties/StaffProperties.tsx
+++ b/src/staff/components/StaffProperties/StaffProperties.tsx
@@ -67,7 +67,7 @@ export const StaffProperties = ({
   onChange,
   onImageDelete,
   onImageUpload,
-}: StaffPropertiesProps): JSX.Element => {
+}: StaffPropertiesProps): React.ReactNode => {
   const intl = useIntl();
   const imgInputAnchor = createRef<HTMLInputElement>();
   const clickImgInput = (): void => {

--- a/src/structures/components/MenuBulkDeleteDialog/MenuBulkDeleteDialog.tsx
+++ b/src/structures/components/MenuBulkDeleteDialog/MenuBulkDeleteDialog.tsx
@@ -22,7 +22,7 @@ export const MenuBulkDeleteDialog = ({
   onClose,
   onConfirm,
   open,
-}: MenuBulkDeleteDialogProps): JSX.Element => {
+}: MenuBulkDeleteDialogProps): React.ReactNode => {
   const isSubmitting = confirmButtonState === "loading";
 
   const handleClose = (): void => {

--- a/src/structures/components/MenuCreateDialog/MenuCreateDialog.tsx
+++ b/src/structures/components/MenuCreateDialog/MenuCreateDialog.tsx
@@ -35,7 +35,7 @@ export const MenuCreateDialog = ({
   onClose,
   onConfirm,
   open,
-}: MenuCreateDialogProps): JSX.Element => {
+}: MenuCreateDialogProps): React.ReactNode => {
   const intl = useIntl();
   const isSubmittingRef = useRef(false);
   const formErrors = getFormErrors(["name"], errors);

--- a/src/structures/components/MenuDeleteDialog/MenuDeleteDialog.tsx
+++ b/src/structures/components/MenuDeleteDialog/MenuDeleteDialog.tsx
@@ -23,7 +23,7 @@ export const MenuDeleteDialog = ({
   onConfirm,
   open,
   subtitle,
-}: MenuDeleteDialogProps): JSX.Element => {
+}: MenuDeleteDialogProps): React.ReactNode => {
   const isSubmitting = confirmButtonState === "loading";
 
   const handleClose = (): void => {

--- a/src/structures/components/MenuItemDialog/MenuItemDialog.tsx
+++ b/src/structures/components/MenuItemDialog/MenuItemDialog.tsx
@@ -46,7 +46,7 @@ export const MenuItemDialog = ({
   onClose,
   onSubmit,
   open,
-}: MenuItemDialogProps): JSX.Element => {
+}: MenuItemDialogProps): React.ReactNode => {
   const intl = useIntl();
   const isSubmittingRef = useRef(false);
 

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialog.tsx
@@ -32,7 +32,7 @@ export const TaxCountryDialog = ({
   onClose,
   onConfirm,
   open,
-}: TaxCountryDialogProps): JSX.Element => {
+}: TaxCountryDialogProps): React.ReactNode => {
   const intl = useIntl();
   const countryItems = useMemo(() => toCountryPickerItems(countries), [countries]);
   const countriesByCode = useMemo(

--- a/src/taxes/components/TaxCountryDialog/TaxCountryDialogCountriesList.tsx
+++ b/src/taxes/components/TaxCountryDialog/TaxCountryDialogCountriesList.tsx
@@ -17,7 +17,7 @@ export const TaxCountryDialogCountriesList = ({
   countries,
   onSelect,
   selectedCountryId,
-}: TaxCountryDialogCountriesListProps): JSX.Element => {
+}: TaxCountryDialogCountriesListProps): React.ReactNode => {
   return (
     <>
       {countries.map((country, index) => (


### PR DESCRIPTION
JSX.Element excludes null, strings, numbers, and fragments that components legitimately return. Fixes all 340 react-doctor no-jsx-element-type diagnostics.

createNavigationLucideIcon's factories declared `() => JSX.Element` as a function type, which the rule does not flag but which blocked widening the components they return, so those widened too.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
