### PR TITLE
refactor: gate webhook secretKey to the main schema

### DIFF
--- a/schema-staging.graphql
+++ b/schema-staging.graphql
@@ -1754,9 +1754,6 @@ type Webhook implements Node @doc(category: "Webhooks") {
   """Informs if webhook is activated."""
   isActive: Boolean!
 
-  """Used to create a hash signature for each payload."""
-  secretKey: String @deprecated(reason: "As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.")
-
   """Used to define payloads for specific events."""
   subscriptionQuery: String
 
@@ -22612,9 +22609,6 @@ input WebhookCreateInput @doc(category: "Webhooks") {
   """Determine if webhook will be set active or not."""
   isActive: Boolean
 
-  """The secret key used to create a hash signature with each payload."""
-  secretKey: String @deprecated(reason: "As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.")
-
   """Subscription query used to define a webhook payload."""
   query: String
 
@@ -22674,9 +22668,6 @@ input WebhookUpdateInput @doc(category: "Webhooks") {
 
   """Determine if webhook will be set active or not."""
   isActive: Boolean
-
-  """Use to create a hash signature with each payload."""
-  secretKey: String @deprecated(reason: "As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.")
 
   """Subscription query used to define a webhook payload."""
   query: String

--- a/src/extensions/components/WebhookDetailsPage/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/extensions/components/WebhookDetailsPage/components/WebhookInfo/WebhookInfo.tsx
@@ -2,6 +2,7 @@ import { DashboardCard } from "@dashboard/components/Card";
 import FormSpacer from "@dashboard/components/FormSpacer";
 import Link from "@dashboard/components/Link";
 import { type WebhookErrorFragment } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import { commonMessages } from "@dashboard/intl";
 import { WEBHOOK_PAYLOAD_SIGNATURE_DOCS_URL } from "@dashboard/links";
 import { getFormErrors } from "@dashboard/utils/errors";
@@ -67,59 +68,64 @@ export const WebhookInfo = ({ data, disabled, errors, onChange, setValue }: Webh
           value={data.targetUrl}
           onChange={onChange}
         />
-        <FormSpacer />
-        <Input
-          disabled={disabled}
-          error={!!formErrors.secretKey}
-          helperText={
-            getWebhookErrorMessage(formErrors.secretKey, intl) ||
-            intl.formatMessage(messages.secretKeyDescription)
-          }
-          label={intl.formatMessage(messages.secretKey)}
-          name="secretKey"
-          value={data.secretKey}
-          onChange={onChange}
-          endAdornment={
-            <Tooltip>
-              <Tooltip.Trigger>
-                <Chip
-                  backgroundColor="critical1"
-                  borderColor="critical1"
-                  color="critical1"
-                  size="medium"
-                  style={{ cursor: "pointer" }}
-                >
-                  {intl.formatMessage(commonMessages.deprecated)}
-                </Chip>
-              </Tooltip.Trigger>
-              <Tooltip.Content side="top">
-                <Tooltip.Arrow />
-                <Box
-                  backgroundColor="critical1"
-                  padding={4}
-                  borderRadius={2}
-                  style={{ minWidth: 200 }}
-                >
-                  <Text fontWeight="bold" color="default1" marginBottom={2}>
-                    <FormattedMessage defaultMessage="Deprecated" id="z9c6/C" />
-                  </Text>
-                  <Box display="flex" gap={1} alignItems="center">
-                    <Text color="default1">
-                      <FormattedMessage {...messages.useSignature} />
-                    </Text>
-                    <Link
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={WEBHOOK_PAYLOAD_SIGNATURE_DOCS_URL}
+        {/* secretKey is removed from the API in 3.24; drop this once staging becomes main */}
+        {isMainSchema() && (
+          <>
+            <FormSpacer />
+            <Input
+              disabled={disabled}
+              error={!!formErrors.secretKey}
+              helperText={
+                getWebhookErrorMessage(formErrors.secretKey, intl) ||
+                intl.formatMessage(messages.secretKeyDescription)
+              }
+              label={intl.formatMessage(messages.secretKey)}
+              name="secretKey"
+              value={data.secretKey}
+              onChange={onChange}
+              endAdornment={
+                <Tooltip>
+                  <Tooltip.Trigger>
+                    <Chip
+                      backgroundColor="critical1"
+                      borderColor="critical1"
+                      color="critical1"
+                      size="medium"
+                      style={{ cursor: "pointer" }}
                     >
-                      <FormattedMessage {...messages.learnMore} />
-                    </Link>
-                  </Box>
-                </Box>
-              </Tooltip.Content>
-            </Tooltip>
-          }
-        />
+                      {intl.formatMessage(commonMessages.deprecated)}
+                    </Chip>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side="top">
+                    <Tooltip.Arrow />
+                    <Box
+                      backgroundColor="critical1"
+                      padding={4}
+                      borderRadius={2}
+                      style={{ minWidth: 200 }}
+                    >
+                      <Text fontWeight="bold" color="default1" marginBottom={2}>
+                        <FormattedMessage defaultMessage="Deprecated" id="z9c6/C" />
+                      </Text>
+                      <Box display="flex" gap={1} alignItems="center">
+                        <Text color="default1">
+                          <FormattedMessage {...messages.useSignature} />
+                        </Text>
+                        <Link
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          href={WEBHOOK_PAYLOAD_SIGNATURE_DOCS_URL}
+                        >
+                          <FormattedMessage {...messages.learnMore} />
+                        </Link>
+                      </Box>
+                    </Box>
+                  </Tooltip.Content>
+                </Tooltip>
+              }
+            />
+          </>
+        )}
       </DashboardCard.Content>
     </DashboardCard>
   );

--- a/src/extensions/views/AddCustomExtensionWebhook/AddCustomExtensionWebhook.stagingSchema.test.tsx
+++ b/src/extensions/views/AddCustomExtensionWebhook/AddCustomExtensionWebhook.stagingSchema.test.tsx
@@ -1,0 +1,79 @@
+import {
+  useAppQuery,
+  useWebhookCreateMutation,
+  WebhookEventTypeAsyncEnum,
+} from "@dashboard/graphql";
+import { render } from "@testing-library/react";
+
+import { type WebhookFormData } from "../../components/WebhookDetailsPage/WebhookDetailsPage";
+import { AddCustomExtensionWebhook } from "./AddCustomExtensionWebhook";
+
+const mockWebhookDetailsPage = jest.fn();
+
+jest.mock("@dashboard/graphql/schemaVersion", () => ({
+  isMainSchema: () => false,
+  isStagingSchema: () => true,
+}));
+
+jest.mock("@dashboard/graphql", () => ({
+  ...(jest.requireActual("@dashboard/graphql") as object),
+  useAppQuery: jest.fn(),
+  useWebhookCreateMutation: jest.fn(),
+}));
+
+jest.mock("@dashboard/hooks/useNavigator", () => () => jest.fn());
+
+jest.mock("@dashboard/hooks/useNotifier/useNotifier", () => ({
+  useNotifier: () => jest.fn(),
+}));
+
+jest.mock("../../hooks/useAvailableEvents", () => ({
+  useAvailableEvents: () => [],
+}));
+
+jest.mock("../../components/WebhookDetailsPage/WebhookDetailsPage", () => ({
+  WebhookDetailsPage: (props: unknown) => {
+    mockWebhookDetailsPage(props);
+
+    return <div data-test-id="webhook-details-page" />;
+  },
+}));
+
+describe("AddCustomExtensionWebhook with staging schema", () => {
+  const mockWebhookCreate = jest.fn();
+
+  const formData: WebhookFormData = {
+    syncEvents: [],
+    asyncEvents: [WebhookEventTypeAsyncEnum.ORDER_CREATED],
+    isActive: true,
+    name: "Test webhook",
+    secretKey: "secret",
+    targetUrl: "https://example.com/webhook",
+    subscriptionQuery: "subscription { event { ... on OrderCreated { order { id } } } }",
+    customHeaders: "{}",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppQuery as jest.Mock).mockReturnValue({ data: { app: { name: "Test app" } } });
+    (useWebhookCreateMutation as jest.Mock).mockReturnValue([
+      mockWebhookCreate.mockResolvedValue({ data: { webhookCreate: { errors: [] } } }),
+      { status: "default", data: undefined },
+    ]);
+  });
+
+  it("omits secretKey, removed from the API in 3.24", async () => {
+    // Arrange
+    render(<AddCustomExtensionWebhook appId="app-1" />);
+
+    const { onSubmit } = mockWebhookDetailsPage.mock.calls[0][0];
+
+    // Act
+    await onSubmit(formData);
+
+    // Assert
+    expect(mockWebhookCreate).toHaveBeenCalledWith({
+      variables: { input: expect.objectContaining({ secretKey: undefined }) },
+    });
+  });
+});

--- a/src/extensions/views/AddCustomExtensionWebhook/AddCustomExtensionWebhook.tsx
+++ b/src/extensions/views/AddCustomExtensionWebhook/AddCustomExtensionWebhook.tsx
@@ -5,6 +5,7 @@ import {
   useWebhookCreateMutation,
   WebhookEventTypeAsyncEnum,
 } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier/useNotifier";
 import { extractMutationErrors } from "@dashboard/misc";
@@ -53,7 +54,8 @@ export const AddCustomExtensionWebhook = ({ appId }: CustomAppWebhookCreateProps
               : data.asyncEvents,
             isActive: data.isActive,
             name: data.name,
-            secretKey: data.secretKey,
+            // Removed from the input in 3.24; staging builds stop sending it
+            secretKey: isMainSchema() ? data.secretKey : undefined,
             targetUrl: data.targetUrl,
             query: data.subscriptionQuery,
             customHeaders: data.customHeaders,

--- a/src/extensions/views/EditCustomExtensionWebhook/EditCustomExtensionWebhook.tsx
+++ b/src/extensions/views/EditCustomExtensionWebhook/EditCustomExtensionWebhook.tsx
@@ -6,6 +6,7 @@ import {
   useWebhookUpdateMutation,
   WebhookEventTypeAsyncEnum,
 } from "@dashboard/graphql";
+import { isMainSchema } from "@dashboard/graphql/schemaVersion";
 import { useNotifier } from "@dashboard/hooks/useNotifier/useNotifier";
 import { extractMutationErrors, getStringOrPlaceholder } from "@dashboard/misc";
 import { useIntl } from "react-intl";
@@ -54,7 +55,8 @@ export const EditCustomExtensionWebhook = ({ id }: EditCustomExtensionWebhookPro
               : data.asyncEvents,
             isActive: data.isActive,
             name: data.name,
-            secretKey: data.secretKey,
+            // Removed from the input in 3.24; staging builds stop sending it
+            secretKey: isMainSchema() ? data.secretKey : undefined,
             targetUrl: data.targetUrl,
             query: data.subscriptionQuery,
             customHeaders: data.customHeaders,

--- a/src/fragments/webhooks.ts
+++ b/src/fragments/webhooks.ts
@@ -21,7 +21,10 @@ export const webhookDetailsFragment = gql`
     asyncEvents {
       eventType
     }
-    secretKey
+    # Removed from Webhook in 3.24. @lockSchema keeps it off the wire on staging builds, so the
+    # one document serves both schemas — see src/graphql/lockSchema.ts. Readers are gated behind
+    # isMainSchema(); delete the line and its readers once staging becomes main.
+    secretKey @lockSchema(schema: "main")
     targetUrl
     subscriptionQuery
     customHeaders

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -4220,7 +4220,7 @@ export const WebhookDetailsFragmentDoc = gql`
   asyncEvents {
     eventType
   }
-  secretKey
+  secretKey @lockSchema(schema: "main")
   targetUrl
   subscriptionQuery
   customHeaders

--- a/src/graphql/typePoliciesStaging.generated.ts
+++ b/src/graphql/typePoliciesStaging.generated.ts
@@ -7331,7 +7331,7 @@ export type WarehouseUpdatedFieldPolicy = {
 	version?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type WebhookKeySpecifier = ('app' | 'asyncEvents' | 'customHeaders' | 'eventDeliveries' | 'events' | 'id' | 'identifier' | 'isActive' | 'name' | 'secretKey' | 'subscriptionQuery' | 'syncEvents' | 'targetUrl' | WebhookKeySpecifier)[];
+export type WebhookKeySpecifier = ('app' | 'asyncEvents' | 'customHeaders' | 'eventDeliveries' | 'events' | 'id' | 'identifier' | 'isActive' | 'name' | 'subscriptionQuery' | 'syncEvents' | 'targetUrl' | WebhookKeySpecifier)[];
 export type WebhookFieldPolicy = {
 	app?: FieldPolicy<any> | FieldReadFunction<any>,
 	asyncEvents?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -7342,7 +7342,6 @@ export type WebhookFieldPolicy = {
 	identifier?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
-	secretKey?: FieldPolicy<any> | FieldReadFunction<any>,
 	subscriptionQuery?: FieldPolicy<any> | FieldReadFunction<any>,
 	syncEvents?: FieldPolicy<any> | FieldReadFunction<any>,
 	targetUrl?: FieldPolicy<any> | FieldReadFunction<any>

--- a/src/graphql/typesStaging.generated.ts
+++ b/src/graphql/typesStaging.generated.ts
@@ -9200,11 +9200,6 @@ export type WebhookCreateInput = {
   name?: InputMaybe<Scalars['String']['input']>;
   /** Subscription query used to define a webhook payload. */
   query?: InputMaybe<Scalars['String']['input']>;
-  /**
-   * The secret key used to create a hash signature with each payload.
-   * @deprecated As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
-   */
-  secretKey?: InputMaybe<Scalars['String']['input']>;
   /** The synchronous events that webhook wants to subscribe. */
   syncEvents?: InputMaybe<Array<WebhookEventTypeSyncEnum>>;
   /** The url to receive the payload. */
@@ -10258,11 +10253,6 @@ export type WebhookUpdateInput = {
   name?: InputMaybe<Scalars['String']['input']>;
   /** Subscription query used to define a webhook payload. */
   query?: InputMaybe<Scalars['String']['input']>;
-  /**
-   * Use to create a hash signature with each payload.
-   * @deprecated As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
-   */
-  secretKey?: InputMaybe<Scalars['String']['input']>;
   /** The synchronous events that webhook wants to subscribe. */
   syncEvents?: InputMaybe<Array<WebhookEventTypeSyncEnum>>;
   /** The url to receive the payload. */


### PR DESCRIPTION
secretKey is removed from Webhook, WebhookCreateInput and WebhookUpdateInput in 3.24, so staging builds must stop reading and sending it. Uses the existing @lockSchema mechanism to keep one document serving both schemas, and gates the form field and mutation input behind isMainSchema().

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
