### PR TITLE
Stop warning about shipping on drafts that don't need it

### DIFF
--- a/.changeset/draft-order-shipping-alert-digital.md
+++ b/.changeset/draft-order-shipping-alert-digital.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Draft orders that don't need shipping no longer warn about missing shipping methods.
+
+A draft made up entirely of non-shippable products (digital goods, for instance) has no shipping methods to offer, so the draft page warned that the destination country was unavailable for the channel and listed it under "You will not be able to finalize this draft because:". Finalizing such an order never checks shipping at all, so the warning named a blocker that did not exist. The alert is now limited to drafts that actually require shipping; the inactive-channel and no-products alerts are unchanged.

--- a/src/orders/components/OrderDraftPage/OrderDraftAlert.test.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftAlert.test.tsx
@@ -65,6 +65,7 @@ describe("OrderDraftAlert", () => {
           {...alertProps}
           order={{
             ...order("--url--"),
+            isShippingRequired: true,
             shippingMethods: [],
           }}
           data-test-id="draft-alert"
@@ -74,5 +75,43 @@ describe("OrderDraftAlert", () => {
 
     expect(screen.getByText(/Wyspy Salomona/)).toBeInTheDocument();
     expect(screen.getByText(/{configLink}/)).toBeInTheDocument();
+  });
+
+  it("doesn't render no shipping methods alert when the order doesn't require shipping", () => {
+    render(
+      <Wrapper>
+        <OrderDraftAlert
+          {...alertProps}
+          order={{
+            ...order("--url--"),
+            isShippingRequired: false,
+            shippingMethods: [],
+          }}
+          data-test-id="draft-alert"
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByTestId("draft-alert")).toBeNull();
+  });
+
+  it("still reports the other blockers when the order doesn't require shipping", () => {
+    render(
+      <Wrapper>
+        <OrderDraftAlert
+          {...alertProps}
+          order={{
+            ...order("--url--"),
+            isShippingRequired: false,
+            shippingMethods: [],
+            channel: { ...channelsList[0], isActive: false },
+          }}
+          data-test-id="draft-alert"
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Orders cannot be placed in an inactive channel.")).toBeInTheDocument();
+    expect(screen.queryByText(/Wyspy Salomona/)).toBeNull();
   });
 });

--- a/src/orders/components/OrderDraftPage/OrderDraftAlert.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftAlert.tsx
@@ -14,8 +14,10 @@ const getAlerts = (
   order?: OrderDetailsFragment,
   channelUsabilityData?: ChannelUsabilityDataQuery,
 ) => {
+  // An order that carries no shippable lines is finalized without a shipping method,
+  // so the absence of one is not a blocker and must not be reported as such.
   const canDetermineShippingMethods =
-    order?.shippingAddress?.country.code && !!order?.lines?.length;
+    !!order?.isShippingRequired && !!order?.shippingAddress?.country.code && !!order?.lines?.length;
   const isChannelInactive = order && !order.channel.isActive;
   const noProductsInChannel = channelUsabilityData?.products?.totalCount === 0;
   const noShippingMethodsInChannel =


### PR DESCRIPTION
Fixes #3061

### What this fixes

A draft order made up entirely of non-shippable products — digital goods, for example — has no shipping methods to offer. The draft page took that to mean the channel was misconfigured and showed:

> **You will not be able to finalize this draft because:**
> {country} is not available as a shipping destination for this channel, check shipping zones configuration.

Finalizing skips shipping validation entirely when the order doesn't require shipping, so the alert named a blocker that doesn't exist and sent the user off to fix shipping zones that have nothing wrong with them.

Reproduction from the issue (still present on `main`):

1. Create a channel with no shipping methods
2. Create a product that is not shippable
3. Create a draft order with that product in that channel → the warning appears, and Finalize works anyway

### Why it happens

`getAlerts` decides it can judge shipping availability from nothing more than an address and some lines:

```ts
// src/orders/components/OrderDraftPage/OrderDraftAlert.tsx
const canDetermineShippingMethods =
  order?.shippingAddress?.country.code && !!order?.lines?.length;

const noShippingMethodsInChannel =
  canDetermineShippingMethods && order?.shippingMethods.length === 0;
```

`order.shippingMethods` is empty for a non-shippable order because there is nothing to ship, not because the channel lacks zones — the two cases are indistinguishable at this point unless `isShippingRequired` is consulted.

### The change

Gate the alert on the order actually requiring shipping. The inactive-channel and no-products alerts are untouched, and a draft that *does* require shipping still gets the warning exactly as before.

### A note on the existing test

`renders no shipping methods in channel alert` was passing only because the shared `order()` fixture sets `isShippingRequired: false` at the order level (while its lines set `true` — the fixture is internally inconsistent). That test was therefore asserting the buggy path. It now sets the flag explicitly so it keeps covering what it was written to cover; I confirmed it passes both with and without this change, so no existing coverage is weakened.

### Testing

Two new tests: one for the digital-only draft staying quiet, one confirming the other blockers are still reported when shipping isn't required. Both fail against the unfixed component; the four pre-existing tests pass in either state.

`pnpm run check-types` (including `tsc-strict`), `pnpm run knip`, `pnpm run lint:changesets` and ESLint on the touched paths are all clean. A `patch` changeset is included.
