### PR TITLE
Clear draft order finalize errors once the data is filled in

### DIFF
--- a/.changeset/draft-order-finalize-stale-errors.md
+++ b/.changeset/draft-order-finalize-stale-errors.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Draft order errors now disappear once the missing details are filled in.
+
+Clicking "Finalize" on an incomplete draft order marks the missing billing address, shipping address and shipping method. Those errors come from the `draftOrderComplete` result, which Apollo keeps until the mutation runs again, so they stayed on screen even after the customer, addresses and carrier had been picked. Each of them is now dropped as soon as the draft actually carries the data it was complaining about.

--- a/src/orders/views/OrderDetails/OrderDraftDetails/getUnresolvedFinalizeErrors.test.ts
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/getUnresolvedFinalizeErrors.test.ts
@@ -1,0 +1,146 @@
+import {
+  type AddressFragment,
+  type OrderDetailsFragment,
+  OrderErrorCode,
+  type OrderErrorFragment,
+} from "@dashboard/graphql";
+
+import { getUnresolvedFinalizeErrors } from "./getUnresolvedFinalizeErrors";
+
+type DraftOrder = Pick<
+  OrderDetailsFragment,
+  "billingAddress" | "shippingAddress" | "shippingMethod"
+>;
+
+const address: AddressFragment = {
+  __typename: "Address",
+  city: "Wrocław",
+  cityArea: "",
+  companyName: "",
+  countryArea: "",
+  firstName: "Jan",
+  id: "QWRkcmVzczox",
+  lastName: "Kowalski",
+  phone: null,
+  postalCode: "50-001",
+  streetAddress1: "Rynek 1",
+  streetAddress2: "",
+  country: {
+    __typename: "CountryDisplay",
+    code: "PL",
+    country: "Poland",
+  },
+};
+
+const emptyDraft: DraftOrder = {
+  billingAddress: null,
+  shippingAddress: null,
+  shippingMethod: null,
+};
+
+const createError = (code: OrderErrorCode, field: string | null): OrderErrorFragment => ({
+  __typename: "OrderError",
+  code,
+  field,
+  addressType: null,
+  message: "Error",
+  orderLines: null,
+});
+
+const noBillingAddress = createError(OrderErrorCode.BILLING_ADDRESS_NOT_SET, "order");
+const noShippingAddress = createError(OrderErrorCode.ORDER_NO_SHIPPING_ADDRESS, "order");
+const noShippingMethod = createError(OrderErrorCode.SHIPPING_METHOD_REQUIRED, "shipping");
+
+describe("getUnresolvedFinalizeErrors", () => {
+  it("keeps every error while the draft is still missing all of the data", () => {
+    // Arrange
+    const errors = [noBillingAddress, noShippingAddress, noShippingMethod];
+
+    // Act
+    const result = getUnresolvedFinalizeErrors(errors, emptyDraft);
+
+    // Assert
+    expect(result).toEqual(errors);
+  });
+
+  it("drops the billing address error once a billing address is set", () => {
+    // Arrange
+    const order: DraftOrder = { ...emptyDraft, billingAddress: address };
+
+    // Act
+    const result = getUnresolvedFinalizeErrors([noBillingAddress, noShippingAddress], order);
+
+    // Assert
+    expect(result).toEqual([noShippingAddress]);
+  });
+
+  it("drops the shipping address error once a shipping address is set", () => {
+    // Arrange
+    const order: DraftOrder = { ...emptyDraft, shippingAddress: address };
+
+    // Act
+    const result = getUnresolvedFinalizeErrors([noBillingAddress, noShippingAddress], order);
+
+    // Assert
+    expect(result).toEqual([noBillingAddress]);
+  });
+
+  it("drops the shipping method error once a shipping method is chosen", () => {
+    // Arrange
+    const order: DraftOrder = {
+      ...emptyDraft,
+      shippingMethod: { __typename: "ShippingMethod", id: "U2hpcHBpbmdNZXRob2Q6MQ==" },
+    };
+
+    // Act
+    const result = getUnresolvedFinalizeErrors([noShippingMethod], order);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("drops every error once the whole draft is filled in", () => {
+    // Arrange
+    const order: DraftOrder = {
+      billingAddress: address,
+      shippingAddress: address,
+      shippingMethod: { __typename: "ShippingMethod", id: "U2hpcHBpbmdNZXRob2Q6MQ==" },
+    };
+
+    // Act
+    const result = getUnresolvedFinalizeErrors(
+      [noBillingAddress, noShippingAddress, noShippingMethod],
+      order,
+    );
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("keeps errors it cannot tell apart from the current draft state", () => {
+    // Arrange
+    const insufficientStock = createError(OrderErrorCode.INSUFFICIENT_STOCK, "lines");
+    const order: DraftOrder = {
+      billingAddress: address,
+      shippingAddress: address,
+      shippingMethod: { __typename: "ShippingMethod", id: "U2hpcHBpbmdNZXRob2Q6MQ==" },
+    };
+
+    // Act
+    const result = getUnresolvedFinalizeErrors([insufficientStock], order);
+
+    // Assert
+    expect(result).toEqual([insufficientStock]);
+  });
+
+  it("keeps the errors untouched when the order has not loaded yet", () => {
+    // Arrange
+    const errors = [noBillingAddress];
+
+    // Act
+    const result = getUnresolvedFinalizeErrors(errors, undefined);
+
+    // Assert
+    expect(result).toEqual(errors);
+  });
+});

--- a/src/orders/views/OrderDetails/OrderDraftDetails/getUnresolvedFinalizeErrors.ts
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/getUnresolvedFinalizeErrors.ts
@@ -1,0 +1,39 @@
+import {
+  type OrderDetailsFragment,
+  OrderErrorCode,
+  type OrderErrorFragment,
+} from "@dashboard/graphql";
+
+type DraftOrder = Pick<
+  OrderDetailsFragment,
+  "billingAddress" | "shippingAddress" | "shippingMethod"
+>;
+
+/**
+ * `draftOrderComplete` reports what was missing at the moment Finalize was clicked.
+ * Apollo keeps that result around until the mutation runs again, so the errors would
+ * otherwise stay on screen after the user has already filled the missing data in.
+ */
+const isResolved = (error: OrderErrorFragment, order: DraftOrder): boolean => {
+  switch (error.code) {
+    case OrderErrorCode.BILLING_ADDRESS_NOT_SET:
+      return !!order.billingAddress;
+    case OrderErrorCode.ORDER_NO_SHIPPING_ADDRESS:
+      return !!order.shippingAddress;
+    case OrderErrorCode.SHIPPING_METHOD_REQUIRED:
+      return !!order.shippingMethod;
+    default:
+      return false;
+  }
+};
+
+export const getUnresolvedFinalizeErrors = (
+  errors: OrderErrorFragment[],
+  order: DraftOrder | null | undefined,
+): OrderErrorFragment[] => {
+  if (!order) {
+    return errors;
+  }
+
+  return errors.filter(error => !isResolved(error, order));
+};

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -48,6 +48,7 @@ import OrderDraftPage from "../../../components/OrderDraftPage/OrderDraftPage";
 import { OrderProductAddDialog } from "../../../components/OrderProductAddDialog/OrderProductAddDialog";
 import OrderShippingMethodEditDialog from "../../../components/OrderShippingMethodEditDialog/OrderShippingMethodEditDialog";
 import { orderDraftListUrl, type OrderUrlDialog, type OrderUrlQueryParams } from "../../../urls";
+import { getUnresolvedFinalizeErrors } from "./getUnresolvedFinalizeErrors";
 
 interface OrderDraftDetailsProps {
   id: string;
@@ -180,7 +181,10 @@ export const OrderDraftDetails = ({
 
     return errors;
   };
-  const errors = orderDraftFinalize.opts.data?.draftOrderComplete.errors || [];
+  const errors = getUnresolvedFinalizeErrors(
+    orderDraftFinalize.opts.data?.draftOrderComplete.errors || [],
+    order,
+  );
 
   return (
     <>


### PR DESCRIPTION
Fixes #3982

### What this fixes

Clicking **Finalize** on an incomplete draft order marks what is missing — billing address, shipping address, shipping method. Filling those details in does not clear the markers: they stay on the page until the mutation is fired again, with no way to dismiss them.

Reproduction from the issue (confirmed still present on `main`):

1. Create a draft order and add products
2. Click **Finalize** → errors appear for the missing address and carrier
3. Pick a customer, add shipping and billing addresses, pick a shipping carrier
4. The errors are still there

### Why it happens

The draft view reads the errors straight off the last mutation result:

```ts
// src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
const errors = orderDraftFinalize.opts.data?.draftOrderComplete.errors || [];
```

`draftOrderComplete` reports what was missing *at the moment Finalize was clicked*. Apollo keeps that result in `opts.data` until the mutation runs again, so the array never reflects the edits made afterwards. It is fanned out to `OrderCustomer` (which looks for `BILLING_ADDRESS_NOT_SET` / `ORDER_NO_SHIPPING_ADDRESS`) and to `OrderValue` (which pulls the `shipping` field error), so all three markers go stale together.

### The change

`getUnresolvedFinalizeErrors` filters that snapshot against the draft as it stands now, dropping each error as soon as the order carries the data it was reporting missing:

| Error code | Dropped when |
| --- | --- |
| `BILLING_ADDRESS_NOT_SET` | `order.billingAddress` is set |
| `ORDER_NO_SHIPPING_ADDRESS` | `order.shippingAddress` is set |
| `SHIPPING_METHOD_REQUIRED` | `order.shippingMethod` is set |

Anything else passes through untouched. `SHIPPING_NOT_APPLICABLE` and line-level errors such as `INSUFFICIENT_STOCK` cannot be judged stale from client state — there is no way to tell whether the user changed the thing the error was about — so they are deliberately left alone, as is the case where the order has not loaded yet.

Filtering at the source means every consumer of these errors is fixed at once, and nothing about how they are rendered had to change.

### Testing

7 unit tests covering each code, the combined case, the untouched fallthrough and the unloaded order. Reverting the helper to the previous pass-through behaviour fails 4 of them, so they pin the fix rather than just describing it.

`pnpm run check-types` (including `tsc-strict`), `pnpm run knip`, `pnpm run lint:changesets` and ESLint on the touched paths are all clean. A `patch` changeset is included.
