### PR TITLE
fix: prepend app mount uri to links opened in new tab

### DIFF
--- a/.changeset/thick-moons-shave.md
+++ b/.changeset/thick-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Now "Open product details" in order lines opens a working link when the Dashboard is mounted under a sub-path (e.g. `/dashboard/`). Previously the new tab dropped the mount point and landed on a 404. The same fix applies to the channel catalog "view products" links.

--- a/src/channels/components/ChannelCatalogSection/ChannelCatalogSection.tsx
+++ b/src/channels/components/ChannelCatalogSection/ChannelCatalogSection.tsx
@@ -11,6 +11,7 @@ import {
 import { SetupChecklistReviewList } from "@dashboard/components/SetupChecklist/SetupChecklistReviewList";
 import { type SetupChecklistReviewItem } from "@dashboard/components/SetupChecklist/types";
 import { ProductsIcon } from "@dashboard/icons/Products";
+import { withAppMountUri } from "@dashboard/utils/urls";
 import { Box, Skeleton, Text } from "@saleor/macaw-ui-next";
 import { Eye, Plus } from "lucide-react";
 import { useCallback, useMemo } from "react";
@@ -79,7 +80,7 @@ export const ChannelCatalogSection = ({
     (isPublished: boolean) => {
       // New tab keeps channel details open and avoids SPA filter-state races.
       window.open(
-        productListUrlWithChannelCatalogFilters({ channel, isPublished }),
+        withAppMountUri(productListUrlWithChannelCatalogFilters({ channel, isPublished })),
         "_blank",
         "noopener,noreferrer",
       );

--- a/src/components/Datagrid/hooks/useRowAnchor.ts
+++ b/src/components/Datagrid/hooks/useRowAnchor.ts
@@ -1,5 +1,5 @@
-import { getAppMountUri } from "@dashboard/config";
 import { getCellAction } from "@dashboard/products/components/ProductListDatagrid/datagrid";
+import { withAppMountUri } from "@dashboard/utils/urls";
 import {
   type DataEditorProps,
   type GridMouseEventArgs,
@@ -125,7 +125,7 @@ export const useRowAnchor = ({
       anchor.style.width = `${args.bounds.width}px`;
       anchor.style.top = `${args.bounds.y}px`;
       anchor.style.height = `${args.bounds.height}px`;
-      anchor.href = getAppMountUri() + (href.startsWith("/") ? href.slice(1) : href);
+      anchor.href = withAppMountUri(href);
       anchor.dataset.reactRouterPath = href;
       anchor.style.display = "block";
     },

--- a/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
@@ -17,6 +17,7 @@ import { type OrderDiscountCommonInput } from "@dashboard/orders/components/Orde
 import { useOrderLineDiscountContext } from "@dashboard/products/components/OrderDiscountProviders/OrderLineDiscountProvider";
 import { productUrl } from "@dashboard/products/urls";
 import { ListViews } from "@dashboard/types";
+import { withAppMountUri } from "@dashboard/utils/urls";
 import { type Item } from "@glideapps/glide-data-grid";
 import { Box } from "@saleor/macaw-ui-next";
 import { ExternalLink, Percent, Trash2 } from "lucide-react";
@@ -113,7 +114,7 @@ export const OrderDraftDetailsDatagrid = ({
           const productId = lines[index]?.variant?.product.id;
 
           if (productId) {
-            window.open(productUrl(productId), "_blank", "noopener,noreferrer");
+            window.open(withAppMountUri(productUrl(productId)), "_blank", "noopener,noreferrer");
           }
         },
       },

--- a/src/orders/utils/getOrderLineRowMenuItems.tsx
+++ b/src/orders/utils/getOrderLineRowMenuItems.tsx
@@ -10,7 +10,8 @@ import {
   shouldOfferLineReturnAction,
 } from "@dashboard/orders/utils/getOrderLineActionUrls";
 import { getOrderRefundNavigation } from "@dashboard/orders/utils/getOrderRefundNavigation";
-import { productPath } from "@dashboard/products/urls";
+import { productUrl } from "@dashboard/products/urls";
+import { withAppMountUri } from "@dashboard/utils/urls";
 import { ExternalLink, PackageIcon, Undo2 } from "lucide-react";
 import { type IntlShape } from "react-intl";
 
@@ -41,7 +42,7 @@ export const getOrderLineRowMenuItems = ({
       icon: <ExternalLink size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />,
       onSelect: () => {
         if (productId) {
-          window.open(productPath(productId), "_blank", "noopener,noreferrer");
+          window.open(withAppMountUri(productUrl(productId)), "_blank", "noopener,noreferrer");
         }
       },
     },

--- a/src/utils/urls.test.ts
+++ b/src/utils/urls.test.ts
@@ -1,5 +1,5 @@
 import { productTypeUrl } from "@dashboard/productTypes/urls";
-import { getMultipleUrlValues, withQuery } from "@dashboard/utils/urls";
+import { getMultipleUrlValues, withAppMountUri, withQuery } from "@dashboard/utils/urls";
 
 describe("withQuery", () => {
   it("omits the query string when there are no params", () => {
@@ -74,5 +74,28 @@ describe("getMultipleUrlValues", () => {
     );
 
     expect(getMultipleUrlValues(url.search, "activeField")).toEqual(["name", "description"]);
+  });
+});
+
+describe("withAppMountUri", () => {
+  afterEach(() => {
+    window.__SALEOR_CONFIG__.APP_MOUNT_URI = "/";
+  });
+
+  it("prepends the mount point to router-relative paths", () => {
+    // Arrange
+    window.__SALEOR_CONFIG__.APP_MOUNT_URI = "/dashboard/";
+
+    // Act / Assert
+    expect(withAppMountUri("/products/id?")).toBe("/dashboard/products/id?");
+    expect(withAppMountUri("products/id")).toBe("/dashboard/products/id");
+  });
+
+  it("leaves the path unchanged when mounted at root", () => {
+    // Arrange
+    window.__SALEOR_CONFIG__.APP_MOUNT_URI = "/";
+
+    // Act / Assert
+    expect(withAppMountUri("/products/id")).toBe("/products/id");
   });
 });

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -52,3 +52,11 @@ export const getMultipleUrlValues = (urlSearch: string, fieldName: string): stri
 
   return params.getAll(fieldName);
 };
+
+/**
+ * Router-relative paths (e.g. productUrl()) are resolved by react-router against its
+ * basename. Anything that leaves the router - window.open, anchor href - must prepend
+ * APP_MOUNT_URI itself, otherwise the link drops the dashboard mount point.
+ */
+export const withAppMountUri = (path: string) =>
+  getAppMountUri() + (path.startsWith("/") ? path.slice(1) : path);


### PR DESCRIPTION
window.open bypasses react-router, so router-relative paths built by url helpers lost the basename and 404'd on sub-path deployments (e.g. /dashboard/). Extracted the mount-point prefixing already inlined in useRowAnchor into withAppMountUri and used it at every window.open that takes an internal path.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
