### PR TITLE
refactor(graphiql): delete unreachable code from both GraphiQL forks

### DIFF
--- a/src/components/DevModePanel/DevModePanel.tsx
+++ b/src/components/DevModePanel/DevModePanel.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { useDashboardTheme } from "@dashboard/components/GraphiQL/styles";
+import { CodeMirrorFontSizeOverrides } from "@dashboard/components/GraphiQL/shared";
 import { DashboardModal } from "@dashboard/components/Modal";
 import { useOnboarding } from "@dashboard/welcomePage/WelcomePageOnboarding/onboardingContext/OnboardingContext";
 import { type FetcherOpts, type FetcherParams } from "@graphiql/toolkit";
@@ -15,7 +15,6 @@ import { getFetcher } from "./utils";
 export const DevModePanel = () => {
   const intl = useIntl();
   const subtitle = useContextualLink("dev_panel");
-  const { rootStyle } = useDashboardTheme();
   const { markOnboardingStepAsCompleted } = useOnboarding();
   const { isDevModeVisible, variables, devModeContent, setDevModeVisibility } = useDevModeContext();
   const fetcher = async (graphQLParams: FetcherParams, opts: FetcherOpts) => {
@@ -29,17 +28,6 @@ export const DevModePanel = () => {
 
     return result;
   };
-  const overwriteCodeMirrorCSSVariables = {
-    __html: `
-      .graphiql-container, .CodeMirror-info, .CodeMirror-lint-tooltip, reach-portal{
-        --font-size-hint: ${rootStyle["--font-size-hint"]} !important;
-        --font-size-inline-code: ${rootStyle["--font-size-inline-code"]} !important;
-        --font-size-body: ${rootStyle["--font-size-body"]} !important;
-        --font-size-h4: ${rootStyle["--font-size-h4"]} !important;
-        --font-size-h3: ${rootStyle["--font-size-h3"]} !important;
-        --font-size-h2: ${rootStyle["--font-size-h2"]} !important;
-    `,
-  };
 
   return (
     <DashboardModal open={isDevModeVisible} onChange={() => setDevModeVisibility(false)}>
@@ -49,7 +37,7 @@ export const DevModePanel = () => {
         height="100%"
         disableEscapeKeyDown
       >
-        <style dangerouslySetInnerHTML={overwriteCodeMirrorCSSVariables}></style>
+        <CodeMirrorFontSizeOverrides />
         <DashboardModal.Header>
           {intl.formatMessage(messages.title)}
 

--- a/src/components/GraphiQL/GraphiQL.tsx
+++ b/src/components/GraphiQL/GraphiQL.tsx
@@ -8,8 +8,6 @@ import {
   PrettifyIcon,
   QueryEditor,
   ToolbarButton,
-  Tooltip,
-  UnStyledButton,
   useCopyQuery,
   useEditorContext,
   usePluginContext,
@@ -23,42 +21,14 @@ import { useIntl } from "react-intl";
 
 import DryRun from "../DryRun/DryRun";
 import { messages } from "./messages";
+import { CodeMirrorFontSizeOverrides, PluginSidebarSection } from "./shared";
 import { useDashboardTheme, useEditorStyles, useGraphiQLThemeSwitcher, useStyles } from "./styles";
 
 type GraphiQLProps = Omit<GraphiQLProviderProps, "children"> & GraphiQLInterfaceProps;
 
-function GraphiQL({
-  dangerouslyAssumeSchemaIsValid,
-  defaultQuery,
-  defaultTabs,
-  externalFragments,
-  fetcher,
-  getDefaultFieldNames,
-  headers,
-  initialTabs,
-  inputValueDeprecation,
-  introspectionQueryName,
-  maxHistoryLength,
-  onEditOperationName,
-  onSchemaChange,
-  onTabChange,
-  onTogglePluginVisibility,
-  operationName,
-  plugins,
-  query,
-  response,
-  schema,
-  schemaDescription,
-  shouldPersistHeaders,
-  storage,
-  validationRules,
-  variables,
-  visiblePlugin,
-  defaultHeaders,
-  ...props
-}: GraphiQLProps & { data: WebhookFormData }) {
+function GraphiQL(props: GraphiQLProps & { data: WebhookFormData }) {
   // Ensure props are correct
-  if (typeof fetcher !== "function") {
+  if (typeof props.fetcher !== "function") {
     throw new TypeError(
       "The `GraphiQL` component requires a `fetcher` function to be passed as prop.",
     );
@@ -68,35 +38,7 @@ function GraphiQL({
   const [result, setResult] = useState("");
 
   return (
-    <GraphiQLProvider
-      getDefaultFieldNames={getDefaultFieldNames}
-      dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
-      defaultQuery={defaultQuery}
-      defaultHeaders={defaultHeaders}
-      defaultTabs={defaultTabs}
-      externalFragments={externalFragments}
-      fetcher={fetcher}
-      headers={headers}
-      initialTabs={initialTabs}
-      inputValueDeprecation={inputValueDeprecation}
-      introspectionQueryName={introspectionQueryName}
-      maxHistoryLength={maxHistoryLength}
-      onEditOperationName={onEditOperationName}
-      onSchemaChange={onSchemaChange}
-      onTabChange={onTabChange}
-      onTogglePluginVisibility={onTogglePluginVisibility}
-      plugins={plugins}
-      visiblePlugin={visiblePlugin}
-      operationName={operationName}
-      query={query}
-      response={response}
-      schema={schema}
-      schemaDescription={schemaDescription}
-      shouldPersistHeaders={shouldPersistHeaders}
-      storage={storage}
-      validationRules={validationRules}
-      variables={variables}
-    >
+    <GraphiQLProvider {...props}>
       <GraphiQLInterface
         {...props}
         showDialog={showDialog}
@@ -106,13 +48,14 @@ function GraphiQL({
       <DryRun
         showDialog={showDialog}
         setShowDialog={setShowDialog}
-        query={query}
+        query={props.query}
         setResult={setResult}
         syncEvents={props.data.syncEvents}
       />
     </GraphiQLProvider>
   );
 }
+
 type AddSuffix<Obj extends Record<string, any>, Suffix extends string> = {
   [Key in keyof Obj as `${string & Key}${Suffix}`]: Obj[Key];
 };
@@ -160,17 +103,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
       pluginResize.setHiddenElement(null);
     }
   };
-  const overwriteCodeMirrorCSSVariables = {
-    __html: `
-      .graphiql-container, .CodeMirror-info, .CodeMirror-lint-tooltip, reach-portal{
-        --font-size-hint: ${rootStyle["--font-size-hint"]} !important;
-        --font-size-inline-code: ${rootStyle["--font-size-inline-code"]} !important;
-        --font-size-body: ${rootStyle["--font-size-body"]} !important;
-        --font-size-h4: ${rootStyle["--font-size-h4"]} !important;
-        --font-size-h3: ${rootStyle["--font-size-h3"]} !important;
-        --font-size-h2: ${rootStyle["--font-size-h2"]} !important;
-    `,
-  };
 
   return (
     <div
@@ -178,37 +110,9 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
       className={clsx("graphiql-container", classes.graphiqlContainer)}
       style={rootStyle}
     >
-      <style dangerouslySetInnerHTML={overwriteCodeMirrorCSSVariables}></style>
+      <CodeMirrorFontSizeOverrides />
       <div className="graphiql-sidebar">
-        <div className="graphiql-sidebar-section">
-          {pluginContext?.plugins.map(plugin => {
-            const isVisible = plugin === pluginContext.visiblePlugin;
-            const label = `${isVisible ? "Hide" : "Show"} ${plugin.title}`;
-            const Icon = plugin.icon;
-
-            return (
-              <Tooltip key={plugin.title} label={label}>
-                <UnStyledButton
-                  type="button"
-                  className={isVisible ? "active" : ""}
-                  onClick={() => {
-                    if (isVisible) {
-                      pluginContext.setVisiblePlugin(null);
-                      pluginResize.setHiddenElement("first");
-                    } else {
-                      pluginContext.setVisiblePlugin(plugin);
-                      pluginResize.setHiddenElement(null);
-                    }
-                  }}
-                  aria-label={label}
-                >
-                  <Icon aria-hidden="true" />
-                </UnStyledButton>
-              </Tooltip>
-            );
-          })}
-        </div>
-        <div className="graphiql-sidebar-section"></div>
+        <PluginSidebarSection pluginResize={pluginResize} />
       </div>
       <div className={clsx("graphiql-main", classes.main)}>
         <div

--- a/src/components/GraphiQL/GraphiQL.tsx
+++ b/src/components/GraphiQL/GraphiQL.tsx
@@ -12,31 +12,18 @@ import {
   UnStyledButton,
   useCopyQuery,
   useEditorContext,
-  type UseHeaderEditorArgs,
   usePluginContext,
   usePrettifyEditors,
   type UseQueryEditorArgs,
-  type UseResponseEditorArgs,
-  type UseVariableEditorArgs,
   type WriteableEditorProps,
 } from "@graphiql/react";
 import clsx from "clsx";
-import { type ComponentType, type PropsWithChildren, type ReactNode, useState } from "react";
-import * as React from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { useIntl } from "react-intl";
 
 import DryRun from "../DryRun/DryRun";
 import { messages } from "./messages";
 import { useDashboardTheme, useEditorStyles, useGraphiQLThemeSwitcher, useStyles } from "./styles";
-
-interface GraphiQLToolbarConfig {
-  /**
-   * This content will be rendered after the built-in buttons of the toolbar.
-   * Note that this will not apply if you provide a completely custom toolbar
-   * (by passing `GraphiQL.Toolbar` as child to the `GraphiQL` component).
-   */
-  additionalContent?: React.ReactNode;
-}
 
 type GraphiQLProps = Omit<GraphiQLProviderProps, "children"> & GraphiQLInterfaceProps;
 
@@ -126,25 +113,15 @@ function GraphiQL({
     </GraphiQLProvider>
   );
 }
-// Export main windows/panes to be used separately if desired.
-GraphiQL.Toolbar = GraphiQLToolbar;
-
 type AddSuffix<Obj extends Record<string, any>, Suffix extends string> = {
   [Key in keyof Obj as `${string & Key}${Suffix}`]: Obj[Key];
 };
 
 type GraphiQLInterfaceProps = WriteableEditorProps &
   AddSuffix<Pick<UseQueryEditorArgs, "onEdit">, "Query"> &
-  Pick<UseQueryEditorArgs, "onCopyQuery"> &
-  AddSuffix<Pick<UseVariableEditorArgs, "onEdit">, "Variables"> &
-  AddSuffix<Pick<UseHeaderEditorArgs, "onEdit">, "Headers"> &
-  Pick<UseResponseEditorArgs, "responseTooltip"> & {
-    children?: ReactNode;
-    defaultEditorToolsVisibility?: boolean | "variables" | "headers";
-    isHeadersEditorEnabled?: boolean;
-    toolbar?: GraphiQLToolbarConfig;
+  Pick<UseQueryEditorArgs, "onCopyQuery"> & {
     showDialog?: boolean;
-    setShowDialog?: React.Dispatch<React.SetStateAction<boolean>>;
+    setShowDialog?: Dispatch<SetStateAction<boolean>>;
     result?: string;
   };
 
@@ -161,8 +138,7 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   useGraphiQLThemeSwitcher();
 
   const PluginContent = pluginContext?.visiblePlugin?.content;
-  const children = React.Children.toArray(props.children);
-  const toolbar = children.find(child => isChildComponentType(child, GraphiQL.Toolbar)) || (
+  const toolbar = (
     <>
       <ToolbarButton
         onClick={() => props.setShowDialog(true)}
@@ -177,7 +153,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
       <ToolbarButton onClick={() => copy()} label="Copy query (Shift-Ctrl-C)">
         <CopyIcon className="graphiql-toolbar-icon" aria-hidden="true" />
       </ToolbarButton>
-      {props.toolbar?.additionalContent || null}
     </>
   );
   const onClickReference = () => {
@@ -302,20 +277,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
       </div>
     </div>
   );
-}
-
-function GraphiQLToolbar<TProps>(props: PropsWithChildren<TProps>) {
-  return <>{props.children}</>;
-}
-
-GraphiQLToolbar.displayName = "GraphiQLToolbar";
-
-function isChildComponentType<T extends ComponentType>(child: any, component: T): child is T {
-  if (child?.type?.displayName && child.type.displayName === component.displayName) {
-    return true;
-  }
-
-  return child.type === component;
 }
 
 export default GraphiQL;

--- a/src/components/GraphiQL/shared.tsx
+++ b/src/components/GraphiQL/shared.tsx
@@ -1,0 +1,73 @@
+import { Tooltip, UnStyledButton, type useDragResize, usePluginContext } from "@graphiql/react";
+
+import { useDashboardTheme } from "./styles";
+
+/**
+ * The sidebar buttons that toggle each registered GraphiQL plugin (doc
+ * explorer, history, ...). Shared by both GraphiQL variants.
+ */
+export const PluginSidebarSection = ({
+  pluginResize,
+}: {
+  pluginResize: ReturnType<typeof useDragResize>;
+}) => {
+  const pluginContext = usePluginContext();
+
+  return (
+    <div className="graphiql-sidebar-section">
+      {pluginContext?.plugins.map(plugin => {
+        const isVisible = plugin === pluginContext.visiblePlugin;
+        const label = `${isVisible ? "Hide" : "Show"} ${plugin.title}`;
+        const Icon = plugin.icon;
+
+        return (
+          <Tooltip key={plugin.title} label={label}>
+            <UnStyledButton
+              type="button"
+              className={isVisible ? "active" : ""}
+              onClick={() => {
+                if (isVisible) {
+                  pluginContext.setVisiblePlugin(null);
+                  pluginResize.setHiddenElement("first");
+                } else {
+                  pluginContext.setVisiblePlugin(plugin);
+                  pluginResize.setHiddenElement(null);
+                }
+              }}
+              aria-label={label}
+            >
+              <Icon aria-hidden="true" />
+            </UnStyledButton>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};
+
+/**
+ * GraphiQL sizes CodeMirror through CSS variables that its own stylesheet sets
+ * on `.graphiql-container`. CodeMirror renders tooltips into portals outside
+ * that container, so the variables have to be re-declared globally to keep the
+ * dashboard font scale.
+ */
+export const CodeMirrorFontSizeOverrides = () => {
+  const { rootStyle } = useDashboardTheme();
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+      .graphiql-container, .CodeMirror-info, .CodeMirror-lint-tooltip, reach-portal{
+        --font-size-hint: ${rootStyle["--font-size-hint"]} !important;
+        --font-size-inline-code: ${rootStyle["--font-size-inline-code"]} !important;
+        --font-size-body: ${rootStyle["--font-size-body"]} !important;
+        --font-size-h4: ${rootStyle["--font-size-h4"]} !important;
+        --font-size-h3: ${rootStyle["--font-size-h3"]} !important;
+        --font-size-h2: ${rootStyle["--font-size-h2"]} !important;
+      }
+    `,
+      }}
+    />
+  );
+};

--- a/src/components/GraphiQL/styles.ts
+++ b/src/components/GraphiQL/styles.ts
@@ -65,6 +65,24 @@ export const useEditorStyles = () => {
   };
 };
 
+/**
+ * GraphiQL is sized and coloured through CSS custom properties. React's
+ * `CSSProperties` does not know about custom properties, so intersect it to
+ * keep both the `style={...}` assignability and the indexed reads.
+ */
+type DashboardThemeStyle = React.CSSProperties &
+  Record<
+    | "--font-size-body"
+    | "--font-size-h2"
+    | "--font-size-h3"
+    | "--font-size-h4"
+    | "--font-weight-regular"
+    | "--font-size-hint"
+    | "--font-size-inline-code"
+    | "--color-base",
+    string
+  >;
+
 export const useDashboardTheme = () => {
   const {
     themeValues: {
@@ -72,7 +90,7 @@ export const useDashboardTheme = () => {
     },
   } = useTheme();
   const match = background.default1.match(/hsla\(([^)]+)\)/);
-  const rootStyle = {
+  const rootStyle: DashboardThemeStyle = {
     "--font-size-body": vars.fontSize[4],
     "--font-size-h2": vars.fontSize[6],
     "--font-size-h3": vars.fontSize[5],
@@ -81,7 +99,7 @@ export const useDashboardTheme = () => {
     "--font-size-hint": vars.fontSize[5],
     "--font-size-inline-code": vars.fontSize[3],
     "--color-base": match ? match[1] : background.default1,
-  } as React.CSSProperties;
+  };
 
   return { rootStyle };
 };

--- a/src/components/GraphiQLPlain/GraphiQL.tsx
+++ b/src/components/GraphiQLPlain/GraphiQL.tsx
@@ -8,12 +8,9 @@
 import "graphiql/graphiql.min.css";
 
 import {
-  Button,
-  ButtonGroup,
   ChevronDownIcon,
   ChevronUpIcon,
   CopyIcon,
-  Dialog,
   ExecuteButton,
   GraphiQLProvider,
   type GraphiQLProviderProps,
@@ -41,26 +38,14 @@ import {
   type UseQueryEditorArgs,
   type UseResponseEditorArgs,
   useSchemaContext,
-  useStorageContext,
-  useTheme,
   type UseVariableEditorArgs,
   VariableEditor,
   type WriteableEditorProps,
 } from "@graphiql/react";
-import { type ComponentType, type PropsWithChildren, type ReactNode, useState } from "react";
-import * as React from "react";
+import { useState } from "react";
 
 import { useDashboardTheme, useGraphiQLThemeSwitcher } from "../GraphiQL/styles";
 import { AttachAuthButton } from "./AttachAuthButton";
-
-interface GraphiQLToolbarConfig {
-  /**
-   * This content will be rendered after the built-in buttons of the toolbar.
-   * Note that this will not apply if you provide a completely custom toolbar
-   * (by passing `GraphiQL.Toolbar` as child to the `GraphiQL` component).
-   */
-  additionalContent?: React.ReactNode;
-}
 
 /**
  * API docs for this live here:
@@ -143,12 +128,10 @@ function GraphiQL({
       validationRules={validationRules}
       variables={variables}
     >
-      <GraphiQLInterface showPersistHeadersSettings={shouldPersistHeaders} {...props} />
+      <GraphiQLInterface {...props} />
     </GraphiQLProvider>
   );
 }
-GraphiQL.Toolbar = GraphiQLToolbar;
-GraphiQL.Footer = GraphiQLFooter;
 
 type AddSuffix<Obj extends Record<string, any>, Suffix extends string> = {
   [Key in keyof Obj as `${string & Key}${Suffix}`]: Obj[Key];
@@ -160,7 +143,6 @@ type GraphiQLInterfaceProps = WriteableEditorProps &
   AddSuffix<Pick<UseVariableEditorArgs, "onEdit">, "Variables"> &
   AddSuffix<Pick<UseHeaderEditorArgs, "onEdit">, "Headers"> &
   Pick<UseResponseEditorArgs, "responseTooltip"> & {
-    children?: ReactNode;
     /**
      * Set the default state for the editor tools.
      * - `false` hides the editor tools
@@ -176,16 +158,6 @@ type GraphiQLInterfaceProps = WriteableEditorProps &
      * @default true
      */
     isHeadersEditorEnabled?: boolean;
-    /**
-     * An object that allows configuration of the toolbar next to the query
-     * editor.
-     */
-    toolbar?: GraphiQLToolbarConfig;
-    /**
-     * Indicates if settings for persisting headers should appear in the
-     * settings modal.
-     */
-    showPersistHeadersSettings?: boolean;
   };
 
 function GraphiQLInterface(props: GraphiQLInterfaceProps) {
@@ -193,7 +165,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   const editorContext = useEditorContext({ nonNull: true });
   const executionContext = useExecutionContext({ nonNull: true });
   const schemaContext = useSchemaContext({ nonNull: true });
-  const storageContext = useStorageContext();
   const pluginContext = usePluginContext();
   const copy = useCopyQuery({ onCopyQuery: props.onCopyQuery });
   const merge = useMergeQuery();
@@ -202,7 +173,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
 
   useGraphiQLThemeSwitcher();
 
-  const { theme, setTheme } = useTheme();
   const PluginContent = pluginContext?.visiblePlugin?.content;
   const pluginResize = useDragResize({
     defaultSizeRelation: 1 / 3,
@@ -237,10 +207,7 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
         : "variables";
     },
   );
-  const [showDialog, setShowDialog] = useState<"settings" | "short-keys" | null>(null);
-  const [clearStorageStatus, setClearStorageStatus] = useState<"success" | "error" | null>(null);
-  const children = React.Children.toArray(props.children);
-  const toolbar = children.find(child => isChildComponentType(child, GraphiQL.Toolbar)) || (
+  const toolbar = (
     <>
       <ToolbarButton onClick={() => prettify()} label="Prettify query (Shift-Ctrl-P)">
         <PrettifyIcon className="graphiql-toolbar-icon" aria-hidden="true" />
@@ -251,21 +218,13 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
       <ToolbarButton onClick={() => copy()} label="Copy query (Shift-Ctrl-C)">
         <CopyIcon className="graphiql-toolbar-icon" aria-hidden="true" />
       </ToolbarButton>
-      {props.toolbar?.additionalContent || null}
     </>
   );
-  const footer = children.find(child => isChildComponentType(child, GraphiQL.Footer));
   const onClickReference = () => {
     if (pluginResize.hiddenElement === "first") {
       pluginResize.setHiddenElement(null);
     }
   };
-  const modifier =
-    window.navigator.platform.toLowerCase().indexOf("mac") === 0 ? (
-      <code className="graphiql-key">Cmd</code>
-    ) : (
-      <code className="graphiql-key">Ctrl</code>
-    );
 
   return (
     <div data-testid="graphiql-container" className="graphiql-container" style={{ ...rootStyle }}>
@@ -537,216 +496,14 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                     responseTooltip={props.responseTooltip}
                     keyMap={props.keyMap}
                   />
-                  {footer}
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      {/* @ts-expect-error legacy types */}
-      <Dialog isOpen={showDialog === "short-keys"} onDismiss={() => setShowDialog(null)}>
-        <div className="graphiql-dialog-header">
-          <div className="graphiql-dialog-title">Short Keys</div>
-          <Dialog.Close onClick={() => setShowDialog(null)} />
-        </div>
-        <div className="graphiql-dialog-section">
-          <div>
-            <table className="graphiql-table">
-              <thead>
-                <tr>
-                  <th>Short key</th>
-                  <th>Function</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    {modifier}
-                    {" + "}
-                    <code className="graphiql-key">F</code>
-                  </td>
-                  <td>Search in editor</td>
-                </tr>
-                <tr>
-                  <td>
-                    {modifier}
-                    {" + "}
-                    <code className="graphiql-key">K</code>
-                  </td>
-                  <td>Search in documentation</td>
-                </tr>
-                <tr>
-                  <td>
-                    {modifier}
-                    {" + "}
-                    <code className="graphiql-key">Enter</code>
-                  </td>
-                  <td>Execute query</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code className="graphiql-key">Ctrl</code>
-                    {" + "}
-                    <code className="graphiql-key">Shift</code>
-                    {" + "}
-                    <code className="graphiql-key">P</code>
-                  </td>
-                  <td>Prettify editors</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code className="graphiql-key">Ctrl</code>
-                    {" + "}
-                    <code className="graphiql-key">Shift</code>
-                    {" + "}
-                    <code className="graphiql-key">M</code>
-                  </td>
-                  <td>Merge fragments definitions into operation definition</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code className="graphiql-key">Ctrl</code>
-                    {" + "}
-                    <code className="graphiql-key">Shift</code>
-                    {" + "}
-                    <code className="graphiql-key">C</code>
-                  </td>
-                  <td>Copy query</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code className="graphiql-key">Ctrl</code>
-                    {" + "}
-                    <code className="graphiql-key">Shift</code>
-                    {" + "}
-                    <code className="graphiql-key">R</code>
-                  </td>
-                  <td>Re-fetch schema using introspection</td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              The editors use{" "}
-              <a
-                href="https://codemirror.net/5/doc/manual.html#keymaps"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                CodeMirror Key Maps
-              </a>{" "}
-              that add more short keys. This instance of Graph<em>i</em>QL uses{" "}
-              <code>{props.keyMap || "sublime"}</code>.
-            </p>
-          </div>
-        </div>
-      </Dialog>
-      {/* @ts-expect-error legacy types */}
-      <Dialog
-        isOpen={showDialog === "settings"}
-        onDismiss={() => {
-          setShowDialog(null);
-          setClearStorageStatus(null);
-        }}
-      >
-        <div className="graphiql-dialog-header">
-          <div className="graphiql-dialog-title">Settings</div>
-          <Dialog.Close
-            onClick={() => {
-              setShowDialog(null);
-              setClearStorageStatus(null);
-            }}
-          />
-        </div>
-        <div className="graphiql-dialog-section">
-          <div>
-            <div className="graphiql-dialog-section-title">Theme</div>
-            <div className="graphiql-dialog-section-caption">
-              Adjust how the interface looks like.
-            </div>
-          </div>
-          <div>
-            <ButtonGroup>
-              <Button
-                type="button"
-                className={theme === null ? "active" : ""}
-                onClick={() => setTheme(null)}
-              >
-                System
-              </Button>
-              <Button
-                type="button"
-                className={theme === "light" ? "active" : ""}
-                onClick={() => setTheme("light")}
-              >
-                Light
-              </Button>
-              <Button
-                type="button"
-                className={theme === "dark" ? "active" : ""}
-                onClick={() => setTheme("dark")}
-              >
-                Dark
-              </Button>
-            </ButtonGroup>
-          </div>
-        </div>
-        {storageContext ? (
-          <div className="graphiql-dialog-section">
-            <div>
-              <div className="graphiql-dialog-section-title">Clear storage</div>
-              <div className="graphiql-dialog-section-caption">
-                Remove all locally stored data and start fresh.
-              </div>
-            </div>
-            <div>
-              <Button
-                type="button"
-                state={clearStorageStatus || undefined}
-                disabled={clearStorageStatus === "success"}
-                onClick={() => {
-                  try {
-                    setClearStorageStatus("success");
-                  } catch {
-                    setClearStorageStatus("error");
-                  }
-                }}
-              >
-                {clearStorageStatus === "success"
-                  ? "Cleared data"
-                  : clearStorageStatus === "error"
-                    ? "Failed"
-                    : "Clear data"}
-              </Button>
-            </div>
-          </div>
-        ) : null}
-      </Dialog>
     </div>
   );
-}
-
-// Configure the UI by providing this Component as a child of GraphiQL.
-function GraphiQLToolbar<TProps>(props: PropsWithChildren<TProps>) {
-  return <>{props.children}</>;
-}
-
-GraphiQLToolbar.displayName = "GraphiQLToolbar";
-
-// Configure the UI by providing this Component as a child of GraphiQL.
-function GraphiQLFooter<TProps>(props: PropsWithChildren<TProps>) {
-  return <div className="graphiql-footer">{props.children}</div>;
-}
-
-GraphiQLFooter.displayName = "GraphiQLFooter";
-
-// Determines if the React child is of the same type of the provided React component
-function isChildComponentType<T extends ComponentType>(child: any, component: T): child is T {
-  if (child?.type?.displayName && child.type.displayName === component.displayName) {
-    return true;
-  }
-
-  return child.type === component;
 }
 
 export default GraphiQL;

--- a/src/components/GraphiQLPlain/GraphiQL.tsx
+++ b/src/components/GraphiQLPlain/GraphiQL.tsx
@@ -28,7 +28,6 @@ import {
   Tooltip,
   UnStyledButton,
   useCopyQuery,
-  useDragResize,
   useEditorContext,
   useExecutionContext,
   type UseHeaderEditorArgs,
@@ -44,7 +43,8 @@ import {
 } from "@graphiql/react";
 import { useState } from "react";
 
-import { useDashboardTheme, useGraphiQLThemeSwitcher } from "../GraphiQL/styles";
+import { PluginSidebarSection } from "../GraphiQL/shared";
+import { useDashboardTheme, useEditorStyles, useGraphiQLThemeSwitcher } from "../GraphiQL/styles";
 import { AttachAuthButton } from "./AttachAuthButton";
 
 /**
@@ -61,73 +61,16 @@ type GraphiQLProps = Omit<GraphiQLProviderProps, "children"> & GraphiQLInterface
  * @see https://github.com/graphql/graphiql#usage
  */
 
-function GraphiQL({
-  dangerouslyAssumeSchemaIsValid,
-  defaultQuery,
-  defaultTabs,
-  externalFragments,
-  fetcher,
-  getDefaultFieldNames,
-  headers,
-  initialTabs,
-  inputValueDeprecation,
-  introspectionQueryName,
-  maxHistoryLength,
-  onEditOperationName,
-  onSchemaChange,
-  onTabChange,
-  onTogglePluginVisibility,
-  operationName,
-  plugins,
-  query,
-  response,
-  schema,
-  schemaDescription,
-  shouldPersistHeaders,
-  storage,
-  validationRules,
-  variables,
-  visiblePlugin,
-  defaultHeaders,
-  ...props
-}: GraphiQLProps) {
+function GraphiQL(props: GraphiQLProps) {
   // Ensure props are correct
-  if (typeof fetcher !== "function") {
+  if (typeof props.fetcher !== "function") {
     throw new TypeError(
       "The `GraphiQL` component requires a `fetcher` function to be passed as prop.",
     );
   }
 
   return (
-    <GraphiQLProvider
-      getDefaultFieldNames={getDefaultFieldNames}
-      dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
-      defaultQuery={defaultQuery}
-      defaultHeaders={defaultHeaders}
-      defaultTabs={defaultTabs}
-      externalFragments={externalFragments}
-      fetcher={fetcher}
-      headers={headers}
-      initialTabs={initialTabs}
-      inputValueDeprecation={inputValueDeprecation}
-      introspectionQueryName={introspectionQueryName}
-      maxHistoryLength={maxHistoryLength}
-      onEditOperationName={onEditOperationName}
-      onSchemaChange={onSchemaChange}
-      onTabChange={onTabChange}
-      onTogglePluginVisibility={onTogglePluginVisibility}
-      plugins={plugins}
-      visiblePlugin={visiblePlugin}
-      operationName={operationName}
-      query={query}
-      response={response}
-      schema={schema}
-      schemaDescription={schemaDescription}
-      shouldPersistHeaders={shouldPersistHeaders}
-      storage={storage}
-      validationRules={validationRules}
-      variables={variables}
-    >
+    <GraphiQLProvider {...props}>
       <GraphiQLInterface {...props} />
     </GraphiQLProvider>
   );
@@ -166,6 +109,7 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   const executionContext = useExecutionContext({ nonNull: true });
   const schemaContext = useSchemaContext({ nonNull: true });
   const pluginContext = usePluginContext();
+  const { pluginResize, editorResize, editorToolsResize } = useEditorStyles();
   const copy = useCopyQuery({ onCopyQuery: props.onCopyQuery });
   const merge = useMergeQuery();
   const prettify = usePrettifyEditors();
@@ -174,23 +118,6 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   useGraphiQLThemeSwitcher();
 
   const PluginContent = pluginContext?.visiblePlugin?.content;
-  const pluginResize = useDragResize({
-    defaultSizeRelation: 1 / 3,
-    direction: "horizontal",
-    initiallyHidden: pluginContext?.visiblePlugin ? undefined : "first",
-    sizeThresholdSecond: 200,
-    storageKey: "docExplorerFlex",
-  });
-  const editorResize = useDragResize({
-    direction: "horizontal",
-    storageKey: "editorFlex",
-  });
-  const editorToolsResize = useDragResize({
-    defaultSizeRelation: 3,
-    direction: "vertical",
-    sizeThresholdSecond: 60,
-    storageKey: "secondaryEditorFlex",
-  });
   const [activeSecondaryEditor, setActiveSecondaryEditor] = useState<"variables" | "headers">(
     () => {
       if (
@@ -229,34 +156,7 @@ function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   return (
     <div data-testid="graphiql-container" className="graphiql-container" style={{ ...rootStyle }}>
       <div className="graphiql-sidebar">
-        <div className="graphiql-sidebar-section">
-          {pluginContext?.plugins.map(plugin => {
-            const isVisible = plugin === pluginContext.visiblePlugin;
-            const label = `${isVisible ? "Hide" : "Show"} ${plugin.title}`;
-            const Icon = plugin.icon;
-
-            return (
-              <Tooltip key={plugin.title} label={label}>
-                <UnStyledButton
-                  type="button"
-                  className={isVisible ? "active" : ""}
-                  onClick={() => {
-                    if (isVisible) {
-                      pluginContext.setVisiblePlugin(null);
-                      pluginResize.setHiddenElement("first");
-                    } else {
-                      pluginContext.setVisiblePlugin(plugin);
-                      pluginResize.setHiddenElement(null);
-                    }
-                  }}
-                  aria-label={label}
-                >
-                  <Icon aria-hidden="true" />
-                </UnStyledButton>
-              </Tooltip>
-            );
-          })}
-        </div>
+        <PluginSidebarSection pluginResize={pluginResize} />
         <div className="graphiql-sidebar-section">
           <Tooltip label="Re-fetch GraphQL schema">
             <UnStyledButton

--- a/src/extensions/components/WebhookDetailsPage/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
+++ b/src/extensions/components/WebhookDetailsPage/components/WebhookSubscriptionQuery/WebhookSubscriptionQuery.tsx
@@ -58,14 +58,11 @@ export const WebhookSubscriptionQuery = ({
       </DashboardCard.Header>
       <DashboardCard.Content className={classes.cardContent}>
         <GraphiQL
-          data-test-id="graphiql-webhook"
-          defaultEditorToolsVisibility={"headers"}
           fetcher={fetcher}
           query={query}
           storage={null}
           onEditQuery={setQuery}
           plugins={[explorerPlugin]}
-          isHeadersEditorEnabled={false}
           data={data}
         />
       </DashboardCard.Content>


### PR DESCRIPTION
GraphiQLPlain is a vendored copy of graphiql@2.4.7's GraphiQL.tsx. The fork
removed upstream's Settings and Short Keys sidebar buttons but kept both
Dialogs, so `showDialog` could only ever be null -- ~180 lines of markup that
never rendered, plus the state, `useStorageContext`, `useTheme` and `modifier`
that only fed them. `showPersistHeadersSettings` was passed and declared but
never read, since the settings section that used it was already gone.

Neither consumer passes children to either fork, so `GraphiQL.Toolbar`,
`GraphiQL.Footer`, `isChildComponentType` and the `toolbar.additionalContent`
escape hatch were unreachable in both.

WebhookSubscriptionQuery passed `defaultEditorToolsVisibility`,
`isHeadersEditorEnabled` and `data-test-id` to the stripped fork, which has no
editor tools and hardcodes its own test id -- all three were silently dropped.
Removed them from the call site and the props type so it stops advertising
behaviour it does not have.

No behaviour change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
